### PR TITLE
fix(peers): require admin on peer data-plane management routes

### DIFF
--- a/backend/src/api/handlers/peer.rs
+++ b/backend/src/api/handlers/peer.rs
@@ -1,7 +1,7 @@
 //! Mesh peer discovery and management API handlers.
 
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Extension, Path, Query, State},
     routing::{get, post, put},
     Json, Router,
 };
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::Result;
 use crate::services::peer_service::{PeerService, PeerStatus, ProbeResult};
@@ -285,8 +286,10 @@ async fn probe_peer(
 )]
 async fn mark_unreachable(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((peer_id, target_id)): Path<(Uuid, Uuid)>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = PeerService::new(state.db.clone());
     service.mark_unreachable(peer_id, target_id).await
 }
@@ -352,9 +355,11 @@ async fn get_chunk_availability(
 )]
 async fn update_chunk_availability(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((peer_id, artifact_id)): Path<(Uuid, Uuid)>,
     Json(body): Json<UpdateChunkAvailabilityBody>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
     service
         .update_chunk_availability(peer_id, artifact_id, &body.chunk_bitmap, body.total_chunks)
@@ -453,9 +458,11 @@ async fn get_scored_peers(
 )]
 async fn update_network_profile(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(peer_id): Path<Uuid>,
     Json(body): Json<NetworkProfileBody>,
 ) -> Result<()> {
+    auth.require_admin()?;
     // Parse time strings if provided
     let window_start = body
         .sync_window_start
@@ -1081,6 +1088,173 @@ mod tests {
 
             let _ = sqlx::query("DELETE FROM peer_instances WHERE id = ANY($1)")
                 .bind(vec![src, dst])
+                .execute(&pool)
+                .await;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Authorization tests for the peer data-plane management routes (GHSA-f7qf).
+    //
+    // The mutating peer routes (update_network_profile, update_chunk_availability,
+    // mark_unreachable) manage federation-wide transfer / chunk / network state
+    // and are admin-only, mirroring `peers::register_peer`. A non-admin
+    // authenticated caller must be rejected with 403 FORBIDDEN before any state
+    // change; an admin still succeeds. Before the guard these returned 2xx (or a
+    // service-level error) for a non-admin — never a 403.
+    //
+    // Runtime-skips when no `DATABASE_URL` is set (NOT `#[ignore]`).
+    // -----------------------------------------------------------------------
+    mod authz {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::api::middleware::auth::AuthExtension;
+        use axum::body::Bytes;
+        use axum::http::StatusCode;
+        use axum::Router;
+        use uuid::Uuid;
+
+        fn admin() -> AuthExtension {
+            let mut a = tdh::make_auth(Uuid::new_v4(), "fed.admin");
+            a.is_admin = true;
+            a
+        }
+
+        fn non_admin() -> AuthExtension {
+            // make_auth defaults to is_admin: false — a plain authenticated user.
+            tdh::make_auth(Uuid::new_v4(), "low.priv")
+        }
+
+        fn profile_app(state: crate::api::SharedState, auth: AuthExtension) -> Router {
+            // network_profile_router()'s handler extracts Path<Uuid>, so mount it
+            // behind a `/:id` prefix to supply the peer id.
+            let router = Router::new().nest("/:id", super::super::network_profile_router());
+            tdh::router_with_auth_ext(router, state, auth)
+        }
+
+        fn chunk_app(state: crate::api::SharedState, auth: AuthExtension) -> Router {
+            let router = Router::new().nest("/:id/chunks", super::super::chunk_router());
+            tdh::router_with_auth_ext(router, state, auth)
+        }
+
+        fn conn_app(state: crate::api::SharedState, auth: AuthExtension) -> Router {
+            let router = Router::new().nest("/:id/connections", super::super::peer_router());
+            tdh::router_with_auth_ext(router, state, auth)
+        }
+
+        #[tokio::test]
+        async fn non_admin_cannot_update_network_profile() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-authz");
+            let peer = tdh::register_test_peer(&pool, "authz-np", "deny").await;
+
+            let (status, _) = tdh::send(
+                profile_app(state, non_admin()),
+                tdh::put_json(
+                    format!("/{}/network-profile", peer),
+                    Bytes::from_static(b"{}"),
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "a non-admin must be denied (403) on update_network_profile"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn admin_can_update_network_profile() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-authz");
+            let peer = tdh::register_test_peer(&pool, "authz-np", "allow").await;
+
+            let (status, _) = tdh::send(
+                profile_app(state, admin()),
+                tdh::put_json(
+                    format!("/{}/network-profile", peer),
+                    Bytes::from_static(b"{\"max_bandwidth_bps\":1000}"),
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "an admin must still be able to update a peer network profile"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn non_admin_cannot_update_chunk_availability() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-authz");
+            let peer = tdh::register_test_peer(&pool, "authz-chunk", "deny").await;
+
+            let (status, _) = tdh::send(
+                chunk_app(state, non_admin()),
+                tdh::put_json(
+                    format!("/{}/chunks/{}", peer, Uuid::new_v4()),
+                    Bytes::from_static(b"{\"chunk_bitmap\":[1],\"total_chunks\":1}"),
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "a non-admin must be denied (403) on update_chunk_availability, \
+                 before any chunk-availability row is written"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn non_admin_cannot_mark_unreachable() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-authz");
+            let peer = tdh::register_test_peer(&pool, "authz-unreach", "deny").await;
+
+            let (status, _) = tdh::send(
+                conn_app(state, non_admin()),
+                tdh::post(
+                    format!("/{}/connections/{}/unreachable", peer, Uuid::new_v4()),
+                    "application/json",
+                    Bytes::new(),
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "a non-admin must be denied (403) on mark_unreachable"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
                 .execute(&pool)
                 .await;
         }

--- a/backend/src/api/handlers/transfer.rs
+++ b/backend/src/api/handlers/transfer.rs
@@ -1,7 +1,7 @@
 //! Chunked transfer API handlers for swarm-based artifact distribution.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Extension, Path, State},
     routing::{get, post},
     Json, Router,
 };
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::Result;
 use crate::services::transfer_service::{InitTransferRequest, TransferService};
@@ -93,9 +94,11 @@ pub struct FailBody {
 )]
 async fn init_transfer(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(peer_id): Path<Uuid>,
     Json(body): Json<InitTransferBody>,
 ) -> Result<Json<TransferSessionResponse>> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
 
     let session = service
@@ -213,9 +216,11 @@ async fn get_session(
 )]
 async fn complete_chunk(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((_peer_id, session_id, chunk_index)): Path<(Uuid, Uuid, i32)>,
     Json(body): Json<CompleteChunkBody>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
     service
         .complete_chunk(session_id, chunk_index, &body.checksum, body.source_peer_id)
@@ -241,9 +246,11 @@ async fn complete_chunk(
 )]
 async fn fail_chunk(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((_peer_id, session_id, chunk_index)): Path<(Uuid, Uuid, i32)>,
     Json(body): Json<FailBody>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
     service
         .fail_chunk(session_id, chunk_index, &body.error)
@@ -268,8 +275,10 @@ async fn fail_chunk(
 )]
 async fn retry_chunk(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((_peer_id, session_id, chunk_index)): Path<(Uuid, Uuid, i32)>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
     service.retry_chunk(session_id, chunk_index).await
 }
@@ -291,8 +300,10 @@ async fn retry_chunk(
 )]
 async fn complete_session(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((_peer_id, session_id)): Path<(Uuid, Uuid)>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
     service.complete_session(session_id).await
 }
@@ -315,9 +326,11 @@ async fn complete_session(
 )]
 async fn fail_session(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((_peer_id, session_id)): Path<(Uuid, Uuid)>,
     Json(body): Json<FailBody>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = TransferService::new(state.db.clone());
     service.fail_session(session_id, &body.error).await
 }
@@ -650,5 +663,104 @@ mod tests {
             format!("{:?}", TransferStatus::Failed).to_lowercase(),
             "failed"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Authorization tests for the transfer data-plane routes (GHSA-f7qf).
+    //
+    // init_transfer (and its sibling chunk/session mutators) drive federation
+    // transfer sessions and are admin-only, mirroring `peers::register_peer`. A
+    // non-admin authenticated caller must be rejected with 403 FORBIDDEN before
+    // any session is created; an admin passes the gate. Before the guard a
+    // non-admin was let straight through to the service layer.
+    //
+    // Runtime-skips when no `DATABASE_URL` is set (NOT `#[ignore]`).
+    // -----------------------------------------------------------------------
+    mod authz {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::api::middleware::auth::AuthExtension;
+        use axum::body::Bytes;
+        use axum::http::StatusCode;
+        use axum::Router;
+        use uuid::Uuid;
+
+        fn admin() -> AuthExtension {
+            let mut a = tdh::make_auth(Uuid::new_v4(), "fed.admin");
+            a.is_admin = true;
+            a
+        }
+
+        fn non_admin() -> AuthExtension {
+            tdh::make_auth(Uuid::new_v4(), "low.priv")
+        }
+
+        fn transfer_app(state: crate::api::SharedState, auth: AuthExtension) -> Router {
+            // Mirror the production mount point: transfer::router() lives under
+            // /:id/transfer.
+            let router = Router::new().nest("/:id/transfer", super::super::router());
+            tdh::router_with_auth_ext(router, state, auth)
+        }
+
+        fn init_req(peer: Uuid) -> axum::http::Request<axum::body::Body> {
+            tdh::post(
+                format!("/{}/transfer/init", peer),
+                "application/json",
+                Bytes::from(format!("{{\"artifact_id\":\"{}\"}}", Uuid::new_v4()).into_bytes()),
+            )
+        }
+
+        #[tokio::test]
+        async fn non_admin_cannot_init_transfer() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-transfer-authz");
+            let peer = tdh::register_test_peer(&pool, "authz-init", "deny").await;
+
+            let (status, _) = tdh::send(transfer_app(state, non_admin()), init_req(peer)).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "a non-admin must be denied (403) on init_transfer, before any \
+                 transfer session is created"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn admin_passes_init_transfer_gate() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-transfer-authz");
+            let peer = tdh::register_test_peer(&pool, "authz-init", "allow").await;
+
+            // An admin clears the authorization gate and reaches the service
+            // layer; with a random artifact id the service returns 404
+            // "Artifact not found" — crucially NOT a 403. This proves the guard
+            // does not over-block legitimate admin callers.
+            let (status, _) = tdh::send(transfer_app(state, admin()), init_req(peer)).await;
+
+            assert_ne!(
+                status,
+                StatusCode::FORBIDDEN,
+                "an admin must clear the authorization gate on init_transfer"
+            );
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "admin reaches the service layer; unknown artifact -> 404"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
+                .execute(&pool)
+                .await;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds admin authorization to the peer **data-plane management** routes, which were
mounted under `auth_middleware` (authentication) only — with no authorization
check in the router or the handlers.

Any authenticated user, regardless of privilege, could mutate federation-wide
peer state: initialise/complete/fail transfer sessions and their chunks, mark
peer connections unreachable, overwrite chunk-availability records, and change a
peer's network profile (bandwidth caps, sync windows, concurrency limits).

The sibling registration handler (`peers::register_peer` / `announce_peer`)
already gates with `auth.require_admin()?`. These data-plane handlers were the
omission; this PR brings them to parity.

Because the affected routers mix read-only routes (`GET` session/manifest/list/
scored-peer lookups) with the mutating ones, the guard is applied per-handler
rather than by moving the subtree under `admin_middleware`, so the read-only
status endpoints stay reachable for non-admin callers.

Handlers now gated with `auth.require_admin()?` (403 for non-admins):

- `handlers/transfer.rs`: `init_transfer`, `complete_chunk`, `fail_chunk`,
  `retry_chunk`, `complete_session`, `fail_session`
- `handlers/peer.rs`: `mark_unreachable`, `update_chunk_availability`,
  `update_network_profile`

`require_admin` is reused deliberately (no new gate is introduced) so this change
composes cleanly with the in-flight work making `require_admin` scope-aware.

Read-only peer routes (`list_peers`, `discover_peers`, `get_session`,
`get_chunk_manifest`, `get_chunk_availability`, `get_peers_with_chunks`,
`get_scored_peers`) are intentionally left reachable for authenticated
non-admins.

Ref: advisory GHSA-f7qf.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added DB-backed authorization tests (`#[cfg(test)] mod authz`, runtime-skip when
`DATABASE_URL` is unset):

- `handlers/peer.rs`: `non_admin_cannot_update_network_profile` (403),
  `admin_can_update_network_profile` (200),
  `non_admin_cannot_update_chunk_availability` (403),
  `non_admin_cannot_mark_unreachable` (403)
- `handlers/transfer.rs`: `non_admin_cannot_init_transfer` (403),
  `admin_passes_init_transfer_gate` (admin clears the gate → reaches the service
  layer)

Each non-admin test asserts `403 FORBIDDEN`; on the pre-fix code the same
requests reached the handler body (2xx / 404 / 500), never a 403, so the tests
fail before this change and pass after.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (authorization only; no route/schema changes)
