### PR TITLE
fix(migration): populate upstream_url for migrated remote/proxy repositories (#2822)

### DIFF
--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -126,6 +126,14 @@ pub struct RepositoryListItem {
     /// up (issue #2783).
     #[serde(default)]
     pub members: Vec<String>,
+    /// For remote/proxy repositories: the upstream URL the source proxies. This
+    /// is distinct from `url` (which for Nexus is the repo's own browse URL).
+    /// It is threaded into the migrated Artifact Keeper repo's `upstream_url`
+    /// column; a remote repo migrated without it is rejected by the
+    /// `check_upstream_url` constraint (issue #2822). Populated best-effort from
+    /// the Artifactory remote-config `url` / Nexus `proxy.remoteUrl`.
+    #[serde(default)]
+    pub upstream_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -505,7 +513,17 @@ impl ArtifactoryClient {
 
     /// List all repositories
     pub async fn list_repositories(&self) -> Result<Vec<RepositoryListItem>, ArtifactoryError> {
-        self.get("/api/repositories").await
+        let mut items: Vec<RepositoryListItem> = self.get("/api/repositories").await?;
+        // Artifactory's `/api/repositories` reports a remote repo's configured
+        // upstream in the `url` field. Capture it as `upstream_url` so remote
+        // repos migrate with a non-NULL upstream; otherwise Artifact Keeper's
+        // `check_upstream_url` constraint rejects the created repo (issue #2822).
+        for item in items.iter_mut() {
+            if item.repo_type.eq_ignore_ascii_case("remote") {
+                item.upstream_url = item.url.clone();
+            }
+        }
+        Ok(items)
     }
 
     /// Get repository configuration

--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -337,7 +337,13 @@ impl MigrationService {
             package_type: normalized_package_type,
             description: repo.description.clone(),
             format_compatibility,
-            upstream_url: None, // Will be set from repo_config for remote repos
+            // Thread the source-reported upstream URL through so remote/proxy
+            // repos migrate with a non-NULL `upstream_url`. Populated by the
+            // source clients (Artifactory remote-config `url` / Nexus
+            // `proxy.remoteUrl`); previously hard-coded to `None`, which made
+            // every remote repo fail the AK `check_upstream_url` constraint and
+            // get skipped (issue #2822).
+            upstream_url: repo.upstream_url.clone(),
             // Carry the source-side member keys (Nexus `group.memberNames` /
             // Artifactory virtual `repositories`) through so virtual/group repos
             // can be correlated to their migrated AK members later. Previously
@@ -455,6 +461,17 @@ impl MigrationService {
 
         let repo_type = config.repo_type.to_artifact_keeper();
 
+        // A remote repo with no resolvable upstream URL cannot satisfy the
+        // `check_upstream_url` constraint (repo_type='remote' requires a
+        // NOT-NULL upstream_url). Surface a clear config error here instead of
+        // letting the raw SQLSTATE 23514 bubble up from the INSERT (issue #2822).
+        if config.repo_type == RepositoryType::Remote && config.upstream_url.is_none() {
+            return Err(MigrationError::ConfigError(format!(
+                "remote repo {}: source did not report an upstream URL",
+                config.source_key
+            )));
+        }
+
         // The repositories table schema has no `metadata`, `display_name`, or
         // `repository_type` columns. The corresponding columns are `name` and
         // `repo_type`, and `storage_path` is NOT NULL — so the INSERT must
@@ -464,8 +481,8 @@ impl MigrationService {
             Self::build_storage_path(storage_backend, storage_base, &config.target_key);
         let repo_id: (Uuid,) = sqlx::query_as(
             r#"
-            INSERT INTO repositories (key, name, description, format, repo_type, storage_path, storage_backend)
-            VALUES ($1, $2, $3, $4::repository_format, $5::repository_type, $6, $7)
+            INSERT INTO repositories (key, name, description, format, repo_type, storage_path, storage_backend, upstream_url)
+            VALUES ($1, $2, $3, $4::repository_format, $5::repository_type, $6, $7, $8)
             RETURNING id
             "#,
         )
@@ -476,6 +493,7 @@ impl MigrationService {
         .bind(repo_type)
         .bind(&storage_path)
         .bind(storage_backend)
+        .bind(&config.upstream_url)
         .fetch_one(&self.db)
         .await?;
 
@@ -1494,6 +1512,113 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Remote/proxy upstream_url persistence on create_repository (issue #2822)
+    // -----------------------------------------------------------------------
+
+    /// DB-backed proof for #2822: `create_repository` persists a remote repo's
+    /// `upstream_url` (satisfying the `check_upstream_url` constraint), rejects a
+    /// remote repo with no upstream via a clear `ConfigError` (NOT a raw SQLSTATE
+    /// 23514), and still accepts a Local repo with a NULL `upstream_url`.
+    ///
+    /// Fails-before: prior to the fix the INSERT omitted `upstream_url`, so every
+    /// remote repo hit the constraint and was skipped.
+    ///
+    /// No-ops when `DATABASE_URL` is unset so it skips cleanly off-CI.
+    #[tokio::test]
+    async fn test_create_repository_persists_remote_upstream_url_2822() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let svc = MigrationService::new(pool.clone());
+        let sfx = uuid::Uuid::new_v4().simple().to_string();
+
+        // Remote repo WITH an upstream URL: created, and the row carries it.
+        let rkey = format!("remote-{sfx}");
+        let cfg = RepositoryMigrationConfig {
+            source_key: rkey.clone(),
+            target_key: rkey.clone(),
+            repo_type: RepositoryType::Remote,
+            package_type: "maven".to_string(),
+            description: None,
+            format_compatibility: FormatCompatibility::Full,
+            upstream_url: Some("https://repo1.maven.org/maven2/".to_string()),
+            members: vec![],
+        };
+        let id = svc
+            .create_repository(&cfg, "/staging", "filesystem")
+            .await
+            .expect("remote repo with upstream_url should be created");
+        let row: (Option<String>,) =
+            sqlx::query_as("SELECT upstream_url FROM repositories WHERE id = $1")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .expect("read upstream_url");
+        assert_eq!(row.0, Some("https://repo1.maven.org/maven2/".to_string()));
+
+        // Remote repo WITHOUT an upstream URL: a clear ConfigError, not a 23514.
+        let rkey_bad = format!("remote-bad-{sfx}");
+        let cfg_bad = RepositoryMigrationConfig {
+            source_key: rkey_bad.clone(),
+            target_key: rkey_bad.clone(),
+            repo_type: RepositoryType::Remote,
+            package_type: "maven".to_string(),
+            description: None,
+            format_compatibility: FormatCompatibility::Full,
+            upstream_url: None,
+            members: vec![],
+        };
+        let err = svc
+            .create_repository(&cfg_bad, "/staging", "filesystem")
+            .await
+            .expect_err("remote repo without upstream_url must be rejected");
+        match err {
+            MigrationError::ConfigError(msg) => {
+                assert!(msg.contains(&rkey_bad), "error names the repo: {msg}");
+                assert!(
+                    msg.contains("upstream URL"),
+                    "error explains the cause: {msg}"
+                );
+            }
+            other => panic!("expected ConfigError, got {other:?}"),
+        }
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM repositories WHERE key = $1")
+            .bind(&rkey_bad)
+            .fetch_one(&pool)
+            .await
+            .expect("count bad repo");
+        assert_eq!(count.0, 0, "rejected remote repo is not persisted");
+
+        // A Local repo with a NULL upstream_url remains constraint-legal.
+        let lkey = format!("local-{sfx}");
+        let cfg_local = RepositoryMigrationConfig {
+            source_key: lkey.clone(),
+            target_key: lkey.clone(),
+            repo_type: RepositoryType::Local,
+            package_type: "maven".to_string(),
+            description: None,
+            format_compatibility: FormatCompatibility::Full,
+            upstream_url: None,
+            members: vec![],
+        };
+        let lid = svc
+            .create_repository(&cfg_local, "/staging", "filesystem")
+            .await
+            .expect("local repo with NULL upstream_url should be created");
+
+        for id in [id, lid] {
+            sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await
+                .ok();
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // storage_path convention for auto-provisioned repos (#2336, #2025)
     // -----------------------------------------------------------------------
 
@@ -1719,6 +1844,7 @@ mod tests {
             url: None,
             description: None,
             members: vec![],
+            upstream_url: None,
         };
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.package_type, "debian");
@@ -1742,6 +1868,7 @@ mod tests {
             url: None,
             description: None,
             members: vec![],
+            upstream_url: None,
         };
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.package_type, "maven");
@@ -1757,6 +1884,7 @@ mod tests {
             url: None,
             description: None,
             members: vec![],
+            upstream_url: None,
         };
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.package_type, "rpm");
@@ -1772,6 +1900,7 @@ mod tests {
             url: None,
             description: None,
             members: vec![],
+            upstream_url: None,
         };
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.package_type, "generic");
@@ -1789,10 +1918,34 @@ mod tests {
             url: Some("https://repo1.maven.org/maven2/".to_string()),
             description: None,
             members: vec![],
+            upstream_url: None,
         };
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.repo_type, RepositoryType::Remote);
         assert_eq!(config.package_type, "maven");
+    }
+
+    #[test]
+    fn test_prepare_repository_migration_threads_upstream_url_2822() {
+        // A remote/proxy source repo's `upstream_url` must be threaded into the
+        // migration config so `create_repository` can persist it and satisfy the
+        // `check_upstream_url` constraint (issue #2822). Previously the field was
+        // hard-coded to `None`, so every remote repo was skipped.
+        let repo = RepositoryListItem {
+            key: "docker-proxy".to_string(),
+            repo_type: "proxy".to_string(),
+            package_type: "docker".to_string(),
+            url: Some("https://nexus.example.com/repository/docker-proxy/".to_string()),
+            description: None,
+            members: vec![],
+            upstream_url: Some("https://registry-1.docker.io/".to_string()),
+        };
+        let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
+        assert_eq!(config.repo_type, RepositoryType::Remote);
+        assert_eq!(
+            config.upstream_url,
+            Some("https://registry-1.docker.io/".to_string()),
+        );
     }
 
     #[test]
@@ -1806,6 +1959,7 @@ mod tests {
             url: None,
             description: None,
             members: vec!["maven-releases".to_string(), "maven-central".to_string()],
+            upstream_url: None,
         };
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.repo_type, RepositoryType::Virtual);
@@ -2448,6 +2602,7 @@ mod tests {
             description: Some("Maven releases".to_string()),
             url: Some("http://artifactory/libs-release-local".to_string()),
             members: vec![],
+            upstream_url: None,
         };
 
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
@@ -2472,6 +2627,7 @@ mod tests {
             description: None,
             url: Some("http://artifactory/conan-local".to_string()),
             members: vec![],
+            upstream_url: None,
         };
 
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
@@ -2489,6 +2645,7 @@ mod tests {
             description: None,
             url: Some("http://artifactory/unknown-repo".to_string()),
             members: vec![],
+            upstream_url: None,
         };
 
         let result = MigrationService::prepare_repository_migration(&repo, None);

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -4512,6 +4512,7 @@ mod tests {
             url: None,
             description: None,
             members: vec![],
+            upstream_url: None,
         }
     }
 

--- a/backend/src/services/nexus_client.rs
+++ b/backend/src/services/nexus_client.rs
@@ -75,6 +75,10 @@ pub struct NexusRepositorySettings {
     pub name: String,
     #[serde(default)]
     pub group: Option<NexusGroupAttributes>,
+    /// The `proxy` attributes block of a Nexus `proxy`-type repository, which
+    /// carries the upstream `remoteUrl` this repo proxies (issue #2822).
+    #[serde(default)]
+    pub proxy: Option<NexusProxyAttributes>,
 }
 
 /// The `group` attributes block of a Nexus `group`-type repository.
@@ -83,6 +87,15 @@ pub struct NexusGroupAttributes {
     /// Ordered member repository names aggregated by this group.
     #[serde(rename = "memberNames", default)]
     pub member_names: Vec<String>,
+}
+
+/// The `proxy` attributes block of a Nexus `proxy`-type repository.
+#[derive(Debug, Deserialize)]
+pub struct NexusProxyAttributes {
+    /// Upstream URL that this proxy repository mirrors. Maps onto the migrated
+    /// Artifact Keeper repo's `upstream_url` (issue #2822).
+    #[serde(rename = "remoteUrl", default)]
+    pub remote_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -216,25 +229,36 @@ impl NexusClient {
                 url: r.url,
                 description: None,
                 members: vec![],
+                upstream_url: None,
             })
             .collect();
 
-        // The browse list above does not carry group membership, so `group`
-        // repos would migrate to Artifact Keeper `virtual` repos with zero
-        // members. Enrich them from the settings endpoint, which reports each
-        // group's ordered `memberNames` (issue #2783). Best-effort: if the
+        // The browse list above does not carry group membership or a proxy
+        // repo's upstream URL, so `group` repos would migrate to Artifact Keeper
+        // `virtual` repos with zero members (issue #2783) and `proxy` repos
+        // (≡ AK `remote`) would migrate with a NULL `upstream_url` and be
+        // rejected by the `check_upstream_url` constraint (issue #2822). Enrich
+        // both from the settings endpoint, which reports each group's ordered
+        // `memberNames` and each proxy's `proxy.remoteUrl`. Best-effort: if the
         // settings endpoint is unavailable (older Nexus, restricted token), we
-        // fall back to no members rather than failing the whole listing.
-        if items.iter().any(|i| i.repo_type == "group") {
+        // fall back to no enrichment rather than failing the whole listing.
+        if items
+            .iter()
+            .any(|i| i.repo_type == "group" || i.repo_type == "proxy")
+        {
             match self
                 .get::<Vec<NexusRepositorySettings>>("/service/rest/v1/repositorySettings")
                 .await
             {
-                Ok(settings) => Self::apply_group_members(&mut items, settings),
+                Ok(settings) => {
+                    Self::apply_group_members(&mut items, &settings);
+                    Self::apply_proxy_upstreams(&mut items, &settings);
+                }
                 Err(e) => {
                     tracing::warn!(
-                        "Could not fetch Nexus repository settings to resolve group members; \
-                         migrated virtual repos may have no members: {}",
+                        "Could not fetch Nexus repository settings to resolve group members / \
+                         proxy upstreams; migrated virtual repos may have no members and \
+                         migrated proxy repos may be skipped: {}",
                         e
                     );
                 }
@@ -247,20 +271,45 @@ impl NexusClient {
     /// Copy each Nexus `group` repo's ordered `memberNames` onto the matching
     /// `RepositoryListItem`. Factored out (pure, no I/O) so the group→member
     /// correlation can be unit-tested without a live Nexus (issue #2783).
-    fn apply_group_members(
-        items: &mut [RepositoryListItem],
-        settings: Vec<NexusRepositorySettings>,
-    ) {
+    fn apply_group_members(items: &mut [RepositoryListItem], settings: &[NexusRepositorySettings]) {
         use std::collections::HashMap;
-        let mut members_by_name: HashMap<String, Vec<String>> = settings
-            .into_iter()
-            .filter_map(|s| s.group.map(|g| (s.name, g.member_names)))
+        let members_by_name: HashMap<&str, &Vec<String>> = settings
+            .iter()
+            .filter_map(|s| s.group.as_ref().map(|g| (s.name.as_str(), &g.member_names)))
             .collect();
 
         for item in items.iter_mut() {
             if item.repo_type == "group" {
-                if let Some(members) = members_by_name.remove(&item.key) {
-                    item.members = members;
+                if let Some(members) = members_by_name.get(item.key.as_str()) {
+                    item.members = (*members).clone();
+                }
+            }
+        }
+    }
+
+    /// Copy each Nexus `proxy` repo's `proxy.remoteUrl` onto the matching
+    /// `RepositoryListItem`'s `upstream_url`. Mirrors `apply_group_members`
+    /// (pure, no I/O) so the correlation can be unit-tested without a live
+    /// Nexus (issue #2822).
+    fn apply_proxy_upstreams(
+        items: &mut [RepositoryListItem],
+        settings: &[NexusRepositorySettings],
+    ) {
+        use std::collections::HashMap;
+        let upstreams_by_name: HashMap<&str, &str> = settings
+            .iter()
+            .filter_map(|s| {
+                s.proxy
+                    .as_ref()
+                    .and_then(|p| p.remote_url.as_deref())
+                    .map(|u| (s.name.as_str(), u))
+            })
+            .collect();
+
+        for item in items.iter_mut() {
+            if item.repo_type == "proxy" {
+                if let Some(url) = upstreams_by_name.get(item.key.as_str()) {
+                    item.upstream_url = Some((*url).to_string());
                 }
             }
         }
@@ -588,6 +637,7 @@ mod tests {
                 url: None,
                 description: None,
                 members: vec![],
+                upstream_url: None,
             },
             RepositoryListItem {
                 key: "maven-public".into(),
@@ -596,6 +646,7 @@ mod tests {
                 url: None,
                 description: None,
                 members: vec![],
+                upstream_url: None,
             },
         ];
 
@@ -609,7 +660,7 @@ mod tests {
         )
         .unwrap();
 
-        NexusClient::apply_group_members(&mut items, settings);
+        NexusClient::apply_group_members(&mut items, &settings);
 
         // The hosted repo is untouched; the group repo carries its members in
         // the source-declared order (which becomes virtual-member priority).
@@ -617,6 +668,91 @@ mod tests {
         assert_eq!(
             items[1].members,
             vec!["maven-releases".to_string(), "maven-central".to_string()],
+        );
+    }
+
+    #[test]
+    fn test_nexus_repository_settings_deserializes_proxy_remote_url_2822() {
+        // A `proxy` repo's settings carry the upstream at `proxy.remoteUrl`.
+        let settings: Vec<NexusRepositorySettings> = serde_json::from_str(
+            r#"[
+                {"name":"maven-central","format":"maven2","type":"proxy",
+                 "proxy":{"remoteUrl":"https://repo1.maven.org/maven2/"}}
+            ]"#,
+        )
+        .unwrap();
+        assert_eq!(settings.len(), 1);
+        assert_eq!(
+            settings[0]
+                .proxy
+                .as_ref()
+                .and_then(|p| p.remote_url.as_deref()),
+            Some("https://repo1.maven.org/maven2/"),
+        );
+        // The new optional `proxy` field must not disturb group parsing.
+        assert!(settings[0].group.is_none());
+    }
+
+    #[test]
+    fn test_group_parsing_unaffected_by_new_proxy_field_2822() {
+        // A group repo (no `proxy` block) still deserializes and its
+        // memberNames are parsed as before.
+        let settings: Vec<NexusRepositorySettings> = serde_json::from_str(
+            r#"[
+                {"name":"maven-public","format":"maven2","type":"group",
+                 "group":{"memberNames":["maven-releases","maven-central"]}}
+            ]"#,
+        )
+        .unwrap();
+        assert!(settings[0].proxy.is_none());
+        assert_eq!(
+            settings[0].group.as_ref().unwrap().member_names,
+            vec!["maven-releases".to_string(), "maven-central".to_string()],
+        );
+    }
+
+    #[test]
+    fn test_apply_proxy_upstreams_copies_remote_url_onto_proxy_repos_2822() {
+        // Proxy repos get their `proxy.remoteUrl` as `upstream_url`; non-proxy
+        // repos and proxies absent from settings keep a `None` upstream.
+        let mut items = vec![
+            RepositoryListItem {
+                key: "maven-releases".into(),
+                repo_type: "hosted".into(),
+                package_type: "maven2".into(),
+                url: None,
+                description: None,
+                members: vec![],
+                upstream_url: None,
+            },
+            RepositoryListItem {
+                key: "maven-central".into(),
+                repo_type: "proxy".into(),
+                package_type: "maven2".into(),
+                // The browse `url` is the repo's own Nexus URL, NOT the upstream.
+                url: Some("https://nexus.example.com/repository/maven-central/".into()),
+                description: None,
+                members: vec![],
+                upstream_url: None,
+            },
+        ];
+
+        let settings: Vec<NexusRepositorySettings> = serde_json::from_str(
+            r#"[
+                {"name":"maven-releases","format":"maven2","type":"hosted"},
+                {"name":"maven-central","format":"maven2","type":"proxy",
+                 "proxy":{"remoteUrl":"https://repo1.maven.org/maven2/"}}
+            ]"#,
+        )
+        .unwrap();
+
+        NexusClient::apply_proxy_upstreams(&mut items, &settings);
+
+        // The hosted repo is untouched; the proxy repo carries the upstream.
+        assert!(items[0].upstream_url.is_none());
+        assert_eq!(
+            items[1].upstream_url,
+            Some("https://repo1.maven.org/maven2/".to_string()),
         );
     }
 

--- a/backend/src/services/source_registry.rs
+++ b/backend/src/services/source_registry.rs
@@ -268,6 +268,7 @@ mod tests {
                 url: Some("http://localhost/libs-release".to_string()),
                 description: Some("Release repo".to_string()),
                 members: vec![],
+                upstream_url: None,
             }])
         }
 


### PR DESCRIPTION
## Summary

Remote/proxy source repositories were silently skipped during migration. When
provisioning a destination repository for a Nexus `proxy` / Artifactory `remote`
source (both map to Artifact Keeper `RepositoryType::Remote`),
`create_repository` INSERTed the row **without** an `upstream_url`. The
`repositories.check_upstream_url` constraint requires a non-NULL `upstream_url`
for `repo_type = 'remote'`, so every such INSERT failed with SQLSTATE `23514`,
the repo was skipped, and `total_failed` was incremented. Customers migrating
from Nexus/Artifactory lost all of their proxy/remote repositories.

This is a **pre-existing bug** (not a 1.6.1 regression): `upstream_url` was never
captured from the source nor persisted. It is fixed forward here.

The fix captures the source-side upstream URL and persists it:

- **`nexus_client.rs`** — `NexusRepositorySettings` gains an optional `proxy`
  block (`proxy.remoteUrl`, serde-defaulted). The settings-fetch trigger is
  broadened from group-only to also include `proxy` repos, and a new pure
  helper `apply_proxy_upstreams` maps `remoteUrl` onto the matching
  `RepositoryListItem.upstream_url` (mirroring the existing
  `apply_group_members` pattern). Best-effort: a restricted token that cannot
  read settings warns and continues rather than failing the whole listing.
- **`artifactory_client.rs`** — `RepositoryListItem` gains
  `upstream_url: Option<String>`. Artifactory's `/api/repositories` reports a
  remote repo's configured upstream in the `url` field; it is captured onto
  `upstream_url` for `remote`-type entries. Additive only.
- **`migration_service.rs`** — `prepare_repository_migration` now threads
  `repo.upstream_url` into `RepositoryMigrationConfig` (was hard-coded `None`).
  `create_repository` adds `upstream_url` to the INSERT column list + bind. A
  `Remote` source with no resolvable upstream now returns a clear
  `MigrationError::ConfigError("remote repo <key>: source did not report an
  upstream URL")` instead of letting the raw SQLSTATE `23514` surface.

No DB migration: the `upstream_url` column already exists (`003_repositories.sql`).
Non-remote repos bind `NULL`, which the constraint permits.

Closes #2822

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New coverage (no prior `create_repository` test used `Remote`):

- `nexus_client`: `NexusRepositorySettings` deserializes `proxy.remoteUrl`;
  `apply_proxy_upstreams` copies it onto the matching proxy `RepositoryListItem`;
  group parsing is unaffected by the new optional field.
- `migration_service`: `prepare_repository_migration` threads `upstream_url`
  into the config for a Remote repo.
- `migration_service` (DB-backed, guarded by `DATABASE_URL`):
  `create_repository` with `RepositoryType::Remote` + `Some(url)` persists
  `upstream_url` and succeeds; `Remote` + `None` returns
  `MigrationError::ConfigError` (NOT a raw sqlx `23514`); a `Local` repo with a
  `NULL` `upstream_url` still succeeds.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Notes
- No `.sqlx` regeneration needed: the modified `create_repository` INSERT uses
  the runtime `sqlx::query_as` API (not the compile-time `query!` macro), so it
  produces no `.sqlx` entry. `SQLX_OFFLINE=true cargo build --lib` passes against
  the committed cache with these changes. (There is unrelated pre-existing drift
  in the committed `backend/.sqlx` vs `cargo sqlx prepare --all-targets`;
  deliberately left out of this PR to keep the diff minimal.)
