### PR TITLE
fix(sso): per-provider trust_group_names opt-in for OIDC operator-group attachment

### DIFF
--- a/backend/migrations/176_oidc_trust_group_names.sql
+++ b/backend/migrations/176_oidc_trust_group_names.sql
@@ -1,0 +1,17 @@
+-- Fix C (#2823): per-provider opt-in restoring pre-1.6.1 name-matching for an
+-- operator-TRUSTED OIDC IdP only. #2759 (1.6.1) added an ownership guard to the
+-- group-sync upsert so an IdP-supplied group name can no longer attach a
+-- federated user to a same-named operator-managed group (external_source IS
+-- NULL); that regressed GitLab-OIDC deployments that pre-create operator groups
+-- and expect the OIDC `groups` claim to attach users by name (Jon Craig, #2823).
+--
+-- This column re-enables name-matching against operator-managed groups for a
+-- SINGLE provider the operator explicitly trusts. DEFAULT false: every existing
+-- and every other provider stays fully guarded exactly as 1.6.1/1.6.2 -- no
+-- grandfathering, no global relaxation. When true, the sync attaches the user to
+-- the existing operator group by resolving its id; the group's external_source /
+-- external_provider_id stay NULL (the group is NOT adopted into the OIDC
+-- namespace), and another provider's oidc-owned groups are never attached
+-- regardless of this flag.
+ALTER TABLE oidc_configs
+    ADD COLUMN IF NOT EXISTS trust_group_names BOOLEAN NOT NULL DEFAULT false;

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -551,8 +551,15 @@ async fn oidc_callback_inner(
     //     Auto-create groups (tagged with external_source = 'oidc') on first
     //     sight and reconcile membership so removed groups drop their members.
     if row.map_groups_to_groups {
-        if let Err(e) =
-            sync_oidc_groups_to_local_groups(&state.db, user.id, provider_id, &groups).await
+        if let Err(e) = sync_federated_groups_to_local_groups(
+            &state.db,
+            user.id,
+            provider_id,
+            "oidc",
+            &groups,
+            row.trust_group_names,
+        )
+        .await
         {
             tracing::warn!(
                 error = %e,
@@ -706,9 +713,15 @@ pub async fn ldap_login(
         let group_names = ldap_svc
             .resolve_group_names(&ldap_dn, &ldap_username, &ldap_member_of)
             .await;
-        if let Err(e) =
-            sync_federated_groups_to_local_groups(&state.db, user.id, id, "ldap", &group_names)
-                .await
+        if let Err(e) = sync_federated_groups_to_local_groups(
+            &state.db,
+            user.id,
+            id,
+            "ldap",
+            &group_names,
+            false,
+        )
+        .await
         {
             tracing::warn!(
                 user_id = %user.id,
@@ -981,9 +994,15 @@ pub async fn saml_acs(
     // removed groups drop their members. Non-fatal: login still succeeds if
     // the sync fails.
     if row.map_groups_to_groups {
-        if let Err(e) =
-            sync_federated_groups_to_local_groups(&state.db, user.id, id, "saml", &saml_groups)
-                .await
+        if let Err(e) = sync_federated_groups_to_local_groups(
+            &state.db,
+            user.id,
+            id,
+            "saml",
+            &saml_groups,
+            false,
+        )
+        .await
         {
             tracing::warn!(
                 error = %e,
@@ -1221,15 +1240,27 @@ pub(crate) fn extract_oidc_groups(claims: &serde_json::Value, groups_claim: &str
 
 /// Reconcile an OIDC user's group memberships against the `groups` table.
 /// Thin wrapper over [`sync_federated_groups_to_local_groups`] with the
-/// `oidc` source tag, preserved so the #1094 call site and tests stay
-/// unchanged.
+/// `oidc` source tag, preserved so its existing test callers stay unchanged.
+///
+/// This is the **guarded** (trust-off) entrypoint: it forwards
+/// `trust_group_names = false`, so the #2759 ownership guard is always in
+/// force here and operator-managed groups are never attached by name. The
+/// trusted path (Fix C, #2823) is invoked by the OIDC login handler calling
+/// [`sync_federated_groups_to_local_groups`] directly with the provider's
+/// `trust_group_names` flag.
+// The OIDC login handler now calls the core fn directly (to pass the
+// per-provider trust flag), so in a non-test build this guarded wrapper is
+// only referenced by its unit tests; keep it as the documented trust-off
+// entrypoint without tripping the lib-target dead-code lint.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn sync_oidc_groups_to_local_groups(
     pool: &sqlx::PgPool,
     user_id: Uuid,
     provider_id: Uuid,
     oidc_groups: &[String],
 ) -> Result<()> {
-    sync_federated_groups_to_local_groups(pool, user_id, provider_id, "oidc", oidc_groups).await
+    sync_federated_groups_to_local_groups(pool, user_id, provider_id, "oidc", oidc_groups, false)
+        .await
 }
 
 /// Reconcile a federated user's group memberships against the `groups` table.
@@ -1262,6 +1293,7 @@ pub(crate) async fn sync_federated_groups_to_local_groups(
     provider_id: Uuid,
     source: &str,
     idp_groups: &[String],
+    trust_group_names: bool,
 ) -> Result<()> {
     let mut tx = pool
         .begin()
@@ -1273,6 +1305,39 @@ pub(crate) async fn sync_federated_groups_to_local_groups(
     for name in idp_groups {
         if name.trim().is_empty() {
             continue;
+        }
+
+        // Fix C (#2823): when this provider is operator-trusted, a claim may
+        // attach the user to an EXISTING operator-managed group
+        // (external_source IS NULL) matching by name, WITHOUT rewriting the
+        // group's ownership. The SELECT's `external_source IS NULL` predicate
+        // means another provider's oidc-owned groups (non-NULL source) are
+        // never matched here, and we only INSERT a membership row — the groups
+        // row is never mutated — so #2759's protection stays fully intact for
+        // every untrusted provider.
+        if trust_group_names {
+            let operator_group: Option<(Uuid,)> = sqlx::query_as(
+                r#"SELECT id FROM groups WHERE name = $1 AND external_source IS NULL"#,
+            )
+            .bind(name)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            if let Some((group_id,)) = operator_group {
+                sqlx::query(
+                    r#"INSERT INTO user_group_members (user_id, group_id)
+                       VALUES ($1, $2)
+                       ON CONFLICT (user_id, group_id) DO NOTHING"#,
+                )
+                .bind(user_id)
+                .bind(group_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+                current_group_ids.push(group_id);
+                continue; // operator group stays operator-owned; skip the guarded upsert
+            }
         }
 
         // Find-or-create the group atomically, scoped to THIS provider's
@@ -2870,6 +2935,29 @@ mod tests {
                 .await;
         }
 
+        /// Insert an operator-managed group: `external_source` /
+        /// `external_provider_id` are left NULL (not owned by any IdP).
+        async fn make_operator_group(pool: &PgPool, name: &str) -> Uuid {
+            let id = Uuid::new_v4();
+            sqlx::query("INSERT INTO groups (id, name) VALUES ($1, $2)")
+                .bind(id)
+                .bind(name)
+                .execute(pool)
+                .await
+                .expect("insert operator group");
+            id
+        }
+
+        async fn group_external_provider_id(pool: &PgPool, group_id: Uuid) -> Option<Uuid> {
+            let row: Option<(Option<Uuid>,)> =
+                sqlx::query_as("SELECT external_provider_id FROM groups WHERE id = $1")
+                    .bind(group_id)
+                    .fetch_optional(pool)
+                    .await
+                    .expect("group provider lookup");
+            row.and_then(|(p,)| p)
+        }
+
         #[tokio::test]
         async fn test_sync_creates_groups_and_membership() {
             let Some(pool) = db_helpers::try_pool().await else {
@@ -3059,6 +3147,7 @@ mod tests {
                 provider_id,
                 "ldap",
                 &[privileged.clone(), legit.clone()],
+                false,
             )
             .await
             .expect("sync succeeds; colliding name is skipped, not fatal");
@@ -3113,6 +3202,7 @@ mod tests {
                 provider_id,
                 "ldap",
                 std::slice::from_ref(&name),
+                false,
             )
             .await
             .expect("sync succeeds; foreign-source collision is skipped");
@@ -3306,6 +3396,7 @@ mod tests {
                 provider_id,
                 "saml",
                 &[g1.clone(), g2.clone()],
+                false,
             )
             .await
             .expect("saml sync");
@@ -3352,6 +3443,7 @@ mod tests {
                 provider_id,
                 "ldap",
                 &[devops.clone(), qa.clone()],
+                false,
             )
             .await
             .expect("first ldap sync");
@@ -3373,6 +3465,7 @@ mod tests {
                 provider_id,
                 "ldap",
                 std::slice::from_ref(&devops),
+                false,
             )
             .await
             .expect("second ldap sync");
@@ -3399,6 +3492,7 @@ mod tests {
                 provider_id,
                 "saml",
                 &[eng.clone(), ops.clone()],
+                false,
             )
             .await
             .expect("first saml sync");
@@ -3413,6 +3507,7 @@ mod tests {
                 provider_id,
                 "saml",
                 std::slice::from_ref(&eng),
+                false,
             )
             .await
             .expect("second saml sync");
@@ -3479,6 +3574,7 @@ mod tests {
                 provider_id,
                 "saml",
                 std::slice::from_ref(&saml_name),
+                false,
             )
             .await
             .expect("saml sync");
@@ -3515,6 +3611,7 @@ mod tests {
                 provider_id,
                 "saml",
                 std::slice::from_ref(&saml_name),
+                false,
             )
             .await
             .expect("saml sync");
@@ -3555,6 +3652,7 @@ mod tests {
                     "\t".to_string(),
                     real.clone(),
                 ],
+                false,
             )
             .await
             .expect("saml sync");
@@ -3565,6 +3663,198 @@ mod tests {
             assert!(group_id_by_name(&pool, "   ").await.is_none());
 
             cleanup_groups(&pool, &[real_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        // ===================================================================
+        // Fix C (#2823): trust_group_names per-provider opt-in.
+        // ===================================================================
+
+        /// (a) trust OFF: an OIDC claim naming an existing operator-managed
+        /// group must NOT attach the user (the #2759 guard holds), and the
+        /// operator group's `external_source` stays NULL.
+        #[tokio::test]
+        async fn test_trust_off_operator_group_not_attached() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            let provider_id = Uuid::new_v4();
+            let name = rand_group_name("ops-team");
+            let group_id = make_operator_group(&pool, &name).await;
+
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "oidc",
+                std::slice::from_ref(&name),
+                false,
+            )
+            .await
+            .expect("sync succeeds; operator group is skipped under the guard");
+
+            assert!(
+                !user_is_in_group(&pool, user_id, group_id).await,
+                "trust OFF: user must not be attached to the operator group"
+            );
+            assert_eq!(
+                group_external_source(&pool, group_id).await,
+                None,
+                "operator group must stay NULL-source"
+            );
+
+            cleanup_groups(&pool, &[group_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        /// (b) trust ON: an OIDC claim naming an existing operator-managed
+        /// group attaches the user (membership row only), and the group stays
+        /// operator-owned — `external_source` and `external_provider_id` both
+        /// remain NULL.
+        #[tokio::test]
+        async fn test_trust_on_operator_group_attached_owner_unchanged() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            let provider_id = Uuid::new_v4();
+            let name = rand_group_name("ops-team");
+            let group_id = make_operator_group(&pool, &name).await;
+
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "oidc",
+                std::slice::from_ref(&name),
+                true,
+            )
+            .await
+            .expect("sync succeeds; trusted operator-group attach");
+
+            assert!(
+                user_is_in_group(&pool, user_id, group_id).await,
+                "trust ON: user must be attached to the operator group"
+            );
+            assert_eq!(
+                group_external_source(&pool, group_id).await,
+                None,
+                "operator group must stay NULL-source (not adopted into OIDC namespace)"
+            );
+            assert_eq!(
+                group_external_provider_id(&pool, group_id).await,
+                None,
+                "operator group's external_provider_id must stay NULL"
+            );
+
+            cleanup_groups(&pool, &[group_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        /// (c) cross-provider isolation: provider B first auto-creates an
+        /// oidc-owned group `H` (source='oidc', provider=B). Provider A with
+        /// trust ON claiming `H` must NOT attach A's user, and `H`'s owner is
+        /// unchanged (still provider B). Trust only relaxes the NULL-source
+        /// operator case, never a foreign provider's oidc-owned group.
+        #[tokio::test]
+        async fn test_trust_on_cross_provider_oidc_group_not_attached() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_b = make_user(&pool).await;
+            let user_a = make_user(&pool).await;
+            let provider_b = Uuid::new_v4();
+            let provider_a = Uuid::new_v4();
+            let name = rand_group_name("shared");
+
+            // Provider B auto-creates the oidc-owned group.
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_b,
+                provider_b,
+                "oidc",
+                std::slice::from_ref(&name),
+                false,
+            )
+            .await
+            .expect("provider B first sync auto-creates its oidc group");
+            let group_id = group_id_by_name(&pool, &name).await.expect("B's group");
+
+            // Provider A, trust ON, claims the same name.
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_a,
+                provider_a,
+                "oidc",
+                std::slice::from_ref(&name),
+                true,
+            )
+            .await
+            .expect("provider A sync succeeds; foreign oidc group is refused");
+
+            assert!(
+                !user_is_in_group(&pool, user_a, group_id).await,
+                "trust ON must NOT attach A's user to B's oidc-owned group"
+            );
+            assert_eq!(
+                group_external_source(&pool, group_id).await.as_deref(),
+                Some("oidc"),
+                "B's group stays oidc-owned"
+            );
+            assert_eq!(
+                group_external_provider_id(&pool, group_id).await,
+                Some(provider_b),
+                "B's group's external_provider_id must stay provider B"
+            );
+
+            cleanup_groups(&pool, &[group_id]).await;
+            cleanup_user(&pool, user_a).await;
+            cleanup_user(&pool, user_b).await;
+        }
+
+        /// (d) trust ON, brand-new name: no group exists, so the guarded
+        /// auto-create path still runs — the group is created oidc-owned and
+        /// the user attached. Proves trust does not break the create path.
+        #[tokio::test]
+        async fn test_trust_on_new_name_auto_creates_oidc_group() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            let provider_id = Uuid::new_v4();
+            let name = rand_group_name("brand-new");
+
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "oidc",
+                std::slice::from_ref(&name),
+                true,
+            )
+            .await
+            .expect("trusted sync of a brand-new name auto-creates + attaches");
+
+            let group_id = group_id_by_name(&pool, &name)
+                .await
+                .expect("group auto-created");
+            assert!(
+                user_is_in_group(&pool, user_id, group_id).await,
+                "user must be attached to the auto-created group"
+            );
+            assert_eq!(
+                group_external_source(&pool, group_id).await.as_deref(),
+                Some("oidc"),
+                "auto-created group is oidc-owned"
+            );
+            assert_eq!(
+                group_external_provider_id(&pool, group_id).await,
+                Some(provider_id),
+                "auto-created group owned by this provider"
+            );
+
+            cleanup_groups(&pool, &[group_id]).await;
             cleanup_user(&pool, user_id).await;
         }
     }

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -1031,6 +1031,7 @@ mod tests {
             pkce_enabled: true,
             map_groups_to_groups: false,
             allow_legacy_rsa_keys: false,
+            trust_group_names: false,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1042,6 +1043,7 @@ mod tests {
         assert!(!json["auto_create_users"].as_bool().unwrap());
         assert!(json["pkce_enabled"].as_bool().unwrap());
         assert!(!json["map_groups_to_groups"].as_bool().unwrap());
+        assert!(!json["trust_group_names"].as_bool().unwrap());
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1564,6 +1564,7 @@ fn build_oidc_request_from_values(
         pkce_enabled: None,
         map_groups_to_groups: None,
         allow_legacy_rsa_keys: None,
+        trust_group_names: None,
     })
 }
 

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -63,6 +63,13 @@ pub struct OidcConfigRow {
     /// Defaults to false; intended only for legacy IdPs (e.g. Lark
     /// AnyCross) whose JWKS still publishes a 1024-bit RSA key.
     pub allow_legacy_rsa_keys: bool,
+    /// Opt-in compatibility flag (migration 176, #2823): when true, an OIDC
+    /// `groups` claim from THIS provider may attach the user to an existing
+    /// operator-managed group (`external_source IS NULL`) matching by name,
+    /// inserting only a membership row and leaving the group operator-owned.
+    /// Defaults to false, in which case the #2759 ownership guard is fully
+    /// intact and operator groups are never touched by IdP-supplied names.
+    pub trust_group_names: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -196,6 +203,11 @@ pub struct OidcConfigResponse {
     /// 2048 bits via a restricted RS256/384/512 PKCS#1 v1.5 path.
     /// Below the OWASP ASVS 4.0 baseline; only enable for legacy IdPs.
     pub allow_legacy_rsa_keys: bool,
+    /// Opt-in compatibility flag (migration 176, #2823): when true, this
+    /// provider's OIDC `groups` claim may attach users to existing
+    /// operator-managed groups (`external_source IS NULL`) by name, leaving
+    /// those groups operator-owned. Defaults to false (the #2759 guard holds).
+    pub trust_group_names: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -287,6 +299,12 @@ pub struct CreateOidcConfigRequest {
     /// `false`. Below the OWASP ASVS 4.0 baseline; only enable for legacy
     /// IdPs such as Lark AnyCross.
     pub allow_legacy_rsa_keys: Option<bool>,
+    /// Opt-in compatibility flag (migration 176, #2823): when `true`, this
+    /// provider's OIDC `groups` claim may attach the user to an existing
+    /// operator-managed group (`external_source IS NULL`) matching by name,
+    /// leaving that group operator-owned. Defaults to `false`, preserving the
+    /// #2759 ownership guard for every provider.
+    pub trust_group_names: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -311,6 +329,7 @@ pub struct UpdateOidcConfigRequest {
     pub pkce_enabled: Option<bool>,
     pub map_groups_to_groups: Option<bool>,
     pub allow_legacy_rsa_keys: Option<bool>,
+    pub trust_group_names: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -551,6 +570,7 @@ impl AuthConfigService {
             SELECT id, name, issuer_url, client_id, client_secret_encrypted,
                    scopes, attribute_mapping, is_enabled, auto_create_users,
                    pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                   trust_group_names,
                    created_at, updated_at
             FROM oidc_configs
             ORDER BY name
@@ -569,6 +589,7 @@ impl AuthConfigService {
             SELECT id, name, issuer_url, client_id, client_secret_encrypted,
                    scopes, attribute_mapping, is_enabled, auto_create_users,
                    pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                   trust_group_names,
                    created_at, updated_at
             FROM oidc_configs
             WHERE id = $1
@@ -590,6 +611,7 @@ impl AuthConfigService {
             SELECT id, name, issuer_url, client_id, client_secret_encrypted,
                    scopes, attribute_mapping, is_enabled, auto_create_users,
                    pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                   trust_group_names,
                    created_at, updated_at
             FROM oidc_configs
             WHERE id = $1
@@ -630,16 +652,19 @@ impl AuthConfigService {
         let pkce_enabled = req.pkce_enabled.unwrap_or(true);
         let map_groups_to_groups = req.map_groups_to_groups.unwrap_or(false);
         let allow_legacy_rsa_keys = req.allow_legacy_rsa_keys.unwrap_or(false);
+        let trust_group_names = req.trust_group_names.unwrap_or(false);
 
         let row = sqlx::query_as::<_, OidcConfigRow>(
             r#"
             INSERT INTO oidc_configs (id, name, issuer_url, client_id, client_secret_encrypted,
                                       scopes, attribute_mapping, is_enabled, auto_create_users,
-                                      pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                                      pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                                      trust_group_names)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             RETURNING id, name, issuer_url, client_id, client_secret_encrypted,
                       scopes, attribute_mapping, is_enabled, auto_create_users,
                       pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                      trust_group_names,
                       created_at, updated_at
             "#,
         )
@@ -655,6 +680,7 @@ impl AuthConfigService {
         .bind(pkce_enabled)
         .bind(map_groups_to_groups)
         .bind(allow_legacy_rsa_keys)
+        .bind(trust_group_names)
         .fetch_one(pool)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to create OIDC config: {e}")))?;
@@ -672,6 +698,7 @@ impl AuthConfigService {
             SELECT id, name, issuer_url, client_id, client_secret_encrypted,
                    scopes, attribute_mapping, is_enabled, auto_create_users,
                    pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                   trust_group_names,
                    created_at, updated_at
             FROM oidc_configs
             WHERE id = $1
@@ -704,6 +731,7 @@ impl AuthConfigService {
         let allow_legacy_rsa_keys = req
             .allow_legacy_rsa_keys
             .unwrap_or(existing.allow_legacy_rsa_keys);
+        let trust_group_names = req.trust_group_names.unwrap_or(existing.trust_group_names);
 
         // Preserve existing encrypted secret if not provided
         let secret_hex = if let Some(new_secret) = &req.client_secret {
@@ -719,11 +747,13 @@ impl AuthConfigService {
             SET name = $1, issuer_url = $2, client_id = $3, client_secret_encrypted = $4,
                 scopes = $5, attribute_mapping = $6, is_enabled = $7, auto_create_users = $8,
                 pkce_enabled = $9, map_groups_to_groups = $10, allow_legacy_rsa_keys = $11,
+                trust_group_names = $12,
                 updated_at = NOW()
-            WHERE id = $12
+            WHERE id = $13
             RETURNING id, name, issuer_url, client_id, client_secret_encrypted,
                       scopes, attribute_mapping, is_enabled, auto_create_users,
                       pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                      trust_group_names,
                       created_at, updated_at
             "#,
         )
@@ -738,6 +768,7 @@ impl AuthConfigService {
         .bind(pkce_enabled)
         .bind(map_groups_to_groups)
         .bind(allow_legacy_rsa_keys)
+        .bind(trust_group_names)
         .bind(id)
         .fetch_one(pool)
         .await
@@ -771,6 +802,7 @@ impl AuthConfigService {
             RETURNING id, name, issuer_url, client_id, client_secret_encrypted,
                       scopes, attribute_mapping, is_enabled, auto_create_users,
                       pkce_enabled, map_groups_to_groups, allow_legacy_rsa_keys,
+                      trust_group_names,
                       created_at, updated_at
             "#,
         )
@@ -798,6 +830,7 @@ impl AuthConfigService {
             pkce_enabled: row.pkce_enabled,
             map_groups_to_groups: row.map_groups_to_groups,
             allow_legacy_rsa_keys: row.allow_legacy_rsa_keys,
+            trust_group_names: row.trust_group_names,
             created_at: row.created_at,
             updated_at: row.updated_at,
         }
@@ -1911,6 +1944,7 @@ impl From<CreateOidcConfigRequest> for UpdateOidcConfigRequest {
             pkce_enabled: c.pkce_enabled,
             map_groups_to_groups: c.map_groups_to_groups,
             allow_legacy_rsa_keys: c.allow_legacy_rsa_keys,
+            trust_group_names: c.trust_group_names,
         }
     }
 }
@@ -2029,6 +2063,7 @@ mod tests {
             pkce_enabled: true,
             map_groups_to_groups: false,
             allow_legacy_rsa_keys: false,
+            trust_group_names: false,
             created_at: now,
             updated_at: now,
         }
@@ -2342,6 +2377,7 @@ mod tests {
             pkce_enabled: true,
             map_groups_to_groups: false,
             allow_legacy_rsa_keys: false,
+            trust_group_names: false,
             created_at: now,
             updated_at: now,
         };
@@ -2822,6 +2858,7 @@ mod tests {
             pkce_enabled: None,
             map_groups_to_groups: None,
             allow_legacy_rsa_keys: None,
+            trust_group_names: None,
         };
         let u: UpdateOidcConfigRequest = c.into();
         assert_eq!(u.issuer_url, Some("https://idp".to_string()));
@@ -2896,6 +2933,7 @@ mod tests {
                 pkce_enabled: None,
                 map_groups_to_groups: None,
                 allow_legacy_rsa_keys: None,
+                trust_group_names: None,
             }
         }
 
@@ -3054,6 +3092,7 @@ mod tests {
                 pkce_enabled: None,
                 map_groups_to_groups: None,
                 allow_legacy_rsa_keys: None,
+                trust_group_names: None,
             };
             let updated = AuthConfigService::update_oidc(&pool, created.id, update)
                 .await
@@ -3098,6 +3137,7 @@ mod tests {
                 pkce_enabled: None,
                 map_groups_to_groups: None,
                 allow_legacy_rsa_keys: None,
+                trust_group_names: None,
             };
             let updated = AuthConfigService::update_oidc(&pool, created.id, update)
                 .await
@@ -3136,6 +3176,7 @@ mod tests {
                 pkce_enabled: Some(false),
                 map_groups_to_groups: Some(true),
                 allow_legacy_rsa_keys: None,
+                trust_group_names: None,
             };
             let updated = AuthConfigService::update_oidc(&pool, created.id, update)
                 .await
@@ -3171,6 +3212,7 @@ mod tests {
                 pkce_enabled: None,
                 map_groups_to_groups: None,
                 allow_legacy_rsa_keys: None,
+                trust_group_names: None,
             };
             let updated = AuthConfigService::update_oidc(&pool, created.id, update)
                 .await

--- a/backend/tests/sso_oidc_login_callback_e2e_tests.rs
+++ b/backend/tests/sso_oidc_login_callback_e2e_tests.rs
@@ -290,6 +290,7 @@ async fn create_provider_with(pool: &PgPool, idp: &MockIdp, opts: ProviderOpts) 
             pkce_enabled: Some(true),
             map_groups_to_groups: Some(opts.map_groups_to_groups),
             allow_legacy_rsa_keys: None,
+            trust_group_names: None,
         },
     )
     .await


### PR DESCRIPTION
## Summary

Adds a per-provider, default-false `trust_group_names` opt-in to OIDC providers
(`oidc_configs`) that restores pre-1.6.1 name-matching against **operator-managed**
groups for a single IdP the operator explicitly trusts.

Background: #2759 (1.6.1) added an ownership guard to the group-sync upsert
(`ON CONFLICT (name) DO UPDATE ... WHERE groups.external_source = EXCLUDED.external_source
AND groups.external_provider_id = EXCLUDED.external_provider_id`). For an
operator-created group `external_source IS NULL`, so `NULL = 'oidc'` is never true, the
`DO UPDATE` is skipped, no `RETURNING id` comes back, and the federated user is never
attached. That is the intended hardening for the general case, but it regressed
deployments that pre-create operator groups and expect the OIDC `groups` claim to
attach users to them by name (GitLab-OIDC, reported in #2823).

This change keeps that guard on and default-on for every provider. When an admin sets
`trust_group_names = true` for one provider, the sync — before the guarded upsert —
resolves an existing group whose name matches and whose `external_source IS NULL`
(operator-managed only) and inserts a `user_group_members` row for it, leaving the
`groups` row untouched (`external_source` / `external_provider_id` stay NULL, so the
group is not adopted into the OIDC namespace). Groups owned by a different provider
(`external_source = 'oidc'`, non-NULL) are never matched by this path and still fall
through to the guarded upsert, which requires a matching `external_provider_id`, so
cross-provider attachment remains impossible even with trust on.

Implementation mirrors the existing `allow_legacy_rsa_keys` per-provider flag end to
end (Row / Response / Create / Update / all SELECT/INSERT/UPDATE/RETURNING lists /
`oidc_row_to_response`). All OIDC CRUD uses runtime `sqlx::query`/`query_as`, so no
`.sqlx` regeneration is needed. Admin mutation continues to ride the existing
`require_admin` + `admin_middleware` gating (no handler changes). Migration `176`
adds the column `NOT NULL DEFAULT false`.

Closes #2823

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Four DB-backed unit tests were added to `sso.rs::tests::sync_db`, calling the core
`sync_federated_groups_to_local_groups` directly:
- `test_trust_off_operator_group_not_attached` — trust OFF: operator group not attached, source stays NULL (the #2759 guard).
- `test_trust_on_operator_group_attached_owner_unchanged` — trust ON: user attached, group's `external_source`/`external_provider_id` stay NULL.
- `test_trust_on_cross_provider_oidc_group_not_attached` — trust ON but another provider's oidc-owned group: NOT attached, owner unchanged.
- `test_trust_on_new_name_auto_creates_oidc_group` — trust ON, brand-new name: auto-created oidc-owned + attached (create path intact).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification (DTF tier `oidc-group-sync`, image `artifact-keeper-backend:fix-2823`):

```
--- CASE 1 happy path: claim [gitlab-devs] auto-creates group (external_source=oidc) and attaches user ---
  PASS
--- CASE 2 (#2759 guard): OIDC claim matching an operator NULL-source group does NOT attach the user (trust OFF) ---
  PASS
--- CASE 3 (pending #2823): trust_group_names=true attaches the user to the operator group ---
  PASS
--- CASE 4 cross-provider: a claim matching another OIDC provider's group does NOT attach the user ---
  PASS

  Results: 6 passed, 0 failed, 0 skipped (6 total)
=== TIER oidc-group-sync: PASS (exit 0) ===
```

CASE 3 flips from SKIP to PASS (POST accepts + persists `trust_group_names`, GET
round-trips `== true`, OIDC login attaches the user to the pre-created operator group
and `groups.external_source` for that group stays NULL). CASE 1 / CASE 2 (#2759 guard)
/ CASE 4 (cross-provider isolation) stay green. All 20 `sync_db` unit tests pass
against a throwaway Postgres; `cargo fmt --check`, `cargo clippy --lib --tests -D
warnings`, and jscpd (<3%) are green.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

`CreateOidcConfigRequest` / `UpdateOidcConfigRequest` / `OidcConfigResponse` gain an
optional `trust_group_names` field (existing `ToSchema` derives auto-update the spec;
no new endpoints). Migration `176_oidc_trust_group_names.sql` is a single additive
`ADD COLUMN IF NOT EXISTS ... NOT NULL DEFAULT false` and is reversible via `DROP COLUMN`.
