### PR TITLE
fix(auth): require an explicit admin group for federated admin mapping (#2829)

### DIFF
--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -2616,35 +2616,26 @@ impl AuthService {
     /// # Returns
     /// * `RoleMapping` - The mapped roles and admin status
     pub fn map_groups_to_roles(
-        &self,
         groups: &[String],
         required_admin_group: Option<&str>,
     ) -> RoleMapping {
         let mut mapping = RoleMapping::default();
 
-        // Normalize groups to lowercase for case-insensitive matching
+        // Normalize groups to lowercase for case-insensitive role matching below.
         let normalized_groups: Vec<String> = groups.iter().map(|g| g.to_lowercase()).collect();
 
-        // Check for admin groups: if admin_group is explicitly configured, use
-        // exact match only; otherwise fall back to built-in pattern matching.
+        // Admin is granted ONLY when a provider has an explicit admin group
+        // configured and a claim matches it by exact, case-insensitive
+        // equality. There is deliberately no implicit pattern-based fallback:
+        // when no admin group is configured, `mapping.is_admin` stays `None`,
+        // which the COALESCE-based apply preserves any operator-set is_admin
+        // and never grants admin from a self-asserted group claim.
         if let Some(ag) = required_admin_group {
-            let ag_lower = ag.to_lowercase();
-            if normalized_groups.contains(&ag_lower) {
+            if groups.iter().any(|g| g.eq_ignore_ascii_case(ag)) {
                 mapping.is_admin = Some(true);
                 mapping.roles.push("admin".to_string());
             } else {
                 mapping.is_admin = Some(false);
-            }
-        } else {
-            let admin_patterns = ["admin", "administrators", "superusers", "artifact-admins"];
-            for group in &normalized_groups {
-                for pattern in &admin_patterns {
-                    if group.contains(pattern) {
-                        mapping.is_admin = Some(true);
-                        mapping.roles.push("admin".to_string());
-                        break;
-                    }
-                }
             }
         }
 
@@ -2816,7 +2807,7 @@ impl AuthService {
         credentials: &FederatedCredentials,
     ) -> Result<User> {
         // Map groups to roles
-        let role_mapping = self.map_groups_to_roles(
+        let role_mapping = Self::map_groups_to_roles(
             &credentials.groups,
             credentials.required_admin_group.as_deref(),
         );
@@ -4289,8 +4280,9 @@ mod tests {
     // Since it does not use self.db or self.config, we just need any instance.
     // We'll test using the same approach: direct key construction.
 
-    // Reimplement map_groups_to_roles locally since AuthService requires PgPool
-    // and we cannot create one without a real database connection.
+    // map_groups_to_roles is an associated fn (no self / PgPool needed), so these
+    // wrappers call the REAL AuthService::map_groups_to_roles and the unit tests
+    // exercise the production logic rather than a divergence-prone reimplementation.
     fn test_map_groups_to_roles(groups: &[String]) -> RoleMapping {
         test_map_groups_to_roles_with_admin(groups, None)
     }
@@ -4299,81 +4291,64 @@ mod tests {
         groups: &[String],
         required_admin_group: Option<&str>,
     ) -> RoleMapping {
-        let mut mapping = RoleMapping::default();
-        let normalized_groups: Vec<String> = groups.iter().map(|g| g.to_lowercase()).collect();
-
-        if let Some(ag) = required_admin_group {
-            let ag_lower = ag.to_lowercase();
-            if normalized_groups.contains(&ag_lower) {
-                mapping.is_admin = Some(true);
-                mapping.roles.push("admin".to_string());
-            } else {
-                mapping.is_admin = Some(false);
-            }
-        } else {
-            let admin_patterns = ["admin", "administrators", "superusers", "artifact-admins"];
-            for group in &normalized_groups {
-                for pattern in &admin_patterns {
-                    if group.contains(pattern) {
-                        mapping.is_admin = Some(true);
-                        mapping.roles.push("admin".to_string());
-                        break;
-                    }
-                }
-            }
-        }
-
-        let role_mappings = [
-            ("developers", "developer"),
-            ("readonly", "reader"),
-            ("deployers", "deployer"),
-            ("artifact-publishers", "publisher"),
-        ];
-
-        for group in &normalized_groups {
-            for (pattern, role) in &role_mappings {
-                if group.contains(pattern) && !mapping.roles.contains(&role.to_string()) {
-                    mapping.roles.push(role.to_string());
-                }
-            }
-        }
-
-        if !mapping.roles.contains(&"user".to_string()) {
-            mapping.roles.push("user".to_string());
-        }
-
-        mapping
+        AuthService::map_groups_to_roles(groups, required_admin_group)
     }
 
+    // Without an explicitly-configured admin group, a self-asserted group claim
+    // can NEVER grant admin -- there is no implicit pattern-based fallback. All
+    // of these previously granted admin via substring matching; they now assert
+    // the hardened default (is_admin stays None, so the COALESCE apply preserves
+    // whatever is_admin the user already had).
     #[test]
     fn test_map_groups_admin_group() {
         let mapping = test_map_groups_to_roles(&["team-admin".to_string()]);
-        assert_eq!(mapping.is_admin, Some(true));
-        assert!(mapping.roles.contains(&"admin".to_string()));
+        assert!(mapping.is_admin.is_none());
+        assert!(!mapping.roles.contains(&"admin".to_string()));
     }
 
     #[test]
     fn test_map_groups_administrators_group() {
         let mapping = test_map_groups_to_roles(&["CN=Administrators,DC=corp".to_string()]);
-        assert_eq!(mapping.is_admin, Some(true));
+        assert!(mapping.is_admin.is_none());
     }
 
     #[test]
     fn test_map_groups_superusers_group() {
         let mapping = test_map_groups_to_roles(&["superusers".to_string()]);
-        assert_eq!(mapping.is_admin, Some(true));
+        assert!(mapping.is_admin.is_none());
     }
 
     #[test]
     fn test_map_groups_artifact_admins_group() {
         let mapping = test_map_groups_to_roles(&["artifact-admins".to_string()]);
-        assert_eq!(mapping.is_admin, Some(true));
+        assert!(mapping.is_admin.is_none());
     }
 
     #[test]
     fn test_map_groups_case_insensitive_admin() {
+        // "ADMIN-TEAM" no longer grants admin without a configured admin group.
         let mapping = test_map_groups_to_roles(&["ADMIN-TEAM".to_string()]);
-        assert_eq!(mapping.is_admin, Some(true));
+        assert!(mapping.is_admin.is_none());
+    }
+
+    #[test]
+    fn test_map_groups_no_admin_group_backend_admins_denied() {
+        // Substring "admin" claim without a configured admin group -> no admin.
+        let mapping = test_map_groups_to_roles(&["backend-admins".to_string()]);
+        assert!(mapping.is_admin.is_none());
+        assert!(!mapping.roles.contains(&"admin".to_string()));
+    }
+
+    #[test]
+    fn test_map_groups_no_admin_group_nonadmin_users_denied() {
+        let mapping = test_map_groups_to_roles(&["nonadmin-users".to_string()]);
+        assert!(mapping.is_admin.is_none());
+    }
+
+    #[test]
+    fn test_map_groups_no_admin_group_administrative_staff_denied() {
+        let mapping = test_map_groups_to_roles(&["administrative-staff".to_string()]);
+        assert!(mapping.is_admin.is_none());
     }
 
     #[test]
@@ -4427,7 +4402,12 @@ mod tests {
 
     #[test]
     fn test_map_groups_admin_plus_developer() {
-        let mapping = test_map_groups_to_roles(&["admin".to_string(), "developers".to_string()]);
+        // With an explicit admin group configured and an exact-matching claim,
+        // the user gets admin AND the developer role from the non-admin map.
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["admin".to_string(), "developers".to_string()],
+            Some("admin"),
+        );
         assert_eq!(mapping.is_admin, Some(true));
         assert!(mapping.roles.contains(&"admin".to_string()));
         assert!(mapping.roles.contains(&"developer".to_string()));
@@ -4481,6 +4461,47 @@ mod tests {
         // "company-admin-team" contains "admin" but should NOT match required "admin"
         let mapping =
             test_map_groups_to_roles_with_admin(&["company-admin-team".to_string()], Some("admin"));
+        assert_eq!(mapping.is_admin, Some(false));
+    }
+
+    #[test]
+    fn test_required_admin_group_exact_grants_admin() {
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["platform-admins".to_string()],
+            Some("platform-admins"),
+        );
+        assert_eq!(mapping.is_admin, Some(true));
+        assert!(mapping.roles.contains(&"admin".to_string()));
+    }
+
+    #[test]
+    fn test_required_admin_group_case_insensitive_exact_grants_admin() {
+        // Case-insensitive exact equality (aligns with SamlService/LdapService
+        // is_admin_from_groups): a case-differing exact claim still grants.
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["Platform-Admins".to_string()],
+            Some("platform-admins"),
+        );
+        assert_eq!(mapping.is_admin, Some(true));
+    }
+
+    #[test]
+    fn test_required_admin_group_suffix_does_not_match() {
+        // "platform-admins-x" must NOT match required "platform-admins" (exact only).
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["platform-admins-x".to_string()],
+            Some("platform-admins"),
+        );
+        assert_eq!(mapping.is_admin, Some(false));
+    }
+
+    #[test]
+    fn test_required_admin_group_prefix_does_not_match() {
+        // "platform-admin" (short) must NOT match required "platform-admins".
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["platform-admin".to_string()],
+            Some("platform-admins"),
+        );
         assert_eq!(mapping.is_admin, Some(false));
     }
 


### PR DESCRIPTION
## Summary

Federated (OIDC/SAML/LDAP) admin role was inferred from group-name patterns when a
provider had no admin group configured. `AuthService::map_groups_to_roles` fell back
to a case-insensitive substring match against a built-in pattern list
(`admin`, `administrators`, `superusers`, `artifact-admins`) whenever
`required_admin_group` was `None` — which is the default for every federated provider
that has not set an admin group (OIDC `attribute_mapping.admin_group` / `OIDC_ADMIN_GROUP`,
SAML `admin_group`, LDAP `admin_group_dn`). A self-asserted IdP group claim whose name
merely contained one of those substrings therefore set `users.is_admin = true`.

This PR tightens the default: admin is granted **only** when a provider has an explicit
admin group configured **and** a claim matches it by exact, case-insensitive equality.

Changes in `backend/src/services/auth_service.rs`:
- Remove the implicit pattern-based admin fallback entirely. With no admin group
  configured, `mapping.is_admin` stays `None`, and the existing `is_admin = COALESCE($5, is_admin)`
  apply preserves any operator-set `is_admin` — a claim can neither grant nor clear admin.
- Match a configured admin group by exact, case-insensitive equality
  (`eq_ignore_ascii_case`), aligning with the existing
  `SamlService`/`LdapService::is_admin_from_groups` contract. Exact match only — never
  substring/prefix/suffix.
- Make `map_groups_to_roles` an associated fn (it uses no `self` state), update the sole
  call site in `sync_federated_user`, and delete the test-module reimplementation so the
  unit tests exercise the real function (removes a near-duplicate copy).
- Non-admin role mappings (developer/reader/deployer/publisher) are unchanged.

This is a deliberate default-tightening **security / breaking change** and needs a
CHANGELOG note at cut: operators who relied on the implicit default lose claim-driven
auto-admin and must set an explicit admin group (OIDC `attribute_mapping.admin_group` or
`OIDC_ADMIN_GROUP`; SAML `admin_group`; LDAP `admin_group_dn`) to restore it.

Closes #2829.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Coverage:
- Rewritten/added unit tests in `auth_service.rs` assert the new contract against the
  real function: no admin group + `team-admin`/`backend-admins`/`nonadmin-users`/
  `administrative-staff`/`ADMIN-TEAM`/`CN=Administrators,...`/`superusers`/`artifact-admins`
  → `is_admin` not set; explicit admin group → admin only on exact (case-insensitive)
  claim, not on `platform-admins-x` or `platform-admin`.
- DTF tier `oidc-group-sync` (artifact-keeper-test) gains **CASE 5** (regression guard,
  drives real OIDC login with `nonadmin-users`/`backend-admins` claims and an
  operator-grant-preservation check) and **CASE 6** (exact-match). Discriminating
  evidence — same tier, two images:

  Fix image (`artifact-keeper-backend:fix-2829`, slot 10):
  ```
  CASE 5 (#2829 guard): no admin group -> claim 'nonadmin-users'/'backend-admins' does NOT grant admin ... PASS
  CASE 5 (#2829): operator-granted admin is PRESERVED across a federated re-login ... PASS
  CASE 6 (#2829 exact-match): configured admin_group grants admin ONLY on exact claim ... PASS
  Results: 9 passed, 0 failed, 1 skipped   (CASE 3 SKIP = pending #2823; CASE 1/2/4 PASS)
  ```

  Pre-fix baseline (`artifact-keeper-backend:1.6.2-rc`, slot 11):
  ```
  CASE 5 (#2829 guard): no admin group -> claim 'nonadmin-users'/'backend-admins' does NOT grant admin ...
    FAIL: default-open admin escalation (login5a=307 is_admin5a='t' login5b=307 is_admin5b='t')
  Results: 8 passed, 1 failed, 1 skipped
  ```
  CASE 5 flips RED (is_admin granted) on the pre-fix image — the discriminator.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — DTF `oidc-group-sync` CASE 5/6
- [x] Manually tested locally — `cargo fmt --check`, `SQLX_OFFLINE=true cargo build --lib --tests`, `cargo clippy --lib --tests -D warnings`, `cargo test --lib map_groups` (30 pass), DTF tier on fix + baseline images
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable) — no migration (admin-group config sources already exist)
- [x] N/A - no API changes
