### PR TITLE
fix(sso): resolve OIDC group memberships from candidate claims + userinfo (GitLab groups_direct/inherited)

### DIFF
--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -458,6 +458,12 @@ async fn oidc_callback_inner(
         .as_str()
         .ok_or_else(|| AppError::Internal("Token response missing id_token".into()))?;
 
+    // Capture the access_token for a later userinfo group fetch (#2831). GitLab
+    // delivers only DIRECT memberships in the id_token; the effective set incl.
+    // inherited subgroups is read from /userinfo with this bearer token. Absent
+    // ⇒ userinfo is skipped and id_token groups are used as-is.
+    let access_token = token_response["access_token"].as_str().map(str::to_owned);
+
     // 5. Verify ID token signature and validate standard claims
     let claims = validate_id_token(
         &http_client,
@@ -475,7 +481,7 @@ async fn oidc_callback_inner(
 
     let username_claim = resolve_oidc_claim_name(attr, "username_claim", "preferred_username");
     let email_claim = resolve_oidc_claim_name(attr, "email_claim", "email");
-    let groups_claim = resolve_oidc_claim_name(attr, "groups_claim", "groups");
+    let group_claim_candidates = oidc_groups_claim_candidates(attr);
 
     let sub = claims["sub"]
         .as_str()
@@ -492,7 +498,7 @@ async fn oidc_callback_inner(
 
     let display_name = claims["name"].as_str().map(|s| s.to_string());
 
-    let groups = extract_oidc_groups(&claims, groups_claim);
+    let id_token_groups = extract_oidc_groups(&claims, &group_claim_candidates);
 
     // Read admin group setting from DB attribute_mapping, falling back to env
     let required_admin_group = attr
@@ -500,6 +506,50 @@ async fn oidc_callback_inner(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .or_else(|| std::env::var("OIDC_ADMIN_GROUP").ok());
+
+    // 6a. Merge in group memberships from the userinfo endpoint (#2831).
+    //
+    // GitLab (and OIDC providers that separate direct vs effective membership)
+    // deliver only DIRECT groups in the id_token (`groups_direct`) and the full
+    // EFFECTIVE set incl. inherited subgroups at `/oauth/userinfo` (`groups`).
+    // Reading the id_token alone misses inherited subgroups, so we also fetch
+    // userinfo (default-on; opt-out via attribute_mapping.fetch_userinfo_groups)
+    // and union the two sets. The fetch is gated so it only fires when groups
+    // are actually consumed (group→group mapping or admin-group elevation), and
+    // is NON-FATAL: any failure degrades to id_token groups only and login still
+    // succeeds.
+    let want_userinfo_groups = (row.map_groups_to_groups || required_admin_group.is_some())
+        && userinfo_groups_enabled(attr);
+
+    let userinfo_groups: Vec<String> = if want_userinfo_groups {
+        match discovery["userinfo_endpoint"].as_str() {
+            None => {
+                tracing::debug!(
+                    "OIDC discovery has no userinfo_endpoint; using id_token groups only"
+                );
+                Vec::new()
+            }
+            Some(endpoint) => match validate_oidc_fetch_url(endpoint, "OIDC userinfo endpoint") {
+                Err(e) => {
+                    tracing::warn!(error = %e, "OIDC userinfo endpoint failed SSRF guard; skipping");
+                    Vec::new()
+                }
+                Ok(()) => {
+                    fetch_userinfo_groups(
+                        &http_client,
+                        endpoint,
+                        access_token.as_deref(),
+                        &group_claim_candidates,
+                    )
+                    .await
+                }
+            },
+        }
+    } else {
+        Vec::new()
+    };
+
+    let groups = merge_group_sets(id_token_groups, userinfo_groups);
 
     // 7. Authenticate via federated flow (find/create user + generate tokens)
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
@@ -1183,25 +1233,42 @@ pub(crate) fn resolve_oidc_claim_name<'a>(
 /// them as a scalar string — the array form (below) preserves them verbatim.
 const OIDC_GROUP_CLAIM_DELIMS: &[char] = &[',', ';', ' ', '\t', '\n', '\r'];
 
-/// Extract user groups from JWT claims using the configured groups claim name.
+/// Ordered OIDC groups-claim candidates.
+///
+/// An explicit non-empty `attribute_mapping.groups_claim` pins resolution to
+/// that single claim (behaviour unchanged from today); otherwise fall through
+/// the documented default order `groups` → `groups_direct` → `roles`.
+///
+/// The default order covers the common IdPs without per-provider config:
+/// Keycloak/Okta/Azure publish under `groups`; GitLab (issue #2831) publishes
+/// membership paths under `groups_direct`; some setups map roles under `roles`.
+/// Only the first candidate that yields a non-empty list is used
+/// ([`extract_oidc_groups`]), so a provider that emits several of these keys
+/// resolves deterministically by this precedence.
+pub(crate) fn oidc_groups_claim_candidates(attr: &serde_json::Value) -> Vec<&str> {
+    match attr.get("groups_claim").and_then(|v| v.as_str()) {
+        Some(name) if !name.trim().is_empty() => vec![name],
+        _ => vec!["groups", "groups_direct", "roles"],
+    }
+}
+
+/// Parse a single OIDC claim value into a list of group names.
 ///
 /// Handles the two shapes IdPs emit the groups claim in (issue #2781):
 /// - a JSON **array** of names — the standard form (Keycloak/Okta/Azure with a
-///   groups mapper). Only string elements are kept, verbatim.
+///   groups mapper). Only string elements are kept, verbatim. GitLab full
+///   group **paths** (e.g. `"platform/backend"`, issue #2831) pass through
+///   unchanged — the `/` is not a delimiter, so paths are never split.
 /// - a single JSON **string** — some IdPs/claim-mappers emit the groups claim
 ///   as one scalar value, either a lone group name (`"admins"`) or a delimited
-///   list (`"admins,developers"` / `"admins developers"`). Previously this
-///   shape was silently dropped, so those users had zero groups synced even
-///   with "Map OIDC groups to local groups" enabled. It is now split on the
-///   usual list delimiters.
+///   list (`"admins,developers"` / `"admins developers"`). It is split on the
+///   usual list delimiters (which do NOT include `/`, so a single GitLab path
+///   string stays intact).
 ///
 /// Blank entries are discarded and each name is trimmed. Non-string / absent
-/// claims yield no groups. The result is passed straight into the shared,
-/// namespace-scoped reconciler, so this never over-grants: names only ever
-/// auto-create or attach within this provider's `external_source='oidc'`
-/// namespace and can never bind to an operator-managed group (#2759).
-pub(crate) fn extract_oidc_groups(claims: &serde_json::Value, groups_claim: &str) -> Vec<String> {
-    match &claims[groups_claim] {
+/// claims yield no groups.
+fn groups_from_claim(v: &serde_json::Value) -> Vec<String> {
+    match v {
         serde_json::Value::Array(arr) => arr
             .iter()
             .filter_map(|v| v.as_str())
@@ -1217,6 +1284,119 @@ pub(crate) fn extract_oidc_groups(claims: &serde_json::Value, groups_claim: &str
             .collect(),
         _ => Vec::new(),
     }
+}
+
+/// Extract user groups from JWT claims, trying each candidate claim name in
+/// order and returning the first that yields a non-empty list.
+///
+/// The candidate list comes from [`oidc_groups_claim_candidates`]: an explicit
+/// single-element slice when a provider configures `groups_claim`, or the
+/// default fallback order otherwise. GitLab (issue #2831) delivers membership
+/// paths under `groups_direct`, so the default order lets it resolve without
+/// per-provider config while explicit configuration is honoured exactly.
+///
+/// The result is passed straight into the shared, namespace-scoped reconciler,
+/// so this never over-grants: names only ever auto-create or attach within this
+/// provider's `external_source='oidc'` namespace and can never bind to an
+/// operator-managed group (#2759).
+pub(crate) fn extract_oidc_groups(claims: &serde_json::Value, candidates: &[&str]) -> Vec<String> {
+    for name in candidates {
+        let groups = groups_from_claim(&claims[*name]);
+        if !groups.is_empty() {
+            return groups;
+        }
+    }
+    Vec::new()
+}
+
+/// Union of the id_token-derived and userinfo-derived OIDC group sets.
+///
+/// Order: id_token (direct) groups first, then any userinfo (effective) groups
+/// not already present. Dedup is exact-string (GitLab paths are preserved
+/// verbatim — no normalization, case-folding, or trimming here). GitLab (issue
+/// #2831) carries only DIRECT memberships in the id_token (`groups_direct`) and
+/// the full EFFECTIVE set including inherited subgroups at `/oauth/userinfo`
+/// (`groups`); the union is what surfaces inherited subgroups.
+pub(crate) fn merge_group_sets(
+    id_token_groups: Vec<String>,
+    userinfo_groups: Vec<String>,
+) -> Vec<String> {
+    let mut out = id_token_groups;
+    for g in userinfo_groups {
+        if !out.iter().any(|e| e == &g) {
+            out.push(g);
+        }
+    }
+    out
+}
+
+/// Whether to fetch groups from the OIDC `/userinfo` endpoint for a provider.
+///
+/// On by default; an operator disables it per-provider with
+/// `attribute_mapping.fetch_userinfo_groups = false` (stored in the free-form
+/// `attribute_mapping` JSON, so this needs no schema column). Absent or
+/// non-boolean ⇒ enabled.
+pub(crate) fn userinfo_groups_enabled(attr: &serde_json::Value) -> bool {
+    attr.get("fetch_userinfo_groups")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
+
+/// Fetch and extract group memberships from the OIDC userinfo endpoint.
+///
+/// NON-FATAL by contract: every failure path (no access_token / non-200 /
+/// network / timeout / non-JSON / no groups) returns an empty `Vec` after a
+/// `warn!`/`debug!`. It never returns `Err` and never propagates `?`, so a
+/// userinfo outage cannot break login — it degrades to the id_token-only group
+/// set (issue #2831).
+///
+/// SECURITY: the caller MUST have already passed `userinfo_endpoint` through
+/// [`validate_oidc_fetch_url`] (the same SSRF guard used for the token
+/// endpoint). That gate is the sole entry to this function, so the
+/// `Authorization: Bearer <access_token>` is only ever sent to an
+/// SSRF-validated host. `http_client` is the shared [`sso_client`] whose
+/// per-hop redirect policy re-runs the SSRF block-list on every hop and whose
+/// SSRF DNS resolver blocks rebinding; the per-request 10s timeout bounds a
+/// slow/hung userinfo so it cannot pin a login worker.
+///
+/// [`sso_client`]: crate::services::http_client::sso_client
+async fn fetch_userinfo_groups(
+    http_client: &reqwest::Client,
+    userinfo_endpoint: &str,
+    access_token: Option<&str>,
+    candidates: &[&str],
+) -> Vec<String> {
+    let Some(token) = access_token else {
+        tracing::warn!("no access_token for OIDC userinfo; using id_token groups only");
+        return Vec::new();
+    };
+    let resp = match http_client
+        .get(userinfo_endpoint)
+        .bearer_auth(token)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "OIDC userinfo request failed; using id_token groups only");
+            return Vec::new();
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::warn!(status = %resp.status(), "OIDC userinfo non-200; using id_token groups only");
+        return Vec::new();
+    }
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "OIDC userinfo not JSON; using id_token groups only");
+            return Vec::new();
+        }
+    };
+    // Same candidate resolution as the id_token path; GitLab delivers the
+    // effective set under `groups` (candidate[0]).
+    extract_oidc_groups(&body, candidates)
 }
 
 /// Reconcile an OIDC user's group memberships against the `groups` table.
@@ -2485,7 +2665,7 @@ mod tests {
         let claims = serde_json::json!({
             "groups": ["admin", "developers", "users"]
         });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert_eq!(groups, vec!["admin", "developers", "users"]);
     }
 
@@ -2494,21 +2674,21 @@ mod tests {
         let claims = serde_json::json!({
             "roles": ["manager", "viewer"]
         });
-        let groups = extract_oidc_groups(&claims, "roles");
+        let groups = extract_oidc_groups(&claims, &["roles"]);
         assert_eq!(groups, vec!["manager", "viewer"]);
     }
 
     #[test]
     fn test_extract_groups_missing_claim() {
         let claims = serde_json::json!({ "sub": "user-123" });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert!(groups.is_empty());
     }
 
     #[test]
     fn test_extract_groups_empty_array() {
         let claims = serde_json::json!({ "groups": [] });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert!(groups.is_empty());
     }
 
@@ -2517,21 +2697,21 @@ mod tests {
         // Some IdPs emit a lone group as a bare string, not a 1-element array.
         // This must sync as a single group, not be dropped (#2781).
         let claims = serde_json::json!({ "groups": "admin" });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert_eq!(groups, vec!["admin"]);
     }
 
     #[test]
     fn test_extract_groups_comma_delimited_string() {
         let claims = serde_json::json!({ "groups": "admin,developers,users" });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert_eq!(groups, vec!["admin", "developers", "users"]);
     }
 
     #[test]
     fn test_extract_groups_space_delimited_string() {
         let claims = serde_json::json!({ "groups": "admin developers users" });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert_eq!(groups, vec!["admin", "developers", "users"]);
     }
 
@@ -2539,14 +2719,14 @@ mod tests {
     fn test_extract_groups_delimited_string_trims_and_drops_blanks() {
         // Mixed delimiters + stray whitespace must not yield empty entries.
         let claims = serde_json::json!({ "groups": " admin, ,developers;  users " });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert_eq!(groups, vec!["admin", "developers", "users"]);
     }
 
     #[test]
     fn test_extract_groups_array_trims_whitespace() {
         let claims = serde_json::json!({ "groups": [" admin ", "developers", "  "] });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert_eq!(groups, vec!["admin", "developers"]);
     }
 
@@ -2554,7 +2734,7 @@ mod tests {
     fn test_extract_groups_non_string_scalar_claim() {
         // A numeric/boolean claim is still not a valid groups value.
         let claims = serde_json::json!({ "groups": 42 });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         assert!(groups.is_empty());
     }
 
@@ -2563,7 +2743,7 @@ mod tests {
         let claims = serde_json::json!({
             "groups": ["admin", 42, "users", null, true]
         });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
         // Only string values are extracted
         assert_eq!(groups, vec!["admin", "users"]);
     }
@@ -2571,7 +2751,199 @@ mod tests {
     #[test]
     fn test_extract_groups_null_claim() {
         let claims = serde_json::json!({ "groups": null });
-        let groups = extract_oidc_groups(&claims, "groups");
+        let groups = extract_oidc_groups(&claims, &["groups"]);
+        assert!(groups.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // oidc_groups_claim_candidates (multi-name resolution, #2831)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_candidates_explicit_pins_single_claim() {
+        let attr = serde_json::json!({ "groups_claim": "roles" });
+        assert_eq!(oidc_groups_claim_candidates(&attr), vec!["roles"]);
+    }
+
+    #[test]
+    fn test_candidates_absent_uses_default_order() {
+        let attr = serde_json::json!({});
+        assert_eq!(
+            oidc_groups_claim_candidates(&attr),
+            vec!["groups", "groups_direct", "roles"]
+        );
+    }
+
+    #[test]
+    fn test_candidates_empty_string_uses_default_order() {
+        let attr = serde_json::json!({ "groups_claim": "" });
+        assert_eq!(
+            oidc_groups_claim_candidates(&attr),
+            vec!["groups", "groups_direct", "roles"]
+        );
+    }
+
+    #[test]
+    fn test_candidates_whitespace_only_uses_default_order() {
+        let attr = serde_json::json!({ "groups_claim": "   " });
+        assert_eq!(
+            oidc_groups_claim_candidates(&attr),
+            vec!["groups", "groups_direct", "roles"]
+        );
+    }
+
+    #[test]
+    fn test_candidates_non_string_uses_default_order() {
+        let attr = serde_json::json!({ "groups_claim": 42 });
+        assert_eq!(
+            oidc_groups_claim_candidates(&attr),
+            vec!["groups", "groups_direct", "roles"]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_oidc_groups candidate-slice resolution (#2831)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_groups_first_non_empty_candidate_wins() {
+        // `groups` absent/empty, `groups_direct` populated → groups_direct wins.
+        let claims = serde_json::json!({
+            "groups": [],
+            "groups_direct": ["platform", "platform/backend"],
+        });
+        let groups = extract_oidc_groups(&claims, &["groups", "groups_direct", "roles"]);
+        assert_eq!(groups, vec!["platform", "platform/backend"]);
+    }
+
+    #[test]
+    fn test_extract_groups_precedence_groups_over_direct() {
+        // Both present → first candidate (`groups`) wins deterministically.
+        let claims = serde_json::json!({
+            "groups": ["from-groups"],
+            "groups_direct": ["from-direct"],
+        });
+        let groups = extract_oidc_groups(&claims, &["groups", "groups_direct", "roles"]);
+        assert_eq!(groups, vec!["from-groups"]);
+    }
+
+    #[test]
+    fn test_extract_groups_all_candidates_empty() {
+        let claims = serde_json::json!({ "sub": "u1" });
+        let groups = extract_oidc_groups(&claims, &["groups", "groups_direct", "roles"]);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_extract_groups_gitlab_paths_preserved_verbatim() {
+        // GitLab full paths must not be split, lowercased, or trimmed of slashes.
+        let claims = serde_json::json!({
+            "groups_direct": ["Platform", "platform/backend", "infra/backend"],
+        });
+        let groups = extract_oidc_groups(&claims, &["groups", "groups_direct", "roles"]);
+        assert_eq!(
+            groups,
+            vec!["Platform", "platform/backend", "infra/backend"]
+        );
+    }
+
+    #[test]
+    fn test_extract_groups_third_candidate_roles_fallback() {
+        let claims = serde_json::json!({ "roles": ["role-team"] });
+        let groups = extract_oidc_groups(&claims, &["groups", "groups_direct", "roles"]);
+        assert_eq!(groups, vec!["role-team"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // merge_group_sets (id_token + userinfo union, #2831)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_merge_group_sets_userinfo_empty_is_id_token_verbatim() {
+        let merged = merge_group_sets(
+            vec!["platform".to_string(), "platform/backend".to_string()],
+            vec![],
+        );
+        assert_eq!(merged, vec!["platform", "platform/backend"]);
+    }
+
+    #[test]
+    fn test_merge_group_sets_id_token_empty_is_userinfo_verbatim() {
+        let merged = merge_group_sets(vec![], vec!["platform".to_string()]);
+        assert_eq!(merged, vec!["platform"]);
+    }
+
+    #[test]
+    fn test_merge_group_sets_union_dedup_id_token_first() {
+        // bob: id_token direct = [platform]; userinfo effective =
+        // [platform, platform/backend] → union with the inherited subgroup,
+        // deduped, id_token order first.
+        let merged = merge_group_sets(
+            vec!["platform".to_string()],
+            vec!["platform".to_string(), "platform/backend".to_string()],
+        );
+        assert_eq!(merged, vec!["platform", "platform/backend"]);
+    }
+
+    #[test]
+    fn test_merge_group_sets_paths_verbatim_case_sensitive() {
+        // Exact-string dedup: differing case is NOT collapsed.
+        let merged = merge_group_sets(vec!["Platform".to_string()], vec!["platform".to_string()]);
+        assert_eq!(merged, vec!["Platform", "platform"]);
+    }
+
+    #[test]
+    fn test_merge_group_sets_both_empty() {
+        let merged = merge_group_sets(vec![], vec![]);
+        assert!(merged.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // userinfo_groups_enabled toggle (#2831)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_userinfo_groups_enabled_default_on() {
+        assert!(userinfo_groups_enabled(&serde_json::json!({})));
+    }
+
+    #[test]
+    fn test_userinfo_groups_enabled_opt_out() {
+        assert!(!userinfo_groups_enabled(
+            &serde_json::json!({ "fetch_userinfo_groups": false })
+        ));
+    }
+
+    #[test]
+    fn test_userinfo_groups_enabled_explicit_true() {
+        assert!(userinfo_groups_enabled(
+            &serde_json::json!({ "fetch_userinfo_groups": true })
+        ));
+    }
+
+    #[test]
+    fn test_userinfo_groups_enabled_non_bool_defaults_on() {
+        assert!(userinfo_groups_enabled(
+            &serde_json::json!({ "fetch_userinfo_groups": "yes" })
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // fetch_userinfo_groups NON-FATAL contract (#2831)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_fetch_userinfo_groups_no_access_token_is_empty() {
+        // No access_token ⇒ empty Vec, never a panic/error (login must survive
+        // a missing token). No network is touched on this branch.
+        let client = crate::services::http_client::sso_client();
+        let groups = fetch_userinfo_groups(
+            &client,
+            "https://idp.example.com/oauth/userinfo",
+            None,
+            &["groups", "groups_direct", "roles"],
+        )
+        .await;
         assert!(groups.is_empty());
     }
 
@@ -2924,7 +3296,7 @@ mod tests {
             // Simulate an IdP that emits the groups claim as a single
             // comma-delimited string rather than a JSON array.
             let claims = serde_json::json!({ "groups": format!("{g1},{g2}") });
-            let groups = extract_oidc_groups(&claims, "groups");
+            let groups = extract_oidc_groups(&claims, &["groups"]);
             assert_eq!(groups, vec![g1.clone(), g2.clone()]);
 
             sync_oidc_groups_to_local_groups(&pool, user_id, provider_id, &groups)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1535,13 +1535,15 @@ fn build_oidc_request_from_values(
         .scopes
         .map(|s| s.split_whitespace().map(String::from).collect::<Vec<_>>());
 
-    let groups_claim_val = env.groups_claim.unwrap_or_else(|| "groups".to_string());
-
     let mut attr_map = serde_json::Map::new();
-    attr_map.insert(
-        "groups_claim".into(),
-        serde_json::Value::String(groups_claim_val),
-    );
+    // Insert groups_claim ONLY when explicitly configured (mirrors
+    // username_claim/email_claim below). Leaving it absent lets the OIDC
+    // callback's multi-name candidate resolution engage, so an env-bootstrapped
+    // GitLab provider (which publishes under `groups_direct`) syncs groups
+    // without the operator having to set OIDC_GROUPS_CLAIM (#2831).
+    if let Some(claim) = env.groups_claim.filter(|v| !v.is_empty()) {
+        attr_map.insert("groups_claim".into(), serde_json::Value::String(claim));
+    }
     if let Some(uri) = env.redirect_uri {
         attr_map.insert("redirect_uri".into(), serde_json::Value::String(uri));
     }
@@ -2267,7 +2269,10 @@ mod tests {
     }
 
     #[test]
-    fn test_bootstrap_request_default_groups_claim() {
+    fn test_bootstrap_request_default_groups_claim_absent() {
+        // When OIDC_GROUPS_CLAIM is unset, groups_claim must NOT be persisted,
+        // so the OIDC callback's multi-name candidate fallback can engage for
+        // env-bootstrapped GitLab providers (#2831).
         let req = build_oidc_request_from_values(env(
             Some("https://idp.example.com"),
             Some("client"),
@@ -2276,7 +2281,7 @@ mod tests {
         .unwrap();
 
         let attr = req.attribute_mapping.unwrap();
-        assert_eq!(attr["groups_claim"], "groups");
+        assert!(attr.as_object().unwrap().get("groups_claim").is_none());
     }
 
     #[test]
@@ -2415,9 +2420,10 @@ mod tests {
 
         let attr = req.attribute_mapping.unwrap();
         let obj = attr.as_object().unwrap();
-        // Only groups_claim should be present (it always has a default)
-        assert_eq!(obj.len(), 1);
-        assert!(obj.contains_key("groups_claim"));
+        // With no optional claims set, the attribute_mapping is empty:
+        // groups_claim is now only inserted when explicitly configured (#2831).
+        assert!(obj.is_empty());
+        assert!(!obj.contains_key("groups_claim"));
         assert!(!obj.contains_key("redirect_uri"));
         assert!(!obj.contains_key("username_claim"));
         assert!(!obj.contains_key("email_claim"));


### PR DESCRIPTION
## Summary

OIDC group sync only ever read the `groups` claim from the id_token, so GitLab
(and other IdPs that split direct vs effective membership) synced no groups.
This resolves memberships from a candidate claim list and merges in the
userinfo endpoint, matching how GitLab actually delivers group data.

GitLab publishes memberships two ways, confirmed against a live GitLab CE 19.2:

- the **id_token** carries only **direct** memberships under `groups_direct`
  (full paths like `platform`, `platform/backend`), with no `groups` key;
- **`/oauth/userinfo`** carries the full **effective** set incl. inherited
  subgroups under `groups`.

Reading the id_token `groups` claim alone found nothing; even reading
`groups_direct` misses inherited subgroups (e.g. a user who is a direct member
of `platform` only, but inherits `platform/backend`). This change:

1. **Candidate claim resolution.** When no explicit `attribute_mapping.groups_claim`
   is configured, group extraction now tries the first non-empty of
   `["groups", "groups_direct", "roles"]`. An explicit `groups_claim` still pins
   resolution to that single claim exactly as before. `extract_oidc_groups` takes
   a candidate slice; a single-element slice reproduces the prior behaviour.
2. **Full-path group names, verbatim.** GitLab paths (`platform/backend`) are
   preserved as the group name — unique within an instance and DB-safe
   (`groups.name` is `VARCHAR(255)`, no CHECK constraint). No split, lowercase,
   or slash stripping. Last-segment naming was rejected because it collides
   distinct groups (`platform/backend` vs `infra/backend`).
3. **userinfo merge.** After extracting id_token groups, the callback fetches
   the discovery-advertised `userinfo_endpoint` with the provider access token
   and unions its groups (id_token first, deduped). This surfaces inherited
   subgroups. The fetch is **non-fatal**: any failure (missing endpoint, SSRF
   refusal, non-200, network, timeout, non-JSON) degrades to id_token-only
   groups with a `warn!`, and login still succeeds. Default-on; operators of a
   userinfo-less IdP opt out with `attribute_mapping.fetch_userinfo_groups = false`
   (free-form JSON, no migration). The fetch only fires when groups are actually
   consumed (`map_groups_to_groups` or an admin group is configured).
4. **Env-bootstrap companion.** `build_oidc_request_from_values` no longer
   unconditionally persists `groups_claim = "groups"`; it is inserted only when
   `OIDC_GROUPS_CLAIM` is set (mirroring `username_claim`/`email_claim`), so an
   env-bootstrapped GitLab provider leaves the key absent and hits the candidate
   fallback.

### Security

The userinfo fetch is a new attacker-influenceable outbound request (the target
comes from the provider's discovery document), so it reuses the existing
token-endpoint posture exactly:

- the `userinfo_endpoint` is passed through the **same** `validate_oidc_fetch_url`
  SSRF guard used for `token_endpoint` before any fetch; the guard is the sole
  entry to the fetch, so the `Authorization: Bearer` is only ever sent to a
  validated host;
- the fetch uses the shared `sso_client()` (per-hop redirect SSRF re-check +
  SSRF DNS resolver) plus a per-request 10s timeout, so a slow/hung or
  redirect-pivoting userinfo cannot pin a login worker or reach an internal host;
- the merged set feeds admin-group elevation, which remains exact-match
  (unchanged) and is fed from the same access token issued by the same
  SSRF-validated IdP that signed the id_token.

No SAML/LDAP or `sync_federated_groups_to_local_groups` behaviour changes — the
reconciler simply receives the fuller, merged list.

Closes #2831.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Backend unit tests cover the candidate resolver (explicit/empty/whitespace/absent),
first-non-empty candidate selection, verbatim path preservation, the array/string
value shapes, `merge_group_sets` (union/dedup/order/verbatim/empty), the
`userinfo_groups_enabled` toggle, and the `fetch_userinfo_groups` non-fatal
contract. The `oidc-group-sync` deploy-test tier gains cases for the GitLab
`groups_direct` headline, explicit-override, full-path naming, precedence,
string shape, empty no-op, `roles` fallback, the userinfo inheritance headline,
userinfo-down graceful degrade, the userinfo SSRF guard, and merge dedup. The
two headline cases (GitLab `groups_direct` sync; inherited subgroup via userinfo)
are RED on the pre-fix image and GREEN here. Cross-checked against live GitLab
CE 19.2: alice resolves both `platform` and `platform/backend`; bob (direct
member of `platform` only) gains the inherited `platform/backend` via userinfo.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
