### PR TITLE
fix(openapi): tag POST /signing/artifacts/{id}/sign operation

### DIFF
--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -511,6 +511,7 @@ pub struct SignArtifactResponse {
 #[utoipa::path(
     post,
     path = "/api/v1/signing/artifacts/{artifact_id}/sign",
+    tag = "signing",
     params(
         ("artifact_id" = Uuid, Path, description = "Artifact ID")
     ),
@@ -846,6 +847,40 @@ mod tests {
                 signing_handler_body(name).contains("require_signing_admin"),
                 "{name} MUST call require_signing_admin (admin gate) — CWE-862 regression guard"
             );
+        }
+    }
+
+    #[test]
+    fn test_openapi_paths_all_have_non_empty_tags() {
+        // #2721: the exported OpenAPI operation for POST
+        // /signing/artifacts/{id}/sign must carry a non-empty `tags` array.
+        // Spectral's error-severity `operation-tags` rule fails the SDK
+        // generation pipeline on any operation with `tags: []`, so every path
+        // in this doc must be tagged — pin the whole surface, not just the one
+        // handler that regressed, so a future untagged sibling also trips here.
+        let doc = serde_json::to_value(SigningApiDoc::openapi())
+            .expect("SigningApiDoc serializes to JSON");
+        let paths = doc["paths"]
+            .as_object()
+            .expect("openapi doc has a paths object");
+        assert!(
+            !paths.is_empty(),
+            "signing doc must expose at least one path"
+        );
+        for (path, item) in paths {
+            let operations = item.as_object().expect("path item is an object");
+            for method in ["get", "post", "put", "delete", "patch", "head", "options"] {
+                let Some(op) = operations.get(method) else {
+                    continue;
+                };
+                let tags = op["tags"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{method} {path} must declare a tags array"));
+                assert!(
+                    !tags.is_empty(),
+                    "{method} {path} must have a non-empty tags array (#2721)"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The `#[utoipa::path]` macro for `sign_artifact` (POST
`/api/v1/signing/artifacts/{artifact_id}/sign`) omitted `tag = "signing"`, so the
exported OpenAPI operation carried `tags: []`. Spectral's error-severity
`operation-tags` rule fails the artifact-keeper-api SDK generation pipeline on any
untagged operation, so all SDKs were skipped and the exported spec had to be
hand-patched for v1.6.0.

This adds `tag = "signing"` to the path macro so the operation is tagged
consistently with its sibling `/signing/keys` and `/signing/repositories`
operations, letting future spec syncs export cleanly.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_openapi_paths_all_have_non_empty_tags` generates `SigningApiDoc::openapi()`
and asserts every path/operation exposes a non-empty `tags` array. It fails on
`main` (`post /api/v1/signing/artifacts/{artifact_id}/sign must have a non-empty
tags array`) and passes with this change. Pinning the whole signing surface means a
future untagged sibling trips this test instead of the SDK pipeline.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Closes #2721
