### PR TITLE
fix: normalize Maven/Gradle packages.name to groupId:artifactId for grouped listings

### DIFF
--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -748,7 +748,9 @@ async fn complete(
         }
     }
 
-    if let Some((package_name, package_version)) = completed_package_catalog_entry(&session) {
+    if let Some((package_name, package_version)) =
+        completed_package_catalog_entry(&session, &repo.format)
+    {
         PackageService::new(state.db.clone())
             .try_create_or_update_from_artifact(
                 session.repository_id,
@@ -1091,14 +1093,39 @@ fn maven_package_metadata_from_artifact_metadata(
     Some(catalog)
 }
 
-fn completed_package_catalog_entry(
-    session: &upload_service::UploadSession,
-) -> Option<(String, &str)> {
+fn completed_package_catalog_entry<'a>(
+    session: &'a upload_service::UploadSession,
+    format: &crate::models::repository::RepositoryFormat,
+) -> Option<(String, &'a str)> {
     let version = completed_artifact_version(session)?;
+    // #2723: Maven/Gradle grouped listings key the catalog `packages` row on
+    // `groupId:artifactId`. Prefer the replicated POM metadata's coordinates;
+    // otherwise, for a Maven/Gradle repo, derive the grouped name from the
+    // artifact path so a generically-pushed asset joins the same component
+    // instead of landing under a bare artifactId/filename.
     let name = replicated_maven_artifact_metadata(session)
         .and_then(maven_package_name_from_metadata)
+        .or_else(|| maven_grouped_name_for_format(session, format))
         .unwrap_or_else(|| completed_artifact_name(session).to_string());
     Some((name, version))
+}
+
+/// Derive the grouped `groupId:artifactId` catalog name from the completed
+/// upload's path for Maven/Gradle repositories (#2723). Returns `None` for
+/// other formats or when the path is not a parseable Maven GAV layout, leaving
+/// the caller's bare-name fallback in place.
+fn maven_grouped_name_for_format(
+    session: &upload_service::UploadSession,
+    format: &crate::models::repository::RepositoryFormat,
+) -> Option<String> {
+    use crate::models::repository::RepositoryFormat;
+    if !matches!(format, RepositoryFormat::Maven | RepositoryFormat::Gradle) {
+        return None;
+    }
+    match crate::formats::maven::MavenHandler::parse_coordinates(&session.artifact_path) {
+        Ok(coords) => Some(format!("{}:{}", coords.group_id, coords.artifact_id)),
+        Err(_) => None,
+    }
 }
 
 fn completed_package_description(session: &upload_service::UploadSession) -> Option<&str> {
@@ -1659,8 +1686,30 @@ mod tests {
         );
 
         assert_eq!(
-            completed_package_catalog_entry(&session),
+            completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
             Some(("large-check".to_string(), "20260603T082854Z"))
+        );
+    }
+
+    #[test]
+    fn test_completed_package_catalog_entry_derives_grouped_name_for_maven_repo() {
+        // #2723: a generically-pushed Maven asset (no replicated POM metadata)
+        // must still land under the grouped `groupId:artifactId` catalog name
+        // derived from its GAV path, not the bare artifactId/filename.
+        let session = test_upload_session(
+            "org/example/ak/maven/ak-core/1.0.0/ak-core-1.0.0.jar",
+            None,
+            Some("1.0.0"),
+        );
+
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
+            Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
+        );
+        // A non-Maven repo keeps the bare artifact name.
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
+            Some(("ak-core-1.0.0.jar".to_string(), "1.0.0"))
         );
     }
 
@@ -1685,7 +1734,7 @@ mod tests {
         }));
 
         assert_eq!(
-            completed_package_catalog_entry(&session),
+            completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
             Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
         );
         assert_eq!(
@@ -1717,7 +1766,7 @@ mod tests {
         }));
 
         assert_eq!(
-            completed_package_catalog_entry(&session),
+            completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
             Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
         );
         assert_eq!(completed_package_description(&session), None);
@@ -1729,7 +1778,10 @@ mod tests {
         let session =
             test_upload_session("large-check/20260603T082854Z/large-160m.bin", None, None);
 
-        assert_eq!(completed_package_catalog_entry(&session), None);
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
+            None
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/formats/maven.rs
+++ b/backend/src/formats/maven.rs
@@ -214,6 +214,22 @@ impl MavenHandler {
         path.ends_with("maven-metadata.xml")
     }
 
+    /// Normalize a catalog `packages.name` for a Maven/Gradle artifact to the
+    /// grouped `groupId:artifactId` form that hosted/virtual grouped listings
+    /// key on (#2723).
+    ///
+    /// The dedicated Maven upload handler already records this form. The
+    /// generic finalize/chunked write paths otherwise persist the bare
+    /// artifactId (or filename), which splits a single component across
+    /// multiple grouped rows. Falls back to `bare_name` when `path` is not a
+    /// parseable Maven GAV layout, so non-Maven-shaped keys are left untouched.
+    pub fn grouped_package_name(path: &str, bare_name: &str) -> String {
+        match Self::parse_coordinates(path) {
+            Ok(coords) => format!("{}:{}", coords.group_id, coords.artifact_id),
+            Err(_) => bare_name.to_string(),
+        }
+    }
+
     /// Parse POM file
     pub fn parse_pom(content: &[u8]) -> Result<PomProject> {
         let content_str = std::str::from_utf8(content)
@@ -601,6 +617,29 @@ mod tests {
         assert_eq!(coords.version, "3.8.1");
         assert_eq!(coords.classifier, None);
         assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_grouped_package_name_normalizes_gav_path() {
+        // #2723: a Maven GAV path normalizes to `groupId:artifactId`,
+        // matching what the dedicated upload handler records.
+        assert_eq!(
+            MavenHandler::grouped_package_name(
+                "org/apache/maven/maven-core/3.8.1/maven-core-3.8.1.jar",
+                "maven-core-3.8.1.jar",
+            ),
+            "org.apache.maven:maven-core"
+        );
+    }
+
+    #[test]
+    fn test_grouped_package_name_falls_back_on_non_gav_path() {
+        // A path that is not a parseable Maven GAV layout keeps the bare name,
+        // so non-Maven-shaped keys are never mangled.
+        assert_eq!(
+            MavenHandler::grouped_package_name("not-a-gav.bin", "not-a-gav.bin"),
+            "not-a-gav.bin"
+        );
     }
 
     #[test]

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -916,11 +916,31 @@ impl ArtifactService {
 
         // Populate packages / package_versions tables (non-blocking)
         if let Some(ref ver) = artifact.version {
+            // #2723: Maven/Gradle grouped listings key the catalog `packages`
+            // row on `groupId:artifactId`. The dedicated Maven upload handler
+            // already records that form; normalize this generic finalize path
+            // (replication / migration / generic push) to match instead of
+            // persisting the bare artifactId or filename, which would split a
+            // single component across multiple grouped rows.
+            let package_name = match self.repo_service.get_by_id(artifact.repository_id).await {
+                Ok(repo)
+                    if matches!(
+                        repo.format,
+                        RepositoryFormat::Maven | RepositoryFormat::Gradle
+                    ) =>
+                {
+                    crate::formats::maven::MavenHandler::grouped_package_name(
+                        &artifact.path,
+                        &artifact.name,
+                    )
+                }
+                _ => artifact.name.clone(),
+            };
             let pkg_svc = crate::services::package_service::PackageService::new(self.db.clone());
             pkg_svc
                 .try_create_or_update_from_artifact(
                     artifact.repository_id,
-                    &artifact.name,
+                    &package_name,
                     ver,
                     artifact.size_bytes,
                     &artifact.checksum_sha256,


### PR DESCRIPTION
## Summary

Maven/Gradle hosted and virtual grouped listings key the catalog `packages`
row on the grouped `groupId:artifactId` name. The dedicated Maven upload
handler already records that form, but two generic write paths persist the
bare artifactId (or filename) for a Maven asset instead, which splits one
Maven component across several grouped rows:

- `ArtifactService::finalize_upload` (generic finalize used by
  replication / migration / generic pushes) recorded `artifact.name` verbatim.
- The chunked-upload completion (`completed_package_catalog_entry`) only
  derived the grouped name from replicated POM metadata and otherwise fell
  back to the bare artifact name.

This normalizes both paths so a Maven/Gradle asset's `packages.name` is the
grouped `groupId:artifactId` form, matching the native upload handler. The
grouped name is derived from the artifact's GAV path; a path that is not a
parseable Maven layout keeps the bare name, so non-Maven-shaped keys and
other formats are untouched.

A new shared helper `MavenHandler::grouped_package_name(path, bare_name)`
centralizes the normalization so both call sites (and the native handler's
existing behavior) stay consistent.

Scope note: this is the write-path normalization only. Backfilling existing
bare `packages.name` rows and rerouting the in-memory grouping in
`repositories.rs` through the catalog keyset are the remaining, separately
reviewable steps of #2723 and are intentionally not included here.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added:
- `formats::maven::tests::test_grouped_package_name_normalizes_gav_path`
- `formats::maven::tests::test_grouped_package_name_falls_back_on_non_gav_path`
- `api::handlers::upload::tests::test_completed_package_catalog_entry_derives_grouped_name_for_maven_repo`
  (asserts a generically-pushed Maven asset with no replicated POM metadata
  lands under `groupId:artifactId`, and a non-Maven repo keeps the bare name)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2723
