### PR TITLE
fix(cran,rubygems): advertise stored-filename coordinates for bare-path uploads

### DIFF
--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -396,31 +396,65 @@ async fn upload_package(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Derive the `(package, version)` coordinates a CRAN client reconstructs the
+/// download filename from, preferring the artifact's **actual stored filename**.
+///
+/// R's `install.packages()` turns each PACKAGES `Package`/`Version` pair back
+/// into `{package}_{version}.tar.gz` and GETs it from `src/contrib/`, which the
+/// download route resolves by filename suffix. Packages published natively are
+/// stored at `{name}/{version}/{name}_{version}.tar.gz`, whose basename already
+/// parses back to the same coordinates — so this is **byte-identical** for them.
+/// But a package pushed through the generic chunked-upload flow is stored at its
+/// bare filename with the whole basename as `name` and a `sha256-<prefix>`
+/// fallback `version` (see `upload.rs::completed_format_artifact_version`), so
+/// emitting the stored columns would advertise `{basename}_{sha256-…}.tar.gz`, a
+/// path the suffix-resolving route can never serve. Re-deriving from the stored
+/// filename keeps the index coherent with the served route for both upload
+/// flows — the CRAN analogue of the helm `index.yaml` fix (#2753 / #2589).
+///
+/// Falls back to the stored `name`/`version` when the basename does not follow
+/// the `{name}_{version}.tar.gz` convention (an arbitrary bare-path object that
+/// no reconstruction could resolve anyway).
+fn source_index_coordinates(path: &str, name: &str, version: &str) -> (String, String) {
+    path.rsplit('/')
+        .next()
+        .filter(|f| !f.is_empty())
+        .and_then(|filename| CranHandler::parse_path(&format!("src/contrib/{}", filename)).ok())
+        .and_then(|info| Some((info.name?, info.version?)))
+        .unwrap_or_else(|| (name.to_string(), version.to_string()))
+}
+
 /// Build PACKAGES index in CRAN DCF text format for source packages.
 async fn build_source_index(db: &PgPool, repo_id: uuid::Uuid) -> Result<String, Response> {
-    let artifacts = sqlx::query!(
+    use sqlx::Row;
+    // Runtime query (not the `query!` macro) so the added `a.path` column does
+    // not require regenerating the offline sqlx data for the `Check Rust` gate,
+    // mirroring the helm index builder.
+    let rows = sqlx::query(
         r#"
-        SELECT a.name, a.version, am.metadata as "metadata?"
+        SELECT a.name, a.version, a.path, am.metadata
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
         WHERE a.repository_id = $1
           AND a.is_deleted = false
         ORDER BY a.name, a.created_at DESC
         "#,
-        repo_id
     )
+    .bind(repo_id)
     .fetch_all(db)
     .await
     .map_err(super::db_err)?;
 
     let mut index = String::new();
-    for a in &artifacts {
-        write_dcf_record(
-            &mut index,
-            &a.name,
-            a.version.as_deref().unwrap_or_default(),
-            a.metadata.as_ref(),
-        );
+    for row in &rows {
+        let name: String = row.get("name");
+        let version: Option<String> = row.get("version");
+        let path: String = row.get("path");
+        let metadata: Option<serde_json::Value> = row.get("metadata");
+
+        let (pkg, ver) =
+            source_index_coordinates(&path, &name, version.as_deref().unwrap_or_default());
+        write_dcf_record(&mut index, &pkg, &ver, metadata.as_ref());
     }
 
     Ok(index)
@@ -660,6 +694,49 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // source_index_coordinates — advertise coordinates the download route can
+    // resolve for both native and bare-path (generic) uploads (#2754).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_source_index_coordinates_native_path_is_byte_identical() {
+        // Native upload path: `{name}/{version}/{name}_{version}.tar.gz`.
+        // The stored columns already match the basename, so the advertised
+        // coordinates are unchanged.
+        let (pkg, ver) =
+            source_index_coordinates("ggplot2/3.4.0/ggplot2_3.4.0.tar.gz", "ggplot2", "3.4.0");
+        assert_eq!(pkg, "ggplot2");
+        assert_eq!(ver, "3.4.0");
+    }
+
+    #[test]
+    fn test_source_index_coordinates_bare_path_uses_filename() {
+        // Bare-path generic upload: stored `name` is the whole basename and
+        // `version` is the `sha256-<prefix>` fallback. The advertised
+        // coordinates must come from the filename so the R client reconstructs
+        // `dplyr_1.1.0.tar.gz` (which the suffix route serves), NOT
+        // `dplyr_1.1.0.tar.gz_sha256-abcdef012345.tar.gz`.
+        let (pkg, ver) = source_index_coordinates(
+            "dplyr_1.1.0.tar.gz",
+            "dplyr_1.1.0.tar.gz",
+            "sha256-abcdef012345",
+        );
+        assert_eq!(pkg, "dplyr");
+        assert_eq!(ver, "1.1.0");
+        // Guard against a regression back to the broken reconstruction.
+        assert_ne!(ver, "sha256-abcdef012345");
+    }
+
+    #[test]
+    fn test_source_index_coordinates_non_cran_basename_falls_back() {
+        // A bare-path object that is not a CRAN source package name falls back
+        // to the stored columns (nothing could make it resolvable).
+        let (pkg, ver) = source_index_coordinates("data.zip", "data.zip", "sha256-deadbeef");
+        assert_eq!(pkg, "data.zip");
+        assert_eq!(ver, "sha256-deadbeef");
+    }
+
+    // -----------------------------------------------------------------------
     // DB-backed router tests for download_package, upload_package, and
     // build_source_index. Use the shared `test_db_helpers::Fixture` so this
     // file does not duplicate the per-test scaffolding.
@@ -855,6 +932,48 @@ mod tests {
         assert!(text.contains("Package: ggplot2"));
         assert!(text.contains("Version: 3.4.0"));
         assert!(text.contains("Depends: R (>= 3.5.0)"));
+        f.teardown().await;
+    }
+
+    /// #2754: a bare-path generic upload (path == filename, `name` == whole
+    /// basename, `version` == `sha256-<prefix>` fallback) must be advertised in
+    /// PACKAGES with the coordinates the R client reconstructs the *resolvable*
+    /// `{name}_{version}.tar.gz` download from — not the raw sha256 fallback
+    /// (which yields `…tar.gz_sha256-….tar.gz` → 404). Fails on `main`.
+    #[tokio::test]
+    async fn test_cran_index_coords_resolve_for_bare_path_generic_upload() {
+        let Some(f) = tdh::Fixture::setup("local", "cran").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            "cran/mypkg_1.0.0.tar.gz",
+            "mypkg_1.0.0.tar.gz",
+            "mypkg_1.0.0.tar.gz",
+            "sha256-abcdef012345",
+            "application/x-gzip",
+            Bytes::from_static(b"fake-r-pkg"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/src/contrib/PACKAGES", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("Package: mypkg"), "index was: {text}");
+        assert!(text.contains("Version: 1.0.0"), "index was: {text}");
+        assert!(
+            !text.contains("sha256-abcdef012345"),
+            "index still advertises the unresolvable sha256 fallback: {text}"
+        );
         f.teardown().await;
     }
 }

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -385,7 +385,7 @@ async fn push_gem(
 }
 
 const SPECS_QUERY: &str = r#"
-    SELECT name, version
+    SELECT name, version, path
     FROM artifacts
     WHERE repository_id = $1
       AND is_deleted = false
@@ -393,7 +393,7 @@ const SPECS_QUERY: &str = r#"
 "#;
 
 const LATEST_SPECS_QUERY: &str = r#"
-    SELECT DISTINCT ON (LOWER(name)) name, version
+    SELECT DISTINCT ON (LOWER(name)) name, version, path
     FROM artifacts
     WHERE repository_id = $1
       AND is_deleted = false
@@ -404,7 +404,7 @@ const LATEST_SPECS_QUERY: &str = r#"
 // letter (e.g. `1.0.0.beta`, `2.1.0.rc1`). `specs.4.8.gz` carries releases;
 // `prerelease_specs.4.8.gz` carries these.
 const PRERELEASE_SPECS_QUERY: &str = r#"
-    SELECT name, version
+    SELECT name, version, path
     FROM artifacts
     WHERE repository_id = $1
       AND is_deleted = false
@@ -429,9 +429,28 @@ async fn query_gem_specs(
         .map(|r| {
             let name: String = r.get("name");
             let version: Option<String> = r.get("version");
-            serde_json::json!([name, version.unwrap_or_default(), "ruby"])
+            let path: String = r.get("path");
+            // Advertise coordinates derived from the actual stored filename so a
+            // bare-path generic upload (whole basename as `name` + `sha256-…`
+            // fallback `version`) yields a `{name}-{version}.gem` the download
+            // route can serve, instead of a client-reconstructed 404 (#2754).
+            let (name, version) = spec_index_coordinates(&path, name, version.unwrap_or_default());
+            serde_json::json!([name, version, "ruby"])
         })
         .collect())
+}
+
+/// Resolve the `(name, version)` a spec-index client will reconstruct the gem
+/// download filename from, preferring the artifact's actual stored filename over
+/// the stored coordinate columns. Byte-identical for natively published gems;
+/// corrects bare-path generic uploads. See
+/// [`crate::formats::rubygems::coordinates_from_gem_filename`].
+fn spec_index_coordinates(path: &str, name: String, version: String) -> (String, String) {
+    path.rsplit('/')
+        .next()
+        .filter(|f| !f.is_empty())
+        .and_then(crate::formats::rubygems::coordinates_from_gem_filename)
+        .unwrap_or((name, version))
 }
 
 /// Query gem specs from all local (non-remote) virtual members.
@@ -931,6 +950,50 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // spec_index_coordinates — advertise coordinates the download route can
+    // resolve for both native and bare-path (generic) uploads (#2754).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_spec_index_coordinates_native_path_is_byte_identical() {
+        // Native push path: `{name}/{version}/{name}-{version}.gem`.
+        let (name, version) = spec_index_coordinates(
+            "rails/7.0.8/rails-7.0.8.gem",
+            "rails".to_string(),
+            "7.0.8".to_string(),
+        );
+        assert_eq!(name, "rails");
+        assert_eq!(version, "7.0.8");
+    }
+
+    #[test]
+    fn test_spec_index_coordinates_bare_path_uses_filename() {
+        // Bare-path generic upload: stored `name` is the whole basename and
+        // `version` is the `sha256-<prefix>` fallback. The advertised
+        // coordinates must come from the filename so `gem install` reconstructs
+        // `rails-7.0.8.gem` (which the suffix route serves).
+        let (name, version) = spec_index_coordinates(
+            "rails-7.0.8.gem",
+            "rails-7.0.8.gem".to_string(),
+            "sha256-abcdef012345".to_string(),
+        );
+        assert_eq!(name, "rails");
+        assert_eq!(version, "7.0.8");
+        assert_ne!(version, "sha256-abcdef012345");
+    }
+
+    #[test]
+    fn test_spec_index_coordinates_non_gem_basename_falls_back() {
+        let (name, version) = spec_index_coordinates(
+            "archive.tar.gz",
+            "archive.tar.gz".to_string(),
+            "sha256-deadbeef".to_string(),
+        );
+        assert_eq!(name, "archive.tar.gz");
+        assert_eq!(version, "sha256-deadbeef");
+    }
+
+    // -----------------------------------------------------------------------
     // DependencyQuery deserialization
     // -----------------------------------------------------------------------
 
@@ -1320,6 +1383,58 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
 
+        f.teardown().await;
+    }
+
+    /// #2754: a bare-path generic upload (path == filename, `name` == whole
+    /// basename, `version` == `sha256-<prefix>` fallback) must appear in the
+    /// spec index with the coordinates `gem install` reconstructs the
+    /// *resolvable* `{name}-{version}.gem` download from — not the raw sha256
+    /// fallback (which yields `rails-7.0.8.gem-sha256-….gem` → 404). Fails on
+    /// `main`.
+    #[tokio::test]
+    async fn test_rubygems_specs_coords_resolve_for_bare_path_generic_upload() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let Some(f) = tdh::Fixture::setup("local", "rubygems").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            "rubygems/rails-7.0.8.gem",
+            "rails-7.0.8.gem",
+            "rails-7.0.8.gem",
+            "sha256-abcdef012345",
+            "application/octet-stream",
+            bytes::Bytes::from_static(b"gem-data"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) =
+            tdh::send(app, tdh::get(format!("/{}/specs.4.8.gz", f.repo_key))).await;
+        assert_eq!(status, StatusCode::OK);
+        let mut specs = Vec::new();
+        GzDecoder::new(&body[..])
+            .read_to_end(&mut specs)
+            .expect("gunzip specs");
+        assert!(
+            specs.windows(5).any(|w| w == b"rails"),
+            "specs must advertise the gem name"
+        );
+        assert!(
+            specs.windows(5).any(|w| w == b"7.0.8"),
+            "specs must advertise the resolvable version"
+        );
+        assert!(
+            !specs.windows(20).any(|w| w == b"sha256-abcdef012345"),
+            "specs still advertise the unresolvable sha256 fallback version"
+        );
         f.teardown().await;
     }
 

--- a/backend/src/formats/rubygems.rs
+++ b/backend/src/formats/rubygems.rs
@@ -615,6 +615,25 @@ pub(crate) fn package_name_from_gem_filename(filename: &str) -> Option<String> {
     None
 }
 
+/// Split a stored gem filename (`<name>-<version>(-<platform>)?.gem`) into the
+/// `(name, version)` a spec-index client reconstructs the download filename
+/// from. Returns `None` when the basename does not follow the gem naming
+/// convention (an arbitrary bare-path object), so callers can fall back to the
+/// stored coordinate columns.
+///
+/// The spec indices carry `[name, version, platform]` and `gem install`
+/// reconstructs `{name}-{version}.gem`, which the download route resolves by
+/// filename suffix. Native pushes store `{name}/{version}/{name}-{version}.gem`,
+/// whose basename parses back to the same coordinates (byte-identical); a
+/// generic bare-path upload stores the whole basename as `name` and a
+/// `sha256-<prefix>` fallback `version`, so re-deriving from the filename keeps
+/// the advertised coordinate coherent with what the route can serve.
+pub(crate) fn coordinates_from_gem_filename(filename: &str) -> Option<(String, String)> {
+    RubygemsHandler::parse_gem_filename(filename)
+        .ok()
+        .map(|(name, version, _platform)| (name, version))
+}
+
 /// Validate a gem name. RubyGems names match `[A-Za-z0-9._-]+` and may
 /// not start with `.` or `-`. The shadowing guard lowercases via Postgres
 /// `LOWER()`, so we restrict to ASCII to avoid homoglyph attacks where
@@ -1885,6 +1904,33 @@ summary: A summary
             package_name_from_gem_filename("aws-sdk-s3-1.140.0.gem"),
             Some("aws-sdk-s3".to_string())
         );
+    }
+
+    // ------------------------------------------------------------------
+    // coordinates_from_gem_filename — spec-index download-URL coherence
+    // for bare-path generic uploads (#2754)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_coordinates_from_gem_filename_simple() {
+        assert_eq!(
+            coordinates_from_gem_filename("rails-7.0.8.gem"),
+            Some(("rails".to_string(), "7.0.8".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_coordinates_from_gem_filename_hyphenated_name() {
+        assert_eq!(
+            coordinates_from_gem_filename("aws-sdk-s3-1.140.0.gem"),
+            Some(("aws-sdk-s3".to_string(), "1.140.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_coordinates_from_gem_filename_not_a_gem() {
+        // Arbitrary bare-path object → no coordinates to derive.
+        assert_eq!(coordinates_from_gem_filename("archive.tar.gz"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to the #2589 / PR #2753 audit (which fixed the same class for `helm`).

CRAN and RubyGems advertise only **name / version** in their package indices
(CRAN `PACKAGES` DCF, RubyGems `specs.4.8.gz` Marshal); the client then
reconstructs the download filename itself — `{name}_{version}.tar.gz` for R's
`install.packages()`, `{name}-{version}.gem` for `gem install` — and GETs it
from the format's download route, which resolves artifacts by **filename
suffix**.

For a package published through the **generic chunked-upload flow** the artifact
is stored at its **bare filename** with the whole basename persisted as `name`
and a `sha256-<prefix>` **fallback version** (see
`upload.rs::completed_format_artifact_version`). Emitting those stored columns
made the client reconstruct e.g.
`mypkg_1.0.0.tar.gz_sha256-abcdef012345.tar.gz` /
`rails-7.0.8.gem-sha256-abcdef012345.gem` — a path the suffix-resolving download
route can never serve, so the package **404'd even though it was present and
directly downloadable**.

## Fix (serve-time, no migration — retroactive for existing bare-path uploads)

Advertise coordinates derived from the artifact's **actual stored filename**, so
the client's reconstruction matches what the download route serves:

- **CRAN** (`cran.rs`): new `source_index_coordinates(path, name, version)`
  re-derives `(package, version)` from the stored basename via
  `CranHandler::parse_path`, falling back to the stored columns when the
  basename is not a `{name}_{version}.tar.gz` package. `build_source_index` now
  selects `a.path` and uses it. Converted from the `query!` macro to a runtime
  `sqlx::query` (like the helm index builder) so the added column needs no
  offline-sqlx regeneration for the `Check Rust` gate.
- **RubyGems** (`rubygems.rs` + `formats/rubygems.rs`): new
  `coordinates_from_gem_filename` (reuses the existing gem-filename parser) plus
  a handler-side `spec_index_coordinates`; the three spec-index queries now
  select `path` and `query_gem_specs` derives the advertised `(name, version)`
  from it. Already a runtime query — no sqlx change.

For natively published packages the stored basename already equals
`{name}_{version}.tar.gz` / `{name}-{version}.gem`, so the emitted coordinates
are **byte-identical** to before. Only the bare-path generic uploads change.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates tests that would have caught the bug

Coverage that fails on `main` and passes here:
- **Unit** — `source_index_coordinates`, `spec_index_coordinates`,
  `coordinates_from_gem_filename`: native path → byte-identical coordinates;
  bare path with a `sha256-…` version → the derived name/version (with an
  explicit `assert_ne!` guard against the old broken fallback); non-package
  basename → falls back to stored columns.
- **Integration (DB-backed)** —
  `test_cran_index_coords_resolve_for_bare_path_generic_upload` and
  `test_rubygems_specs_coords_resolve_for_bare_path_generic_upload`: seed a
  bare-path artifact (bare path, generic `name`, `sha256-…` version), read the
  live `PACKAGES` / `specs.4.8.gz`, and assert the advertised coordinates are
  the resolvable ones and no longer carry the `sha256-…` fallback. Fail on
  `main`, pass here.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo build --lib --tests`, format unit tests)
- [x] No regressions in existing tests (cran + rubygems suites green)

## API Changes
- [x] N/A - no API changes

Closes #2754
