### PR TITLE
feat(backup): allow custom archive name when creating a backup

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -238,6 +238,12 @@ pub struct CreateBackupRequest {
     #[serde(rename = "type")]
     pub backup_type: Option<String>,
     pub repository_ids: Option<Vec<Uuid>>,
+    /// Optional custom name/label for the backup archive (#2790).
+    ///
+    /// When provided it becomes the identifying part of the archive
+    /// filename. Restricted to letters, digits, `.`, `_`, and `-`; when
+    /// omitted the archive keeps its default `{uuid}` name.
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -406,6 +412,7 @@ pub async fn create_backup(
             backup_type,
             repository_ids: payload.repository_ids,
             created_by: Some(auth.user_id),
+            name: payload.name,
         })
         .await?;
 
@@ -1766,6 +1773,20 @@ mod tests {
         let req: CreateBackupRequest = serde_json::from_value(json).unwrap();
         assert_eq!(req.backup_type, Some("incremental".to_string()));
         assert_eq!(req.repository_ids.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_create_backup_request_custom_name() {
+        let json = r#"{"type": "full", "name": "nightly-prod"}"#;
+        let req: CreateBackupRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, Some("nightly-prod".to_string()));
+    }
+
+    #[test]
+    fn test_create_backup_request_name_defaults_none() {
+        let json = r#"{"type": "full"}"#;
+        let req: CreateBackupRequest = serde_json::from_str(json).unwrap();
+        assert!(req.name.is_none());
     }
 
     #[test]

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -88,6 +88,12 @@ pub struct CreateBackupRequest {
     pub backup_type: BackupType,
     pub repository_ids: Option<Vec<Uuid>>,
     pub created_by: Option<Uuid>,
+    /// Optional operator-supplied name/label for the archive (#2790).
+    ///
+    /// When set it becomes the identifying part of the archive filename;
+    /// when `None` the historical `{uuid}` name is used, so existing
+    /// deployments are unaffected.
+    pub name: Option<String>,
 }
 
 /// Backup service
@@ -208,6 +214,58 @@ fn backup_storage_key(raw_prefix: Option<&str>, relative: &str) -> String {
     }
 }
 
+/// Maximum length of an operator-supplied backup name (before extension).
+const MAX_BACKUP_NAME_LEN: usize = 128;
+
+/// Resolve the base filename (including the `.tar.gz` extension) for a new
+/// backup archive (#2790).
+///
+/// When an operator supplies a custom `name` it is sanitized and used as the
+/// archive's identifying label, with a short unique suffix derived from
+/// `file_id` appended so two backups sharing a name can never resolve to the
+/// same storage key (which would silently overwrite the older archive). When
+/// no name is given the historical `{uuid}.tar.gz` name is preserved, so
+/// existing deployments are unaffected.
+///
+/// The custom name is restricted to `[A-Za-z0-9._-]`; anything containing a
+/// path separator, `..`, whitespace, or any other character is rejected
+/// rather than silently rewritten, so the name can never escape the
+/// `backups/` prefix or smuggle in a traversal sequence.
+fn resolve_backup_filename(name: Option<&str>, file_id: Uuid) -> Result<String> {
+    let Some(raw) = name else {
+        return Ok(format!("{}.tar.gz", file_id));
+    };
+
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Validation(
+            "Backup name must not be empty".to_string(),
+        ));
+    }
+    if trimmed.len() > MAX_BACKUP_NAME_LEN {
+        return Err(AppError::Validation(format!(
+            "Backup name must be at most {} characters",
+            MAX_BACKUP_NAME_LEN
+        )));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(AppError::Validation(
+            "Backup name must not be '.' or '..'".to_string(),
+        ));
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err(AppError::Validation(
+            "Backup name may only contain letters, digits, '.', '_', and '-'".to_string(),
+        ));
+    }
+
+    let suffix = file_id.simple().to_string();
+    Ok(format!("{}-{}.tar.gz", trimmed, &suffix[..8]))
+}
+
 /// Count entries under the `artifacts/` prefix in a tar.gz archive.
 fn count_artifacts_in_tar(tar_data: &[u8]) -> Result<i64> {
     let decoder = GzDecoder::new(tar_data);
@@ -242,13 +300,11 @@ impl BackupService {
     /// Create a new backup job
     pub async fn create(&self, req: CreateBackupRequest) -> Result<Backup> {
         let prefix = std::env::var("BACKUP_S3_PREFIX").ok();
+        let file_id = Uuid::new_v4();
+        let filename = resolve_backup_filename(req.name.as_deref(), file_id)?;
         let storage_path = backup_storage_key(
             prefix.as_deref(),
-            &format!(
-                "backups/{}/{}.tar.gz",
-                Utc::now().format("%Y/%m/%d"),
-                Uuid::new_v4()
-            ),
+            &format!("backups/{}/{}", Utc::now().format("%Y/%m/%d"), filename),
         );
 
         let backup = sqlx::query_as!(
@@ -268,6 +324,7 @@ impl BackupService {
             req.created_by,
             serde_json::json!({
                 "repository_ids": req.repository_ids,
+                "name": req.name,
             })
         )
         .fetch_one(&self.db)
@@ -1438,6 +1495,7 @@ mod tests {
             backup_type: BackupType::Full,
             repository_ids: Some(vec![Uuid::new_v4()]),
             created_by: Some(Uuid::new_v4()),
+            name: None,
         };
         assert_eq!(req.backup_type, BackupType::Full);
         assert!(req.repository_ids.is_some());
@@ -1450,10 +1508,91 @@ mod tests {
             backup_type: BackupType::Metadata,
             repository_ids: None,
             created_by: None,
+            name: None,
         };
         assert_eq!(req.backup_type, BackupType::Metadata);
         assert!(req.repository_ids.is_none());
         assert!(req.created_by.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_backup_filename tests (#2790)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_backup_filename_default_preserves_uuid_name() {
+        let id = Uuid::new_v4();
+        let name = resolve_backup_filename(None, id).unwrap();
+        // Default (no custom name) preserves the historical `{uuid}.tar.gz`.
+        assert_eq!(name, format!("{}.tar.gz", id));
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_custom_name_honored() {
+        let id = Uuid::new_v4();
+        let name = resolve_backup_filename(Some("nightly-prod"), id).unwrap();
+        assert!(
+            name.starts_with("nightly-prod-"),
+            "custom label should lead the filename: {name}"
+        );
+        assert!(name.ends_with(".tar.gz"), "must keep the extension: {name}");
+        // A unique suffix is appended so distinct backups never collide.
+        let suffix = id.simple().to_string();
+        assert_eq!(name, format!("nightly-prod-{}.tar.gz", &suffix[..8]));
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_trims_whitespace() {
+        let id = Uuid::new_v4();
+        let name = resolve_backup_filename(Some("  release  "), id).unwrap();
+        assert!(name.starts_with("release-"), "should be trimmed: {name}");
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_unique_per_id() {
+        let a = resolve_backup_filename(Some("weekly"), Uuid::new_v4()).unwrap();
+        let b = resolve_backup_filename(Some("weekly"), Uuid::new_v4()).unwrap();
+        assert_ne!(a, b, "same label + different id must not collide");
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_rejects_path_separator() {
+        let id = Uuid::new_v4();
+        assert!(resolve_backup_filename(Some("a/b"), id).is_err());
+        assert!(resolve_backup_filename(Some("a\\b"), id).is_err());
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_rejects_traversal() {
+        let id = Uuid::new_v4();
+        assert!(resolve_backup_filename(Some(".."), id).is_err());
+        assert!(resolve_backup_filename(Some("../etc/passwd"), id).is_err());
+        assert!(resolve_backup_filename(Some("."), id).is_err());
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_rejects_empty_and_blank() {
+        let id = Uuid::new_v4();
+        assert!(resolve_backup_filename(Some(""), id).is_err());
+        assert!(resolve_backup_filename(Some("   "), id).is_err());
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_rejects_unsafe_chars() {
+        let id = Uuid::new_v4();
+        // Spaces, control chars, and shell/path metacharacters are rejected.
+        assert!(resolve_backup_filename(Some("my backup"), id).is_err());
+        assert!(resolve_backup_filename(Some("name;rm -rf"), id).is_err());
+        assert!(resolve_backup_filename(Some("null\0byte"), id).is_err());
+    }
+
+    #[test]
+    fn test_resolve_backup_filename_rejects_overlong() {
+        let id = Uuid::new_v4();
+        let long = "a".repeat(MAX_BACKUP_NAME_LEN + 1);
+        assert!(resolve_backup_filename(Some(&long), id).is_err());
+        let ok = "a".repeat(MAX_BACKUP_NAME_LEN);
+        assert!(resolve_backup_filename(Some(&ok), id).is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -905,6 +905,7 @@ async fn execute_due_backup_schedules(db: &PgPool, config: &Config) -> crate::er
                 backup_type: schedule_row.backup_type,
                 repository_ids: schedule_row.include_repositories.clone(),
                 created_by: None, // system-initiated
+                name: None,       // scheduled backups keep the default {uuid} name
             })
             .await;
 


### PR DESCRIPTION
Closes #2790

## Summary

Operators can now supply a custom name/label for a backup archive when
creating a backup, instead of every archive being named with a fixed
`{uuid}.tar.gz`. Requested by a customer (Jon Craig, AK 1.6.0) — this is the
naming piece of the backup-usability work (repository exclusion + run-via-API
are tracked separately in #2772).

What changed:
- `POST /api/v1/admin/backups` accepts an optional `name` field. When present
  it becomes the identifying part of the archive filename
  (`backups/YYYY/MM/DD/{name}-{shortid}.tar.gz`) and is also recorded in the
  backup's `metadata`. When omitted, the archive keeps its historical
  `{uuid}.tar.gz` name, so existing deployments and scheduled backups are
  unaffected.
- The name is validated/sanitized: restricted to `[A-Za-z0-9._-]`; empty,
  overlong (>128 chars), `.`/`..`, path separators (`/`, `\`), whitespace, and
  control characters are rejected with a 400 rather than silently rewritten, so
  a name can never escape the `backups/` prefix or smuggle in a traversal
  sequence.
- A short unique suffix (derived from a fresh UUID) is appended to the custom
  name so two backups sharing a label never resolve to the same storage key
  (which would silently overwrite the older archive).

Scope note: scheduled backups continue to use the default `{uuid}` name — the
schedule's free-form display name is not a filesystem-safe token and forcing it
through the sanitizer could break existing schedules; wiring per-schedule custom
names cleanly is out of scope for this issue.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New unit tests cover: default name preserved, custom name honored (leading
label + extension + unique suffix), whitespace trimming, uniqueness per id,
rejection of path separators / `..` / `.` / empty / blank / unsafe chars /
overlong input, and handler-side deserialization of the new field.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations (existing endpoint;
  request type already annotated)
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no migration
- [ ] N/A - no API changes

Backward compatible: the new request field is optional and defaults to the
prior behavior.