### PR TITLE
feat(sso): expose OIDC provider toggles as env vars for bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,9 @@ JWT_EXPIRATION_SECS=86400
 #   OIDC_USERNAME_CLAIM: ${OIDC_USERNAME_CLAIM:-}
 #   OIDC_EMAIL_CLAIM: ${OIDC_EMAIL_CLAIM:-}
 #   OIDC_ADMIN_GROUP: ${OIDC_ADMIN_GROUP:-}
+#   OIDC_MAP_GROUPS_TO_GROUPS: ${OIDC_MAP_GROUPS_TO_GROUPS:-}
+#   OIDC_AUTO_CREATE_USERS: ${OIDC_AUTO_CREATE_USERS:-}
+#   OIDC_PKCE_ENABLED: ${OIDC_PKCE_ENABLED:-}
 
 # To enable OIDC, OIDC_ISSUER, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET are required.
 # OIDC_ISSUER=https://auth.example.com
@@ -272,6 +275,15 @@ JWT_EXPIRATION_SECS=86400
 # OIDC_ADMIN_GROUP=artifact-admins
 # OIDC_DEFAULT_ROLE=user
 # OIDC_GROUP_ROLE_MAP=engineers:user;security-team:viewer
+# Reflect OIDC group claims as local Artifact Keeper groups (UI toggle #1879).
+# Accepts true/1 or false/0; defaults to false (off) when unset.
+# OIDC_MAP_GROUPS_TO_GROUPS=false
+# Auto-provision users on first OIDC login. Accepts true/1 or false/0;
+# defaults to true when unset.
+# OIDC_AUTO_CREATE_USERS=true
+# Enable PKCE (S256) on the authorization request. Accepts true/1 or false/0;
+# defaults to true (backend default) when unset.
+# OIDC_PKCE_ENABLED=true
 
 # --- LDAP (optional) ---
 # When LDAP_URL and LDAP_BASE_DN are set, the backend seeds an enabled LDAP

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1497,6 +1497,9 @@ struct OidcEnvVars {
     redirect_uri: Option<String>,
     username_claim: Option<String>,
     email_claim: Option<String>,
+    map_groups_to_groups: Option<String>,
+    auto_create_users: Option<String>,
+    pkce_enabled: Option<String>,
 }
 
 /// Build a CreateOidcConfigRequest from OIDC_* environment variables.
@@ -1513,6 +1516,9 @@ fn build_oidc_bootstrap_request(
         redirect_uri: std::env::var("OIDC_REDIRECT_URI").ok(),
         username_claim: std::env::var("OIDC_USERNAME_CLAIM").ok(),
         email_claim: std::env::var("OIDC_EMAIL_CLAIM").ok(),
+        map_groups_to_groups: std::env::var("OIDC_MAP_GROUPS_TO_GROUPS").ok(),
+        auto_create_users: std::env::var("OIDC_AUTO_CREATE_USERS").ok(),
+        pkce_enabled: std::env::var("OIDC_PKCE_ENABLED").ok(),
     })
 }
 
@@ -1554,6 +1560,17 @@ fn build_oidc_request_from_values(
         attr_map.insert("email_claim".into(), serde_json::Value::String(claim));
     }
 
+    // Provider toggles configurable via env for GitOps/disconnected deploys
+    // (#2792). Absent vars preserve the prior bootstrap defaults so existing
+    // deployments are unaffected: `auto_create_users` stays on, while
+    // `map_groups_to_groups` (#1879, pairs with #2781) and `pkce_enabled` fall
+    // through to the service-layer create defaults (false / true respectively).
+    // Accepts "true"/"1" (case-sensitive, mirroring the LDAP bootstrap).
+    let env_flag = |v: String| v == "true" || v == "1";
+    let map_groups_to_groups = env.map_groups_to_groups.map(env_flag);
+    let pkce_enabled = env.pkce_enabled.map(env_flag);
+    let auto_create_users = Some(env.auto_create_users.map(env_flag).unwrap_or(true));
+
     Some(CreateOidcConfigRequest {
         name,
         issuer_url: issuer,
@@ -1562,9 +1579,9 @@ fn build_oidc_request_from_values(
         scopes,
         attribute_mapping: Some(serde_json::Value::Object(attr_map)),
         is_enabled: Some(true),
-        auto_create_users: Some(true),
-        pkce_enabled: None,
-        map_groups_to_groups: None,
+        auto_create_users,
+        pkce_enabled,
+        map_groups_to_groups,
         allow_legacy_rsa_keys: None,
     })
 }
@@ -2382,6 +2399,115 @@ mod tests {
     }
 
     #[test]
+    fn test_bootstrap_request_default_toggles() {
+        // With none of the toggle env vars set, the bootstrap request preserves
+        // the historical defaults: auto_create_users forced on, and
+        // map_groups_to_groups / pkce_enabled left to the service-layer create
+        // defaults (None -> false / true respectively) (#2792).
+        let req = build_oidc_request_from_values(env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        ))
+        .unwrap();
+
+        assert_eq!(req.auto_create_users, Some(true));
+        assert_eq!(req.map_groups_to_groups, None);
+        assert_eq!(req.pkce_enabled, None);
+    }
+
+    #[test]
+    fn test_bootstrap_request_map_groups_to_groups_enabled() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.map_groups_to_groups = Some("true".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.map_groups_to_groups, Some(true));
+    }
+
+    #[test]
+    fn test_bootstrap_request_map_groups_to_groups_numeric_true() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.map_groups_to_groups = Some("1".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.map_groups_to_groups, Some(true));
+    }
+
+    #[test]
+    fn test_bootstrap_request_map_groups_to_groups_disabled() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.map_groups_to_groups = Some("false".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.map_groups_to_groups, Some(false));
+    }
+
+    #[test]
+    fn test_bootstrap_request_auto_create_users_override() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.auto_create_users = Some("false".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.auto_create_users, Some(false));
+    }
+
+    #[test]
+    fn test_bootstrap_request_auto_create_users_explicit_true() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.auto_create_users = Some("1".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.auto_create_users, Some(true));
+    }
+
+    #[test]
+    fn test_bootstrap_request_pkce_enabled_override() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.pkce_enabled = Some("false".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.pkce_enabled, Some(false));
+    }
+
+    #[test]
+    fn test_bootstrap_request_pkce_enabled_true() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.pkce_enabled = Some("true".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.pkce_enabled, Some(true));
+    }
+
+    #[test]
     fn test_bootstrap_request_all_optional_fields() {
         let req = build_oidc_request_from_values(OidcEnvVars {
             name: Some("Corporate OIDC".into()),
@@ -2393,6 +2519,7 @@ mod tests {
             redirect_uri: Some("https://app.corp.com/sso/callback".into()),
             username_claim: Some("samaccountname".into()),
             email_claim: Some("mail".into()),
+            ..Default::default()
         })
         .unwrap();
 


### PR DESCRIPTION
## Summary

Exposes three OIDC provider toggles as environment variables in the env
bootstrap path (`bootstrap_oidc_from_env` / `build_oidc_request_from_values`),
so operators can configure them for GitOps and disconnected/air-gapped deploys
without first reaching the admin API or UI. Mirrors the existing `OIDC_*`
env conventions (e.g. `OIDC_GROUPS_CLAIM`, `OIDC_USERNAME_CLAIM`) and the
LDAP bootstrap's boolean parsing.

New env vars:

| Env var | Maps to | Default when unset |
| --- | --- | --- |
| `OIDC_MAP_GROUPS_TO_GROUPS` | `map_groups_to_groups` | `false` (service-layer create default) |
| `OIDC_AUTO_CREATE_USERS` | `auto_create_users` | `true` (preserves prior hardcoded bootstrap value) |
| `OIDC_PKCE_ENABLED` | `pkce_enabled` | `true` (service-layer create default) |

The primary ask is `OIDC_MAP_GROUPS_TO_GROUPS` — the "Map OIDC groups to
local groups" toggle that was previously UI-only (#1879) — for env-driven
enablement (pairs with the group-sync work in #2781 / #2831). The other two
close out the remaining bootstrap toggles that were hardcoded and therefore
not overridable via env.

Booleans accept `true`/`1` (case-sensitive), matching the existing LDAP
`use_starttls` bootstrap parsing. Absent vars preserve the prior bootstrap
behavior exactly, so current deployments are unaffected.

### Scope notes
- `admin_group` is already env-reachable at runtime via the existing
  `OIDC_ADMIN_GROUP` fallback in the OIDC callback, so it is intentionally not
  re-wired here.
- `allow_legacy_rsa_keys` is deliberately left out of the env surface: it is a
  security-below-baseline compatibility flag (sub-2048-bit RSA) and not
  appropriate to toggle via routine GitOps config.
- `groups_claim`, `username_claim`, `email_claim`, `redirect_uri`, `scopes`,
  and `name` were already env-configurable and are unchanged.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix (enhancement: `feat/*`)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added bootstrap unit tests (in `backend/src/main.rs`) covering set and unset
cases for each new var: `test_bootstrap_request_default_toggles`,
`test_bootstrap_request_map_groups_to_groups_{enabled,numeric_true,disabled}`,
`test_bootstrap_request_auto_create_users_{override,explicit_true}`,
`test_bootstrap_request_pkce_enabled_{override,true}`. Full bootstrap suite
(37 tests) green; `SQLX_OFFLINE=true cargo build --lib --tests`, `cargo fmt
--check`, and `cargo clippy` all clean.

## API Changes
- [x] N/A - no API changes

Config-only: reuses the existing `CreateOidcConfigRequest` fields
(`map_groups_to_groups`, `auto_create_users`, `pkce_enabled`) and their
service-layer create/update handling. No schema, migration, or endpoint
changes. `.env.example` updated to document the new vars.

Closes #2792
