### PR TITLE
test: isolate proxy quarantine LRU key + pin npm scope-policy row collation (#2758)

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -9730,11 +9730,18 @@ mod tests {
             .expect("connect_lazy should not fail");
         let state = db_helpers::build_state_presigned(pool, "s3-test", registry_storage.clone());
 
+        // Unique coordinate per test: `proxy_fetch_or_redirect` gates on
+        // `cache_quarantine_gate`, which reads through the process-global
+        // `PROXY_METADATA_LRU` keyed by `proxy-cache/<repo_key>/<path>/…`. A shared
+        // literal coordinate lets the held/not-held siblings poison each other's
+        // LRU entry under in-process `cargo test` parallelism; a per-test key
+        // isolates it (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         let err = super::proxy_fetch_or_redirect(
             &proxy,
             &state,
             Uuid::nil(),
-            "npm-proxy",
+            &repo_key,
             "https://upstream.example.test",
             "lodash",
         )
@@ -9765,11 +9772,13 @@ mod tests {
             .expect("connect_lazy should not fail");
         let state = db_helpers::build_state_presigned(pool, "s3-test", registry_storage.clone());
 
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         let resp = super::proxy_fetch_or_redirect(
             &proxy,
             &state,
             Uuid::nil(),
-            "npm-proxy",
+            &repo_key,
             "https://upstream.example.test",
             "lodash",
         )

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -12970,9 +12970,15 @@ mod tests {
 
         // The rows landed in repository_config under the documented keys.
         let stored: Vec<(String, String)> = sqlx::query_as(
+            // `ORDER BY key COLLATE "C"` pins byte-order sorting so the asserted
+            // row order is deterministic regardless of the database's default
+            // collation. A locale-aware default (e.g. en_US.UTF-8) treats the
+            // underscore as ignorable punctuation and would order
+            // `npm_allowed_scopes` before `npm_allow_unscoped`, flipping the
+            // expected vec under a throwaway-Postgres locale (#2758).
             "SELECT key, value FROM repository_config \
              WHERE repository_id = $1 AND key IN ('npm_allowed_scopes', 'npm_allow_unscoped') \
-             ORDER BY key",
+             ORDER BY key COLLATE \"C\"",
         )
         .bind(repo_id)
         .fetch_all(&pool)

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -7244,8 +7244,16 @@ mod tests {
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
+        // Unique coordinate per test: `cache_quarantine_gate` reads through the
+        // process-global `PROXY_METADATA_LRU`, keyed by the derived metadata key
+        // (`proxy-cache/<repo_key>/<path>/__cache_meta__.json`). A shared literal
+        // coordinate lets one quarantine-gate test's cached sidecar poison a peer
+        // running concurrently in the same process (in-process `cargo test`
+        // parallelism); a per-test key isolates the LRU entry (#2758). Mirrors the
+        // `format!("maven-central-{}", Uuid::new_v4())` pattern used elsewhere.
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         let err = service
-            .cache_quarantine_gate("npm-proxy", "lodash")
+            .cache_quarantine_gate(&repo_key, "lodash")
             .await
             .expect_err("an active hold must block the redirect fast path");
         match err {
@@ -7263,9 +7271,11 @@ mod tests {
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate(&repo_key, "lodash")
                 .await
                 .is_ok(),
             "an elapsed hold must not block the redirect"
@@ -7280,9 +7290,11 @@ mod tests {
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate(&repo_key, "lodash")
                 .await
                 .is_ok(),
             "a sidecar with no hold must not block the redirect"
@@ -7294,9 +7306,11 @@ mod tests {
         let mock = Arc::new(CacheFreshMock::new(/* metadata = */ None, true));
         let service = build_proxy_service_with_storage(mock.clone());
 
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate(&repo_key, "lodash")
                 .await
                 .is_ok(),
             "a missing sidecar means no hold known -> allow"
@@ -7314,9 +7328,11 @@ mod tests {
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate(&repo_key, "lodash")
                 .await
                 .is_ok(),
             "a sidecar read/parse error must be treated as no hold known"


### PR DESCRIPTION
## Summary

Fixes two pre-existing test-hygiene flakes reported by multiple 1.7.0 workers. Both pass solo and under `cargo nextest` (process-per-test) but fail under plain `cargo test --workspace --lib` (in-process thread parallelism) or under a locale-aware throwaway Postgres — which is why CI (nextest) never saw them.

**1. Proxy quarantine/hold tests shared a process-global cache key.**
`ProxyService::cache_quarantine_gate` (and `proxy_fetch_or_redirect`, which calls it) reads sidecar metadata through the process-global `PROXY_METADATA_LRU` — a moka cache with a 30s TTL and single-flight `try_get_with`, keyed by the derived metadata key `proxy-cache/<repo_key>/<path>/__cache_meta__.json`. Every quarantine-gate and redirect test used the identical literal coordinate (`npm-proxy` / `lodash`), so the first test to populate the LRU for that key handed its own mock's sidecar value to every concurrent peer that read the same key within the TTL window. Whichever test won the race decided the others' outcome — a held-hold sidecar poisoning a no-hold assertion, and vice versa.

Fix: give each affected test a unique `repo_key` (`format!("npm-proxy-{}", Uuid::new_v4())`), mirroring the existing `format!("maven-central-{}", Uuid::new_v4())` pattern already used elsewhere in the same test module to isolate the LRU. The mocks return their metadata based only on the key suffix, so the coordinate change only affects LRU isolation — no behavioral change.

Affected tests:
- `services::proxy_service` — `test_cache_quarantine_gate_blocks_when_hold_active`, `..._allows_when_hold_elapsed`, `..._allows_when_no_hold`, `..._allows_when_sidecar_missing`, `..._allows_on_sidecar_read_error`
- `api::handlers::proxy_helpers` — `test_proxy_fetch_or_redirect_blocks_held_entry_2075`, `test_proxy_fetch_or_redirect_redirects_when_not_held_2075`

**2. `npm_scope_policy_put_get_round_trip_db` asserted a locale-sensitive row order.**
The stored-rows assertion used `ORDER BY key`. On a cluster whose default collation is locale-aware (e.g. `en_US.UTF-8`), the underscore is treated as ignorable punctuation, so `key` sorts `npm_allowed_scopes` before `npm_allow_unscoped` (comparing `...allowedscopes` vs `...allowunscoped`), flipping the expected `Vec`. A C-locale throwaway Postgres happens to pass. Fix: pin byte-order sorting with `ORDER BY key COLLATE "C"`, making the assertion deterministic regardless of the database's default collation.

Test-only change; no product code is touched.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

The changed tests themselves are the regression coverage. Verified failing on `main` and passing on this branch:
- Proxy tests: on `main`, 16-thread in-process runs of the 7 tests fail 2–5 per run non-deterministically; on this branch they pass 8/8 runs.
- npm test: on `main`, against an `en_US.UTF-8` Postgres it fails with `left: [npm_allowed_scopes, npm_allow_unscoped]` / `right: [npm_allow_unscoped, npm_allowed_scopes]`; on this branch it passes.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2758
