### PR TITLE
fix(nuget): resolve remote-proxy v3 upstream URLs from the service index

### DIFF
--- a/backend/src/formats/nuget.rs
+++ b/backend/src/formats/nuget.rs
@@ -170,6 +170,83 @@ impl NugetHandler {
         id.to_lowercase()
     }
 
+    /// Map an AK-normalized NuGet v3 request path to the **upstream** URL, using
+    /// the upstream feed's own service index to discover its resource base URLs.
+    ///
+    /// NuGet v3 is non-uniform: the configured `upstream_url` is the *service
+    /// index*, and the real `PackageBaseAddress` (flat-container) and
+    /// `RegistrationsBaseUrl` bases are listed *inside* it and differ per feed
+    /// (e.g. nuget.org serves flat-container at `/v3-flatcontainer/` and
+    /// registration at `/v3/registration5-*/`). Naively appending the request
+    /// path to `upstream_url` produces `.../v3/index.json/v3/flatcontainer/...`
+    /// which the upstream rejects with 400 (surfaced to the client as 502).
+    /// Resolving the bases from the service index fixes it for any conformant
+    /// v3 feed instead of hard-coding nuget.org's layout.
+    pub fn resolve_upstream_url(
+        service_index: &ServiceIndex,
+        upstream_url: &str,
+        ak_path: &str,
+    ) -> Result<String> {
+        let path = ak_path.trim_start_matches('/');
+
+        // The service index itself is fetched from the configured upstream URL.
+        if path == "v3/index.json" || path == "index.json" {
+            return Ok(upstream_url.to_string());
+        }
+
+        // Flat-container: package versions listing + package content (.nupkg).
+        for prefix in ["v3/flatcontainer/", "v3-flatcontainer/", "flatcontainer/"] {
+            if let Some(rest) = path.strip_prefix(prefix) {
+                let base =
+                    Self::resource_base(service_index, "PackageBaseAddress").ok_or_else(|| {
+                        AppError::BadGateway(
+                            "upstream NuGet service index has no PackageBaseAddress resource"
+                                .to_string(),
+                        )
+                    })?;
+                return Ok(format!("{}/{}", base.trim_end_matches('/'), rest));
+            }
+        }
+
+        // Registration: package + version registration.
+        for prefix in ["v3/registration/", "registration/"] {
+            if let Some(rest) = path.strip_prefix(prefix) {
+                let base = Self::resource_base(service_index, "RegistrationsBaseUrl").ok_or_else(
+                    || {
+                        AppError::BadGateway(
+                            "upstream NuGet service index has no RegistrationsBaseUrl resource"
+                                .to_string(),
+                        )
+                    },
+                )?;
+                return Ok(format!("{}/{}", base.trim_end_matches('/'), rest));
+            }
+        }
+
+        // Unknown path shape: fall back to joining against the feed root (the
+        // configured URL with a trailing `index.json` stripped).
+        let root = upstream_url
+            .trim_end_matches('/')
+            .trim_end_matches("index.json")
+            .trim_end_matches('/');
+        Ok(format!("{}/{}", root, path))
+    }
+
+    /// Base URL of the service-index resource whose `@type` starts with
+    /// `type_prefix`, preferring the plainest variant (no gzip / SemVer2, checked
+    /// across both `@type` and `@id`) for the widest client compatibility.
+    fn resource_base<'a>(index: &'a ServiceIndex, type_prefix: &str) -> Option<&'a str> {
+        index
+            .resources
+            .iter()
+            .filter(|r| r.resource_type.starts_with(type_prefix))
+            .min_by_key(|r| {
+                let s = format!("{} {}", r.resource_type, r.id).to_lowercase();
+                (s.contains("gz") as u8, s.contains("semver2") as u8)
+            })
+            .map(|r| r.id.as_str())
+    }
+
     /// Extract nuspec from nupkg file
     pub fn extract_nuspec(content: &[u8]) -> Result<NuSpec> {
         let cursor = std::io::Cursor::new(content);
@@ -529,6 +606,93 @@ pub struct CatalogEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- resolve_upstream_url (remote-proxy v3 resolution) ----
+
+    fn nuget_org_index() -> ServiceIndex {
+        ServiceIndex {
+            version: "3.0.0".to_string(),
+            resources: vec![
+                ServiceResource {
+                    id: "https://api.nuget.org/v3-flatcontainer/".to_string(),
+                    resource_type: "PackageBaseAddress/3.0.0".to_string(),
+                    comment: None,
+                },
+                ServiceResource {
+                    id: "https://api.nuget.org/v3/registration5-semver1/".to_string(),
+                    resource_type: "RegistrationsBaseUrl".to_string(),
+                    comment: None,
+                },
+                ServiceResource {
+                    id: "https://api.nuget.org/v3/registration5-gz-semver2/".to_string(),
+                    resource_type: "RegistrationsBaseUrl/3.6.0".to_string(),
+                    comment: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_resolve_upstream_url_flatcontainer() {
+        let idx = nuget_org_index();
+        let up = "https://api.nuget.org/v3/index.json";
+        assert_eq!(
+            NugetHandler::resolve_upstream_url(
+                &idx,
+                up,
+                "v3/flatcontainer/newtonsoft.json/index.json"
+            )
+            .unwrap(),
+            "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json"
+        );
+        assert_eq!(
+            NugetHandler::resolve_upstream_url(
+                &idx,
+                up,
+                "v3/flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg"
+            )
+            .unwrap(),
+            "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_url_registration_prefers_plain() {
+        let idx = nuget_org_index();
+        let up = "https://api.nuget.org/v3/index.json";
+        // Prefer the non-gzip / non-SemVer2 registration base for compatibility.
+        assert_eq!(
+            NugetHandler::resolve_upstream_url(
+                &idx,
+                up,
+                "v3/registration/newtonsoft.json/index.json"
+            )
+            .unwrap(),
+            "https://api.nuget.org/v3/registration5-semver1/newtonsoft.json/index.json"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_url_service_index_passthrough() {
+        let idx = nuget_org_index();
+        let up = "https://api.nuget.org/v3/index.json";
+        assert_eq!(
+            NugetHandler::resolve_upstream_url(&idx, up, "v3/index.json").unwrap(),
+            up
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_url_missing_resource_is_bad_gateway() {
+        let idx = ServiceIndex {
+            version: "3.0.0".to_string(),
+            resources: vec![],
+        };
+        let up = "https://api.nuget.org/v3/index.json";
+        assert!(
+            NugetHandler::resolve_upstream_url(&idx, up, "v3/flatcontainer/x/index.json").is_err()
+        );
+    }
 
     // ---- NugetHandler::new / Default ----
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2636,7 +2636,9 @@ impl ProxyService {
                 Ok(cached)
             },
             || async {
-                let full_url = Self::build_upstream_url(upstream_url, fetch_path);
+                let full_url = self
+                    .nuget_aware_upstream_url(repo, upstream_url, fetch_path)
+                    .await?;
                 let upstream_result = self
                     .fetch_from_upstream_with_accept(&full_url, repo.id, accept, max)
                     .await;
@@ -3220,7 +3222,9 @@ impl ProxyService {
         }
 
         let upstream_url = Self::remote_target(repo)?;
-        let full_url = Self::build_upstream_url(upstream_url, fetch_path);
+        let full_url = self
+            .nuget_aware_upstream_url(repo, upstream_url, fetch_path)
+            .await?;
         let upstream = match self.fetch_from_upstream_streaming(&full_url, repo.id).await {
             Ok(upstream) => upstream,
             Err(err) => {
@@ -4245,6 +4249,62 @@ impl ProxyService {
         let base = base_url.trim_end_matches('/');
         let path = path.trim_start_matches('/');
         format!("{}/{}", base, path)
+    }
+
+    /// NuGet-aware upstream URL resolution.
+    ///
+    /// The generic [`Self::build_upstream_url`] appends the request path to the
+    /// configured `upstream_url`. That is correct for uniform formats (Maven,
+    /// generic) but wrong for NuGet v3: the configured `upstream_url` is the
+    /// *service index*, and the real `PackageBaseAddress` / `RegistrationsBaseUrl`
+    /// bases live inside it and differ per feed (nuget.org: `/v3-flatcontainer/`,
+    /// `/v3/registration5-*/`). A naive append yields
+    /// `.../v3/index.json/v3/flatcontainer/...` → upstream 400 → 502.
+    ///
+    /// For NuGet-family repos this fetches the upstream service index and maps
+    /// the AK-normalized path onto the upstream's resource bases (see
+    /// [`crate::formats::nuget::NugetHandler::resolve_upstream_url`]). All other
+    /// formats fall through to the generic join unchanged.
+    ///
+    /// NOTE: the service index is fetched per request. nuget.org's index is
+    /// small and CDN-cached, so this is acceptable for correctness; caching the
+    /// parsed index per repo is a worthwhile follow-up.
+    async fn nuget_aware_upstream_url(
+        &self,
+        repo: &Repository,
+        upstream_url: &str,
+        fetch_path: &str,
+    ) -> Result<String> {
+        if !matches!(
+            repo.format,
+            RepositoryFormat::Nuget | RepositoryFormat::Chocolatey | RepositoryFormat::Powershell
+        ) {
+            return Ok(Self::build_upstream_url(upstream_url, fetch_path));
+        }
+
+        let path = fetch_path.trim_start_matches('/');
+        // The service index itself is served from the configured upstream URL.
+        if path == "v3/index.json" || path == "index.json" {
+            return Ok(upstream_url.to_string());
+        }
+
+        // The service index is small metadata; bound it with the metadata ceiling.
+        let resp = self
+            .fetch_from_upstream_with_accept(
+                upstream_url,
+                repo.id,
+                None,
+                DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await?;
+        let index: crate::formats::nuget::ServiceIndex = serde_json::from_slice(&resp.content)
+            .map_err(|e| {
+                AppError::BadGateway(format!(
+                    "failed to parse upstream NuGet service index at {}: {}",
+                    upstream_url, e
+                ))
+            })?;
+        crate::formats::nuget::NugetHandler::resolve_upstream_url(&index, upstream_url, fetch_path)
     }
 
     /// Generate storage key for cached artifact content.


### PR DESCRIPTION
Fixes #2859.

## What

A NuGet remote (proxy) repo pointed at nuget.org returned **502** for every package because the generic `ProxyService::build_upstream_url` appends the request path to the configured `upstream_url` (the v3 service index), producing `…/v3/index.json/v3/flatcontainer/…` → upstream 400 → 502. NuGet v3 is **non-uniform**: `PackageBaseAddress` (flat-container) and `RegistrationsBaseUrl` live *inside* the service index and differ per feed (nuget.org: `/v3-flatcontainer/`, `/v3/registration5-*/`).

## Change

- **`NugetHandler::resolve_upstream_url(&ServiceIndex, upstream_url, ak_path)`** (`formats/nuget.rs`) — maps an AK-normalized v3 path onto the resource base URLs discovered from the upstream service index (works for any conformant v3 feed, not just nuget.org). Prefers the plainest registration variant (no gzip / SemVer2) for widest compatibility. Unit-tested (flat-container, registration, service-index passthrough, missing-resource → `BadGateway`).
- **`ProxyService::nuget_aware_upstream_url(...)`** (`services/proxy_service.rs`) — for `Nuget`/`Chocolatey`/`Powershell` repos, fetches + parses the upstream service index and calls the resolver; all other formats fall through to the generic join unchanged. Wired into the two primary fetch paths:
  - buffered metadata (`fetch_artifact_with_cache_path_and_accept_capped`)
  - streaming content (`open_streaming_leader`)

Together these make `dotnet restore` resolve versions **and** download `.nupkg`s through the proxy.

## Notes / follow-ups

- The upstream service index is fetched **per request** (bounded by `DEFAULT_METADATA_MAX_BYTES`). nuget.org's index is small and CDN-cached, so this is fine for correctness; caching the parsed index per repo is a worthwhile follow-up.
- Remaining `build_upstream_url` call sites on revalidation/direct paths (`check_upstream`, `fetch_upstream_direct`, `fetch_upstream_direct_with_link`, `revalidate_verdict`) still use the generic join. The two hooked paths cover a normal restore; these can get the same one-line `nuget_aware_upstream_url` treatment for full revalidation correctness — happy to fold that in.
- Registration is proxied by URL only; nuget.org's gzip/SemVer2 registration payloads embed absolute upstream `@id`s (no rewrite to the AK feed here). Flat-container — which `dotnet restore` primarily uses — is fully correct.

## Verification

⚠️ **I could not compile this locally** (no Rust toolchain in my environment) — please run CI. The resolver is covered by the added unit tests; the proxy wiring follows the existing `build_upstream_url` call pattern.
