### PR TITLE
fix(formats): advertise stored basename in ansible/puppet/rubygems on-demand metadata download URLs

### DIFF
--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -232,8 +232,12 @@ async fn collection_info(
             repo_key, namespace, name
         ),
         "download_url": format!(
-            "/ansible/{}/download/{}-{}-{}.tar.gz",
-            repo_key, namespace, name, latest_version
+            "/ansible/{}/download/{}",
+            repo_key,
+            proxy_helpers::served_download_filename(
+                &artifact.path,
+                &format!("{}-{}-{}.tar.gz", namespace, name, latest_version)
+            )
         ),
     });
 
@@ -322,16 +326,20 @@ async fn version_info(
     .unwrap_or(Some(0))
     .unwrap_or(0);
 
+    // Advertise the stored basename so the suffix-matching download route
+    // resolves the object for bare-path (generic) uploads as well as native
+    // ones (#2589); byte-identical to the reconstruction for native uploads.
+    let served_filename = proxy_helpers::served_download_filename(
+        &artifact.path,
+        &format!("{}-{}-{}.tar.gz", namespace, name, version),
+    );
     let json = serde_json::json!({
         "namespace": namespace,
         "name": name,
         "version": version,
-        "download_url": format!(
-            "/ansible/{}/download/{}-{}-{}.tar.gz",
-            repo_key, namespace, name, version
-        ),
+        "download_url": format!("/ansible/{}/download/{}", repo_key, served_filename),
         "artifact": {
-            "filename": format!("{}-{}-{}.tar.gz", namespace, name, version),
+            "filename": served_filename,
             "size": artifact.size_bytes,
             "sha256": artifact.checksum_sha256,
         },

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3792,16 +3792,47 @@ pub async fn try_remote_or_virtual_download(
 }
 
 /// Artifact row exposing the columns most metadata endpoints need:
-/// id, version, size, checksum, and the raw `artifact_metadata.metadata`
-/// JSON. Returned by [`find_artifact_by_name_lowercase`] and
+/// id, the stored object `path`, version, size, checksum, and the raw
+/// `artifact_metadata.metadata` JSON. Returned by
+/// [`find_artifact_by_name_lowercase`] and
 /// [`list_artifacts_by_name_lowercase`].
+///
+/// `path` is the raw stored object path. Metadata endpoints advertise a
+/// download URL from its basename (via [`served_download_filename`]) so the
+/// URL resolves through the suffix-matching download route for bare-path
+/// (generically-uploaded) artifacts as well as natively-published ones.
 pub struct ArtifactWithMetadata {
     pub id: Uuid,
+    pub path: String,
     pub name: String,
     pub version: Option<String>,
     pub size_bytes: Option<i64>,
     pub checksum_sha256: Option<String>,
     pub metadata: Option<serde_json::Value>,
+}
+
+/// The filename a suffix-matching download route (`find_local_by_filename_suffix`
+/// and friends) will resolve for a stored artifact `path`: the basename of the
+/// stored object when present, otherwise `fallback` (the format's reconstructed
+/// `{name}-{version}.<ext>`).
+///
+/// For a natively-published artifact stored at `{name}/{version}/{file}` the
+/// basename already equals the reconstructed filename, so the advertised URL is
+/// byte-identical. But an artifact pushed through the generic chunked-upload
+/// flow is stored at its bare filename with generically-derived `name`/`version`
+/// (an empty version falls back to `sha256-<prefix>`; see
+/// `upload.rs::completed_format_artifact_version`), so a reconstructed
+/// `{name}-{version}.<ext>` would advertise a path the download route cannot
+/// resolve. Preferring the real stored basename keeps every format's on-demand
+/// metadata coherent with its served route for both upload flows — the same fix
+/// applied to rpm `primary.xml`, helm `index.yaml`, cran `PACKAGES` and the
+/// rubygems spec index (#2587 / #2589).
+#[must_use]
+pub fn served_download_filename(path: &str, fallback: &str) -> String {
+    match path.rsplit('/').next() {
+        Some(basename) if !basename.is_empty() => basename.to_string(),
+        _ => fallback.to_string(),
+    }
 }
 
 /// Look up an artifact by case-insensitive name AND exact version.
@@ -3815,7 +3846,7 @@ pub async fn find_artifact_by_name_version(
 ) -> Result<Option<ArtifactWithMetadata>, Response> {
     use sqlx::Row;
     let row = sqlx::query(
-        "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+        "SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256, \
                 am.metadata \
          FROM artifacts a \
          LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
@@ -3834,6 +3865,7 @@ pub async fn find_artifact_by_name_version(
 
     Ok(row.map(|r| ArtifactWithMetadata {
         id: r.try_get("id").unwrap_or_default(),
+        path: r.try_get("path").unwrap_or_default(),
         name: r.try_get("name").unwrap_or_default(),
         version: r.try_get("version").ok(),
         size_bytes: r.try_get("size_bytes").ok(),
@@ -3856,7 +3888,7 @@ pub async fn find_artifact_by_name_lowercase(
 ) -> Result<Option<ArtifactWithMetadata>, Response> {
     use sqlx::Row;
     let row = sqlx::query(
-        "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+        "SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256, \
                 am.metadata \
          FROM artifacts a \
          LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
@@ -3874,6 +3906,7 @@ pub async fn find_artifact_by_name_lowercase(
 
     Ok(row.map(|r| ArtifactWithMetadata {
         id: r.try_get("id").unwrap_or_default(),
+        path: r.try_get("path").unwrap_or_default(),
         name: r.try_get("name").unwrap_or_default(),
         version: r.try_get("version").ok(),
         size_bytes: r.try_get("size_bytes").ok(),
@@ -3896,7 +3929,7 @@ pub async fn list_artifacts_by_name_lowercase(
 ) -> Result<Vec<ArtifactWithMetadata>, Response> {
     use sqlx::Row;
     let rows = sqlx::query(
-        "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+        "SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256, \
                 am.metadata \
          FROM artifacts a \
          LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
@@ -3915,6 +3948,7 @@ pub async fn list_artifacts_by_name_lowercase(
         .into_iter()
         .map(|r| ArtifactWithMetadata {
             id: r.try_get("id").unwrap_or_default(),
+            path: r.try_get("path").unwrap_or_default(),
             name: r.try_get("name").unwrap_or_default(),
             version: r.try_get("version").ok(),
             size_bytes: r.try_get("size_bytes").ok(),
@@ -7099,6 +7133,7 @@ mod tests {
         let id = Uuid::new_v4();
         let m = ArtifactWithMetadata {
             id,
+            path: "ggplot2/3.4.0/ggplot2_3.4.0.tar.gz".to_string(),
             name: "ggplot2".to_string(),
             version: Some("3.4.0".to_string()),
             size_bytes: Some(1024),
@@ -7106,6 +7141,7 @@ mod tests {
             metadata: Some(serde_json::json!({"depends": "R (>= 3.5.0)"})),
         };
         assert_eq!(m.id, id);
+        assert_eq!(m.path, "ggplot2/3.4.0/ggplot2_3.4.0.tar.gz");
         assert_eq!(m.name, "ggplot2");
         assert_eq!(m.version.as_deref(), Some("3.4.0"));
         assert_eq!(m.size_bytes, Some(1024));
@@ -7117,6 +7153,7 @@ mod tests {
     fn test_artifact_with_metadata_all_none_optional() {
         let m = ArtifactWithMetadata {
             id: Uuid::new_v4(),
+            path: "lonely.gem".to_string(),
             name: "lonely".to_string(),
             version: None,
             size_bytes: None,
@@ -7128,6 +7165,48 @@ mod tests {
         assert!(m.checksum_sha256.is_none());
         assert!(m.metadata.is_none());
         assert_eq!(m.name, "lonely");
+    }
+
+    #[test]
+    fn test_served_download_filename_native_path_is_byte_identical() {
+        // Natively-published layout `{name}/{version}/{file}`: the basename
+        // already equals the reconstructed `{name}-{version}.<ext>`, so the
+        // advertised URL is unchanged for native uploads.
+        assert_eq!(
+            served_download_filename("ns-coll/1.0.0/ns-coll-1.0.0.tar.gz", "ns-coll-1.0.0.tar.gz"),
+            "ns-coll-1.0.0.tar.gz"
+        );
+        assert_eq!(
+            served_download_filename("foo/1.0.0/foo-1.0.0.gem", "foo-1.0.0.gem"),
+            "foo-1.0.0.gem"
+        );
+    }
+
+    #[test]
+    fn test_served_download_filename_bare_path_prefers_stored_basename() {
+        // Generic bare-path upload: `name`/`version` are derived (version falls
+        // back to `sha256-<prefix>`), so the reconstructed fallback would 404.
+        // The stored basename is what the suffix-matching route resolves.
+        assert_eq!(
+            served_download_filename(
+                "ns-coll-1.0.0.tar.gz",
+                "ns-coll-1.0.0.tar.gz-sha256-deadbeef.tar.gz"
+            ),
+            "ns-coll-1.0.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_served_download_filename_empty_path_falls_back() {
+        assert_eq!(
+            served_download_filename("", "owner-mod-1.0.0.tar.gz"),
+            "owner-mod-1.0.0.tar.gz"
+        );
+        // A path with a trailing slash has no basename; fall back.
+        assert_eq!(
+            served_download_filename("dir/", "owner-mod-1.0.0.tar.gz"),
+            "owner-mod-1.0.0.tar.gz"
+        );
     }
 
     // ── DownloadResponseOpts / VirtualLookup tests ──────────────────────

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -151,8 +151,12 @@ async fn module_info(
             "version": current_version,
             "slug": format!("{}-{}-{}", owner, name, current_version),
             "file_uri": format!(
-                "/puppet/{}/v3/files/{}-{}-{}.tar.gz",
-                repo_key, owner, name, current_version
+                "/puppet/{}/v3/files/{}",
+                repo_key,
+                proxy_helpers::served_download_filename(
+                    &artifact.path,
+                    &format!("{}-{}-{}.tar.gz", owner, name, current_version)
+                )
             ),
         },
         "releases": [],
@@ -187,8 +191,12 @@ async fn release_list(
                 "slug": format!("{}-{}-{}", owner, name, version),
                 "version": version,
                 "file_uri": format!(
-                    "/puppet/{}/v3/files/{}-{}-{}.tar.gz",
-                    repo_key, owner, name, version
+                    "/puppet/{}/v3/files/{}",
+                    repo_key,
+                    proxy_helpers::served_download_filename(
+                        &a.path,
+                        &format!("{}-{}-{}.tar.gz", owner, name, version)
+                    )
                 ),
                 "file_size": a.size_bytes,
                 "file_sha256": a.checksum_sha256,
@@ -249,8 +257,12 @@ async fn release_info(
             "owner": { "slug": owner, "username": owner },
         },
         "file_uri": format!(
-            "/puppet/{}/v3/files/{}-{}-{}.tar.gz",
-            repo_key, owner, name, version
+            "/puppet/{}/v3/files/{}",
+            repo_key,
+            proxy_helpers::served_download_filename(
+                &artifact.path,
+                &format!("{}-{}-{}.tar.gz", owner, name, version)
+            )
         ),
         "file_size": artifact.size_bytes,
         "file_sha256": artifact.checksum_sha256,

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -108,7 +108,10 @@ async fn gem_info(
             .unwrap_or("")
             .to_string();
 
-        let gem_filename = format!("{}-{}.gem", gem_name, version);
+        let gem_filename = proxy_helpers::served_download_filename(
+            &artifact.path,
+            &format!("{}-{}.gem", gem_name, version),
+        );
         let gem_uri = format!("/gems/{}/gems/{}", repo_key, gem_filename);
 
         let json = serde_json::json!({
@@ -177,7 +180,10 @@ async fn gem_versions(
                 .unwrap_or("")
                 .to_string();
 
-            let gem_filename = format!("{}-{}.gem", gem_name, version);
+            let gem_filename = proxy_helpers::served_download_filename(
+                &a.path,
+                &format!("{}-{}.gem", gem_name, version),
+            );
 
             serde_json::json!({
                 "number": version,


### PR DESCRIPTION
## Summary

Follow-up to #2587 (rpm `primary.xml`) and #2754 (cran `PACKAGES` / rubygems
`specs.4.8.gz`), closing the remaining half of the #2589 audit.

Those PRs fixed the **repo-wide** on-demand indices: an artifact pushed through
the generic chunked-upload flow is stored at its **bare filename** with the
whole basename as `name` and a `sha256-<prefix>` fallback `version`
(`upload.rs::completed_format_artifact_version`), so any download URL/coordinate
reconstructed from `{name}-{version}` points at a path the suffix-resolving
download route cannot serve.

This PR audits the **name-addressed metadata endpoints** of the other
suffix-resolved formats and fixes the same class where the on-demand response
advertises a **reconstructed** download URL instead of the stored object's real
filename:

| Format | Endpoint | Field | Before | After |
|--------|----------|-------|--------|-------|
| Ansible Galaxy | `collection_info`, `version_info` | `download_url`, `artifact.filename` | `{namespace}-{name}-{version}.tar.gz` | stored basename |
| Puppet Forge | `module_info`, `release_list`, `release_info` | `file_uri` | `{owner}-{name}-{version}.tar.gz` | stored basename |
| RubyGems | `gem_info`, `gem_versions` | `gem_uri` | `{name}-{version}.gem` | stored basename |

### Fix (serve-time, no migration — retroactive for all historical bare-path artifacts)

- New shared helper `proxy_helpers::served_download_filename(path, fallback)`:
  returns the basename of the stored object `path` when present, else the
  format's reconstructed `{name}-{version}.<ext>`. For a natively-published
  artifact stored at `{name}/{version}/{file}` the basename already equals the
  reconstruction, so the advertised URL is **byte-identical** for native
  uploads; it only diverges for bare-path uploads, where it now matches the
  served route. This is the same fix already applied to helm `index.yaml`
  (`chart_download_url`), cran (`source_index_coordinates`) and rubygems
  (`spec_index_coordinates`).
- `ArtifactWithMetadata` (shared by the ansible/puppet/rubygems name-lookup
  helpers) now carries the stored `path`; the three `sqlx::query` lookups select
  `a.path`. All runtime `sqlx::query` (no `sqlx::query!` macros), so the offline
  `Check Rust` gate is unaffected.

No schema change: entirely serve-time, so it also repairs previously-uploaded
bare-path artifacts.

### Audited and already correct (no change)
- **rpm** `primary.xml` (#2587), **cran** `PACKAGES` + **rubygems**
  `specs.4.8.gz` (#2754), **helm** `index.yaml` — repo-wide indices already
  derive the served location/coordinates from the stored filename.
- **npm** packument and **pypi** simple index already advertise the stored
  basename (`a.path.rsplit('/')`).

### Deliberate follow-ups (out of scope here)
- **hex**: the JSON `/api/packages/{name}` release list (and its virtual-repo
  variant `build_package_info_json`) reconstructs `/tarballs/{name}-{version}.tar`.
  The virtual variant is fed `(version, checksum)` tuples with no stored `path`,
  and hex's primary install path is the **signed registry** payload (which is
  name/version-reconstructed by protocol), so a coherent fix needs a wider query
  change — tracked separately rather than bundled here.
- Formats whose download route does **not** use the shared suffix resolvers
  (debian `pool/`, conda, cocoapods, nuget, …) cannot serve bare-path uploads at
  all today; surfacing them is a separate, larger concern.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Coverage that fails on `main` and passes here:
- **Unit (`proxy_helpers.rs`)** — `served_download_filename`: native
  `{name}/{version}/{file}` layout → basename is byte-identical to the
  reconstruction; bare path → prefers the stored basename over the
  `{name}-{version}` (sha256-fallback) reconstruction; empty/trailing-slash path
  → falls back.
- **DTF tier (`artifact-keeper-test` `ondemand-index-formats`)** — a real
  generic (bare-path) chunked upload of an Ansible collection and a Puppet
  module; reads the served metadata JSON, extracts the advertised
  `download_url` / `file_uri`, and GETs it. Proven **RED → GREEN**:
  - RED (base image): both advertise `{name}-{version}-sha256-….tar.gz` → `404`.
  - GREEN (this image): both advertise the stored basename → `200`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — DTF tier in artifact-keeper-test
- [x] Manually tested locally
- [x] No regressions in existing tests

Gates: `cargo fmt --check` pass · `cargo clippy --lib --tests` clean ·
`cargo test --lib` (changed logic) pass · `jscpd --min-lines 10 --threshold 3`
on changed `.rs` under threshold.

## API Changes
- [x] N/A - no API changes (JSON field values now resolve; shapes unchanged)
