### PR TITLE
fix(repositories): block a disabled format's aliases

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -17967,6 +17967,62 @@ mod tests {
         );
     }
 
+    // Regression: a built-in format that shares a core handler (docker -> oci)
+    // must gate on that handler, so disabling `oci` rejects a `docker` repo.
+    // Fails on main, where the gate looked up "docker" and missed the "oci" row.
+    #[tokio::test]
+    async fn test_create_docker_repo_rejected_when_oci_handler_disabled() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Extension, State};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let storage_dir = std::env::temp_dir().join(format!("pk-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        // Disable the seeded `oci` handler (governs the whole OCI/Docker family).
+        sqlx::query("UPDATE format_handlers SET is_enabled = false WHERE format_key = 'oci'")
+            .execute(&pool)
+            .await
+            .expect("disable oci handler");
+
+        let key = format!("docker-repo-{}", Uuid::new_v4().simple());
+        let payload = make_create_request(&key, "Docker repo", "docker", serde_json::json!({}));
+
+        let result = create_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            payload,
+        )
+        .await;
+
+        sqlx::query("UPDATE format_handlers SET is_enabled = true WHERE format_key = 'oci'")
+            .execute(&pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM repositories WHERE key = $1")
+            .bind(&key)
+            .execute(&pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .ok();
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        let err =
+            result.expect_err("docker repo must be rejected when the oci handler is disabled");
+        assert!(
+            matches!(err, AppError::Validation(ref msg) if msg.contains("disabled")),
+            "expected a Validation error mentioning 'disabled', got {err:?}",
+        );
+    }
+
     // -----------------------------------------------------------------------
     // custom_user_agent: handler plumbing (create / update / get round-trips)
     // -----------------------------------------------------------------------

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -292,6 +292,26 @@ pub(crate) fn derive_format_key(format: &RepositoryFormat) -> String {
     .to_string()
 }
 
+/// Handler key a format gates on; aliases collapse to their core handler (mirrors get_handler_for_format).
+pub(crate) fn format_handler_key(format: &RepositoryFormat) -> String {
+    let key = match format {
+        RepositoryFormat::Gradle => "maven",
+        RepositoryFormat::Yarn | RepositoryFormat::Bower | RepositoryFormat::Pnpm => "npm",
+        RepositoryFormat::Poetry | RepositoryFormat::Conda => "pypi",
+        RepositoryFormat::Chocolatey | RepositoryFormat::Powershell => "nuget",
+        RepositoryFormat::Docker
+        | RepositoryFormat::Podman
+        | RepositoryFormat::Buildx
+        | RepositoryFormat::Oras
+        | RepositoryFormat::WasmOci
+        | RepositoryFormat::HelmOci => "oci",
+        RepositoryFormat::Opentofu => "terraform",
+        RepositoryFormat::Lxc => "incus",
+        other => return derive_format_key(other),
+    };
+    key.to_string()
+}
+
 /// Build a SQL LIKE search pattern from a user query string.
 pub(crate) fn build_search_pattern(query: Option<&str>) -> Option<String> {
     query.map(|q| format!("%{}%", q.to_lowercase()))
@@ -714,7 +734,7 @@ impl RepositoryService {
         let format_key = req
             .format_key
             .clone()
-            .unwrap_or_else(|| derive_format_key(&req.format));
+            .unwrap_or_else(|| format_handler_key(&req.format));
         let format_enabled: Option<bool> =
             sqlx::query_scalar("SELECT is_enabled FROM format_handlers WHERE format_key = $1")
                 .bind(&format_key)
@@ -2645,6 +2665,36 @@ mod tests {
         ];
         for (format, expected) in cases {
             assert_eq!(derive_format_key(&format), expected, "Format {:?}", format);
+        }
+    }
+
+    #[test]
+    fn test_format_handler_key_collapses_aliases_to_core_handler() {
+        // Aliases gate on their core handler's key (see get_handler_for_format).
+        let cases = [
+            (RepositoryFormat::Docker, "oci"),
+            (RepositoryFormat::Podman, "oci"),
+            (RepositoryFormat::Oras, "oci"),
+            (RepositoryFormat::WasmOci, "oci"),
+            (RepositoryFormat::HelmOci, "oci"),
+            (RepositoryFormat::Gradle, "maven"),
+            (RepositoryFormat::Yarn, "npm"),
+            (RepositoryFormat::Bower, "npm"),
+            (RepositoryFormat::Pnpm, "npm"),
+            (RepositoryFormat::Poetry, "pypi"),
+            (RepositoryFormat::Conda, "pypi"),
+            (RepositoryFormat::Chocolatey, "nuget"),
+            (RepositoryFormat::Powershell, "nuget"),
+            (RepositoryFormat::Opentofu, "terraform"),
+            (RepositoryFormat::Lxc, "incus"),
+            // 1:1 formats gate on their own key.
+            (RepositoryFormat::Maven, "maven"),
+            (RepositoryFormat::Npm, "npm"),
+            (RepositoryFormat::Pypi, "pypi"),
+            (RepositoryFormat::Generic, "generic"),
+        ];
+        for (f, expected) in cases {
+            assert_eq!(format_handler_key(&f), expected, "{:?}", f);
         }
     }
 


### PR DESCRIPTION
## Summary

Gate repo creation on the serving handler's key instead of the format's own key, so disabling oci/npm/etc also blocks docker/etc. Adds format_handler_key + a unit test.

## Regression test (required for `fix/*` PRs)
<!--
Hardening Core (https://github.com/orgs/artifact-keeper/projects/2) requires
every bug-fix PR to land with a regression test that fails on `main` and
passes on this PR. Choose one that fits the bug:
  - unit test (closest to the buggy logic)
  - integration test (requires DB/storage/etc.)
  - end-to-end test in artifact-keeper-test (exercises the user flow)

For non-fix PRs (feat/, chore/, docs/, ci/, refactor/) check N/A.
Reviewers should not approve fix/* PRs without a checked box.
-->
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Fixes #2866 
