### PR TITLE
ci(docker-publish): digest-aware republish guard + idempotent mirror + promote mode

### DIFF
--- a/.github/scripts/assert-version-digest-consistent.sh
+++ b/.github/scripts/assert-version-digest-consistent.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Digest-aware republish guard for the exact (chart-pinned) version tag.
+#
+#   usage: assert-version-digest-consistent.sh <version-tag> <incoming-digest> \
+#            <registry>'|'<repository> [more targets...]
+#   env:   GHCR_TOKEN, DOCKERHUB_USERNAME, DOCKERHUB_TOKEN  (for the state probe)
+#          the caller must also be `docker login`-ed to each registry so
+#          `docker buildx imagetools inspect` can read a present tag's digest.
+#
+# <incoming-digest> is the sha256 manifest-list digest this run points the
+# version tag at -- the manifest already assembled on (or resolved from) ghcr
+# THIS run. It is compared against whatever each registry currently serves for
+# <version-tag>.
+#
+# Why this replaces the blunt "tag exists -> refuse" guard
+# --------------------------------------------------------
+# The old guard (assert-stable-tag-free.sh) refused whenever the version tag was
+# PRESENT on either registry. That is correct for a fresh cut but wedges a
+# partial publish permanently: at the v1.6.2 cut the ghcr manifest published,
+# then the Docker Hub copy died on a transient network error, so the job went
+# red with `:1.6.2` already on ghcr. Every re-run then died at the guard --
+# because `:1.6.2` IS published -- and there was no way to finish the mirror.
+#
+# The safety property the guard actually protects is narrower than "the tag
+# exists": it is "a released image is never silently REPLACED WITH DIFFERENT
+# CONTENT". So this guard compares digests instead of mere existence:
+#
+#   absent        -> OK. First publish, or this registry never received the tag
+#                    (partial-publish recovery -- e.g. ghcr has it, Docker Hub
+#                    does not). There is nothing to overwrite.
+#   present, SAME -> OK. The tag already resolves to <incoming-digest>.
+#                    Re-applying it is a byte-for-byte no-op. THIS is what makes
+#                    a plain re-run (or the promote path) idempotent and lets a
+#                    partial publish be completed.
+#   present, DIFF -> REFUSE. The tag is published and resolves to OTHER content.
+#                    Re-pointing it would silently replace a released image with
+#                    different bits (a moved/re-cut git tag the preflight cannot
+#                    detect, or a tamper). This is the supply-chain protection,
+#                    preserved verbatim -- a DIFFERENT digest is still refused.
+#   indeterminate -> REFUSE (fail closed). Exactly as assert-stable-tag-free:
+#                    if the tag's state cannot be PROVEN we never publish over
+#                    it. An auth failure / outage must not read as "absent".
+#
+# State detection is delegated to registry-tag-state.sh, which reads an HTTP
+# status (never an error-text blob) and only ever reports `absent` for a
+# definitive MANIFEST_UNKNOWN 404 from a repository it has proven it can read.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="${SCRIPT_DIR}/registry-tag-state.sh"
+
+# The pure comparison. Kept as a named function with no I/O so it can be
+# exercised directly by --self-test: `decide <state> <existing> <incoming>`
+# returns 0 to ALLOW (publish/no-op) and 1 to REFUSE.
+decide() {
+  local state="$1" existing="$2" incoming="$3"
+  case "$state" in
+    absent)
+      return 0 ;;                                  # nothing published -> allow
+    present)
+      [[ -n "$existing" && "$existing" == "$incoming" ]] && return 0
+      return 1 ;;                                  # missing/other digest -> refuse
+    *)
+      return 1 ;;                                  # indeterminate -> fail closed
+  esac
+}
+
+self_test() {
+  local fails=0 d1='sha256:aaaa' d2='sha256:bbbb'
+  check() { # <desc> <expected 0|1> <state> <existing> <incoming>
+    local desc="$1" want="$2"; shift 2
+    decide "$@"; local got=$?
+    if [[ "$got" -eq "$want" ]]; then
+      echo "  ok   ${desc} (verdict=${got})"
+    else
+      echo "  FAIL ${desc}: wanted ${want} got ${got}"; fails=1
+    fi
+  }
+  # absent -> allow (fresh publish / partial-publish recovery)
+  check "absent allows publish"                 0 absent ''   "$d1"
+  # present + same digest -> allow (idempotent re-apply / promote)
+  check "present same-digest allows re-apply"   0 present "$d1" "$d1"
+  # present + different digest -> REFUSE (the threat: overwrite w/ other bits)
+  check "present different-digest refuses"      1 present "$d2" "$d1"
+  # present but digest unreadable -> REFUSE (cannot prove SAME)
+  check "present unreadable-digest refuses"     1 present ''   "$d1"
+  # indeterminate -> REFUSE (fail closed)
+  check "indeterminate refuses (fail closed)"   1 indeterminate '' "$d1"
+  return "$fails"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+  exit $?
+fi
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <version-tag> <incoming-digest> <registry>|<repository> [more...]" >&2
+  exit 2
+fi
+
+TAG="$1"
+INCOMING="$2"
+shift 2
+
+# Normalize: accept the digest with or without the sha256: prefix.
+[[ "$INCOMING" == sha256:* ]] || INCOMING="sha256:${INCOMING}"
+
+blocked=0
+
+for target in "$@"; do
+  registry="${target%%|*}"
+  repository="${target#*|}"
+  ref="${registry}/${repository}:${TAG}"
+
+  state=$("$PROBE" "$registry" "$repository" "$TAG") || true
+
+  existing=""
+  if [[ "$state" == "present" ]]; then
+    # Read the manifest-list digest the registry currently serves for this tag.
+    existing=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$ref" 2>/dev/null \
+      | jq -r '.digest // empty' 2>/dev/null) || existing=""
+    if [[ -z "$existing" ]]; then
+      # Present per the HTTP probe but its digest could not be read back: treat
+      # as unprovable rather than assume a match. Fails closed via decide().
+      echo "registry-tag-state: ${ref} reported present but its digest was unreadable" >&2
+    fi
+  fi
+
+  if decide "$state" "$existing" "$INCOMING"; then
+    case "$state" in
+      absent)  echo "  ok   ${ref} is not published yet — nothing to overwrite" ;;
+      present) echo "  ok   ${ref} already resolves to ${INCOMING} — idempotent re-apply" ;;
+    esac
+  else
+    case "$state" in
+      present)
+        echo "::error title=Published version would be overwritten::${ref} is published at ${existing:-<unreadable>}, but this run resolves ${INCOMING}. Exact version tags are the identity a chart pins; they are never re-pointed to different content. Cut a new version instead."
+        ;;
+      *)
+        echo "::error title=Registry lookup inconclusive::Unable to prove the state of ${ref} (probe said '${state}'). Refusing to publish rather than risk replacing a published tag."
+        ;;
+    esac
+    blocked=1
+  fi
+done
+
+exit "$blocked"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,9 +12,19 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Candidate image tag (e.g., rc-1.5.9, pr-123, 1.1-dev). Release-managed labels such as latest/dev/stable and version numbers are refused.'
-        required: true
+        description: 'Candidate image tag (e.g., rc-1.5.9, pr-123, 1.1-dev). Release-managed labels such as latest/dev/stable and version numbers are refused. Ignored when promote_version is set.'
+        required: false
         default: 'rc-candidate'
+      # PROMOTE mode (#2698): complete a partially-published release without
+      # rebuilding. Given a version already built on ghcr, resolve its published
+      # manifest-list digest and idempotently (re)apply every version tag and the
+      # Docker Hub mirror for all three images. The digest-aware guard still runs,
+      # so promote can only re-apply the SAME digest -- never replace it -- which
+      # is why it needs no manual tokens: it uses the pipeline's own credentials.
+      promote_version:
+        description: 'PROMOTE: finish/re-apply a version already built on ghcr (e.g. 1.6.2) — re-applies all tags + the Docker Hub mirror for all three images WITHOUT rebuilding. Leave blank for a normal build.'
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -53,6 +63,10 @@ jobs:
       # the string that gets published. Empty for non-dispatch events, where
       # the manual tag line is disabled anyway.
       dispatch_tag: ${{ steps.manual_tag.outputs.tag }}
+      # The validated PROMOTE target version (empty unless this is a promote
+      # dispatch). Non-empty flips the build jobs off and the merge jobs into
+      # re-apply-existing-digest mode.
+      promote_version: ${{ steps.promote.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -82,12 +96,45 @@ jobs:
             exit 1
           fi
 
+      # PROMOTE mode (#2698): validate the requested version and prove it is
+      # already published on ghcr BEFORE any downstream job tries to promote it,
+      # so a typo or an un-built version fails fast here rather than deep in the
+      # graph. Promote never builds; it only re-applies an existing digest, and
+      # the merge jobs re-run the digest-aware guard, so this cannot become a
+      # path to publish new content.
+      - name: Validate promote request
+        id: promote
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != ''
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMOTE_VERSION: ${{ github.event.inputs.promote_version }}
+        run: |
+          set -euo pipefail
+          V="$PROMOTE_VERSION"
+          # A promote target is an EXACT release version (the identity a chart
+          # pins) -- bare or v-prefixed semver with an optional prerelease
+          # suffix -- never a floating/candidate label.
+          if [[ ! "$V" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid promote_version::'${V}' is not an exact version (expected e.g. 1.6.2 or 1.6.2-rc.1)."
+            exit 1
+          fi
+          V="${V#v}"
+          # It must already exist on ghcr; promote completes an existing build.
+          state=$(.github/scripts/registry-tag-state.sh ghcr.io "${BACKEND_IMAGE}" "$V" || true)
+          if [[ "$state" != "present" ]]; then
+            echo "::error title=Nothing to promote::ghcr.io/${BACKEND_IMAGE}:${V} is '${state}', not 'present'. Promote re-applies an already-built version; build it first."
+            exit 1
+          fi
+          echo "Promote target validated: ${V} (present on ghcr.io/${BACKEND_IMAGE})."
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
       # Manual builds are useful for candidate/dev labels, but must not be a
       # back door around the guarded release path. See the script for why the
-      # normalized value is what gets validated and published.
+      # normalized value is what gets validated and published. Skipped in
+      # promote mode (the tag input is ignored there).
       - name: Validate manual tag
         id: manual_tag
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version == ''
         env:
           REQUESTED_TAG: ${{ github.event.inputs.tag }}
         run: |
@@ -99,6 +146,9 @@ jobs:
   build-backend:
     name: Backend (${{ matrix.platform }})
     needs: [publish-preflight]
+    # PROMOTE mode re-applies an existing ghcr digest and never rebuilds, so the
+    # build jobs are skipped entirely there. For every other event this is true.
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != '') }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -192,6 +242,8 @@ jobs:
   build-openscap:
     name: OpenSCAP (${{ matrix.platform }})
     needs: [publish-preflight]
+    # Skipped in PROMOTE mode (re-apply existing digest, no rebuild).
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != '') }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -272,6 +324,8 @@ jobs:
   build-scanner-adapter:
     name: Scanner Adapter (${{ matrix.platform }})
     needs: [publish-preflight]
+    # Skipped in PROMOTE mode (re-apply existing digest, no rebuild).
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != '') }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -697,11 +751,20 @@ jobs:
     # scans them together. `.trivyignore` is the exception path if one image
     # must ship while another is being fixed.
     needs: [publish-preflight, build-backend, scan-containers]
+    # Runs on a normal build (build + scan green) OR in PROMOTE mode, where the
+    # build/scan jobs are skipped because promote re-applies an existing digest.
+    if: >-
+      ${{ !cancelled() && needs.publish-preflight.result == 'success'
+          && (needs.publish-preflight.outputs.promote_version != ''
+              || (needs.build-backend.result == 'success' && needs.scan-containers.result == 'success')) }}
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+    env:
+      # Non-empty => PROMOTE mode: re-apply the existing ghcr digest, no rebuild.
+      PROMOTE_VERSION: ${{ needs.publish-preflight.outputs.promote_version }}
 
     steps:
       - name: Checkout (scripts and VEX files)
@@ -712,6 +775,7 @@ jobs:
             .vex
 
       - name: Download digests
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
@@ -737,28 +801,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # The exact version tag is the identity the Helm chart pins, so it is
-      # published once and never re-pointed -- not by a rerun, and not by a
-      # delete-and-recreate of the git tag, which the preflight cannot detect
-      # (only a repository ruleset can). Both registries are checked because
-      # this run writes to both, and a tag that survives on one is not evidence
-      # about the other. The floating tags (latest, X.Y) are expected to move
-      # and are not checked here.
-      - name: Refuse to overwrite a published backend version
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          .github/scripts/assert-stable-tag-free.sh "$VERSION" \
-            "ghcr.io|${BACKEND_IMAGE}" \
-            "docker.io|${DOCKERHUB_BACKEND}"
-
       - name: Extract metadata (ghcr.io)
         id: meta
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}
@@ -775,6 +820,7 @@ jobs:
 
       - name: Extract metadata (Docker Hub)
         id: meta-dockerhub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: docker.io/${{ env.DOCKERHUB_BACKEND }}
@@ -789,38 +835,163 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
-      - name: Create manifest list and push (ghcr.io)
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:%s ' *)
+      # Resolve, for BOTH modes, the full ghcr + Docker Hub tag sets and the
+      # single "exact" version tag that must be guarded (empty for branch/pr/
+      # manual builds that publish no chart-pinned identity tag).
+      - name: Resolve publish plan
+        id: plan
         env:
-          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
-
-      - name: Inspect image
-        id: inspect
+          META_JSON: ${{ steps.meta.outputs.json }}
+          META_HUB_JSON: ${{ steps.meta-dockerhub.outputs.json }}
+          META_VERSION: ${{ steps.meta.outputs.version }}
+          GH_REF: ${{ github.ref }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.meta.outputs.version }}
-          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            # PROMOTE: no build metadata. Always re-apply the exact identity tag;
+            # for each floating tag (X.Y, latest) re-apply it ONLY if ghcr ALREADY
+            # points it at this version's digest. That way promote mirrors ghcr's
+            # CURRENT state to the missing registry and can never move a floating
+            # tag backwards to an older promoted version.
+            VERSION="${PROMOTE_VERSION}"
+            GIMG="${REGISTRY}/${BACKEND_IMAGE}"; HIMG="docker.io/${DOCKERHUB_BACKEND}"
+            vdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${VERSION}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+            if [[ "${vdig}" != sha256:* ]]; then
+              echo "::error title=Nothing to promote::${GIMG}:${VERSION} is not present on ghcr; cannot promote."; exit 1
+            fi
+            ghcr=( "${GIMG}:${VERSION}" ); hub=( "${HIMG}:${VERSION}" )
+            for ft in "${VERSION%.*}" latest; do
+              fdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${ft}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+              if [[ -n "${fdig}" && "${fdig}" == "${vdig}" ]]; then
+                ghcr+=( "${GIMG}:${ft}" ); hub+=( "${HIMG}:${ft}" )
+                echo "  floating :${ft} -> included (ghcr already at ${VERSION})"
+              else
+                echo "  floating :${ft} -> skipped (ghcr=${fdig:-absent}, not this version)"
+              fi
+            done
+            printf '%s\n' "${ghcr[@]}" | jq -R . | jq -cs . > /tmp/ghcr-tags.json
+            printf '%s\n' "${hub[@]}"  | jq -R . | jq -cs . > /tmp/hub-tags.json
+            echo "exact=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            # NORMAL: tags come straight from docker/metadata-action.
+            jq -c '.tags' <<< "${META_JSON}" > /tmp/ghcr-tags.json
+            jq -c '.tags' <<< "${META_HUB_JSON}" > /tmp/hub-tags.json
+            # Only a clean release tag publishes a guarded exact identity tag.
+            if [[ "${GH_REF}" == refs/tags/v* ]]; then
+              echo "exact=${META_VERSION}" >> "$GITHUB_OUTPUT"
+            else
+              echo "exact=" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "ghcr tags:"; cat /tmp/ghcr-tags.json; echo
+          echo "hub tags:";  cat /tmp/hub-tags.json;  echo
 
+      # Resolve the manifest-list digest this run will point the tags at, WITHOUT
+      # writing the exact/floating tags first:
+      #   NORMAL  - assemble the multi-arch manifest onto a content-addressed
+      #             anchor tag (:sha-...). A sha tag names the content it points
+      #             at, so writing it is safe even on a refuse path, and it makes
+      #             the digest knowable BEFORE the guard runs.
+      #   PROMOTE - the manifest already exists on ghcr; just read its digest.
+      - name: Resolve incoming digest
+        id: incoming
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${BACKEND_IMAGE}"
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            REF="${IMG}:${PROMOTE_VERSION}"
+          else
+            ANCHOR=$(jq -r 'map(select(test(":sha-")))[0] // empty' /tmp/ghcr-tags.json)
+            if [[ -z "${ANCHOR}" ]]; then
+              echo "::error::no :sha- anchor tag in the ghcr tag set; cannot stage the manifest safely"; exit 1
+            fi
+            shopt -s nullglob
+            srcs=()
+            for f in /tmp/digests/*; do srcs+=( "${IMG}@sha256:$(basename "$f")" ); done
+            if [[ "${#srcs[@]}" -eq 0 ]]; then
+              echo "::error::no per-arch digests in /tmp/digests"; exit 1
+            fi
+            docker buildx imagetools create -t "${ANCHOR}" "${srcs[@]}"
+            REF="${ANCHOR}"
+          fi
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${REF}" | jq -r '.digest')
+          [[ "${DIGEST}" == sha256:* ]] || { echo "::error::could not resolve a digest for ${REF}"; exit 1; }
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Incoming manifest-list digest: ${DIGEST} (from ${REF})"
+
+      # Digest-aware republish guard (preserves the supply-chain property).
+      #
+      # Runs whenever an exact chart-pinned identity tag is being published
+      # (release tags AND promote), on BOTH registries this job writes to. The
+      # comparison, spelled out:
+      #   - tag absent            -> allow (fresh publish, or a partial-publish
+      #                              this run is completing on the missing side).
+      #   - tag == incoming digest -> allow (idempotent re-apply / promote no-op).
+      #   - tag != incoming digest -> REFUSE. A released tag would be silently
+      #                              re-pointed to DIFFERENT content (a moved/
+      #                              re-cut git tag the preflight cannot see, or a
+      #                              tamper). This is the exact protection the old
+      #                              "tag exists -> refuse" guard gave, kept intact.
+      #   - state indeterminate    -> REFUSE (fail closed).
+      # This is what lets a partial publish (ghcr done, Docker Hub not) be
+      # completed by a re-run/promote while still forbidding a different-digest
+      # overwrite.
+      - name: Refuse to overwrite a published backend version
+        if: ${{ steps.plan.outputs.exact != '' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .github/scripts/assert-version-digest-consistent.sh \
+            "${{ steps.plan.outputs.exact }}" \
+            "${{ steps.incoming.outputs.digest }}" \
+            "ghcr.io|${BACKEND_IMAGE}" \
+            "docker.io|${DOCKERHUB_BACKEND}"
+
+      # Apply (or re-apply) every ghcr tag at the resolved digest. Re-pointing a
+      # tag to the SAME digest is a no-op, so this is safe to re-run.
+      - name: Apply ghcr tags
+        run: |
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/ghcr-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          docker buildx imagetools create "${args[@]}" \
+            "${REGISTRY}/${BACKEND_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          docker buildx imagetools inspect "${REGISTRY}/${BACKEND_IMAGE}@${{ steps.incoming.outputs.digest }}" >/dev/null
+
+      # Mirror to Docker Hub with retry. A transient PROTOCOL_ERROR/ETIMEDOUT on
+      # the Docker Hub side is exactly what left v1.6.2 half-published; because
+      # imagetools create re-points tags to the SAME digest, each retry is a safe
+      # no-op-or-complete rather than a re-publish.
       - name: Copy to Docker Hub
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta-dockerhub.outputs.json }}') \
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/hub-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          SRC="${REGISTRY}/${BACKEND_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          n=0; max=5
+          until docker buildx imagetools create "${args[@]}" "${SRC}"; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::imagetools create to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
 
       - name: Sign image with cosign (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.incoming.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
+          subject-digest: ${{ steps.incoming.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
@@ -833,7 +1004,7 @@ jobs:
             docker scout attestation add \
               --file "$vex" \
               --predicate-type https://openvex.dev/ns/v0.2.0 \
-              ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+              ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.incoming.outputs.digest }}
           done
         continue-on-error: true
 
@@ -842,11 +1013,18 @@ jobs:
     runs-on: ubuntu-latest
     # Gated on the container scan; see merge-backend (#2609).
     needs: [publish-preflight, build-openscap, scan-containers]
+    # Normal build (build + scan green) OR PROMOTE mode. See merge-backend.
+    if: >-
+      ${{ !cancelled() && needs.publish-preflight.result == 'success'
+          && (needs.publish-preflight.outputs.promote_version != ''
+              || (needs.build-openscap.result == 'success' && needs.scan-containers.result == 'success')) }}
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+    env:
+      PROMOTE_VERSION: ${{ needs.publish-preflight.outputs.promote_version }}
 
     steps:
       - name: Checkout (scripts)
@@ -855,6 +1033,7 @@ jobs:
           sparse-checkout: .github/scripts
 
       - name: Download digests
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
@@ -880,23 +1059,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Same rule as the backend: the exact version tag is published once, on
-      # both registries, and is never re-pointed. See merge-backend.
-      - name: Refuse to overwrite a published openscap version
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          .github/scripts/assert-stable-tag-free.sh "$VERSION" \
-            "ghcr.io|${OPENSCAP_IMAGE}" \
-            "docker.io|${DOCKERHUB_OPENSCAP}"
-
       - name: Extract metadata (ghcr.io)
         id: meta
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}
@@ -913,6 +1078,7 @@ jobs:
 
       - name: Extract metadata (Docker Hub)
         id: meta-dockerhub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: docker.io/${{ env.DOCKERHUB_OPENSCAP }}
@@ -927,38 +1093,127 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
-      - name: Create manifest list and push (ghcr.io)
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@sha256:%s ' *)
+      # See merge-backend for the full rationale of the plan/anchor/guard/apply/
+      # mirror sequence. Same shape, OpenSCAP image.
+      - name: Resolve publish plan
+        id: plan
         env:
-          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
-
-      - name: Inspect image
-        id: inspect
+          META_JSON: ${{ steps.meta.outputs.json }}
+          META_HUB_JSON: ${{ steps.meta-dockerhub.outputs.json }}
+          META_VERSION: ${{ steps.meta.outputs.version }}
+          GH_REF: ${{ github.ref }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:${{ steps.meta.outputs.version }}
-          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
-            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            # See merge-backend for the floating-tag rule: re-apply a floating tag
+            # only if ghcr already points it at this version (never move it back).
+            VERSION="${PROMOTE_VERSION}"
+            GIMG="${REGISTRY}/${OPENSCAP_IMAGE}"; HIMG="docker.io/${DOCKERHUB_OPENSCAP}"
+            vdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${VERSION}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+            if [[ "${vdig}" != sha256:* ]]; then
+              echo "::error title=Nothing to promote::${GIMG}:${VERSION} is not present on ghcr; cannot promote."; exit 1
+            fi
+            ghcr=( "${GIMG}:${VERSION}" ); hub=( "${HIMG}:${VERSION}" )
+            for ft in "${VERSION%.*}" latest; do
+              fdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${ft}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+              if [[ -n "${fdig}" && "${fdig}" == "${vdig}" ]]; then
+                ghcr+=( "${GIMG}:${ft}" ); hub+=( "${HIMG}:${ft}" )
+                echo "  floating :${ft} -> included (ghcr already at ${VERSION})"
+              else
+                echo "  floating :${ft} -> skipped (ghcr=${fdig:-absent}, not this version)"
+              fi
+            done
+            printf '%s\n' "${ghcr[@]}" | jq -R . | jq -cs . > /tmp/ghcr-tags.json
+            printf '%s\n' "${hub[@]}"  | jq -R . | jq -cs . > /tmp/hub-tags.json
+            echo "exact=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            jq -c '.tags' <<< "${META_JSON}" > /tmp/ghcr-tags.json
+            jq -c '.tags' <<< "${META_HUB_JSON}" > /tmp/hub-tags.json
+            if [[ "${GH_REF}" == refs/tags/v* ]]; then
+              echo "exact=${META_VERSION}" >> "$GITHUB_OUTPUT"
+            else
+              echo "exact=" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "ghcr tags:"; cat /tmp/ghcr-tags.json; echo
+          echo "hub tags:";  cat /tmp/hub-tags.json;  echo
+
+      - name: Resolve incoming digest
+        id: incoming
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${OPENSCAP_IMAGE}"
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            REF="${IMG}:${PROMOTE_VERSION}"
+          else
+            ANCHOR=$(jq -r 'map(select(test(":sha-")))[0] // empty' /tmp/ghcr-tags.json)
+            if [[ -z "${ANCHOR}" ]]; then
+              echo "::error::no :sha- anchor tag in the ghcr tag set; cannot stage the manifest safely"; exit 1
+            fi
+            shopt -s nullglob
+            srcs=()
+            for f in /tmp/digests/*; do srcs+=( "${IMG}@sha256:$(basename "$f")" ); done
+            if [[ "${#srcs[@]}" -eq 0 ]]; then
+              echo "::error::no per-arch digests in /tmp/digests"; exit 1
+            fi
+            docker buildx imagetools create -t "${ANCHOR}" "${srcs[@]}"
+            REF="${ANCHOR}"
+          fi
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${REF}" | jq -r '.digest')
+          [[ "${DIGEST}" == sha256:* ]] || { echo "::error::could not resolve a digest for ${REF}"; exit 1; }
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Incoming manifest-list digest: ${DIGEST} (from ${REF})"
+
+      - name: Refuse to overwrite a published openscap version
+        if: ${{ steps.plan.outputs.exact != '' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .github/scripts/assert-version-digest-consistent.sh \
+            "${{ steps.plan.outputs.exact }}" \
+            "${{ steps.incoming.outputs.digest }}" \
+            "ghcr.io|${OPENSCAP_IMAGE}" \
+            "docker.io|${DOCKERHUB_OPENSCAP}"
+
+      - name: Apply ghcr tags
+        run: |
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/ghcr-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          docker buildx imagetools create "${args[@]}" \
+            "${REGISTRY}/${OPENSCAP_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          docker buildx imagetools inspect "${REGISTRY}/${OPENSCAP_IMAGE}@${{ steps.incoming.outputs.digest }}" >/dev/null
 
       - name: Copy to Docker Hub
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta-dockerhub.outputs.json }}') \
-            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.inspect.outputs.digest }}
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/hub-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          SRC="${REGISTRY}/${OPENSCAP_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          n=0; max=5
+          until docker buildx imagetools create "${args[@]}" "${SRC}"; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::imagetools create to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
 
       - name: Sign image with cosign (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.incoming.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
+          subject-digest: ${{ steps.incoming.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
@@ -967,11 +1222,22 @@ jobs:
     runs-on: ubuntu-latest
     # Gated on the container scan; see merge-backend (#2609).
     needs: [publish-preflight, build-scanner-adapter, scan-containers]
+    # Normal build (build + scan green) OR PROMOTE mode. See merge-backend.
+    if: >-
+      ${{ !cancelled() && needs.publish-preflight.result == 'success'
+          && (needs.publish-preflight.outputs.promote_version != ''
+              || (needs.build-scanner-adapter.result == 'success' && needs.scan-containers.result == 'success')) }}
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+    env:
+      # Non-empty => PROMOTE mode. The adapter is independently versioned, so
+      # promote re-applies the adapter version recorded in docker/scanner-adapter/
+      # VERSION at the checked-out ref; run promote from the release commit so
+      # that file names the version that shipped with the release being completed.
+      PROMOTE_VERSION: ${{ needs.publish-preflight.outputs.promote_version }}
 
     steps:
       - name: Checkout
@@ -1001,6 +1267,7 @@ jobs:
           fi
 
       - name: Download digests
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
@@ -1042,6 +1309,7 @@ jobs:
       # demands a VERSION bump.
       - name: Decide stable adapter publication
         id: adapter_publish
+        if: ${{ env.PROMOTE_VERSION == '' }}
         env:
           ADAPTER_VERSION: ${{ steps.adapter_version.outputs.version }}
           STABLE_REQUESTED: ${{ steps.adapter_version.outputs.stable_requested }}
@@ -1088,7 +1356,15 @@ jobs:
           fi
 
           if [[ "$GHCR_STATE" != "$HUB_STATE" ]]; then
-            echo "::error title=Adapter registries disagree::${ADAPTER_VERSION} is ${GHCR_STATE} on ghcr.io but ${HUB_STATE} on docker.io. Reconcile the two registries before publishing; this job will not resolve the split by overwriting either one."
+            # One registry has the exact tag, the other does not -- typically a
+            # partial publish whose Docker Hub mirror died mid-run. A fresh build
+            # must NOT resolve that by re-pushing the exact tag (a rebuild has a
+            # new digest and would move the tag that is meant to be immutable), so
+            # this path still fails closed. The digest-safe way to finish it is
+            # the PROMOTE dispatch, which re-applies the ALREADY-published digest:
+            #   gh workflow run docker-publish.yml -f promote_version=<AK version>
+            # run from the release commit. See the promote path below.
+            echo "::error title=Adapter registries disagree::${ADAPTER_VERSION} is ${GHCR_STATE} on ghcr.io but ${HUB_STATE} on docker.io — likely a partial publish. A rebuild will not re-point the immutable exact tag. Complete it with the promote dispatch (promote_version=<AK version>, run from the release commit), which re-applies the published digest."
             exit 1
           fi
 
@@ -1127,6 +1403,7 @@ jobs:
 
       - name: Extract metadata (ghcr.io)
         id: meta
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
@@ -1147,6 +1424,7 @@ jobs:
 
       - name: Extract metadata (Docker Hub)
         id: meta-dockerhub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: docker.io/${{ env.DOCKERHUB_SCANNER_ADAPTER }}
@@ -1163,6 +1441,7 @@ jobs:
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
       - name: Create manifest list and push (ghcr.io)
+        if: ${{ env.PROMOTE_VERSION == '' }}
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -1176,6 +1455,7 @@ jobs:
 
       - name: Inspect image
         id: inspect
+        if: ${{ env.PROMOTE_VERSION == '' }}
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:${{ steps.meta.outputs.version }}
           DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
@@ -1187,26 +1467,117 @@ jobs:
       # unchanged-source rebuild from a version collision, so a Docker Hub index
       # without it would have no provenance anchor at all.
       - name: Copy to Docker Hub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         env:
           ADAPTER_VERSION: ${{ steps.adapter_version.outputs.version }}
           DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta-dockerhub.outputs.json }}
         run: |
-          docker buildx imagetools create \
+          set -euo pipefail
+          # Retry the cross-registry copy: a transient PROTOCOL_ERROR/ETIMEDOUT on
+          # the Docker Hub side is what leaves a release half-published. imagetools
+          # create re-points tags to the SAME digest, so each retry is a safe
+          # no-op-or-complete.
+          # shellcheck disable=SC2046  # tag args are intentionally word-split
+          n=0; max=5
+          until docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.revision=${GITHUB_SHA}" \
             --annotation "index:org.opencontainers.image.version=${ADAPTER_VERSION}" \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::imagetools create to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
+
+      # ── PROMOTE path (#2698) ──────────────────────────────────────────────
+      # Re-apply the adapter's already-published version + floating tags and the
+      # Docker Hub mirror WITHOUT rebuilding, to finish a partial publish. The
+      # exact tag is only ever re-pointed to its OWN published digest, and the
+      # digest-aware guard enforces that.
+      - name: Promote — resolve published adapter digest
+        id: promote_digest
+        if: ${{ env.PROMOTE_VERSION != '' }}
+        env:
+          ADAPTER_VERSION: ${{ steps.adapter_version.outputs.version }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${SCANNER_ADAPTER_IMAGE}"
+          state=$(.github/scripts/registry-tag-state.sh ghcr.io "${SCANNER_ADAPTER_IMAGE}" "${ADAPTER_VERSION}" || true)
+          if [[ "$state" != "present" ]]; then
+            echo "::error title=Nothing to promote for scanner-adapter::ghcr.io/${SCANNER_ADAPTER_IMAGE}:${ADAPTER_VERSION} is '${state}'. The adapter VERSION at this ref (${ADAPTER_VERSION}) is not the published one; run promote from the release commit."
+            exit 1
+          fi
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${IMG}:${ADAPTER_VERSION}" | jq -r '.digest')
+          [[ "${DIGEST}" == sha256:* ]] || { echo "::error::could not resolve adapter digest"; exit 1; }
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Promoting scanner-adapter ${ADAPTER_VERSION} at ${DIGEST}"
+
+      - name: Promote — refuse to overwrite a published scanner-adapter version
+        if: ${{ env.PROMOTE_VERSION != '' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .github/scripts/assert-version-digest-consistent.sh \
+            "${{ steps.adapter_version.outputs.version }}" \
+            "${{ steps.promote_digest.outputs.digest }}" \
+            "ghcr.io|${SCANNER_ADAPTER_IMAGE}" \
+            "docker.io|${DOCKERHUB_SCANNER_ADAPTER}"
+
+      - name: Promote — re-apply adapter tags (ghcr + Docker Hub)
+        if: ${{ env.PROMOTE_VERSION != '' }}
+        env:
+          V: ${{ steps.adapter_version.outputs.version }}
+          MINOR: ${{ steps.adapter_version.outputs.minor }}
+          MAJOR: ${{ steps.adapter_version.outputs.major }}
+          DIGEST: ${{ steps.promote_digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          GIMG="${REGISTRY}/${SCANNER_ADAPTER_IMAGE}"
+          HIMG="docker.io/${DOCKERHUB_SCANNER_ADAPTER}"
+          # Always re-apply the exact identity tag (guarded to the same digest).
+          gargs=( -t "${GIMG}:${V}" ); hargs=( -t "${HIMG}:${V}" )
+          # Re-apply each floating tag (adapter's own X.Y / X / latest line) ONLY
+          # if ghcr already points it at this version, so promote never moves a
+          # floating tag backwards (mirror ghcr's current state to Docker Hub).
+          for ft in "${MINOR}" "${MAJOR}" latest; do
+            fdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${ft}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+            if [[ -n "${fdig}" && "${fdig}" == "${DIGEST}" ]]; then
+              gargs+=( -t "${GIMG}:${ft}" ); hargs+=( -t "${HIMG}:${ft}" )
+              echo "  floating :${ft} -> included (ghcr already at ${V})"
+            else
+              echo "  floating :${ft} -> skipped (ghcr=${fdig:-absent}, not this version)"
+            fi
+          done
+          docker buildx imagetools create "${gargs[@]}" "${GIMG}@${DIGEST}"
+          n=0; max=5
+          until docker buildx imagetools create "${hargs[@]}" "${GIMG}@${DIGEST}"; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::adapter promote to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
 
       - name: Sign image with cosign (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest || steps.promote_digest.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
+          subject-digest: ${{ steps.inspect.outputs.digest || steps.promote_digest.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,11 @@ jobs:
   # docker-publish.yml runs INDEPENDENTLY on the same tag push and publishes
   # ghcr.io/.../artifact-keeper-backend:${VERSION} as a manifest list. Nothing
   # connects the two workflows except this poll of the registry. Once
-  # merge-backend has pushed the tag, `assert-stable-tag-free` in
-  # docker-publish.yml guarantees it can never be re-pointed, so the
-  # tag->digest binding is stable the moment it first resolves.
+  # merge-backend has pushed the tag, the digest-aware republish guard
+  # (`assert-version-digest-consistent`) in docker-publish.yml guarantees it can
+  # never be re-pointed to DIFFERENT content -- only re-applied to the same
+  # digest, a no-op -- so the tag->digest binding is stable the moment it first
+  # resolves.
   #
   # This job blocks the release gate until that manifest list exists and
   # captures its digest, so the gate deploys and tests the EXACT bytes that
@@ -539,7 +541,8 @@ jobs:
       # ── Candidate-digest tripwire (issue #2696) ─────────────────────────────
       # Re-resolve the published ghcr backend:${VERSION} digest and assert it
       # EQUALS the digest resolve-candidate-digest handed the gate. With
-      # docker-publish's `assert-stable-tag-free` in place a mismatch should be
+      # docker-publish's digest-aware republish guard
+      # (`assert-version-digest-consistent`) in place a mismatch should be
       # impossible; this step makes "bytes tested == bytes published" observable
       # and RED per release -- the direct "prove it" artifact for the bar. Paste
       # this line, the gate's pod-imageID assertion, and resolve's output into


### PR DESCRIPTION
## Summary

The `docker-publish.yml` release workflow is non-idempotent: a partially-published
release cannot be completed, and a re-run dies at the very guard meant to protect
it. This makes the "Refuse to overwrite a published version" guard **digest-aware**
(preserving the supply-chain protection), makes the tag/mirror steps idempotent,
adds a retry to the flaky Docker Hub copy, and adds a **promote** dispatch mode to
finish a partial publish without rebuilding. Implements #2698 and #2824.

### Root cause (v1.6.2)

`merge-backend` publishes the ghcr manifest (`:1.6.2`) and then does "Copy to
Docker Hub" **in the same job**. At the v1.6.2 cut the ghcr publish succeeded, then
the Docker Hub copy died on a transient network `PROTOCOL_ERROR`, so the job went
red — leaving `:1.6.2` on ghcr with no Docker Hub mirror. The job **starts** with a
guard (`assert-stable-tag-free.sh`) that refuses if the version tag already exists
on either registry. Because `:1.6.2` now *does* exist on ghcr, **every re-run dies
at that guard** → the partial publish is permanently unrecoverable. `workflow_dispatch`
also refused version-number inputs, so it could not be re-fired for `1.6.2` either.

### The fix

**1. Digest-aware guard (new `.github/scripts/assert-version-digest-consistent.sh`).**
The guard no longer refuses on mere existence. Per registry it now decides:

| existing `:VERSION` state | verdict |
|---|---|
| absent | **allow** — fresh publish, or the tag never reached this registry (partial-publish recovery) |
| present, digest **==** this run's | **allow** — idempotent no-op re-apply |
| present, digest **!=** this run's | **REFUSE** — a released image would be silently replaced with different bits |
| indeterminate | **REFUSE** — fail closed (unchanged from before) |

State is read via the existing `registry-tag-state.sh` (HTTP-status based, never
error-text matching — an auth failure/outage can never read as "absent"); a present
tag's digest is read with `docker buildx imagetools inspect`.

**2. Idempotent, guard-before-overwrite ordering.** For backend/openscap the
multi-arch manifest is now assembled onto a **content-addressed `:sha-` anchor tag
first**, so this run's manifest-list digest is known **before** the guard runs and
**nothing chart-pinned is written on a refuse path**. Only after the guard passes are
the exact/floating tags applied (re-pointing a tag to the same digest is a no-op).

**3. Resilient Docker Hub copy.** All three images wrap the cross-registry
`imagetools create` in a 5-attempt backoff retry, so a transient
`PROTOCOL_ERROR`/`ETIMEDOUT` no longer fails the release.

**4. Promote/complete mode (#2698).** New `workflow_dispatch` input
`promote_version: X.Y.Z` runs a build-free path: it resolves the already-built ghcr
digest for that version and idempotently re-applies every version tag + the Docker
Hub mirror for all three images. It passes the same digest-aware guard (so it can
only ever re-apply the same digest, never replace it) and uses the pipeline's own
credentials — no manual tokens. Floating tags (`:latest`, `:X.Y`) are re-applied
**only where ghcr already points them at that version**, so promote never moves a
floating tag backwards.

### Preserved safety property (threat model)

- **A genuine DIFFERENT-digest overwrite is still refused.** The `preflight` already
  blocks force-pushed/moved git tags; the delete-then-recreate case it cannot detect
  produces new build artifacts → a new manifest-list digest → the guard sees
  `existing != incoming` and **refuses**. A tamper/re-cut cannot silently replace a
  released image. Indeterminate registry state still fails closed.
- **SAME-digest re-application is now allowed** (absent, or already at this digest),
  which is exactly what lets a partial publish be completed and a re-run be idempotent.

This is proven by the script's `--self-test` (feeds same vs different vs absent vs
indeterminate and asserts allow/refuse):

```
$ bash .github/scripts/assert-version-digest-consistent.sh --self-test
  ok   absent allows publish
  ok   present same-digest allows re-apply
  ok   present different-digest refuses
  ok   present unreadable-digest refuses
  ok   indeterminate refuses (fail closed)
```

### Completing v1.6.2 once this merges

`gh workflow run docker-publish.yml -f promote_version=1.6.2` (from the 1.6.2 release
commit). Promote resolves `ghcr:1.6.2`'s existing digest, the guard passes
(ghcr already at that digest; Docker Hub absent → allow), and it re-applies the
version tags + mirrors all three images to Docker Hub — no rebuild, no manual token.
Fallback: because the guard is now digest-aware, a plain **Re-run failed jobs** on the
original run also completes backend/openscap while the retained digest artifacts exist.

### Validation

- `actionlint` clean (no new errors; shellcheck info/warning count went *down* vs
  baseline because the new steps use quoted arrays). YAML parses.
- Guard `--self-test` passes; tag-array/floating-gate plumbing unit-tested locally.
- Diff is surgical and symmetric across the three images; `release.yml` comments that
  named the old guard were updated to the new one (the property they rely on is
  unchanged).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
  <!-- assert-version-digest-consistent.sh --self-test asserts SAME-digest is ALLOWED
       (the wedge) and DIFFERENT-digest is REFUSED (the protection). -->

## Test Checklist
- [x] Unit tests added/updated  <!-- guard --self-test + local plumbing tests -->
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally  <!-- actionlint, shellcheck, self-test, plumbing harness -->
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes  <!-- CI workflow only -->

Closes #2698
Closes #2824