### PR TITLE
fix(auth): stop startup admin provisioning from hijacking a federated identity (#2875)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1787,12 +1787,50 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         .await
         .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
+    // #2875: detect installs already affected by the pre-fix collision. A row
+    // that is `auth_provider = 'local'` yet still carries a federated
+    // `external_id` is the fingerprint of a federated identity that a prior
+    // build merged into the built-in local admin. We cannot safely un-merge it
+    // automatically (the original local-admin credentials were overwritten and
+    // the federated user's original username is lost), so surface it loudly for
+    // manual remediation. Read-only; never mutates.
+    let collided: Option<(i64,)> = sqlx::query_as(
+        "SELECT COUNT(*) FROM users WHERE auth_provider = 'local' AND external_id IS NOT NULL",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+    if let Some((n,)) = collided {
+        if n > 0 {
+            tracing::error!(
+                collided_accounts = n,
+                "SECURITY (#2875): {n} local account(s) still carry a federated external_id -- the \
+                 fingerprint of an SSO identity merged into a local account by a pre-fix build. \
+                 Review these rows: an operator should verify each account's true owner, reset the \
+                 built-in admin credential, and clear the stray external_id on any account that \
+                 should remain local. See the v1.6.3 advisory.",
+            );
+        }
+    }
+
     // Re-check admin existence while holding the lock (double-check pattern).
-    let admin_row: Option<(bool,)> =
-        sqlx::query_as("SELECT must_change_password FROM users WHERE is_admin = true LIMIT 1")
-            .fetch_optional(&mut *tx)
-            .await
-            .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+    //
+    // #2875: only a NON-FEDERATED admin counts as "the built-in admin exists".
+    // A federated (SSO) principal always carries `external_id`; if such a user
+    // happens to be admin (e.g. an OIDC user named `admin` under
+    // SKIP_ADMIN_PROVISIONING, or granted admin then demoted), it must NOT be
+    // mistaken for the built-in local admin here -- otherwise the maintenance
+    // branch below would flip its `auth_provider` to 'local' and stamp the
+    // built-in admin password onto it, merging the two identities. Excluding
+    // `external_id IS NOT NULL` routes that case to the create branch, whose
+    // upsert is itself guarded against clobbering a federated row.
+    let admin_row: Option<(bool,)> = sqlx::query_as(
+        "SELECT must_change_password FROM users \
+         WHERE is_admin = true AND external_id IS NULL LIMIT 1",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
     let demo_mode = matches!(std::env::var("DEMO_MODE").as_deref(), Ok("true" | "1"));
 
@@ -1802,7 +1840,8 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         // already correct but fixes installs that ended up with a wrong value.
         sqlx::query(
             "UPDATE users SET auth_provider = 'local' \
-             WHERE username = 'admin' AND auth_provider != 'local'",
+             WHERE username = 'admin' AND auth_provider != 'local' \
+               AND external_id IS NULL",
         )
         .execute(&mut *tx)
         .await
@@ -1856,9 +1895,16 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
                 } else {
                     // File written successfully, now update the DB hash to match.
                     let password_hash = AuthService::hash_password(&password).await?;
-                    sqlx::query("UPDATE users SET password_hash = $1 WHERE username = 'admin'")
-                        .bind(&password_hash)
-                        .execute(&mut *tx)
+                    // #2875: never write the built-in admin password onto a
+                    // federated row; scope strictly to the local, non-federated
+                    // built-in admin.
+                    sqlx::query(
+                        "UPDATE users SET password_hash = $1 \
+                         WHERE username = 'admin' AND auth_provider = 'local' \
+                           AND external_id IS NULL",
+                    )
+                    .bind(&password_hash)
+                    .execute(&mut *tx)
                         .await
                         .map_err(|e| {
                             artifact_keeper_backend::error::AppError::Database(e.to_string())
@@ -1921,7 +1967,15 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
 
     let password_hash = AuthService::hash_password(&password).await?;
 
-    sqlx::query(
+    // #2875: the built-in admin is keyed on username='admin'. If a FEDERATED
+    // (SSO) user already holds that username, the ON CONFLICT upsert must NOT
+    // clobber it -- doing so would stamp the built-in admin password onto the
+    // federated account and flip it to a local login, merging the two
+    // identities into one admin account. The WHERE on DO UPDATE restricts the
+    // update to a genuine local, non-federated row; when the conflicting row is
+    // federated the update is skipped (rows_affected == 0) and we refuse to
+    // provision rather than hijack the identity.
+    let provisioned = sqlx::query(
         r#"
         INSERT INTO users (username, email, password_hash, is_admin, must_change_password, auth_provider)
         VALUES ('admin', 'admin@localhost', $1, true, $2, 'local')
@@ -1929,6 +1983,7 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
             SET password_hash = EXCLUDED.password_hash,
                 must_change_password = EXCLUDED.must_change_password,
                 auth_provider = 'local'
+            WHERE users.auth_provider = 'local' AND users.external_id IS NULL
         "#,
     )
     .bind(&password_hash)
@@ -1936,6 +1991,24 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
     .execute(&mut *tx)
     .await
     .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+
+    if provisioned.rows_affected() == 0 {
+        // The 'admin' username is held by a federated (external_id IS NOT NULL)
+        // account. Refuse to overwrite it. Do NOT abort startup (the federated
+        // account may legitimately be the SSO-managed admin); log loudly and
+        // continue without a built-in local admin.
+        tx.rollback()
+            .await
+            .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+        tracing::error!(
+            "Refusing to provision the built-in 'admin' user: the username 'admin' is already held \
+             by a federated (SSO) account. Overwriting it would merge that identity with the local \
+             admin (#2875). Rename or remove the federated account, or set \
+             SKIP_ADMIN_PROVISIONING=true to let SSO manage admin access. Continuing without a \
+             built-in local admin."
+        );
+        return Ok(false);
+    }
 
     tx.commit()
         .await

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1905,10 +1905,10 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
                     )
                     .bind(&password_hash)
                     .execute(&mut *tx)
-                        .await
-                        .map_err(|e| {
-                            artifact_keeper_backend::error::AppError::Database(e.to_string())
-                        })?;
+                    .await
+                    .map_err(|e| {
+                        artifact_keeper_backend::error::AppError::Database(e.to_string())
+                    })?;
                     log_admin_setup_banner(&password_file, Some(&password));
                 }
             }


### PR DESCRIPTION
Closes #2875. **Security fix — targeted for the v1.6.3 hotfix.**

## Impact
A federated (OIDC/SAML/LDAP) user can be silently **merged into the built-in local admin account**, giving cross-identity admin login. Reported on backend 1.6.2 (Helm/K8s/RDS): after granting then removing admin from an SSO user and a backend restart, the SSO login resolves to the local `admin` account (audit `actor_id` collapses onto the admin, top-right shows `admin`, full admin retained).

## Root cause
Startup `provision_admin_user` (main.rs) identifies the built-in admin as *"the row whose `username = admin"`* with no guard that it is a **local, non-federated** account. When a federated user holds `username=admin` (natural under `SKIP_ADMIN_PROVISIONING`=#211, or IdP `preferred_username=admin`), a restart:
1. the existence check `WHERE is_admin = true` treats the federated admin as the built-in admin → maintenance branch;
2. that branch flips `auth_provider` → `local`;
3. `INSERT ... ON CONFLICT (username) DO UPDATE` stamps the built-in admin password onto the federated row.

Federated `sync_federated_user` lets the row acquire `username=admin` in the first place (it rewrites username from the IdP claim without collision protection — unlike the sibling `oidc_service` path).

## Fix
No provisioning statement may cross the local/federated boundary (a federated identity always has `external_id`; the built-in local admin never does):
- existence check counts only **non-federated** admins (`is_admin = true AND external_id IS NULL`) → a federated admin routes to the create branch, not the mutate-in-place branch;
- the `auth_provider` repair flip and the password-file-regen update both add `external_id IS NULL`;
- the create-branch upsert guards `DO UPDATE ... WHERE auth_provider=local AND external_id IS NULL` → a conflicting federated `admin` is never clobbered; on 0 rows affected it **refuses to provision** (clear log) rather than hijack;
- read-only boot-time **detector** logs a SECURITY error for already-merged installs (`auth_provider=local AND external_id IS NOT NULL`), since pre-fix merges cannot be auto-un-merged.

## Validation
DB-level repro of the exact provisioning SQL (offline `cargo check` green):
- **Exploit case** (federated OIDC `admin` + restart): existence check 0 rows, guarded upsert `rows_affected=0` → **refuses; federated row untouched** (still `oidc`, no local password). Blocked.
- **Fresh install**: local admin created normally (no regression).
- **Local admin + federated user**: both intact, federated user untouched (no regression).

E2E regression coverage lands as a DTF tier (separate test-repo change).

## Not in this PR (separate, lower severity)
The reporter’s "delete OIDC account → db operation failed" is an unrelated FK issue: several `created_by UUID REFERENCES users(id)` FKs (`020_migration_tables`, `027_signing_keys`) lack `ON DELETE`, so deleting a user who created those rows is RESTRICT-blocked. Filing separately.