### PR TITLE
Release v1.6.3 — security hotfix #2875 (federated admin-collision) + pipeline idempotency back-port

### DIFF
--- a/.github/scripts/assert-version-digest-consistent.sh
+++ b/.github/scripts/assert-version-digest-consistent.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Digest-aware republish guard for the exact (chart-pinned) version tag.
+#
+#   usage: assert-version-digest-consistent.sh <version-tag> <incoming-digest> \
+#            <registry>'|'<repository> [more targets...]
+#   env:   GHCR_TOKEN, DOCKERHUB_USERNAME, DOCKERHUB_TOKEN  (for the state probe)
+#          the caller must also be `docker login`-ed to each registry so
+#          `docker buildx imagetools inspect` can read a present tag's digest.
+#
+# <incoming-digest> is the sha256 manifest-list digest this run points the
+# version tag at -- the manifest already assembled on (or resolved from) ghcr
+# THIS run. It is compared against whatever each registry currently serves for
+# <version-tag>.
+#
+# Why this replaces the blunt "tag exists -> refuse" guard
+# --------------------------------------------------------
+# The old guard (assert-stable-tag-free.sh) refused whenever the version tag was
+# PRESENT on either registry. That is correct for a fresh cut but wedges a
+# partial publish permanently: at the v1.6.2 cut the ghcr manifest published,
+# then the Docker Hub copy died on a transient network error, so the job went
+# red with `:1.6.2` already on ghcr. Every re-run then died at the guard --
+# because `:1.6.2` IS published -- and there was no way to finish the mirror.
+#
+# The safety property the guard actually protects is narrower than "the tag
+# exists": it is "a released image is never silently REPLACED WITH DIFFERENT
+# CONTENT". So this guard compares digests instead of mere existence:
+#
+#   absent        -> OK. First publish, or this registry never received the tag
+#                    (partial-publish recovery -- e.g. ghcr has it, Docker Hub
+#                    does not). There is nothing to overwrite.
+#   present, SAME -> OK. The tag already resolves to <incoming-digest>.
+#                    Re-applying it is a byte-for-byte no-op. THIS is what makes
+#                    a plain re-run (or the promote path) idempotent and lets a
+#                    partial publish be completed.
+#   present, DIFF -> REFUSE. The tag is published and resolves to OTHER content.
+#                    Re-pointing it would silently replace a released image with
+#                    different bits (a moved/re-cut git tag the preflight cannot
+#                    detect, or a tamper). This is the supply-chain protection,
+#                    preserved verbatim -- a DIFFERENT digest is still refused.
+#   indeterminate -> REFUSE (fail closed). Exactly as assert-stable-tag-free:
+#                    if the tag's state cannot be PROVEN we never publish over
+#                    it. An auth failure / outage must not read as "absent".
+#
+# State detection is delegated to registry-tag-state.sh, which reads an HTTP
+# status (never an error-text blob) and only ever reports `absent` for a
+# definitive MANIFEST_UNKNOWN 404 from a repository it has proven it can read.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="${SCRIPT_DIR}/registry-tag-state.sh"
+
+# The pure comparison. Kept as a named function with no I/O so it can be
+# exercised directly by --self-test: `decide <state> <existing> <incoming>`
+# returns 0 to ALLOW (publish/no-op) and 1 to REFUSE.
+decide() {
+  local state="$1" existing="$2" incoming="$3"
+  case "$state" in
+    absent)
+      return 0 ;;                                  # nothing published -> allow
+    present)
+      [[ -n "$existing" && "$existing" == "$incoming" ]] && return 0
+      return 1 ;;                                  # missing/other digest -> refuse
+    *)
+      return 1 ;;                                  # indeterminate -> fail closed
+  esac
+}
+
+self_test() {
+  local fails=0 d1='sha256:aaaa' d2='sha256:bbbb'
+  check() { # <desc> <expected 0|1> <state> <existing> <incoming>
+    local desc="$1" want="$2"; shift 2
+    decide "$@"; local got=$?
+    if [[ "$got" -eq "$want" ]]; then
+      echo "  ok   ${desc} (verdict=${got})"
+    else
+      echo "  FAIL ${desc}: wanted ${want} got ${got}"; fails=1
+    fi
+  }
+  # absent -> allow (fresh publish / partial-publish recovery)
+  check "absent allows publish"                 0 absent ''   "$d1"
+  # present + same digest -> allow (idempotent re-apply / promote)
+  check "present same-digest allows re-apply"   0 present "$d1" "$d1"
+  # present + different digest -> REFUSE (the threat: overwrite w/ other bits)
+  check "present different-digest refuses"      1 present "$d2" "$d1"
+  # present but digest unreadable -> REFUSE (cannot prove SAME)
+  check "present unreadable-digest refuses"     1 present ''   "$d1"
+  # indeterminate -> REFUSE (fail closed)
+  check "indeterminate refuses (fail closed)"   1 indeterminate '' "$d1"
+  return "$fails"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+  exit $?
+fi
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <version-tag> <incoming-digest> <registry>|<repository> [more...]" >&2
+  exit 2
+fi
+
+TAG="$1"
+INCOMING="$2"
+shift 2
+
+# Normalize: accept the digest with or without the sha256: prefix.
+[[ "$INCOMING" == sha256:* ]] || INCOMING="sha256:${INCOMING}"
+
+blocked=0
+
+for target in "$@"; do
+  registry="${target%%|*}"
+  repository="${target#*|}"
+  ref="${registry}/${repository}:${TAG}"
+
+  state=$("$PROBE" "$registry" "$repository" "$TAG") || true
+
+  existing=""
+  if [[ "$state" == "present" ]]; then
+    # Read the manifest-list digest the registry currently serves for this tag.
+    existing=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$ref" 2>/dev/null \
+      | jq -r '.digest // empty' 2>/dev/null) || existing=""
+    if [[ -z "$existing" ]]; then
+      # Present per the HTTP probe but its digest could not be read back: treat
+      # as unprovable rather than assume a match. Fails closed via decide().
+      echo "registry-tag-state: ${ref} reported present but its digest was unreadable" >&2
+    fi
+  fi
+
+  if decide "$state" "$existing" "$INCOMING"; then
+    case "$state" in
+      absent)  echo "  ok   ${ref} is not published yet — nothing to overwrite" ;;
+      present) echo "  ok   ${ref} already resolves to ${INCOMING} — idempotent re-apply" ;;
+    esac
+  else
+    case "$state" in
+      present)
+        echo "::error title=Published version would be overwritten::${ref} is published at ${existing:-<unreadable>}, but this run resolves ${INCOMING}. Exact version tags are the identity a chart pins; they are never re-pointed to different content. Cut a new version instead."
+        ;;
+      *)
+        echo "::error title=Registry lookup inconclusive::Unable to prove the state of ${ref} (probe said '${state}'). Refusing to publish rather than risk replacing a published tag."
+        ;;
+    esac
+    blocked=1
+  fi
+done
+
+exit "$blocked"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,9 +12,19 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Candidate image tag (e.g., rc-1.5.9, pr-123, 1.1-dev). Release-managed labels such as latest/dev/stable and version numbers are refused.'
-        required: true
+        description: 'Candidate image tag (e.g., rc-1.5.9, pr-123, 1.1-dev). Release-managed labels such as latest/dev/stable and version numbers are refused. Ignored when promote_version is set.'
+        required: false
         default: 'rc-candidate'
+      # PROMOTE mode (#2698): complete a partially-published release without
+      # rebuilding. Given a version already built on ghcr, resolve its published
+      # manifest-list digest and idempotently (re)apply every version tag and the
+      # Docker Hub mirror for all three images. The digest-aware guard still runs,
+      # so promote can only re-apply the SAME digest -- never replace it -- which
+      # is why it needs no manual tokens: it uses the pipeline's own credentials.
+      promote_version:
+        description: 'PROMOTE: finish/re-apply a version already built on ghcr (e.g. 1.6.2) — re-applies all tags + the Docker Hub mirror for all three images WITHOUT rebuilding. Leave blank for a normal build.'
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -53,6 +63,10 @@ jobs:
       # the string that gets published. Empty for non-dispatch events, where
       # the manual tag line is disabled anyway.
       dispatch_tag: ${{ steps.manual_tag.outputs.tag }}
+      # The validated PROMOTE target version (empty unless this is a promote
+      # dispatch). Non-empty flips the build jobs off and the merge jobs into
+      # re-apply-existing-digest mode.
+      promote_version: ${{ steps.promote.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -82,12 +96,45 @@ jobs:
             exit 1
           fi
 
+      # PROMOTE mode (#2698): validate the requested version and prove it is
+      # already published on ghcr BEFORE any downstream job tries to promote it,
+      # so a typo or an un-built version fails fast here rather than deep in the
+      # graph. Promote never builds; it only re-applies an existing digest, and
+      # the merge jobs re-run the digest-aware guard, so this cannot become a
+      # path to publish new content.
+      - name: Validate promote request
+        id: promote
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != ''
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMOTE_VERSION: ${{ github.event.inputs.promote_version }}
+        run: |
+          set -euo pipefail
+          V="$PROMOTE_VERSION"
+          # A promote target is an EXACT release version (the identity a chart
+          # pins) -- bare or v-prefixed semver with an optional prerelease
+          # suffix -- never a floating/candidate label.
+          if [[ ! "$V" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid promote_version::'${V}' is not an exact version (expected e.g. 1.6.2 or 1.6.2-rc.1)."
+            exit 1
+          fi
+          V="${V#v}"
+          # It must already exist on ghcr; promote completes an existing build.
+          state=$(.github/scripts/registry-tag-state.sh ghcr.io "${BACKEND_IMAGE}" "$V" || true)
+          if [[ "$state" != "present" ]]; then
+            echo "::error title=Nothing to promote::ghcr.io/${BACKEND_IMAGE}:${V} is '${state}', not 'present'. Promote re-applies an already-built version; build it first."
+            exit 1
+          fi
+          echo "Promote target validated: ${V} (present on ghcr.io/${BACKEND_IMAGE})."
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
       # Manual builds are useful for candidate/dev labels, but must not be a
       # back door around the guarded release path. See the script for why the
-      # normalized value is what gets validated and published.
+      # normalized value is what gets validated and published. Skipped in
+      # promote mode (the tag input is ignored there).
       - name: Validate manual tag
         id: manual_tag
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version == ''
         env:
           REQUESTED_TAG: ${{ github.event.inputs.tag }}
         run: |
@@ -99,6 +146,9 @@ jobs:
   build-backend:
     name: Backend (${{ matrix.platform }})
     needs: [publish-preflight]
+    # PROMOTE mode re-applies an existing ghcr digest and never rebuilds, so the
+    # build jobs are skipped entirely there. For every other event this is true.
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != '') }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -192,6 +242,8 @@ jobs:
   build-openscap:
     name: OpenSCAP (${{ matrix.platform }})
     needs: [publish-preflight]
+    # Skipped in PROMOTE mode (re-apply existing digest, no rebuild).
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != '') }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -272,6 +324,8 @@ jobs:
   build-scanner-adapter:
     name: Scanner Adapter (${{ matrix.platform }})
     needs: [publish-preflight]
+    # Skipped in PROMOTE mode (re-apply existing digest, no rebuild).
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.promote_version != '') }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -489,12 +543,18 @@ jobs:
           # backend-alpine digest output skipped while alpine builds are suspended.
 
       # --- Trivy CVE scanning ---
-      # --ignore-unfixed: only fail on CVEs with available patches.
-      # Unpatched UBI base image CVEs (Red Hat's responsibility) are still
-      # reported in SARIF for visibility but don't block the build.
-      # Trivy scans upload SARIF to GitHub Security tab for visibility.
-      # exit-code: 0 means scan results are informational — unfixed base image
-      # CVEs (Red Hat's responsibility) should not block image publishing.
+      # These scans ENFORCE (#2609): a CRITICAL or HIGH CVE with an available
+      # fix fails this job, and the merge-* jobs `need` this job, so no tag is
+      # published from a failing scan. The exception paths, in order:
+      #   * --ignore-unfixed: CVEs with no released fix (typically UBI base
+      #     image CVEs that are Red Hat's responsibility) are reported in
+      #     SARIF for visibility but do not block publication.
+      #   * .trivyignore: per-CVE accepted exceptions, each justified in that
+      #     file. This is the documented way to unblock a publish while a fix
+      #     is pending.
+      # All three scan steps run to completion (`if: always()` on the later
+      # ones) so a failing image never hides findings in the others, and the
+      # SARIF uploads below also run on failure.
       # NOTE: trivy binary extracted from official GHCR image because the
       # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
       - name: Install Trivy
@@ -515,7 +575,7 @@ jobs:
           # Suppress residual CVEs in the bundled trivy/grype CLI binaries that
           # have no fixed tool release yet (justified per-CVE in .trivyignore).
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       - name: Trivy scan - OpenSCAP
@@ -528,7 +588,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       - name: Trivy scan - Scanner Adapter
@@ -541,7 +601,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       # Alpine scan skipped while alpine builds are suspended.
@@ -555,7 +615,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       - name: Upload Backend Trivy SARIF
@@ -664,13 +724,12 @@ jobs:
           echo "## Container Security Scan Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Trivy CVE Scan" >> $GITHUB_STEP_SUMMARY
-          # These scans run with `exit-code: 0`: they report, they do not gate.
-          # Findings land in code scanning and in the uploaded SARIF. Saying
-          # otherwise here would be the same kind of unearned claim this
-          # workflow's other guards exist to remove. Making the policy real is
-          # tracked separately.
+          # This claim is earned (#2609): the scan steps run with
+          # `exit-code: 1` and every merge-* job `needs` this job, so a
+          # CRITICAL/HIGH fixable finding fails the scan and no tag is
+          # published. Keep this text and that wiring in sync.
           echo "- **Scope**: CRITICAL and HIGH severity, fixed CVEs only (\`.trivyignore\` documents accepted exceptions)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Policy**: reporting only — findings are uploaded to code scanning and do NOT block publication" >> $GITHUB_STEP_SUMMARY
+          echo "- **Policy**: enforced — a CRITICAL/HIGH CVE with an available fix fails this job, and the merge jobs depend on it, so publication is blocked" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **Scanner Adapter**: $([ -f scanner-adapter-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
@@ -687,12 +746,25 @@ jobs:
   merge-backend:
     name: Backend Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-backend]
+    # `scan-containers` is a real gate (#2609): a CRITICAL/HIGH fixable CVE in
+    # ANY of the three images blocks ALL tag publication, because the scan job
+    # scans them together. `.trivyignore` is the exception path if one image
+    # must ship while another is being fixed.
+    needs: [publish-preflight, build-backend, scan-containers]
+    # Runs on a normal build (build + scan green) OR in PROMOTE mode, where the
+    # build/scan jobs are skipped because promote re-applies an existing digest.
+    if: >-
+      ${{ !cancelled() && needs.publish-preflight.result == 'success'
+          && (needs.publish-preflight.outputs.promote_version != ''
+              || (needs.build-backend.result == 'success' && needs.scan-containers.result == 'success')) }}
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+    env:
+      # Non-empty => PROMOTE mode: re-apply the existing ghcr digest, no rebuild.
+      PROMOTE_VERSION: ${{ needs.publish-preflight.outputs.promote_version }}
 
     steps:
       - name: Checkout (scripts and VEX files)
@@ -703,6 +775,7 @@ jobs:
             .vex
 
       - name: Download digests
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
@@ -728,28 +801,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # The exact version tag is the identity the Helm chart pins, so it is
-      # published once and never re-pointed -- not by a rerun, and not by a
-      # delete-and-recreate of the git tag, which the preflight cannot detect
-      # (only a repository ruleset can). Both registries are checked because
-      # this run writes to both, and a tag that survives on one is not evidence
-      # about the other. The floating tags (latest, X.Y) are expected to move
-      # and are not checked here.
-      - name: Refuse to overwrite a published backend version
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          .github/scripts/assert-stable-tag-free.sh "$VERSION" \
-            "ghcr.io|${BACKEND_IMAGE}" \
-            "docker.io|${DOCKERHUB_BACKEND}"
-
       - name: Extract metadata (ghcr.io)
         id: meta
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}
@@ -766,6 +820,7 @@ jobs:
 
       - name: Extract metadata (Docker Hub)
         id: meta-dockerhub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: docker.io/${{ env.DOCKERHUB_BACKEND }}
@@ -780,38 +835,163 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
-      - name: Create manifest list and push (ghcr.io)
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:%s ' *)
+      # Resolve, for BOTH modes, the full ghcr + Docker Hub tag sets and the
+      # single "exact" version tag that must be guarded (empty for branch/pr/
+      # manual builds that publish no chart-pinned identity tag).
+      - name: Resolve publish plan
+        id: plan
         env:
-          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
-
-      - name: Inspect image
-        id: inspect
+          META_JSON: ${{ steps.meta.outputs.json }}
+          META_HUB_JSON: ${{ steps.meta-dockerhub.outputs.json }}
+          META_VERSION: ${{ steps.meta.outputs.version }}
+          GH_REF: ${{ github.ref }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.meta.outputs.version }}
-          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            # PROMOTE: no build metadata. Always re-apply the exact identity tag;
+            # for each floating tag (X.Y, latest) re-apply it ONLY if ghcr ALREADY
+            # points it at this version's digest. That way promote mirrors ghcr's
+            # CURRENT state to the missing registry and can never move a floating
+            # tag backwards to an older promoted version.
+            VERSION="${PROMOTE_VERSION}"
+            GIMG="${REGISTRY}/${BACKEND_IMAGE}"; HIMG="docker.io/${DOCKERHUB_BACKEND}"
+            vdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${VERSION}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+            if [[ "${vdig}" != sha256:* ]]; then
+              echo "::error title=Nothing to promote::${GIMG}:${VERSION} is not present on ghcr; cannot promote."; exit 1
+            fi
+            ghcr=( "${GIMG}:${VERSION}" ); hub=( "${HIMG}:${VERSION}" )
+            for ft in "${VERSION%.*}" latest; do
+              fdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${ft}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+              if [[ -n "${fdig}" && "${fdig}" == "${vdig}" ]]; then
+                ghcr+=( "${GIMG}:${ft}" ); hub+=( "${HIMG}:${ft}" )
+                echo "  floating :${ft} -> included (ghcr already at ${VERSION})"
+              else
+                echo "  floating :${ft} -> skipped (ghcr=${fdig:-absent}, not this version)"
+              fi
+            done
+            printf '%s\n' "${ghcr[@]}" | jq -R . | jq -cs . > /tmp/ghcr-tags.json
+            printf '%s\n' "${hub[@]}"  | jq -R . | jq -cs . > /tmp/hub-tags.json
+            echo "exact=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            # NORMAL: tags come straight from docker/metadata-action.
+            jq -c '.tags' <<< "${META_JSON}" > /tmp/ghcr-tags.json
+            jq -c '.tags' <<< "${META_HUB_JSON}" > /tmp/hub-tags.json
+            # Only a clean release tag publishes a guarded exact identity tag.
+            if [[ "${GH_REF}" == refs/tags/v* ]]; then
+              echo "exact=${META_VERSION}" >> "$GITHUB_OUTPUT"
+            else
+              echo "exact=" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "ghcr tags:"; cat /tmp/ghcr-tags.json; echo
+          echo "hub tags:";  cat /tmp/hub-tags.json;  echo
 
+      # Resolve the manifest-list digest this run will point the tags at, WITHOUT
+      # writing the exact/floating tags first:
+      #   NORMAL  - assemble the multi-arch manifest onto a content-addressed
+      #             anchor tag (:sha-...). A sha tag names the content it points
+      #             at, so writing it is safe even on a refuse path, and it makes
+      #             the digest knowable BEFORE the guard runs.
+      #   PROMOTE - the manifest already exists on ghcr; just read its digest.
+      - name: Resolve incoming digest
+        id: incoming
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${BACKEND_IMAGE}"
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            REF="${IMG}:${PROMOTE_VERSION}"
+          else
+            ANCHOR=$(jq -r 'map(select(test(":sha-")))[0] // empty' /tmp/ghcr-tags.json)
+            if [[ -z "${ANCHOR}" ]]; then
+              echo "::error::no :sha- anchor tag in the ghcr tag set; cannot stage the manifest safely"; exit 1
+            fi
+            shopt -s nullglob
+            srcs=()
+            for f in /tmp/digests/*; do srcs+=( "${IMG}@sha256:$(basename "$f")" ); done
+            if [[ "${#srcs[@]}" -eq 0 ]]; then
+              echo "::error::no per-arch digests in /tmp/digests"; exit 1
+            fi
+            docker buildx imagetools create -t "${ANCHOR}" "${srcs[@]}"
+            REF="${ANCHOR}"
+          fi
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${REF}" | jq -r '.digest')
+          [[ "${DIGEST}" == sha256:* ]] || { echo "::error::could not resolve a digest for ${REF}"; exit 1; }
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Incoming manifest-list digest: ${DIGEST} (from ${REF})"
+
+      # Digest-aware republish guard (preserves the supply-chain property).
+      #
+      # Runs whenever an exact chart-pinned identity tag is being published
+      # (release tags AND promote), on BOTH registries this job writes to. The
+      # comparison, spelled out:
+      #   - tag absent            -> allow (fresh publish, or a partial-publish
+      #                              this run is completing on the missing side).
+      #   - tag == incoming digest -> allow (idempotent re-apply / promote no-op).
+      #   - tag != incoming digest -> REFUSE. A released tag would be silently
+      #                              re-pointed to DIFFERENT content (a moved/
+      #                              re-cut git tag the preflight cannot see, or a
+      #                              tamper). This is the exact protection the old
+      #                              "tag exists -> refuse" guard gave, kept intact.
+      #   - state indeterminate    -> REFUSE (fail closed).
+      # This is what lets a partial publish (ghcr done, Docker Hub not) be
+      # completed by a re-run/promote while still forbidding a different-digest
+      # overwrite.
+      - name: Refuse to overwrite a published backend version
+        if: ${{ steps.plan.outputs.exact != '' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .github/scripts/assert-version-digest-consistent.sh \
+            "${{ steps.plan.outputs.exact }}" \
+            "${{ steps.incoming.outputs.digest }}" \
+            "ghcr.io|${BACKEND_IMAGE}" \
+            "docker.io|${DOCKERHUB_BACKEND}"
+
+      # Apply (or re-apply) every ghcr tag at the resolved digest. Re-pointing a
+      # tag to the SAME digest is a no-op, so this is safe to re-run.
+      - name: Apply ghcr tags
+        run: |
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/ghcr-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          docker buildx imagetools create "${args[@]}" \
+            "${REGISTRY}/${BACKEND_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          docker buildx imagetools inspect "${REGISTRY}/${BACKEND_IMAGE}@${{ steps.incoming.outputs.digest }}" >/dev/null
+
+      # Mirror to Docker Hub with retry. A transient PROTOCOL_ERROR/ETIMEDOUT on
+      # the Docker Hub side is exactly what left v1.6.2 half-published; because
+      # imagetools create re-points tags to the SAME digest, each retry is a safe
+      # no-op-or-complete rather than a re-publish.
       - name: Copy to Docker Hub
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta-dockerhub.outputs.json }}') \
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/hub-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          SRC="${REGISTRY}/${BACKEND_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          n=0; max=5
+          until docker buildx imagetools create "${args[@]}" "${SRC}"; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::imagetools create to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
 
       - name: Sign image with cosign (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.incoming.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
+          subject-digest: ${{ steps.incoming.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
@@ -824,19 +1004,27 @@ jobs:
             docker scout attestation add \
               --file "$vex" \
               --predicate-type https://openvex.dev/ns/v0.2.0 \
-              ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+              ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.incoming.outputs.digest }}
           done
         continue-on-error: true
 
   merge-openscap:
     name: OpenSCAP Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-openscap]
+    # Gated on the container scan; see merge-backend (#2609).
+    needs: [publish-preflight, build-openscap, scan-containers]
+    # Normal build (build + scan green) OR PROMOTE mode. See merge-backend.
+    if: >-
+      ${{ !cancelled() && needs.publish-preflight.result == 'success'
+          && (needs.publish-preflight.outputs.promote_version != ''
+              || (needs.build-openscap.result == 'success' && needs.scan-containers.result == 'success')) }}
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+    env:
+      PROMOTE_VERSION: ${{ needs.publish-preflight.outputs.promote_version }}
 
     steps:
       - name: Checkout (scripts)
@@ -845,6 +1033,7 @@ jobs:
           sparse-checkout: .github/scripts
 
       - name: Download digests
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
@@ -870,23 +1059,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Same rule as the backend: the exact version tag is published once, on
-      # both registries, and is never re-pointed. See merge-backend.
-      - name: Refuse to overwrite a published openscap version
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          .github/scripts/assert-stable-tag-free.sh "$VERSION" \
-            "ghcr.io|${OPENSCAP_IMAGE}" \
-            "docker.io|${DOCKERHUB_OPENSCAP}"
-
       - name: Extract metadata (ghcr.io)
         id: meta
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}
@@ -903,6 +1078,7 @@ jobs:
 
       - name: Extract metadata (Docker Hub)
         id: meta-dockerhub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: docker.io/${{ env.DOCKERHUB_OPENSCAP }}
@@ -917,50 +1093,151 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
-      - name: Create manifest list and push (ghcr.io)
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@sha256:%s ' *)
+      # See merge-backend for the full rationale of the plan/anchor/guard/apply/
+      # mirror sequence. Same shape, OpenSCAP image.
+      - name: Resolve publish plan
+        id: plan
         env:
-          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
-
-      - name: Inspect image
-        id: inspect
+          META_JSON: ${{ steps.meta.outputs.json }}
+          META_HUB_JSON: ${{ steps.meta-dockerhub.outputs.json }}
+          META_VERSION: ${{ steps.meta.outputs.version }}
+          GH_REF: ${{ github.ref }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:${{ steps.meta.outputs.version }}
-          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
-            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            # See merge-backend for the floating-tag rule: re-apply a floating tag
+            # only if ghcr already points it at this version (never move it back).
+            VERSION="${PROMOTE_VERSION}"
+            GIMG="${REGISTRY}/${OPENSCAP_IMAGE}"; HIMG="docker.io/${DOCKERHUB_OPENSCAP}"
+            vdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${VERSION}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+            if [[ "${vdig}" != sha256:* ]]; then
+              echo "::error title=Nothing to promote::${GIMG}:${VERSION} is not present on ghcr; cannot promote."; exit 1
+            fi
+            ghcr=( "${GIMG}:${VERSION}" ); hub=( "${HIMG}:${VERSION}" )
+            for ft in "${VERSION%.*}" latest; do
+              fdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${ft}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+              if [[ -n "${fdig}" && "${fdig}" == "${vdig}" ]]; then
+                ghcr+=( "${GIMG}:${ft}" ); hub+=( "${HIMG}:${ft}" )
+                echo "  floating :${ft} -> included (ghcr already at ${VERSION})"
+              else
+                echo "  floating :${ft} -> skipped (ghcr=${fdig:-absent}, not this version)"
+              fi
+            done
+            printf '%s\n' "${ghcr[@]}" | jq -R . | jq -cs . > /tmp/ghcr-tags.json
+            printf '%s\n' "${hub[@]}"  | jq -R . | jq -cs . > /tmp/hub-tags.json
+            echo "exact=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            jq -c '.tags' <<< "${META_JSON}" > /tmp/ghcr-tags.json
+            jq -c '.tags' <<< "${META_HUB_JSON}" > /tmp/hub-tags.json
+            if [[ "${GH_REF}" == refs/tags/v* ]]; then
+              echo "exact=${META_VERSION}" >> "$GITHUB_OUTPUT"
+            else
+              echo "exact=" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "ghcr tags:"; cat /tmp/ghcr-tags.json; echo
+          echo "hub tags:";  cat /tmp/hub-tags.json;  echo
+
+      - name: Resolve incoming digest
+        id: incoming
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${OPENSCAP_IMAGE}"
+          if [[ -n "${PROMOTE_VERSION}" ]]; then
+            REF="${IMG}:${PROMOTE_VERSION}"
+          else
+            ANCHOR=$(jq -r 'map(select(test(":sha-")))[0] // empty' /tmp/ghcr-tags.json)
+            if [[ -z "${ANCHOR}" ]]; then
+              echo "::error::no :sha- anchor tag in the ghcr tag set; cannot stage the manifest safely"; exit 1
+            fi
+            shopt -s nullglob
+            srcs=()
+            for f in /tmp/digests/*; do srcs+=( "${IMG}@sha256:$(basename "$f")" ); done
+            if [[ "${#srcs[@]}" -eq 0 ]]; then
+              echo "::error::no per-arch digests in /tmp/digests"; exit 1
+            fi
+            docker buildx imagetools create -t "${ANCHOR}" "${srcs[@]}"
+            REF="${ANCHOR}"
+          fi
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${REF}" | jq -r '.digest')
+          [[ "${DIGEST}" == sha256:* ]] || { echo "::error::could not resolve a digest for ${REF}"; exit 1; }
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Incoming manifest-list digest: ${DIGEST} (from ${REF})"
+
+      - name: Refuse to overwrite a published openscap version
+        if: ${{ steps.plan.outputs.exact != '' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .github/scripts/assert-version-digest-consistent.sh \
+            "${{ steps.plan.outputs.exact }}" \
+            "${{ steps.incoming.outputs.digest }}" \
+            "ghcr.io|${OPENSCAP_IMAGE}" \
+            "docker.io|${DOCKERHUB_OPENSCAP}"
+
+      - name: Apply ghcr tags
+        run: |
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/ghcr-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          docker buildx imagetools create "${args[@]}" \
+            "${REGISTRY}/${OPENSCAP_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          docker buildx imagetools inspect "${REGISTRY}/${OPENSCAP_IMAGE}@${{ steps.incoming.outputs.digest }}" >/dev/null
 
       - name: Copy to Docker Hub
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta-dockerhub.outputs.json }}') \
-            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.inspect.outputs.digest }}
+          set -euo pipefail
+          mapfile -t TAGS < <(jq -r '.[]' /tmp/hub-tags.json)
+          args=(); for t in "${TAGS[@]}"; do args+=( -t "$t" ); done
+          SRC="${REGISTRY}/${OPENSCAP_IMAGE}@${{ steps.incoming.outputs.digest }}"
+          n=0; max=5
+          until docker buildx imagetools create "${args[@]}" "${SRC}"; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::imagetools create to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
 
       - name: Sign image with cosign (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.incoming.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
+          subject-digest: ${{ steps.incoming.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
   merge-scanner-adapter:
     name: Scanner Adapter Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-scanner-adapter]
+    # Gated on the container scan; see merge-backend (#2609).
+    needs: [publish-preflight, build-scanner-adapter, scan-containers]
+    # Normal build (build + scan green) OR PROMOTE mode. See merge-backend.
+    if: >-
+      ${{ !cancelled() && needs.publish-preflight.result == 'success'
+          && (needs.publish-preflight.outputs.promote_version != ''
+              || (needs.build-scanner-adapter.result == 'success' && needs.scan-containers.result == 'success')) }}
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+    env:
+      # Non-empty => PROMOTE mode. The adapter is independently versioned, so
+      # promote re-applies the adapter version recorded in docker/scanner-adapter/
+      # VERSION at the checked-out ref; run promote from the release commit so
+      # that file names the version that shipped with the release being completed.
+      PROMOTE_VERSION: ${{ needs.publish-preflight.outputs.promote_version }}
 
     steps:
       - name: Checkout
@@ -990,6 +1267,7 @@ jobs:
           fi
 
       - name: Download digests
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
@@ -1031,6 +1309,7 @@ jobs:
       # demands a VERSION bump.
       - name: Decide stable adapter publication
         id: adapter_publish
+        if: ${{ env.PROMOTE_VERSION == '' }}
         env:
           ADAPTER_VERSION: ${{ steps.adapter_version.outputs.version }}
           STABLE_REQUESTED: ${{ steps.adapter_version.outputs.stable_requested }}
@@ -1077,7 +1356,15 @@ jobs:
           fi
 
           if [[ "$GHCR_STATE" != "$HUB_STATE" ]]; then
-            echo "::error title=Adapter registries disagree::${ADAPTER_VERSION} is ${GHCR_STATE} on ghcr.io but ${HUB_STATE} on docker.io. Reconcile the two registries before publishing; this job will not resolve the split by overwriting either one."
+            # One registry has the exact tag, the other does not -- typically a
+            # partial publish whose Docker Hub mirror died mid-run. A fresh build
+            # must NOT resolve that by re-pushing the exact tag (a rebuild has a
+            # new digest and would move the tag that is meant to be immutable), so
+            # this path still fails closed. The digest-safe way to finish it is
+            # the PROMOTE dispatch, which re-applies the ALREADY-published digest:
+            #   gh workflow run docker-publish.yml -f promote_version=<AK version>
+            # run from the release commit. See the promote path below.
+            echo "::error title=Adapter registries disagree::${ADAPTER_VERSION} is ${GHCR_STATE} on ghcr.io but ${HUB_STATE} on docker.io — likely a partial publish. A rebuild will not re-point the immutable exact tag. Complete it with the promote dispatch (promote_version=<AK version>, run from the release commit), which re-applies the published digest."
             exit 1
           fi
 
@@ -1116,6 +1403,7 @@ jobs:
 
       - name: Extract metadata (ghcr.io)
         id: meta
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
@@ -1136,6 +1424,7 @@ jobs:
 
       - name: Extract metadata (Docker Hub)
         id: meta-dockerhub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: docker.io/${{ env.DOCKERHUB_SCANNER_ADAPTER }}
@@ -1152,6 +1441,7 @@ jobs:
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
       - name: Create manifest list and push (ghcr.io)
+        if: ${{ env.PROMOTE_VERSION == '' }}
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -1165,6 +1455,7 @@ jobs:
 
       - name: Inspect image
         id: inspect
+        if: ${{ env.PROMOTE_VERSION == '' }}
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:${{ steps.meta.outputs.version }}
           DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
@@ -1176,26 +1467,117 @@ jobs:
       # unchanged-source rebuild from a version collision, so a Docker Hub index
       # without it would have no provenance anchor at all.
       - name: Copy to Docker Hub
+        if: ${{ env.PROMOTE_VERSION == '' }}
         env:
           ADAPTER_VERSION: ${{ steps.adapter_version.outputs.version }}
           DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta-dockerhub.outputs.json }}
         run: |
-          docker buildx imagetools create \
+          set -euo pipefail
+          # Retry the cross-registry copy: a transient PROTOCOL_ERROR/ETIMEDOUT on
+          # the Docker Hub side is what leaves a release half-published. imagetools
+          # create re-points tags to the SAME digest, so each retry is a safe
+          # no-op-or-complete.
+          # shellcheck disable=SC2046  # tag args are intentionally word-split
+          n=0; max=5
+          until docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.revision=${GITHUB_SHA}" \
             --annotation "index:org.opencontainers.image.version=${ADAPTER_VERSION}" \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::imagetools create to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
+
+      # ── PROMOTE path (#2698) ──────────────────────────────────────────────
+      # Re-apply the adapter's already-published version + floating tags and the
+      # Docker Hub mirror WITHOUT rebuilding, to finish a partial publish. The
+      # exact tag is only ever re-pointed to its OWN published digest, and the
+      # digest-aware guard enforces that.
+      - name: Promote — resolve published adapter digest
+        id: promote_digest
+        if: ${{ env.PROMOTE_VERSION != '' }}
+        env:
+          ADAPTER_VERSION: ${{ steps.adapter_version.outputs.version }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${SCANNER_ADAPTER_IMAGE}"
+          state=$(.github/scripts/registry-tag-state.sh ghcr.io "${SCANNER_ADAPTER_IMAGE}" "${ADAPTER_VERSION}" || true)
+          if [[ "$state" != "present" ]]; then
+            echo "::error title=Nothing to promote for scanner-adapter::ghcr.io/${SCANNER_ADAPTER_IMAGE}:${ADAPTER_VERSION} is '${state}'. The adapter VERSION at this ref (${ADAPTER_VERSION}) is not the published one; run promote from the release commit."
+            exit 1
+          fi
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${IMG}:${ADAPTER_VERSION}" | jq -r '.digest')
+          [[ "${DIGEST}" == sha256:* ]] || { echo "::error::could not resolve adapter digest"; exit 1; }
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Promoting scanner-adapter ${ADAPTER_VERSION} at ${DIGEST}"
+
+      - name: Promote — refuse to overwrite a published scanner-adapter version
+        if: ${{ env.PROMOTE_VERSION != '' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          .github/scripts/assert-version-digest-consistent.sh \
+            "${{ steps.adapter_version.outputs.version }}" \
+            "${{ steps.promote_digest.outputs.digest }}" \
+            "ghcr.io|${SCANNER_ADAPTER_IMAGE}" \
+            "docker.io|${DOCKERHUB_SCANNER_ADAPTER}"
+
+      - name: Promote — re-apply adapter tags (ghcr + Docker Hub)
+        if: ${{ env.PROMOTE_VERSION != '' }}
+        env:
+          V: ${{ steps.adapter_version.outputs.version }}
+          MINOR: ${{ steps.adapter_version.outputs.minor }}
+          MAJOR: ${{ steps.adapter_version.outputs.major }}
+          DIGEST: ${{ steps.promote_digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          GIMG="${REGISTRY}/${SCANNER_ADAPTER_IMAGE}"
+          HIMG="docker.io/${DOCKERHUB_SCANNER_ADAPTER}"
+          # Always re-apply the exact identity tag (guarded to the same digest).
+          gargs=( -t "${GIMG}:${V}" ); hargs=( -t "${HIMG}:${V}" )
+          # Re-apply each floating tag (adapter's own X.Y / X / latest line) ONLY
+          # if ghcr already points it at this version, so promote never moves a
+          # floating tag backwards (mirror ghcr's current state to Docker Hub).
+          for ft in "${MINOR}" "${MAJOR}" latest; do
+            fdig=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${GIMG}:${ft}" 2>/dev/null | jq -r '.digest' 2>/dev/null || true)
+            if [[ -n "${fdig}" && "${fdig}" == "${DIGEST}" ]]; then
+              gargs+=( -t "${GIMG}:${ft}" ); hargs+=( -t "${HIMG}:${ft}" )
+              echo "  floating :${ft} -> included (ghcr already at ${V})"
+            else
+              echo "  floating :${ft} -> skipped (ghcr=${fdig:-absent}, not this version)"
+            fi
+          done
+          docker buildx imagetools create "${gargs[@]}" "${GIMG}@${DIGEST}"
+          n=0; max=5
+          until docker buildx imagetools create "${hargs[@]}" "${GIMG}@${DIGEST}"; do
+            n=$((n + 1))
+            if [[ "$n" -ge "$max" ]]; then
+              echo "::error title=Docker Hub mirror failed::adapter promote to Docker Hub failed after ${max} attempts."
+              exit 1
+            fi
+            echo "Docker Hub copy attempt ${n}/${max} failed; retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
 
       - name: Sign image with cosign (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest || steps.promote_digest.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
+          subject-digest: ${{ steps.inspect.outputs.digest || steps.promote_digest.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
@@ -1204,7 +1586,8 @@ jobs:
     # Alpine builds suspended; the multi-arch manifest job follows them.
     if: false
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-backend-alpine]
+    # Gated on the container scan; see merge-backend (#2609).
+    needs: [publish-preflight, build-backend-alpine, scan-containers]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,11 @@ jobs:
   # docker-publish.yml runs INDEPENDENTLY on the same tag push and publishes
   # ghcr.io/.../artifact-keeper-backend:${VERSION} as a manifest list. Nothing
   # connects the two workflows except this poll of the registry. Once
-  # merge-backend has pushed the tag, `assert-stable-tag-free` in
-  # docker-publish.yml guarantees it can never be re-pointed, so the
-  # tag->digest binding is stable the moment it first resolves.
+  # merge-backend has pushed the tag, the digest-aware republish guard
+  # (`assert-version-digest-consistent`) in docker-publish.yml guarantees it can
+  # never be re-pointed to DIFFERENT content -- only re-applied to the same
+  # digest, a no-op -- so the tag->digest binding is stable the moment it first
+  # resolves.
   #
   # This job blocks the release gate until that manifest list exists and
   # captures its digest, so the gate deploys and tests the EXACT bytes that
@@ -539,7 +541,8 @@ jobs:
       # ── Candidate-digest tripwire (issue #2696) ─────────────────────────────
       # Re-resolve the published ghcr backend:${VERSION} digest and assert it
       # EQUALS the digest resolve-candidate-digest handed the gate. With
-      # docker-publish's `assert-stable-tag-free` in place a mismatch should be
+      # docker-publish's digest-aware republish guard
+      # (`assert-version-digest-consistent`) in place a mismatch should be
       # impossible; this step makes "bytes tested == bytes published" observable
       # and RED per release -- the direct "prove it" artifact for the bar. Paste
       # this line, the gate's pod-imageID assertion, and resolve's output into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-07-23
+
+A security patch for the 1.6.0 line. In-place upgrade from any 1.6.x is a drop-in image swap with no database migration.
+
+### Security
+
+- **Startup admin provisioning no longer merges a federated (SSO) identity into the built-in local admin** (#2875): when a federated OIDC/SAML/LDAP user held the username `admin` — which occurs under `SKIP_ADMIN_PROVISIONING` (SSO-managed admin) or when the identity provider's username claim is `admin` — a backend restart would convert that user's account to a local login and stamp the built-in admin password onto it, collapsing the two identities into a single administrator account (cross-identity privilege escalation / account takeover). Startup provisioning now refuses to cross the local/federated boundary and never mutates a federated account.
+
+  **Am I affected?** Only deployments using federated SSO where a federated user has, or previously had, the username `admin`. On startup the backend now logs a `SECURITY (#2875)` warning if it detects an already-merged account (a local account that still carries a federated `external_id`); operators of such installs should verify each flagged account's true owner and reset the built-in admin credential. See the advisory (GHSA, pending).
+
 ## [1.6.2] - 2026-07-23
 
 A patch release for the 1.6.0 line resolving three customer-reported migration and OIDC issues from a 1.6.1 field deployment, plus a security fix for federated admin-group mapping. In-place upgrade from 1.6.1 is a drop-in image swap with no database migration. There is **one behavioral breaking change** for federated (OIDC/SAML/LDAP) SSO deployments that rely on implicit admin-group name matching — see **Upgrade notes**.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.6.2",
+        version = "1.6.3",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1882,10 +1882,10 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
                     )
                     .bind(&password_hash)
                     .execute(&mut *tx)
-                        .await
-                        .map_err(|e| {
-                            artifact_keeper_backend::error::AppError::Database(e.to_string())
-                        })?;
+                    .await
+                    .map_err(|e| {
+                        artifact_keeper_backend::error::AppError::Database(e.to_string())
+                    })?;
                     log_admin_setup_banner(&password_file, Some(&password));
                 }
             }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1764,12 +1764,50 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         .await
         .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
+    // #2875: detect installs already affected by the pre-fix collision. A row
+    // that is `auth_provider = 'local'` yet still carries a federated
+    // `external_id` is the fingerprint of a federated identity that a prior
+    // build merged into the built-in local admin. We cannot safely un-merge it
+    // automatically (the original local-admin credentials were overwritten and
+    // the federated user's original username is lost), so surface it loudly for
+    // manual remediation. Read-only; never mutates.
+    let collided: Option<(i64,)> = sqlx::query_as(
+        "SELECT COUNT(*) FROM users WHERE auth_provider = 'local' AND external_id IS NOT NULL",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+    if let Some((n,)) = collided {
+        if n > 0 {
+            tracing::error!(
+                collided_accounts = n,
+                "SECURITY (#2875): {n} local account(s) still carry a federated external_id -- the \
+                 fingerprint of an SSO identity merged into a local account by a pre-fix build. \
+                 Review these rows: an operator should verify each account's true owner, reset the \
+                 built-in admin credential, and clear the stray external_id on any account that \
+                 should remain local. See the v1.6.3 advisory.",
+            );
+        }
+    }
+
     // Re-check admin existence while holding the lock (double-check pattern).
-    let admin_row: Option<(bool,)> =
-        sqlx::query_as("SELECT must_change_password FROM users WHERE is_admin = true LIMIT 1")
-            .fetch_optional(&mut *tx)
-            .await
-            .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+    //
+    // #2875: only a NON-FEDERATED admin counts as "the built-in admin exists".
+    // A federated (SSO) principal always carries `external_id`; if such a user
+    // happens to be admin (e.g. an OIDC user named `admin` under
+    // SKIP_ADMIN_PROVISIONING, or granted admin then demoted), it must NOT be
+    // mistaken for the built-in local admin here -- otherwise the maintenance
+    // branch below would flip its `auth_provider` to 'local' and stamp the
+    // built-in admin password onto it, merging the two identities. Excluding
+    // `external_id IS NOT NULL` routes that case to the create branch, whose
+    // upsert is itself guarded against clobbering a federated row.
+    let admin_row: Option<(bool,)> = sqlx::query_as(
+        "SELECT must_change_password FROM users \
+         WHERE is_admin = true AND external_id IS NULL LIMIT 1",
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
     let demo_mode = matches!(std::env::var("DEMO_MODE").as_deref(), Ok("true" | "1"));
 
@@ -1779,7 +1817,8 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         // already correct but fixes installs that ended up with a wrong value.
         sqlx::query(
             "UPDATE users SET auth_provider = 'local' \
-             WHERE username = 'admin' AND auth_provider != 'local'",
+             WHERE username = 'admin' AND auth_provider != 'local' \
+               AND external_id IS NULL",
         )
         .execute(&mut *tx)
         .await
@@ -1833,9 +1872,16 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
                 } else {
                     // File written successfully, now update the DB hash to match.
                     let password_hash = AuthService::hash_password(&password).await?;
-                    sqlx::query("UPDATE users SET password_hash = $1 WHERE username = 'admin'")
-                        .bind(&password_hash)
-                        .execute(&mut *tx)
+                    // #2875: never write the built-in admin password onto a
+                    // federated row; scope strictly to the local, non-federated
+                    // built-in admin.
+                    sqlx::query(
+                        "UPDATE users SET password_hash = $1 \
+                         WHERE username = 'admin' AND auth_provider = 'local' \
+                           AND external_id IS NULL",
+                    )
+                    .bind(&password_hash)
+                    .execute(&mut *tx)
                         .await
                         .map_err(|e| {
                             artifact_keeper_backend::error::AppError::Database(e.to_string())
@@ -1898,7 +1944,15 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
 
     let password_hash = AuthService::hash_password(&password).await?;
 
-    sqlx::query(
+    // #2875: the built-in admin is keyed on username='admin'. If a FEDERATED
+    // (SSO) user already holds that username, the ON CONFLICT upsert must NOT
+    // clobber it -- doing so would stamp the built-in admin password onto the
+    // federated account and flip it to a local login, merging the two
+    // identities into one admin account. The WHERE on DO UPDATE restricts the
+    // update to a genuine local, non-federated row; when the conflicting row is
+    // federated the update is skipped (rows_affected == 0) and we refuse to
+    // provision rather than hijack the identity.
+    let provisioned = sqlx::query(
         r#"
         INSERT INTO users (username, email, password_hash, is_admin, must_change_password, auth_provider)
         VALUES ('admin', 'admin@localhost', $1, true, $2, 'local')
@@ -1906,6 +1960,7 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
             SET password_hash = EXCLUDED.password_hash,
                 must_change_password = EXCLUDED.must_change_password,
                 auth_provider = 'local'
+            WHERE users.auth_provider = 'local' AND users.external_id IS NULL
         "#,
     )
     .bind(&password_hash)
@@ -1913,6 +1968,24 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
     .execute(&mut *tx)
     .await
     .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+
+    if provisioned.rows_affected() == 0 {
+        // The 'admin' username is held by a federated (external_id IS NOT NULL)
+        // account. Refuse to overwrite it. Do NOT abort startup (the federated
+        // account may legitimately be the SSO-managed admin); log loudly and
+        // continue without a built-in local admin.
+        tx.rollback()
+            .await
+            .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+        tracing::error!(
+            "Refusing to provision the built-in 'admin' user: the username 'admin' is already held \
+             by a federated (SSO) account. Overwriting it would merge that identity with the local \
+             admin (#2875). Rename or remove the federated account, or set \
+             SKIP_ADMIN_PROVISIONING=true to let SSO manage admin access. Continuing without a \
+             built-in local admin."
+        );
+        return Ok(false);
+    }
 
     tx.commit()
         .await


### PR DESCRIPTION
Cuts **v1.6.3** off the 1.6.x line. Closes #2875.

## Contents
1. **#2875 (security)** — startup admin provisioning no longer merges a federated (SSO) identity into the built-in local admin. Back-port of the fix merged to main in #2877. Guards every provisioning statement against crossing the local/federated boundary + a boot-time detector for already-merged installs.
2. **#2869 (pipeline)** — back-ports the idempotent `docker-publish.yml` (digest-aware republish guard + Docker Hub retry + build-free promote mode) to the 1.6.x release line, so this cut publishes on the fixed pipeline and cannot wedge on a partial publish. Already on `main`.
3. **Release chore** — workspace version + `openapi.rs` → 1.6.3, CHANGELOG.

## Validation
- #2875 fix: DB-level repro (hijack blocked, fresh-install + local-admin regression-free); `cargo check`/`fmt` clean; **DTF tier `admin-collision-2875` GREEN 6/6 on the fixed image, RED on shipped 1.6.2** (discriminating). Full CI green on the main PR #2877 (unit re-run passed after a runner-reclaim flake).
- No database migration; in-place image swap from any 1.6.x.

Main-first satisfied: #2875 merged to main (5133f5fc); #2869 already on main.