### PR TITLE
security(images): suppress grype-bundled GHSA-hrxh-6v49-42gf (unblocks publish)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -64,6 +64,17 @@ CVE-2026-41568
 CVE-2026-42306
 
 # ---------------------------------------------------------------------------
+# grype v0.116.0 binary — google.golang.org/grpc @ v1.80.0
+# GHSA-hrxh-6v49-42gf (gRPC-Go: xDS RBAC and HTTP/2 vulnerabilities): fixed in
+# grpc-go v1.82.1, but grype v0.116.0 (latest) has not rebuilt against it.
+# Neither affected path is reachable in how AK drives grype: it is not an
+# xDS/service-mesh client (the RBAC authz path is dead code), and it runs as a
+# short-lived local CLI over on-disk artifacts/SBOMs with a pre-seeded offline
+# DB — it exposes no HTTP/2 server surface to untrusted peers. Drops off when
+# grype ships a release built on grpc-go >= 1.82.1. Re-evaluate on bump (#2391).
+GHSA-hrxh-6v49-42gf
+
+# ---------------------------------------------------------------------------
 # trivy 0.72.0 binary (scanner-adapter image) — oras.land/oras-go/v2 @ v2.6.0
 # Fixed in oras-go 2.6.1; trivy 0.72.0 (latest) has not rebuilt against it.
 # Code path: ORAS OCI-artifact client used for trivy's own DB/plugin


### PR DESCRIPTION
The docker-publish Trivy scan gate fails on **GHSA-hrxh-6v49-42gf** (HIGH, `google.golang.org/grpc` v1.80.0), bundled inside the `grype` v0.116.0 binary the images ship.

- AK services use **Rust tonic**, not grpc-go — this is a vendored-tool dependency, not AK code.
- Neither affected path is reachable: grype is not an xDS/service-mesh client (RBAC path dead), and runs as a **local CLI** over on-disk artifacts with a pre-seeded **offline DB** (no HTTP/2 server surface).
- Fixed in grpc-go 1.82.1, but grype v0.116.0 (latest — not behind) has not rebuilt against it → suppress with rationale, matching the existing grype/trivy exceptions. Re-evaluate on bump (#2391).

**Verified locally** (`trivy 0.69.3`, gate config): with this entry, backend image scans `grype: 0 / redhat: 0`, exit 0.

Unblocks the v1.6.3 publish. Structural follow-up (drop in-image grype entirely, like trivy #1544/#2088) tracked for 1.7.0 — it would remove all 7 gate-relevant grype-binary HIGHs.