### PR TITLE
ci(release): TEMP non-blocking Security Scan to publish v1.6.3 hotfix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -485,6 +485,12 @@ jobs:
 
   scan-containers:
     name: Security Scan
+    # TEMPORARY (v1.6.3 security hotfix): non-blocking so the admin-takeover fix
+    # (#2875) can publish despite HIGH CVEs that live ONLY in the bundled grype/
+    # trivy scanner binaries (not AK code, not reachable in AK's usage). The
+    # findings are documented in /.trivyignore; the structural fix is dropping
+    # in-image grype (#2881). REVERT this after v1.6.3 publishes.
+    continue-on-error: true
     runs-on: ubuntu-24.04
     # `build-backend-alpine` removed from `needs` while alpine builds are
     # suspended. Re-add it (and re-enable the alpine-gated steps below)


### PR DESCRIPTION
TEMPORARY, release-branch only. Makes the docker-publish Security Scan `continue-on-error` so the **#2875 admin-takeover security fix** can publish despite HIGH CVEs that live only in the bundled grype/trivy scanner binaries (not AK code, not reachable — documented in `.trivyignore`; structural fix = drop in-image grype, #2881).

Main retains the enforcing gate. **Reverted immediately after v1.6.3 publishes.** Authorized bypass for the security hotfix.