### PR TITLE
feat(groups): make SSO-synced group membership immutable (#2874) 

### DIFF
--- a/backend/src/api/handlers/groups.rs
+++ b/backend/src/api/handlers/groups.rs
@@ -103,6 +103,8 @@ pub struct GroupRow {
     pub id: Uuid,
     pub name: String,
     pub description: Option<String>,
+    /// SSO provider owning the group (`oidc`/`saml`/`ldap`); `None` for local groups. IdP owns membership (#2874).
+    pub external_source: Option<String>,
     pub member_count: i64,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
@@ -113,6 +115,8 @@ pub struct GroupResponse {
     pub id: Uuid,
     pub name: String,
     pub description: Option<String>,
+    /// See [`GroupRow::external_source`]; lets the frontend disable member editing for SSO groups.
+    pub external_source: Option<String>,
     pub member_count: i64,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
@@ -124,6 +128,7 @@ impl From<GroupRow> for GroupResponse {
             id: row.id,
             name: row.name,
             description: row.description,
+            external_source: row.external_source,
             member_count: row.member_count,
             created_at: row.created_at,
             updated_at: row.updated_at,
@@ -233,7 +238,7 @@ pub async fn list_groups(
     };
     let select_sql = format!(
         r#"
-        SELECT g.id, g.name, g.description, g.created_at, g.updated_at,
+        SELECT g.id, g.name, g.description, g.external_source, g.created_at, g.updated_at,
                COALESCE(COUNT(ugm.user_id), 0) as member_count
         FROM groups g
         LEFT JOIN user_group_members ugm ON ugm.group_id = g.id
@@ -299,6 +304,7 @@ pub struct CreatedGroupRow {
     pub id: Uuid,
     pub name: String,
     pub description: Option<String>,
+    pub external_source: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -353,7 +359,7 @@ pub async fn create_group(
         r#"
         INSERT INTO groups (name, description)
         VALUES ($1, $2)
-        RETURNING id, name, description, created_at, updated_at
+        RETURNING id, name, description, external_source, created_at, updated_at
         "#,
     )
     .bind(&payload.name)
@@ -375,6 +381,7 @@ pub async fn create_group(
         id: group.id,
         name: group.name,
         description: group.description,
+        external_source: group.external_source,
         member_count: 0,
         created_at: group.created_at,
         updated_at: group.updated_at,
@@ -432,7 +439,7 @@ pub async fn get_group(
     };
     let group_sql = format!(
         r#"
-        SELECT g.id, g.name, g.description, g.created_at, g.updated_at,
+        SELECT g.id, g.name, g.description, g.external_source, g.created_at, g.updated_at,
                COALESCE(COUNT(ugm.user_id), 0) as member_count
         FROM groups g
         LEFT JOIN user_group_members ugm ON ugm.group_id = g.id
@@ -529,7 +536,7 @@ pub async fn update_group(
         UPDATE groups
         SET name = $2, description = $3, updated_at = NOW()
         WHERE id = $1
-        RETURNING id, name, description, created_at, updated_at
+        RETURNING id, name, description, external_source, created_at, updated_at
         "#,
     )
     .bind(id)
@@ -553,6 +560,7 @@ pub async fn update_group(
         id: group.id,
         name: group.name,
         description: group.description,
+        external_source: group.external_source,
         member_count,
         created_at: group.created_at,
         updated_at: group.updated_at,
@@ -619,6 +627,29 @@ pub struct MembersRequest {
     pub user_ids: Vec<Uuid>,
 }
 
+/// Gate local membership edits from an `external_source` lookup: outer `None`=no group (404),
+/// inner `None`=local (ok), `Some(idp)`=SSO-owned so reject (#2874, IdP owns its membership).
+fn check_membership_editable(external_source: Option<Option<String>>) -> Result<()> {
+    match external_source {
+        None => Err(AppError::NotFound("Group not found".to_string())),
+        Some(None) => Ok(()),
+        Some(Some(source)) => Err(AppError::Conflict(format!(
+            "Group membership is managed by {source} and must be changed in your identity provider"
+        ))),
+    }
+}
+
+/// Look up a group's `external_source` and enforce [`check_membership_editable`].
+async fn ensure_membership_editable(db: &sqlx::PgPool, id: Uuid) -> Result<()> {
+    let external_source =
+        sqlx::query_scalar::<_, Option<String>>("SELECT external_source FROM groups WHERE id = $1")
+            .bind(id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+    check_membership_editable(external_source)
+}
+
 /// Add members to a group
 #[utoipa::path(
     post,
@@ -660,6 +691,8 @@ pub async fn add_members(
             ));
         }
     }
+
+    ensure_membership_editable(&state.db, id).await?;
 
     for user_id in payload.user_ids {
         sqlx::query(
@@ -722,6 +755,8 @@ pub async fn remove_members(
             ));
         }
     }
+
+    ensure_membership_editable(&state.db, id).await?;
 
     for user_id in payload.user_ids {
         sqlx::query("DELETE FROM user_group_members WHERE user_id = $1 AND group_id = $2")
@@ -948,6 +983,7 @@ mod tests {
             id,
             name: "developers".to_string(),
             description: Some("Dev team".to_string()),
+            external_source: Some("oidc".to_string()),
             member_count: 5,
             created_at: now,
             updated_at: now,
@@ -956,6 +992,7 @@ mod tests {
         assert_eq!(resp.id, id);
         assert_eq!(resp.name, "developers");
         assert_eq!(resp.description, Some("Dev team".to_string()));
+        assert_eq!(resp.external_source, Some("oidc".to_string()));
         assert_eq!(resp.member_count, 5);
     }
 
@@ -966,6 +1003,7 @@ mod tests {
             id: Uuid::new_v4(),
             name: "ops".to_string(),
             description: None,
+            external_source: None,
             member_count: 0,
             created_at: now,
             updated_at: now,
@@ -987,6 +1025,7 @@ mod tests {
             id,
             name: "admins".to_string(),
             description: Some("Admin group".to_string()),
+            external_source: None,
             member_count: 3,
             created_at: now,
             updated_at: now,
@@ -1004,6 +1043,7 @@ mod tests {
             id: Uuid::new_v4(),
             name: "test".to_string(),
             description: None,
+            external_source: None,
             member_count: 0,
             created_at: now,
             updated_at: now,
@@ -1080,6 +1120,7 @@ mod tests {
                 id: Uuid::new_v4(),
                 name: "team".to_string(),
                 description: None,
+                external_source: None,
                 member_count: 2,
                 created_at: now,
                 updated_at: now,
@@ -1173,6 +1214,7 @@ mod tests {
                 id: Uuid::nil(),
                 name: "dev".to_string(),
                 description: Some("Developers".to_string()),
+                external_source: None,
                 member_count: 2,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
@@ -1199,6 +1241,7 @@ mod tests {
                 id: Uuid::nil(),
                 name: "admins".to_string(),
                 description: None,
+                external_source: None,
                 member_count: 2,
                 created_at: now,
                 updated_at: now,
@@ -1235,6 +1278,7 @@ mod tests {
                 id: Uuid::nil(),
                 name: "empty".to_string(),
                 description: None,
+                external_source: None,
                 member_count: 0,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
@@ -1257,6 +1301,7 @@ mod tests {
                 id,
                 name: "ops".to_string(),
                 description: Some("Operations".to_string()),
+                external_source: None,
                 member_count: 1,
                 created_at: now,
                 updated_at: now,
@@ -1288,6 +1333,7 @@ mod tests {
                 id: Uuid::nil(),
                 name: "large".to_string(),
                 description: None,
+                external_source: None,
                 member_count: 500,
                 created_at: now,
                 updated_at: now,
@@ -1453,6 +1499,26 @@ mod tests {
     fn test_add_members_permission_non_admin_denied() {
         let auth = make_auth(false);
         assert!(!check_permission_gate(auth.is_admin, &[], "admin"));
+    }
+
+    #[test]
+    fn test_membership_editable_local_group_ok() {
+        // external_source IS NULL -> operator-managed -> editable.
+        assert!(check_membership_editable(Some(None)).is_ok());
+    }
+
+    #[test]
+    fn test_membership_editable_sso_group_rejected() {
+        // external_source set -> owned by the IdP -> 409 Conflict (#2874).
+        let err = check_membership_editable(Some(Some("oidc".to_string()))).unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[test]
+    fn test_membership_editable_missing_group_not_found() {
+        // no row -> 404, matching the other group handlers.
+        let err = check_membership_editable(None).unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
Closes #2874. Member add/remove on SSO-synced groups (`external_source` set) now returns 409; `external_source` is exposed on group responses so clients can react. Local groups unaffected.                                      
                                                                                                                                                                                                                                  
## Regression test                                                                                                                                                                                                                
- [x] N/A — not a bug fix                                                                                                                                                                                                         
                                                                                                                                                                                                                                  
## Test Checklist                                                                                                                                                                                                                 
- [x] Unit tests added/updated                                                                                                                                                                                                    
- [x] Manually tested locally                                                                                                                                                                                                     
- [x] No regressions in existing tests                                                                                                                                                                                            
                                                                                                                                                                                                                                  
## API Changes                                                                                                                                                                                                                    
- [x] Response types have `#[derive(ToSchema)]` (`external_source` on `GroupResponse`)                                                                                                                                            
- [ ] OpenAPI validates: `cargo test --lib test_openapi_spec_is_valid` (run before merge)                                                                                                                                         
- [x] No migration needed