### PR TITLE
perf(search): back artifact full-text search with a GIN-indexed search_vector (#2871)

### DIFF
--- a/backend/migrations/176_artifacts_search_vector.sql
+++ b/backend/migrations/176_artifacts_search_vector.sql
@@ -1,0 +1,107 @@
+-- Stored, trigger-maintained full-text search vector for artifacts
+-- (PF-009 / #2871, part of the million-artifact perf epic #2516).
+--
+-- SearchService::search (both /search/quick and /search/advanced) filtered on
+-- an INLINE functional predicate:
+--
+--   to_tsvector('english', name || ' ' || path || ' ' || COALESCE(version, ''))
+--     @@ to_tsquery('english', $1)
+--
+-- Nothing on `artifacts` matched that expression, so the planner had no choice
+-- but a Parallel Seq Scan that recomputes to_tsvector('english', ...) for every
+-- live row on every request -- twice, because the exact-count query for
+-- pagination runs the same predicate a second time. EXPLAIN at ~517k rows
+-- showed this pegging Postgres at 11-17 cores with p95 climbing 272ms -> 1.09s
+-- -> 3.63s at 10k / 100k / 500k artifacts.
+--
+-- Fix: materialize the exact same tsvector into a stored `search_vector` column
+-- maintained by a BEFORE INSERT/UPDATE trigger, and back it with a partial GIN
+-- index (WHERE is_deleted = false, matching every caller of this path). The two
+-- search queries then filter on `a.search_vector @@ to_tsquery('english', $1)`,
+-- which the planner satisfies with a Bitmap Index Scan; the COUNT collapses to
+-- the same index-backed bitmap instead of a second full scan. Result semantics
+-- and ordering are unchanged: the stored vector is byte-for-byte the vector the
+-- inline predicate used to compute per row.
+--
+-- The column is nullable and carries no default, so `ADD COLUMN` is a
+-- catalog-only change (no table rewrite, no long ACCESS EXCLUSIVE hold). The
+-- backfill and the (non-concurrent) index build below are the only heavy steps.
+
+-- 1. Catalog-only column add (instant; no rewrite because it is nullable with
+--    no default).
+ALTER TABLE artifacts ADD COLUMN IF NOT EXISTS search_vector tsvector;
+
+-- 2. Trigger function: recompute the stored vector from exactly the same
+--    expression the old inline predicate used. Kept in one place so the stored
+--    column can never drift from the query semantics.
+CREATE OR REPLACE FUNCTION ak_artifacts_search_vector_update() RETURNS trigger AS $$
+BEGIN
+    NEW.search_vector := to_tsvector(
+        'english',
+        NEW.name || ' ' || NEW.path || ' ' || COALESCE(NEW.version, '')
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Fire only when a component of the vector actually changes (plus every
+-- INSERT). Soft-delete (is_deleted) and download/updated_at churn do not touch
+-- name/path/version, so they never pay the recompute -- and a soft-deleted row
+-- drops out of the partial index regardless.
+DROP TRIGGER IF EXISTS ak_artifacts_search_vector_trg ON artifacts;
+CREATE TRIGGER ak_artifacts_search_vector_trg
+    BEFORE INSERT OR UPDATE OF name, path, version ON artifacts
+    FOR EACH ROW
+    EXECUTE FUNCTION ak_artifacts_search_vector_update();
+
+-- 3. In-migration backfill of existing rows. Setting search_vector directly
+--    does NOT re-fire the trigger above (it only fires on name/path/version),
+--    so there is no recursion. This is the one heavy write in this migration;
+--    see the online-upgrade note below for large tables.
+UPDATE artifacts
+   SET search_vector = to_tsvector(
+       'english',
+       name || ' ' || path || ' ' || COALESCE(version, '')
+   )
+ WHERE search_vector IS NULL;
+
+-- 4. Partial GIN index matching the search predicate and every caller's
+--    `is_deleted = false` filter, so tombstoned rows stay out of the index.
+CREATE INDEX IF NOT EXISTS idx_artifacts_search_vector_gin
+    ON artifacts USING gin (search_vector)
+    WHERE is_deleted = false;
+
+-- ---------------------------------------------------------------------------
+-- Online-upgrade path for very large `artifacts` tables (follows the migration
+-- 173 precedent; relates to #2524 PF-008).
+--
+-- sqlx::migrate runs each migration file inside a single transaction, so the
+-- backfill above scans/updates every live row under one transaction and the
+-- non-concurrent index build takes ACCESS EXCLUSIVE on `artifacts` for its
+-- duration -- artifact uploads block until it finishes. On a multi-million-row
+-- table an operator who cannot accept that window should perform the heavy
+-- steps out of band BEFORE deploying this migration, then let the migration
+-- no-op over them (ADD COLUMN IF NOT EXISTS / CREATE INDEX IF NOT EXISTS /
+-- the WHERE search_vector IS NULL backfill all become empty):
+--
+--   -- add the column + trigger (cheap) first:
+--   ALTER TABLE artifacts ADD COLUMN IF NOT EXISTS search_vector tsvector;
+--   -- (create the function + trigger exactly as above)
+--
+--   -- backfill in bounded batches so no single statement holds a long
+--   -- transaction or bloats WAL; run until zero rows are updated:
+--   UPDATE artifacts
+--      SET search_vector = to_tsvector(
+--          'english', name || ' ' || path || ' ' || COALESCE(version, ''))
+--    WHERE id IN (
+--        SELECT id FROM artifacts WHERE search_vector IS NULL LIMIT 10000
+--    );
+--
+--   -- build the index without blocking writes (cannot run inside the
+--   -- migration transaction, hence out of band):
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artifacts_search_vector_gin
+--     ON artifacts USING gin (search_vector) WHERE is_deleted = false;
+--
+-- Functionality is correct without the index -- it is purely a query-plan
+-- accelerator -- and every statement here is idempotent, so re-running the
+-- migration after an out-of-band build is a no-op.

--- a/backend/src/services/search_service.rs
+++ b/backend/src/services/search_service.rs
@@ -125,6 +125,25 @@ fn sanitize_tsquery_lexeme(token: &str) -> String {
         .collect()
 }
 
+/// SQL boolean predicate for the free-text `q` filter, shared verbatim by the
+/// item query (`execute_search`) and the pagination COUNT (`count_results`) so
+/// the two can never diverge.
+///
+/// It matches the stored, GIN-indexed `artifacts.search_vector` column (added
+/// in migration 176) against the bound tsquery in `$1`. When `$1` is NULL (no
+/// free-text term) the predicate short-circuits to TRUE and the query browses
+/// by the other filters.
+///
+/// Referencing the stored column -- instead of the old inline
+/// `to_tsvector('english', name || ' ' || path || ' ' || COALESCE(version,''))`
+/// -- is what lets the planner satisfy the predicate with a Bitmap Index Scan
+/// over the partial GIN index instead of recomputing `to_tsvector` for every
+/// live row on a Parallel Seq Scan (#2871). The stored vector is byte-for-byte
+/// the vector the inline predicate used to compute, so match semantics and
+/// result ordering are unchanged.
+pub(crate) const SEARCH_VECTOR_MATCH: &str =
+    "($1::text IS NULL OR a.search_vector @@ to_tsquery('english', $1))";
+
 /// Convert a user-facing wildcard name filter (using `*`) to a SQL ILIKE
 /// pattern (using `%`).  Returns None if the input is None.
 pub(crate) fn build_name_filter(name: Option<&str>) -> Option<String> {
@@ -326,7 +345,7 @@ impl SearchService {
                 FROM artifacts a
                 JOIN repositories r ON r.id = a.repository_id
                 WHERE a.is_deleted = false
-                  AND ($1::text IS NULL OR to_tsvector('english', a.name || ' ' || a.path || ' ' || COALESCE(a.version, '')) @@ to_tsquery('english', $1))
+                  AND {q_match}
                   AND ($2::text IS NULL OR r.format::text = $2)
                   AND ($3::text IS NULL OR a.name ILIKE $3)
                   AND ($7::uuid[] IS NULL OR r.id = ANY($7))
@@ -335,6 +354,7 @@ impl SearchService {
                 OFFSET $4
                 LIMIT $5
                 "#,
+            q_match = SEARCH_VECTOR_MATCH,
             order_by = order_by,
         );
 
@@ -357,27 +377,33 @@ impl SearchService {
         let q_filter = build_tsquery_filter(query.q.as_deref());
         let name_filter = build_name_filter(query.name.as_deref());
 
-        let count: (i64,) = sqlx::query_as(
+        // Same free-text predicate as execute_search (shared constant) so the
+        // count can never diverge from the item query. Index-backed Bitmap
+        // Index Scan replaces the old second full Seq Scan (#2871).
+        let sql = format!(
             r#"
             SELECT COUNT(*)::BIGINT
             FROM artifacts a
             JOIN repositories r ON r.id = a.repository_id
             WHERE a.is_deleted = false
-              AND ($1::text IS NULL OR to_tsvector('english', a.name || ' ' || a.path || ' ' || COALESCE(a.version, '')) @@ to_tsquery('english', $1))
+              AND {q_match}
               AND ($2::text IS NULL OR r.format::text = $2)
               AND ($3::text IS NULL OR a.name ILIKE $3)
               AND ($5::uuid[] IS NULL OR r.id = ANY($5))
               AND ($4 = false OR r.is_public = true)
             "#,
-        )
-        .bind(&q_filter)
-        .bind(&query.format)
-        .bind(&name_filter)
-        .bind(query.public_only)
-        .bind(&query.accessible_repo_ids)
-        .fetch_one(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+            q_match = SEARCH_VECTOR_MATCH,
+        );
+
+        let count: (i64,) = sqlx::query_as(&sql)
+            .bind(&q_filter)
+            .bind(&query.format)
+            .bind(&name_filter)
+            .bind(query.public_only)
+            .bind(&query.accessible_repo_ids)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(count.0)
     }
@@ -1350,6 +1376,63 @@ mod tests {
         let clause = build_order_by_clause(q.sort_by.as_deref(), q.sort_order.as_deref()).unwrap();
         assert!(clause.contains("a.size_bytes"));
         assert!(clause.contains("ASC"));
+    }
+
+    // -----------------------------------------------------------------------
+    // SEARCH_VECTOR_MATCH -- #2871 (PF-009). The free-text predicate must
+    // filter on the stored, GIN-indexed `search_vector` column so the planner
+    // uses a Bitmap Index Scan, NOT recompute `to_tsvector(...)` per row on a
+    // Seq Scan. These tests pin that contract and the shared-$1/short-circuit
+    // shape so the item query and the COUNT can never silently diverge from
+    // the migration-176 stored column.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_search_vector_match_targets_stored_column_not_inline_tsvector() {
+        // The whole point of #2871: must reference the stored column and must
+        // NOT recompute to_tsvector(...) inline (that was the Seq-Scan bug).
+        assert!(
+            SEARCH_VECTOR_MATCH.contains("a.search_vector @@ to_tsquery('english', $1)"),
+            "predicate must match the stored search_vector column, got {SEARCH_VECTOR_MATCH}"
+        );
+        assert!(
+            !SEARCH_VECTOR_MATCH.contains("to_tsvector"),
+            "predicate must not recompute to_tsvector per row, got {SEARCH_VECTOR_MATCH}"
+        );
+    }
+
+    #[test]
+    fn test_search_vector_match_short_circuits_on_null_query() {
+        // When no free-text term is bound ($1 IS NULL) the predicate must
+        // short-circuit to TRUE so a browse-all (filters-only) request still
+        // returns every visible row, exactly as before.
+        assert!(
+            SEARCH_VECTOR_MATCH.starts_with("($1::text IS NULL OR "),
+            "predicate must short-circuit when $1 is NULL, got {SEARCH_VECTOR_MATCH}"
+        );
+    }
+
+    #[test]
+    fn test_search_vector_match_uses_first_bind_parameter() {
+        // Both execute_search and count_results bind q_filter first, so the
+        // shared predicate must reference $1 (and only $1) for the term.
+        assert!(SEARCH_VECTOR_MATCH.contains("$1"));
+        for p in ["$2", "$3", "$4", "$5", "$6", "$7"] {
+            assert!(
+                !SEARCH_VECTOR_MATCH.contains(p),
+                "shared free-text predicate must only reference $1, found {p}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_vector_match_is_balanced_and_uses_english_config() {
+        // Balanced parens (it is spliced into a larger WHERE) and the same
+        // 'english' text-search config the stored column was built with.
+        let opens = SEARCH_VECTOR_MATCH.matches('(').count();
+        let closes = SEARCH_VECTOR_MATCH.matches(')').count();
+        assert_eq!(opens, closes, "unbalanced parens: {SEARCH_VECTOR_MATCH}");
+        assert!(SEARCH_VECTOR_MATCH.contains("'english'"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #2871

## Summary

Artifact full-text search (`/search/quick` and `/search/advanced`, both served
by `SearchService::search`) filtered on an **inline functional predicate**:

```sql
to_tsvector('english', a.name || ' ' || a.path || ' ' || COALESCE(a.version, ''))
  @@ to_tsquery('english', $1)
```

Nothing on `artifacts` matched that expression, so the planner had no choice but
a Parallel Seq Scan that recomputes `to_tsvector(...)` for every live row on
every request -- **twice**, because the exact-count query for pagination runs
the same predicate a second time. EXPLAIN at ~517k rows showed this pegging
Postgres at 11-17 cores, with p95 climbing 272ms -> 1.09s -> 3.63s at
10k / 100k / 500k artifacts (perf epic #2516).

This PR materializes the exact same tsvector into a stored, GIN-indexed column:

- **Migration `176_artifacts_search_vector.sql`**
  - `ALTER TABLE artifacts ADD COLUMN IF NOT EXISTS search_vector tsvector`
    (nullable, no default -> catalog-only change, no table rewrite).
  - `ak_artifacts_search_vector_update()` trigger function + a
    `BEFORE INSERT OR UPDATE OF name, path, version` trigger that maintains the
    column from the identical expression the inline predicate used.
  - In-migration backfill of existing rows.
  - Partial GIN index `idx_artifacts_search_vector_gin ... WHERE is_deleted = false`
    matching every caller's filter.
  - A documented `CREATE INDEX CONCURRENTLY` / batched-backfill online-upgrade
    path in a comment for very large tables (follows the migration 173
    precedent; relates to #2524 PF-008).
- **`backend/src/services/search_service.rs`** -- both the item query
  (`execute_search`) and the pagination `count_results` now filter on
  `a.search_vector @@ to_tsquery('english', $1)` via one shared
  `SEARCH_VECTOR_MATCH` constant, so the two can never diverge. The planner now
  satisfies the predicate with a Bitmap Index Scan and the COUNT collapses to
  the same index-backed bitmap instead of a second full scan.

Result semantics and ordering are unchanged: the stored vector is byte-for-byte
the vector the inline predicate used to compute per row.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A -- this is a `perf/*` change (behavior preserved). Unit tests pin the
      rewritten predicate; a deployment-test tier (search-gin-2871, tracked
      separately for the artifact-keeper-test repo) validates identical
      results/ordering, exact count, prefix match, metachar-safety, and
      fresh-upload searchability against a live stack.

## Test Checklist
- [x] Unit tests added/updated (`SEARCH_VECTOR_MATCH` contract: targets the
      stored column, short-circuits on NULL `$1`, uses only `$1`, balanced +
      `'english'` config)
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (deployment-test tier search-gin-2871, batched
      into a later artifact-keeper-test MR)
- [x] Manually tested locally (isolated stack: migration applies; column,
      trigger, and partial GIN index present; quick/advanced return identical
      ordered results; exact total count; prefix match; metacharacter query ->
      HTTP 200 empty, not 500; unrelated artifacts excluded; fresh upload
      immediately searchable with its search_vector populated by the trigger;
      `EXPLAIN` confirms the GIN index is used for the predicate)
- [x] No regressions in existing tests (`cargo fmt --check`, `cargo clippy
      --lib -D warnings`, lib unit tests, `jscpd` duplication all clean)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates
- [x] Migration is reversible (if applicable) -- forward-only catalog change
      (column + trigger + partial index); all statements are idempotent
      (`IF NOT EXISTS` / `CREATE OR REPLACE`). No request/response contract
      change: search inputs and outputs are byte-for-byte identical.
- [ ] N/A - no API changes
