### PR TITLE
fix(formats): advertise stored basename in suffix-resolved index download URLs (#2589)

### DIFF
--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -118,6 +118,36 @@ async fn resolve_ansible_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, R
     proxy_helpers::resolve_repo_by_key(db, repo_key, &["ansible"], "an Ansible").await
 }
 
+/// The canonical Galaxy collection artifact filename `{namespace}-{name}-{version}.tar.gz`.
+fn collection_filename(namespace: &str, name: &str, version: &str) -> String {
+    format!("{}-{}-{}.tar.gz", namespace, name, version)
+}
+
+/// Build the `download_url` advertised in the collection/version metadata.
+///
+/// The download route (`GET /ansible/{repo}/download/{file}`) resolves a hosted
+/// collection by its trailing filename suffix (#2587), so the advertised URL
+/// must carry the artifact's actual stored basename. A collection published
+/// through the native `ansible-galaxy` upload is stored at
+/// `{namespace}-{name}-{version}.tar.gz`, byte-identical to the reconstructed
+/// filename; one pushed through the generic upload flow is stored at its bare
+/// path with generically-derived coordinates, so reconstructing the canonical
+/// filename would advertise a path the download route cannot resolve (the
+/// Ansible analogue of the RPM `<location>` fix, #2587 / #2589).
+fn collection_download_url(
+    repo_key: &str,
+    path: &str,
+    namespace: &str,
+    name: &str,
+    version: &str,
+) -> String {
+    let filename = proxy_helpers::advertised_download_filename(
+        path,
+        &collection_filename(namespace, name, version),
+    );
+    format!("/ansible/{}/download/{}", repo_key, filename)
+}
+
 // ---------------------------------------------------------------------------
 // GET /ansible/{repo_key}/api/v3/collections/ — List collections (paginated)
 // ---------------------------------------------------------------------------
@@ -231,9 +261,12 @@ async fn collection_info(
             "/ansible/{}/api/v3/collections/{}/{}/versions/",
             repo_key, namespace, name
         ),
-        "download_url": format!(
-            "/ansible/{}/download/{}-{}-{}.tar.gz",
-            repo_key, namespace, name, latest_version
+        "download_url": collection_download_url(
+            &repo_key,
+            &artifact.path,
+            &namespace,
+            &name,
+            &latest_version,
         ),
     });
 
@@ -326,12 +359,12 @@ async fn version_info(
         "namespace": namespace,
         "name": name,
         "version": version,
-        "download_url": format!(
-            "/ansible/{}/download/{}-{}-{}.tar.gz",
-            repo_key, namespace, name, version
-        ),
+        "download_url": collection_download_url(&repo_key, &artifact.path, &namespace, &name, &version),
         "artifact": {
-            "filename": format!("{}-{}-{}.tar.gz", namespace, name, version),
+            "filename": proxy_helpers::advertised_download_filename(
+                &artifact.path,
+                &collection_filename(&namespace, &name, &version),
+            ),
             "size": artifact.size_bytes,
             "sha256": artifact.checksum_sha256,
         },
@@ -657,6 +690,35 @@ mod tests {
         assert_eq!(info.storage_path, "/tmp/test");
         assert_eq!(info.repo_type, "hosted");
         assert_eq!(info.upstream_url, Some("https://example.com".to_string()));
+    }
+
+    #[test]
+    fn test_collection_download_url_native_path_is_byte_identical() {
+        assert_eq!(
+            collection_download_url(
+                "gx",
+                "community-general-1.2.3.tar.gz",
+                "community",
+                "general",
+                "1.2.3"
+            ),
+            "/ansible/gx/download/community-general-1.2.3.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_collection_download_url_bare_path_advertises_stored_basename() {
+        // Generic upload at a bare/arbitrary path: advertise the real basename
+        // so the suffix download route (with #2587 exact-path fallback) serves
+        // it, instead of the canonical filename that would 404.
+        assert_eq!(
+            collection_download_url("gx", "blob.tar.gz", "community", "general", "1.2.3"),
+            "/ansible/gx/download/blob.tar.gz"
+        );
+        assert_eq!(
+            collection_download_url("gx", "uploads/x/c.tar.gz", "community", "general", "1.2.3"),
+            "/ansible/gx/download/c.tar.gz"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3799,9 +3799,38 @@ pub struct ArtifactWithMetadata {
     pub id: Uuid,
     pub name: String,
     pub version: Option<String>,
+    /// The artifact's actual stored `path`. Index/metadata generators advertise
+    /// its basename as the download filename so the advertised URL resolves to
+    /// the same object the download route serves (#2587 / #2589).
+    pub path: String,
     pub size_bytes: Option<i64>,
     pub checksum_sha256: Option<String>,
     pub metadata: Option<serde_json::Value>,
+}
+
+/// The filename to advertise in a generated index/metadata document so a client
+/// that follows the advertised download URL resolves the same object the
+/// download route serves.
+///
+/// Format download routes resolve a hosted artifact by its trailing filename
+/// suffix, with an exact-path fallback for artifacts stored at their bare (root)
+/// path (see [`resolve_local_artifact_by_suffix`], #2587). An index that
+/// reconstructs `{name}-{version}.<ext>` from coordinates therefore advertises a
+/// path the download route cannot resolve whenever the artifact was pushed
+/// through the generic upload flow and stored at a bare/arbitrary path with
+/// generically-derived coordinates. Preferring the artifact's real stored
+/// basename keeps the advertised URL coherent with the served route for both
+/// upload flows — the generalisation of the RPM `primary.xml` `<location>` fix
+/// (#2587) to other suffix-resolved formats (#2589).
+///
+/// `reconstructed` is used only when `path` has no usable basename (e.g. a
+/// remote upstream entry with no local stored object).
+pub fn advertised_download_filename(path: &str, reconstructed: &str) -> String {
+    path.rsplit('/')
+        .next()
+        .filter(|f| !f.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| reconstructed.to_string())
 }
 
 /// Look up an artifact by case-insensitive name AND exact version.
@@ -3815,7 +3844,7 @@ pub async fn find_artifact_by_name_version(
 ) -> Result<Option<ArtifactWithMetadata>, Response> {
     use sqlx::Row;
     let row = sqlx::query(
-        "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+        "SELECT a.id, a.name, a.version, a.path, a.size_bytes, a.checksum_sha256, \
                 am.metadata \
          FROM artifacts a \
          LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
@@ -3836,6 +3865,7 @@ pub async fn find_artifact_by_name_version(
         id: r.try_get("id").unwrap_or_default(),
         name: r.try_get("name").unwrap_or_default(),
         version: r.try_get("version").ok(),
+        path: r.try_get("path").unwrap_or_default(),
         size_bytes: r.try_get("size_bytes").ok(),
         checksum_sha256: r.try_get("checksum_sha256").ok(),
         metadata: r.try_get("metadata").ok(),
@@ -3856,7 +3886,7 @@ pub async fn find_artifact_by_name_lowercase(
 ) -> Result<Option<ArtifactWithMetadata>, Response> {
     use sqlx::Row;
     let row = sqlx::query(
-        "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+        "SELECT a.id, a.name, a.version, a.path, a.size_bytes, a.checksum_sha256, \
                 am.metadata \
          FROM artifacts a \
          LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
@@ -3876,6 +3906,7 @@ pub async fn find_artifact_by_name_lowercase(
         id: r.try_get("id").unwrap_or_default(),
         name: r.try_get("name").unwrap_or_default(),
         version: r.try_get("version").ok(),
+        path: r.try_get("path").unwrap_or_default(),
         size_bytes: r.try_get("size_bytes").ok(),
         checksum_sha256: r.try_get("checksum_sha256").ok(),
         metadata: r.try_get("metadata").ok(),
@@ -3896,7 +3927,7 @@ pub async fn list_artifacts_by_name_lowercase(
 ) -> Result<Vec<ArtifactWithMetadata>, Response> {
     use sqlx::Row;
     let rows = sqlx::query(
-        "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+        "SELECT a.id, a.name, a.version, a.path, a.size_bytes, a.checksum_sha256, \
                 am.metadata \
          FROM artifacts a \
          LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
@@ -3917,6 +3948,7 @@ pub async fn list_artifacts_by_name_lowercase(
             id: r.try_get("id").unwrap_or_default(),
             name: r.try_get("name").unwrap_or_default(),
             version: r.try_get("version").ok(),
+            path: r.try_get("path").unwrap_or_default(),
             size_bytes: r.try_get("size_bytes").ok(),
             checksum_sha256: r.try_get("checksum_sha256").ok(),
             metadata: r.try_get("metadata").ok(),
@@ -7101,12 +7133,14 @@ mod tests {
             id,
             name: "ggplot2".to_string(),
             version: Some("3.4.0".to_string()),
+            path: "ggplot2/3.4.0/ggplot2_3.4.0.tar.gz".to_string(),
             size_bytes: Some(1024),
             checksum_sha256: Some("def".to_string()),
             metadata: Some(serde_json::json!({"depends": "R (>= 3.5.0)"})),
         };
         assert_eq!(m.id, id);
         assert_eq!(m.name, "ggplot2");
+        assert_eq!(m.path, "ggplot2/3.4.0/ggplot2_3.4.0.tar.gz");
         assert_eq!(m.version.as_deref(), Some("3.4.0"));
         assert_eq!(m.size_bytes, Some(1024));
         assert_eq!(m.checksum_sha256.as_deref(), Some("def"));
@@ -7119,6 +7153,7 @@ mod tests {
             id: Uuid::new_v4(),
             name: "lonely".to_string(),
             version: None,
+            path: "lonely.tar.gz".to_string(),
             size_bytes: None,
             checksum_sha256: None,
             metadata: None,
@@ -7128,6 +7163,34 @@ mod tests {
         assert!(m.checksum_sha256.is_none());
         assert!(m.metadata.is_none());
         assert_eq!(m.name, "lonely");
+    }
+
+    #[test]
+    fn test_advertised_download_filename_prefers_stored_basename() {
+        // Native layout: basename already equals the reconstructed filename.
+        assert_eq!(
+            advertised_download_filename("rails/7.0.0/rails-7.0.0.gem", "rails-7.0.0.gem"),
+            "rails-7.0.0.gem"
+        );
+        // Bare/arbitrary generic-upload path: advertise the real basename, NOT
+        // the reconstructed coordinates the download route could not resolve.
+        assert_eq!(
+            advertised_download_filename("blob.gem", "rails-7.0.0.gem"),
+            "blob.gem"
+        );
+        assert_eq!(
+            advertised_download_filename("uploads/2026/x.tar.gz", "acme-mod-1.0.0.tar.gz"),
+            "x.tar.gz"
+        );
+        // No usable basename (empty / trailing slash) -> reconstructed fallback.
+        assert_eq!(
+            advertised_download_filename("", "acme-mod-1.0.0.tar.gz"),
+            "acme-mod-1.0.0.tar.gz"
+        );
+        assert_eq!(
+            advertised_download_filename("dir/", "acme-mod-1.0.0.tar.gz"),
+            "acme-mod-1.0.0.tar.gz"
+        );
     }
 
     // ── DownloadResponseOpts / VirtualLookup tests ──────────────────────

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -54,6 +54,25 @@ async fn resolve_puppet_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Re
     proxy_helpers::resolve_repo_by_key(db, repo_key, &["puppet"], "a Puppet").await
 }
 
+/// Build the `file_uri` advertised in the Forge module/release metadata.
+///
+/// The download route (`GET /puppet/{repo}/v3/files/{file}`) resolves a hosted
+/// module by its trailing filename suffix (#2587), so the advertised URI must
+/// carry the artifact's actual stored basename. A module published through the
+/// native Forge upload is stored at `{owner}-{name}-{version}.tar.gz`,
+/// byte-identical to the reconstructed filename; one pushed through the generic
+/// upload flow is stored at its bare path with generically-derived coordinates,
+/// so reconstructing the canonical filename would advertise a path the download
+/// route cannot resolve (the Puppet analogue of the RPM `<location>` fix,
+/// #2587 / #2589).
+fn release_file_uri(repo_key: &str, path: &str, owner: &str, name: &str, version: &str) -> String {
+    let filename = proxy_helpers::advertised_download_filename(
+        path,
+        &format!("{}-{}-{}.tar.gz", owner, name, version),
+    );
+    format!("/puppet/{}/v3/files/{}", repo_key, filename)
+}
+
 /// Parse an "owner-name" string into (owner, name) by splitting on the first hyphen.
 #[allow(clippy::result_large_err)]
 fn parse_owner_name(s: &str) -> Result<(String, String), Response> {
@@ -150,10 +169,7 @@ async fn module_info(
         "current_release": {
             "version": current_version,
             "slug": format!("{}-{}-{}", owner, name, current_version),
-            "file_uri": format!(
-                "/puppet/{}/v3/files/{}-{}-{}.tar.gz",
-                repo_key, owner, name, current_version
-            ),
+            "file_uri": release_file_uri(&repo_key, &artifact.path, &owner, &name, &current_version),
         },
         "releases": [],
     });
@@ -186,10 +202,7 @@ async fn release_list(
             serde_json::json!({
                 "slug": format!("{}-{}-{}", owner, name, version),
                 "version": version,
-                "file_uri": format!(
-                    "/puppet/{}/v3/files/{}-{}-{}.tar.gz",
-                    repo_key, owner, name, version
-                ),
+                "file_uri": release_file_uri(&repo_key, &a.path, &owner, &name, &version),
                 "file_size": a.size_bytes,
                 "file_sha256": a.checksum_sha256,
                 "metadata": a.metadata.clone().unwrap_or(serde_json::json!({})),
@@ -248,10 +261,7 @@ async fn release_info(
             "name": name,
             "owner": { "slug": owner, "username": owner },
         },
-        "file_uri": format!(
-            "/puppet/{}/v3/files/{}-{}-{}.tar.gz",
-            repo_key, owner, name, version
-        ),
+        "file_uri": release_file_uri(&repo_key, &artifact.path, &owner, &name, &version),
         "file_size": artifact.size_bytes,
         "file_sha256": artifact.checksum_sha256,
         "downloads": download_count,
@@ -457,6 +467,35 @@ mod tests {
         let (owner, name) = result.unwrap();
         assert_eq!(owner, "puppetlabs");
         assert_eq!(name, "stdlib");
+    }
+
+    #[test]
+    fn test_release_file_uri_native_path_is_byte_identical() {
+        assert_eq!(
+            release_file_uri(
+                "pf",
+                "puppetlabs-stdlib-9.0.0.tar.gz",
+                "puppetlabs",
+                "stdlib",
+                "9.0.0"
+            ),
+            "/puppet/pf/v3/files/puppetlabs-stdlib-9.0.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_release_file_uri_bare_path_advertises_stored_basename() {
+        // Generic upload at a bare/arbitrary path: advertise the real basename
+        // so the suffix download route (with #2587 exact-path fallback) serves
+        // it, instead of the canonical filename that would 404.
+        assert_eq!(
+            release_file_uri("pf", "blob.tar.gz", "puppetlabs", "stdlib", "9.0.0"),
+            "/puppet/pf/v3/files/blob.tar.gz"
+        );
+        assert_eq!(
+            release_file_uri("pf", "uploads/x/m.tar.gz", "puppetlabs", "stdlib", "9.0.0"),
+            "/puppet/pf/v3/files/m.tar.gz"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -108,8 +108,7 @@ async fn gem_info(
             .unwrap_or("")
             .to_string();
 
-        let gem_filename = format!("{}-{}.gem", gem_name, version);
-        let gem_uri = format!("/gems/{}/gems/{}", repo_key, gem_filename);
+        let gem_uri = gem_download_uri(&repo_key, &artifact.path, gem_name, &version);
 
         let json = serde_json::json!({
             "name": gem_name,
@@ -177,14 +176,12 @@ async fn gem_versions(
                 .unwrap_or("")
                 .to_string();
 
-            let gem_filename = format!("{}-{}.gem", gem_name, version);
-
             serde_json::json!({
                 "number": version,
                 "summary": description,
                 "platform": "ruby",
                 "sha": a.checksum_sha256,
-                "gem_uri": format!("/gems/{}/gems/{}", repo_key, gem_filename),
+                "gem_uri": gem_download_uri(&repo_key, &a.path, gem_name, &version),
                 "downloads_count": 0,
             })
         })
@@ -451,6 +448,23 @@ fn spec_index_coordinates(path: &str, name: String, version: String) -> (String,
         .filter(|f| !f.is_empty())
         .and_then(crate::formats::rubygems::coordinates_from_gem_filename)
         .unwrap_or((name, version))
+}
+
+/// Build the `gem_uri` advertised in the JSON gem/version API.
+///
+/// The download route (`GET /gems/{repo}/gems/{file}`) resolves a hosted gem by
+/// its trailing filename suffix (#2587), so the advertised URI must carry the
+/// artifact's actual stored basename. Natively pushed gems are stored at
+/// `{name}-{version}/{name}-{version}.gem`, whose basename equals the
+/// reconstructed `{name}-{version}.gem` — byte-identical for them. A gem pushed
+/// through the generic upload flow is stored at its bare path with
+/// generically-derived coordinates, so reconstructing `{name}-{version}.gem`
+/// would advertise a path the download route cannot resolve (the RubyGems
+/// analogue of the RPM `<location>` fix, #2587 / #2589).
+fn gem_download_uri(repo_key: &str, path: &str, name: &str, version: &str) -> String {
+    let filename =
+        proxy_helpers::advertised_download_filename(path, &format!("{}-{}.gem", name, version));
+    format!("/gems/{}/gems/{}", repo_key, filename)
 }
 
 /// Query gem specs from all local (non-remote) virtual members.
@@ -991,6 +1005,31 @@ mod tests {
         );
         assert_eq!(name, "archive.tar.gz");
         assert_eq!(version, "sha256-deadbeef");
+    }
+
+    #[test]
+    fn test_gem_download_uri_native_path_is_byte_identical() {
+        // Native push: basename already equals `{name}-{version}.gem`.
+        assert_eq!(
+            gem_download_uri("rg", "rails/7.0.8/rails-7.0.8.gem", "rails", "7.0.8"),
+            "/gems/rg/gems/rails-7.0.8.gem"
+        );
+    }
+
+    #[test]
+    fn test_gem_download_uri_bare_path_advertises_stored_basename() {
+        // Generic upload stored at a bare/arbitrary path: the advertised
+        // gem_uri must carry the real basename so the suffix download route
+        // (with #2587 exact-path fallback) resolves it — not the reconstructed
+        // `{name}-{version}.gem` that would 404.
+        assert_eq!(
+            gem_download_uri("rg", "blob.gem", "rails", "7.0.8"),
+            "/gems/rg/gems/blob.gem"
+        );
+        assert_eq!(
+            gem_download_uri("rg", "uploads/x/pkg.gem", "rails", "7.0.8"),
+            "/gems/rg/gems/pkg.gem"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2589

Follow-up to #2587 (RPM `primary.xml` `<location>` + shared suffix-resolver
exact-path fallback) and #2754 (CRAN/RubyGems coordinate indices). This audits
the remaining suffix-resolved formats whose on-demand metadata advertises an
**explicit, directly-followed download URL** and makes each advertise the
artifact's **actual stored basename** so the advertised path resolves to the
same object the download route serves for **bare-path (generic) uploads**.

### The bug, generalized

A format download route resolves a hosted artifact by its trailing filename
suffix, with an exact-path fallback for artifacts stored at their bare (root)
path (`resolve_local_artifact_by_suffix`, #2587). But several formats'
metadata generators reconstruct the advertised download URL from the package
coordinates `{name}(-{version}).ext` instead of the stored path. An artifact
pushed through the generic (bare-path) upload flow is stored at an arbitrary
path whose basename need not equal that reconstruction, so the advertised URL
pointed at a path the download route can never serve — the client follows the
advertised link and 404s even though the artifact is present. This is the RPM
`<location>` bug generalized.

### Formats audited

| Format | Metadata document | Verdict |
| --- | --- | --- |
| RubyGems | `gem_info` / `versions` JSON `gem_uri` | **gap fixed** — advertise stored basename |
| Ansible Galaxy | `collection_info` / `version_info` `download_url` (+ `artifact.filename`) | **gap fixed** |
| Puppet Forge | `module_info` / `release_list` / `release_info` `file_uri` | **gap fixed** |
| RPM | `primary.xml` `<location>` | no-gap (fixed in #2587) |
| Helm | `index.yaml` `urls:` | no-gap (already uses stored basename) |
| PyPI | `/simple/` `<a href>` | no-gap (already uses stored basename) |
| npm | packument `dist.tarball` | no-gap here (already uses stored basename) |
| RubyGems `specs.4.8.gz`, CRAN `PACKAGES` | coordinate indices | no-gap (fixed in #2754) |

Two suffix-resolved formats are **protocol-rigid** and out of scope for this
change: Hex (`mix` reconstructs `{name}-{version}.tar` from the signed registry
payload) and the coordinate-only indices above — their clients rebuild the
filename from coordinates, so an arbitrary stored basename cannot be advertised.
npm's hosted tarball download route additionally constrains the local lookup to
a package-name-prefixed path (separate from the metadata layer audited here);
noted for a follow-up.

### Change

- `proxy_helpers::advertised_download_filename(path, reconstructed)` — prefer
  the artifact's real stored basename, fall back to the reconstruction only when
  the path has no usable basename (e.g. remote upstream entries).
- Add the artifact `path` to `ArtifactWithMetadata` (+ its three shared
  lookup queries) so the by-name metadata endpoints can advertise the basename.
- Per-format URL builders (`gem_download_uri`, `collection_download_url`,
  `release_file_uri`) mirroring Helm's `chart_download_url`.

Minimal, per-format, no migration, no new `sqlx::query!` macros.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Unit tests for the shared helper and each per-format URL builder assert the
native path is byte-identical and a bare/arbitrary path advertises the stored
basename (not the canonical reconstruction). Verified end-to-end on an isolated
instance: a bare-path generic upload for each of the three formats now yields a
metadata document whose advertised URL resolves 200, while the canonical
reconstruction (what a pre-fix build advertised) 404s.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (advertised URL values change; no schema/route changes)
