### PR TITLE
fix(debian): restore lib-test compilation + reconcile #2838/#2770 encoded-separator gates (uniform 400)

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -345,17 +345,6 @@ fn decode_to_fixpoint(raw: &str) -> Option<String> {
     None
 }
 
-/// True when `s` contains a percent-encoded path separator — `%2f`/`%2F` (`/`)
-/// or `%5c`/`%5C` (`\`), in any case. See [`normalized_debian_relpath`] for how
-/// this is used as a defense-in-depth belt (#2562).
-fn contains_encoded_separator(s: &str) -> bool {
-    s.as_bytes().windows(3).any(|w| {
-        w[0] == b'%'
-            && ((w[1].eq_ignore_ascii_case(&b'2') && w[2].eq_ignore_ascii_case(&b'f'))
-                || (w[1].eq_ignore_ascii_case(&b'5') && w[2].eq_ignore_ascii_case(&b'c')))
-    })
-}
-
 /// The upstream base URL to gate against, or `None` for repositories the P2
 /// filter does not apply to (hosted/virtual, or a remote with no upstream).
 fn repo_remote_upstream(repo: &RepoInfo) -> Option<&str> {
@@ -403,9 +392,6 @@ fn normalized_debian_relpath(
         return Err(debian_encoded_separator_rejected(relative));
     }
     if relative.bytes().any(|b| b <= 0x20 || b == 0x7f) {
-        return Err(debian_filter_denied("path", relative));
-    }
-    if contains_encoded_separator(relative) {
         return Err(debian_filter_denied("path", relative));
     }
     let base = reqwest::Url::parse(base_url).map_err(|_| debian_filter_denied("path", relative))?;
@@ -3569,38 +3555,6 @@ mod tests {
     }
 
     #[test]
-    fn test_contains_encoded_separator() {
-        // Encoded slash / backslash, both cases, are detected.
-        for bad in [
-            "dists/bookworm/main%2f..%2fcontrib",
-            "dists/bookworm/main%2F..%2Fcontrib",
-            "pool/main/a%5c..%5cb",
-            "pool/main/a%5C..%5Cb",
-            // Mixed case within the escape.
-            "dists/bookworm/main%2Fcontrib",
-        ] {
-            assert!(
-                contains_encoded_separator(bad),
-                "should flag encoded separator: {bad:?}"
-            );
-        }
-        // Legitimate paths — including a percent-encoded epoch colon and an
-        // encoded `.deb` extension — are NOT flagged.
-        for ok in [
-            "dists/bookworm/main/binary-amd64/Packages.gz",
-            "pool/main/g/gcc/gcc_4%3a10.2.1-1_amd64.deb",
-            "pool/main/0/0ad/0ad_1_arm64%2edeb",
-            // A bare `%2` or `%5` that is not a separator escape.
-            "pool/main/foo%20bar",
-        ] {
-            assert!(
-                !contains_encoded_separator(ok),
-                "should NOT flag legit path: {ok:?}"
-            );
-        }
-    }
-
-    #[test]
     fn test_normalized_relpath_rejects_encoded_separators() {
         // Encoded `/` and `\` in the proxy path are refused as defense-in-depth
         // (#2562), while the equivalent legitimate path resolves normally.
@@ -3643,7 +3597,9 @@ mod tests {
             "main/binary-amd64/Packages.gz"
         )
         .is_ok());
-        // Encoded-slash traversal toward a non-allowlisted component is refused.
+        // Encoded-slash traversal is refused at the choke point as a malformed
+        // request (#2562), uniformly with a 400 regardless of allowlist
+        // contents — the encoded-separator belt fires before the allowlist gate.
         let resp = gate_debian_dists(
             &filter,
             TEST_BASE,
@@ -3651,7 +3607,7 @@ mod tests {
             "main%2f..%2fcontrib/binary-amd64/Packages.gz",
         )
         .unwrap_err();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -3611,13 +3611,13 @@ mod tests {
             "pool/main/m/mypkg%5C..%5Cevil_1_amd64.deb",
         ] {
             assert!(
-                normalized_debian_relpath(TEST_BASE, bad).is_err(),
+                normalized_debian_relpath(TEST_BASE, bad, false).is_err(),
                 "should reject encoded separator: {bad:?}"
             );
         }
         // Legitimate request with real separators still resolves.
         assert_eq!(
-            normalized_debian_relpath(TEST_BASE, "dists/bookworm/main/binary-amd64/Packages.gz")
+            normalized_debian_relpath(TEST_BASE, "dists/bookworm/main/binary-amd64/Packages.gz", false)
                 .unwrap(),
             "dists/bookworm/main/binary-amd64/Packages.gz"
         );

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -3617,8 +3617,12 @@ mod tests {
         }
         // Legitimate request with real separators still resolves.
         assert_eq!(
-            normalized_debian_relpath(TEST_BASE, "dists/bookworm/main/binary-amd64/Packages.gz", false)
-                .unwrap(),
+            normalized_debian_relpath(
+                TEST_BASE,
+                "dists/bookworm/main/binary-amd64/Packages.gz",
+                false,
+            )
+            .unwrap(),
             "dists/bookworm/main/binary-amd64/Packages.gz"
         );
     }


### PR DESCRIPTION
Closes #2892

## Summary
Two overlapping encoded-separator defenses for the Debian proxy filter both landed on `main` and are mutually inconsistent:

- **#2838** added `contains_encoded_separator()` returning **404** (`debian_filter_denied`), unconditionally.
- **#2770** added `has_encoded_path_separator()` (a multi-layer recursive decoder that also catches double-encoded `%252f`) returning **400** (`debian_encoded_separator_rejected`) plus a per-repo `allow_encoded_separators` opt-out.

Developed in parallel, each was green alone. Merged together, `normalized_debian_relpath` ran **both**: the opt-out-gated 400 guard *and* the unconditional 404 belt. That left the module inconsistent — the unconditional 404 belt **defeated the per-repo opt-out**, and the two checks disagreed on the status for the same request — and its lib tests did not compile (a 3rd `allow_encoded_separators` arg was missing at two call sites), blocking merge-CI for every open PR.

## Change
This branch does two things:

1. **Restore lib-test compilation** — add the missing `allow_encoded_separators` (`false`) argument to the two stale `normalized_debian_relpath` test call sites.
2. **Reconcile the #2838/#2770 encoded-separator gates on the uniform-400 contract.** An over-/double-encoded path separator is a *malformed request*, so per RFC 9110 the honest code is **400 Bad Request** — returned **uniformly, independent of allowlist contents**, from the single choke point (`normalized_debian_relpath`), honoring the per-repo `allow_encoded_separators` opt-out.
   - Adopt #2770 as canonical: keep `has_encoded_path_separator` (multi-layer, capped-depth, catches `%252f`) + the opt-out.
   - **Remove #2838's now-redundant unconditional `contains_encoded_separator` → 404 check.** It duplicated a strictly weaker single-layer detector and defeated the opt-out. Its dedicated unit test is removed with the function.
   - `test_gate_dists_blocks_encoded_separator` (the only assertion amended) now expects **400** rather than the stale 404 — the traversal is still asserted blocked. All other encoded-separator tests (choke-point 400, dist-segment 400, opt-out → allowlist, control-byte/escape) pass unchanged.

The `allow_encoded_separators=false` default is unchanged; traversal defense is not weakened (the stronger multi-layer detector is retained and no config branching is introduced — the rejected config-dependent status would have been a filter-state oracle).

## Test
- `cargo test --lib api::handlers::debian` — **156 pass / 0 fail** (full module).
- `cargo fmt --all -- --check` clean; `cargo clippy --lib -- -D warnings` clean.
- `docker build -f docker/Dockerfile.backend` and a live debian remote-proxy repo (isolated pool slot) re-verified: `%252f` (double-encoded) → **400** (guard); single `%2f`/`..` traversal → **404** (blocked at the allowlist gate after the HTTP layer decodes `%2f`→`/`); `%5c` → 400 (pre-existing path middleware); legit unencoded `dists/.../Packages.gz` and `Release` → **200** (served); the per-repo `allow_encoded_separators=true` opt-out cleanly bypasses the guard (`%252f`: 400 → 404, flows to the upstream fetch). No traversal escape in any variant.