### PR TITLE
fix(debian): pass strict mode at the two test call sites missed by the relpath signature change

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -3611,14 +3611,18 @@ mod tests {
             "pool/main/m/mypkg%5C..%5Cevil_1_amd64.deb",
         ] {
             assert!(
-                normalized_debian_relpath(TEST_BASE, bad).is_err(),
+                normalized_debian_relpath(TEST_BASE, bad, false).is_err(),
                 "should reject encoded separator: {bad:?}"
             );
         }
         // Legitimate request with real separators still resolves.
         assert_eq!(
-            normalized_debian_relpath(TEST_BASE, "dists/bookworm/main/binary-amd64/Packages.gz")
-                .unwrap(),
+            normalized_debian_relpath(
+                TEST_BASE,
+                "dists/bookworm/main/binary-amd64/Packages.gz",
+                false
+            )
+            .unwrap(),
             "dists/bookworm/main/binary-amd64/Packages.gz"
         );
     }


### PR DESCRIPTION
## Summary

Fixes the `main` compile break in the backend. Two `#[test]` call sites in `backend/src/api/handlers/debian.rs` still called `normalized_debian_relpath` with two arguments after its signature grew a third.

This is a two-PR semantic collision:

- #2770 changed `normalized_debian_relpath` to take a third parameter, `allow_encoded_separators: bool` (base_url, relative, allow_encoded_separators), so callers can opt into or out of accepting encoded `%2f` / `%5c` separators.
- #2838 landed tests that were written against the old two-argument signature.

Both merged cleanly on their own but together left two test call sites (in `test_normalized_relpath_rejects_encoded_separators`) calling the function with the old arity, which fails to compile. Because the break is in test code under `--all-targets`, it blocks Check Rust for every other open PR.

The fix passes `false` (strict mode) at both call sites, which is the correct value: both assertions verify that encoded separators are rejected, so the test must exercise the strict path.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The updated tests (`test_normalized_relpath_rejects_encoded_separators`) now compile and assert strict-mode rejection of encoded `%2f`/`%5c` separators, and pass on this branch.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2898
