### PR TITLE
fix(tests): authenticate the gRPC SBOM test harness with a real principal

### DIFF
--- a/backend/tests/grpc_sbom_tests.rs
+++ b/backend/tests/grpc_sbom_tests.rs
@@ -1,26 +1,114 @@
 //! Integration tests for gRPC SBOM services.
 //!
-//! These tests verify the gRPC SBOM, CVE History, and Security Policy services.
+//! These tests verify the gRPC SBOM, CVE History, and Security Policy services
+//! end to end, through the SAME authenticated interceptor contract production
+//! wires in `main.rs`. Every production RPC calls `authorize_grpc_scope` as its
+//! first line and fails closed (`Unauthenticated`) when no `GrpcPrincipal` was
+//! stamped into the request extensions (added in #2500). The test server here
+//! therefore registers each service `with_interceptor(..)` using the real
+//! `AuthInterceptor`, and each client attaches a signed access-token Bearer
+//! credential, so the principal is stamped exactly as it is at runtime.
+//!
+//! The interceptor is built with `db = None`: in that documented test mode it
+//! trusts the signed token's `is_admin` / `scopes` claims instead of consulting
+//! the live DB role, which lets a test mint a full-scope admin principal (or a
+//! deliberately restricted one) without provisioning a `users` row.
 
 mod common;
 
-use artifact_keeper_backend::grpc::{
-    generated::{
-        cve_history_service_client::CveHistoryServiceClient,
-        cve_history_service_server::CveHistoryServiceServer,
-        sbom_service_client::SbomServiceClient, sbom_service_server::SbomServiceServer,
-        security_policy_service_client::SecurityPolicyServiceClient,
-        security_policy_service_server::SecurityPolicyServiceServer, CheckLicenseComplianceRequest,
-        GenerateSbomRequest, GetCveTrendsRequest, LicensePolicy as ProtoLicensePolicy,
-        ListLicensePoliciesRequest, PolicyAction, SbomFormat, UpsertLicensePolicyRequest,
+use artifact_keeper_backend::{
+    grpc::{
+        auth_interceptor::AuthInterceptor,
+        generated::{
+            cve_history_service_client::CveHistoryServiceClient,
+            cve_history_service_server::CveHistoryServiceServer,
+            sbom_service_client::SbomServiceClient, sbom_service_server::SbomServiceServer,
+            security_policy_service_client::SecurityPolicyServiceClient,
+            security_policy_service_server::SecurityPolicyServiceServer,
+            CheckLicenseComplianceRequest, GenerateSbomRequest, GetCveTrendsRequest,
+            LicensePolicy as ProtoLicensePolicy, ListLicensePoliciesRequest, PolicyAction,
+            SbomFormat, UpsertLicensePolicyRequest,
+        },
+        sbom_server::{CveHistoryGrpcServer, SbomGrpcServer, SecurityPolicyGrpcServer},
     },
-    sbom_server::{CveHistoryGrpcServer, SbomGrpcServer, SecurityPolicyGrpcServer},
+    services::auth_service::Claims,
 };
+use jsonwebtoken::{encode, EncodingKey, Header};
 use sqlx::PgPool;
 use tokio::net::TcpListener;
 use tonic::transport::{Channel, Server};
+use tonic::{Code, Request};
 
-/// Start a test gRPC server and return the channel for clients.
+/// Shared HS256 secret for the test interceptor and every minted token. It only
+/// has to be internally consistent: the interceptor is created with this secret
+/// and the client tokens are signed with it.
+const TEST_JWT_SECRET: &str = "grpc-sbom-integration-test-secret";
+
+/// Mint a signed access-token JWT for the test plane.
+///
+/// `is_admin` sets the admin floor the interceptor enforces, and `scopes` sets
+/// the per-method action-scope ceiling `authorize_grpc_scope` evaluates. Passing
+/// `scopes = None` mirrors an interactive/full token (no scope restriction), so
+/// `mint_admin_token()` yields a full-scope admin principal.
+fn mint_token(is_admin: bool, scopes: Option<Vec<String>>) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let claims = Claims {
+        sub: uuid::Uuid::new_v4(),
+        username: "grpc-test".to_string(),
+        email: "grpc-test@test.local".to_string(),
+        is_admin,
+        allowed_repo_ids: None,
+        iat: now,
+        iat_ms: Some(now.saturating_mul(1000)),
+        exp: now + 3600,
+        token_type: "access".to_string(),
+        jti: None,
+        family_id: None,
+        scan_pull_repo: None,
+        scopes,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+    )
+    .expect("failed to encode test JWT")
+}
+
+/// Full-scope admin token: passes the admin floor and every per-method scope.
+fn mint_admin_token() -> String {
+    mint_token(true, None)
+}
+
+/// Wrap a request message in a `tonic::Request` carrying an `authorization`
+/// Bearer credential, so the interceptor authenticates it and stamps the
+/// principal.
+fn authed_request<T>(msg: T, token: &str) -> Request<T> {
+    let mut req = Request::new(msg);
+    req.metadata_mut().insert(
+        "authorization",
+        format!("Bearer {}", token)
+            .parse()
+            .expect("valid metadata value"),
+    );
+    req
+}
+
+/// Wrap a request message with a full-scope admin credential. Used by the
+/// success-path tests.
+fn admin_request<T>(msg: T) -> Request<T> {
+    authed_request(msg, &mint_admin_token())
+}
+
+/// Start a test gRPC server wired with the production authentication interceptor
+/// and return a channel for clients.
+///
+/// This mirrors the runtime wiring in `main.rs`: each service is registered via
+/// `with_interceptor(server, move |req| auth.intercept(req))`, so requests carry
+/// a stamped `GrpcPrincipal` and the per-method `authorize_grpc_scope` checks
+/// have a principal to authorize. Registering the raw services without this
+/// interceptor (as this harness did before) makes every RPC fail closed with
+/// `Unauthenticated`.
 async fn start_test_server(pool: PgPool) -> Channel {
     // Find an available port
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -30,12 +118,38 @@ async fn start_test_server(pool: PgPool) -> Channel {
     let cve_history_server = CveHistoryGrpcServer::new(pool.clone());
     let security_policy_server = SecurityPolicyGrpcServer::new(pool);
 
+    // Build the same interceptor production uses. `db = None` selects the
+    // documented test mode: the interceptor trusts the signed token's
+    // `is_admin` / `scopes` claims rather than consulting a live DB role.
+    let auth = AuthInterceptor::new(TEST_JWT_SECRET, None);
+    let sbom_auth = auth.clone();
+    let cve_auth = auth.clone();
+    let policy_auth = auth;
+
     // Spawn the server in a background task
     tokio::spawn(async move {
+        // `Status` is large, so a closure returning `Result<_, Status>` trips
+        // `clippy::result_large_err`; production allows it at the same spot.
+        #[allow(clippy::result_large_err)]
+        let sbom_interceptor = move |req| sbom_auth.intercept(req);
+        #[allow(clippy::result_large_err)]
+        let cve_interceptor = move |req| cve_auth.intercept(req);
+        #[allow(clippy::result_large_err)]
+        let policy_interceptor = move |req| policy_auth.intercept(req);
+
         Server::builder()
-            .add_service(SbomServiceServer::new(sbom_server))
-            .add_service(CveHistoryServiceServer::new(cve_history_server))
-            .add_service(SecurityPolicyServiceServer::new(security_policy_server))
+            .add_service(SbomServiceServer::with_interceptor(
+                sbom_server,
+                sbom_interceptor,
+            ))
+            .add_service(CveHistoryServiceServer::with_interceptor(
+                cve_history_server,
+                cve_interceptor,
+            ))
+            .add_service(SecurityPolicyServiceServer::with_interceptor(
+                security_policy_server,
+                policy_interceptor,
+            ))
             .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
             .await
             .expect("gRPC server failed");
@@ -60,17 +174,30 @@ async fn test_sbom_service_generate_sbom_without_artifact() {
 
     let mut client = SbomServiceClient::new(channel);
 
-    // Try to generate SBOM for non-existent artifact
-    let request = tonic::Request::new(GenerateSbomRequest {
+    // Try to generate an SBOM for a non-existent artifact. The caller is a
+    // full-scope admin, so this passes authorization and reaches the service.
+    let request = admin_request(GenerateSbomRequest {
         artifact_id: uuid::Uuid::new_v4().to_string(),
         format: SbomFormat::Cyclonedx.into(),
         force_regenerate: false,
     });
 
-    let result = client.generate_sbom(request).await;
+    let status = client
+        .generate_sbom(request)
+        .await
+        .expect_err("generating an SBOM for a missing artifact must fail");
 
-    // Should fail because artifact doesn't exist
-    assert!(result.is_err());
+    // The insert into `sbom_documents` violates the NOT NULL foreign key
+    // `artifact_id -> artifacts(id)` (migration 045), which the handler maps to
+    // `Status::internal`. Asserting the exact code proves the failure is the
+    // intended data error, not an auth failure (Unauthenticated /
+    // PermissionDenied) masquerading as a pass, which the previous broad
+    // `is_err()` assertion could not distinguish.
+    assert_eq!(
+        status.code(),
+        Code::Internal,
+        "expected an Internal (FK violation) failure, got: {status:?}"
+    );
 }
 
 #[tokio::test]
@@ -82,7 +209,7 @@ async fn test_cve_history_get_trends() {
     let mut client = CveHistoryServiceClient::new(channel);
 
     // Get global CVE trends
-    let request = tonic::Request::new(GetCveTrendsRequest {
+    let request = admin_request(GetCveTrendsRequest {
         repository_id: String::new(),
         days: 30,
     });
@@ -104,7 +231,7 @@ async fn test_security_policy_list_policies() {
     let mut client = SecurityPolicyServiceClient::new(channel);
 
     // List all policies
-    let request = tonic::Request::new(ListLicensePoliciesRequest {
+    let request = admin_request(ListLicensePoliciesRequest {
         repository_id: String::new(),
     });
 
@@ -141,7 +268,7 @@ async fn test_security_policy_upsert_and_check_compliance() {
         updated_at: None,
     };
 
-    let request = tonic::Request::new(UpsertLicensePolicyRequest {
+    let request = admin_request(UpsertLicensePolicyRequest {
         policy: Some(policy),
     });
 
@@ -151,7 +278,7 @@ async fn test_security_policy_upsert_and_check_compliance() {
     assert!(!created_policy.id.is_empty());
 
     // Check compliance with allowed licenses
-    let request = tonic::Request::new(CheckLicenseComplianceRequest {
+    let request = admin_request(CheckLicenseComplianceRequest {
         licenses: vec!["MIT".to_string(), "Apache-2.0".to_string()],
         repository_id: String::new(),
     });
@@ -163,7 +290,7 @@ async fn test_security_policy_upsert_and_check_compliance() {
     assert!(compliance.violations.is_empty());
 
     // Clean up - delete the test policy
-    let delete_request = tonic::Request::new(
+    let delete_request = admin_request(
         artifact_keeper_backend::grpc::generated::DeleteLicensePolicyRequest {
             id: created_policy.id,
         },
@@ -195,7 +322,7 @@ async fn test_security_policy_check_denied_license() {
         updated_at: None,
     };
 
-    let request = tonic::Request::new(UpsertLicensePolicyRequest {
+    let request = admin_request(UpsertLicensePolicyRequest {
         policy: Some(policy),
     });
 
@@ -204,7 +331,7 @@ async fn test_security_policy_check_denied_license() {
     let created_policy = response.unwrap().into_inner();
 
     // Check compliance with a denied license
-    let request = tonic::Request::new(CheckLicenseComplianceRequest {
+    let request = admin_request(CheckLicenseComplianceRequest {
         licenses: vec!["MIT".to_string(), "GPL-3.0".to_string()],
         repository_id: String::new(),
     });
@@ -217,10 +344,76 @@ async fn test_security_policy_check_denied_license() {
     assert!(compliance.violations.iter().any(|v| v.contains("GPL-3.0")));
 
     // Clean up
-    let delete_request = tonic::Request::new(
+    let delete_request = admin_request(
         artifact_keeper_backend::grpc::generated::DeleteLicensePolicyRequest {
             id: created_policy.id,
         },
     );
     let _ = policy_client.delete_license_policy(delete_request).await;
+}
+
+// ---------------------------------------------------------------------------
+// Negative-path tests: prove authentication and per-method scope authorization
+// are actually enforced over the wire, not just in unit tests. These use the
+// same authenticated harness as the success-path tests above.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // Requires database
+async fn test_grpc_unauthenticated_without_credential() {
+    let ctx = common::TestContext::new().await;
+    let channel = start_test_server(ctx.pool.clone()).await;
+
+    let mut client = SecurityPolicyServiceClient::new(channel);
+
+    // No `authorization` metadata at all: the interceptor rejects the request
+    // before it reaches the service, so no `GrpcPrincipal` is ever stamped.
+    let request = Request::new(ListLicensePoliciesRequest {
+        repository_id: String::new(),
+    });
+
+    let status = client
+        .list_license_policies(request)
+        .await
+        .expect_err("a request with no credential must be rejected");
+
+    assert_eq!(
+        status.code(),
+        Code::Unauthenticated,
+        "expected Unauthenticated for a missing credential, got: {status:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore] // Requires database
+async fn test_grpc_read_only_scope_denied_on_write() {
+    let ctx = common::TestContext::new().await;
+    let channel = start_test_server(ctx.pool.clone()).await;
+
+    let mut client = SbomServiceClient::new(channel);
+
+    // A read-only principal (admin floor satisfied, but scope ceiling limited to
+    // `read:artifacts`) calling a write RPC (`generate_sbom` requires
+    // `write:artifacts`). `authorize_grpc_scope` is the method's first line and
+    // returns before any DB work, so no records are created or need cleanup.
+    let read_only = mint_token(true, Some(vec!["read:artifacts".to_string()]));
+    let request = authed_request(
+        GenerateSbomRequest {
+            artifact_id: uuid::Uuid::new_v4().to_string(),
+            format: SbomFormat::Cyclonedx.into(),
+            force_regenerate: false,
+        },
+        &read_only,
+    );
+
+    let status = client
+        .generate_sbom(request)
+        .await
+        .expect_err("a read-only token must not perform a write RPC");
+
+    assert_eq!(
+        status.code(),
+        Code::PermissionDenied,
+        "expected PermissionDenied for a read-only token on a write RPC, got: {status:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Every gRPC RPC in `backend/src/grpc/sbom_server.rs` calls `authorize_grpc_scope` as its first line, which fails closed with `Unauthenticated` when no `GrpcPrincipal` was stamped into the request extensions (added in #2500, commit 5426f4ef). The integration harness in `backend/tests/grpc_sbom_tests.rs` still registered the raw services with `Server::builder().add_service(...)` (no interceptor) and clients sent bare `tonic::Request::new` with no metadata. Four of the five tests failed deterministically (`test_cve_history_get_trends`, `test_security_policy_list_policies`, `test_security_policy_upsert_and_check_compliance`, `test_security_policy_check_denied_license`); the fifth passed only because it asserted a broad `is_err()`, so an auth failure masqueraded as the intended data failure.

This repairs the harness to authenticate through the same contract production uses, with no production changes and no authorization weakened.

Wiring approach: the test server registers each service via `with_interceptor(server, move |req| auth.intercept(req))` using the real `AuthInterceptor`, mirroring `main.rs`. The interceptor is built with `db = None`, its documented test mode, so it trusts the signed token's `is_admin`/`scopes` claims instead of a live DB role. Each client attaches a signed access-token Bearer credential, so a real `GrpcPrincipal` is stamped exactly as at runtime. A `mint_token(is_admin, scopes)` helper mints full-scope admin tokens for the success paths and a restricted token for the scope test.

Changes:
- Wire `start_test_server` through the production interceptor contract.
- Replace the broad `assert!(result.is_err())` in `test_sbom_service_generate_sbom_without_artifact` with an exact `Code::Internal` assertion. Generating an SBOM for a missing artifact violates the `sbom_documents.artifact_id -> artifacts(id)` NOT NULL foreign key (migration 045), which the handler maps to `Status::internal`. Asserting the exact code means an auth failure (`Unauthenticated`/`PermissionDenied`) can no longer pass as this test.
- Add two negative-path tests: `test_grpc_unauthenticated_without_credential` (no credential -> `Code::Unauthenticated`) and `test_grpc_read_only_scope_denied_on_write` (a read-only-scoped principal on a write RPC -> `Code::PermissionDenied`).

All five existing test names are preserved and the tests stay `#[ignore]` (database-required). `backend/src/grpc/auth_interceptor.rs` already covers the transport/scope unit matrix (unauthenticated, admin floor, wildcard, read-only-denied, missing-principal fail-closed), so no changes were needed there.

Validation (backend clone, PostgreSQL 16 with migrations applied):
- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean for this change (the only failure was a pre-existing `debian.rs` unit-test compile error on `main`, unrelated to this PR). Scoped `cargo clippy --test grpc_sbom_tests -- -D warnings`: clean.
- `DATABASE_URL=... cargo test --test grpc_sbom_tests -- --ignored --test-threads=1`: `7 passed; 0 failed`.
- Load-bearing proof: temporarily reverting the harness to raw `add_service` (no principal injection) makes the success-path tests fail with `Code::Unauthenticated` / "missing authenticated principal", and the missing-artifact test's exact-code assertion catches the masquerade. Restored afterward.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2896
