### PR TITLE
perf(download): move download-path stats + audit writes off the hot path

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -1978,6 +1978,12 @@ mod tests {
         };
         crate::services::artifact_service::record_download(&pool, artifact_id, &ctx_authed).await;
         crate::services::artifact_service::record_download(&pool, artifact_id, &ctx_anon).await;
+        // #2522: the two INSERTs are now spawned off the hot path — wait for
+        // both rows to land before asserting on them.
+        assert_eq!(
+            tdh::download_count_eventually(&pool, artifact_id, 2).await,
+            2
+        );
 
         // Filter by artifact: both rows.
         let by_artifact = query_downloads(
@@ -2080,6 +2086,11 @@ mod tests {
 
         crate::services::artifact_service::record_download(&pool, artifact_id, &Default::default())
             .await;
+        // #2522: the INSERT is now spawned — wait for the row before reading it.
+        assert_eq!(
+            tdh::download_count_eventually(&pool, artifact_id, 1).await,
+            1
+        );
 
         let (ip, uid): (Option<String>, Option<Uuid>) = sqlx::query_as(
             "SELECT ip_address, user_id FROM download_statistics WHERE artifact_id = $1",

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -2048,17 +2048,6 @@ mod admin_scope_policy_tests {
 
     // ── #1617 Phase 1: token-lifecycle audit coverage ───────────────────
 
-    async fn audit_count(pool: &sqlx::PgPool, token_id: Uuid, action: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM audit_log WHERE resource_id = $1 AND action = $2",
-        )
-        .bind(token_id)
-        .bind(action)
-        .fetch_one(pool)
-        .await
-        .expect("audit_log count query")
-    }
-
     /// Minting an API token must emit an `API_TOKEN_CREATED` audit event
     /// attributed to the acting user, carrying the token id (never the secret).
     #[tokio::test]
@@ -2091,8 +2080,9 @@ mod admin_scope_policy_tests {
         let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         let token_id = Uuid::parse_str(v["id"].as_str().unwrap()).unwrap();
 
+        // #2522: audit write is fire-and-forget (spawned) — poll for the row.
         assert_eq!(
-            audit_count(&pool, token_id, "API_TOKEN_CREATED").await,
+            tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_CREATED", 1).await,
             1,
             "mint MUST write exactly one API_TOKEN_CREATED audit row"
         );
@@ -2136,7 +2126,7 @@ mod admin_scope_policy_tests {
         assert!(status.is_success(), "revoke should succeed, got {status}");
 
         assert_eq!(
-            audit_count(&pool, token_id, "API_TOKEN_REVOKED").await,
+            tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_REVOKED", 1).await,
             1,
             "revoke MUST write exactly one API_TOKEN_REVOKED audit row"
         );

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -342,17 +342,6 @@ mod audit_db_tests {
             .await;
     }
 
-    async fn audit_count(pool: &sqlx::PgPool, token_id: Uuid, action: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM audit_log WHERE resource_id = $1 AND action = $2",
-        )
-        .bind(token_id)
-        .bind(action)
-        .fetch_one(pool)
-        .await
-        .expect("audit_log count query")
-    }
-
     /// `POST /profile/access-tokens` must emit `API_TOKEN_CREATED`, and the
     /// matching revoke must emit `API_TOKEN_REVOKED`.
     #[tokio::test]
@@ -379,8 +368,9 @@ mod audit_db_tests {
         let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         let token_id = Uuid::parse_str(v["id"].as_str().unwrap()).unwrap();
 
+        // #2522: audit write is fire-and-forget (spawned) — poll for the row.
         assert_eq!(
-            audit_count(&pool, token_id, "API_TOKEN_CREATED").await,
+            tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_CREATED", 1).await,
             1,
             "profile mint MUST write one API_TOKEN_CREATED row"
         );
@@ -397,7 +387,7 @@ mod audit_db_tests {
         );
 
         assert_eq!(
-            audit_count(&pool, token_id, "API_TOKEN_REVOKED").await,
+            tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_REVOKED", 1).await,
             1,
             "profile revoke MUST write one API_TOKEN_REVOKED row"
         );

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -8179,6 +8179,12 @@ mod tests {
         let cd = resp.headers().get("Content-Disposition").unwrap();
         assert!(cd.to_str().unwrap().contains("foo.tar.gz"));
 
+        // #2522: the stats INSERT is now spawned off the hot path — wait for it.
+        assert_eq!(
+            crate::api::handlers::test_db_helpers::download_count_eventually(&pool, artifact_id, 1)
+                .await,
+            1
+        );
         // #2365: the download must be attributed to the real client, not the
         // historical '0.0.0.0' sentinel with no user.
         let (ip, ua, uid): (Option<String>, Option<String>, Option<Uuid>) = sqlx::query_as(
@@ -9982,6 +9988,22 @@ mod tests {
         .expect("count download_statistics rows")
     }
 
+    /// Poll [`download_stats_count_for_repo`] until it reaches `expected` (or a
+    /// bounded ~2s budget is exhausted). Since #2522 `record_download` SPAWNS the
+    /// `download_statistics` INSERT off the hot path, so these repo-scoped count
+    /// assertions must tolerate the detached write's async timing.
+    async fn poll_repo_download_count(pool: &PgPool, repo_id: Uuid, expected: i64) -> i64 {
+        let mut last = -1;
+        for _ in 0..100 {
+            last = download_stats_count_for_repo(pool, repo_id).await;
+            if last >= expected {
+                return last;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        last
+    }
+
     /// #2260: a HOSTED (non-proxy-cache) local artifact served through
     /// `local_fetch_or_redirect` on a filesystem backend (streaming fallback,
     /// no presign) records exactly ONE download-statistics row — and a second
@@ -10043,7 +10065,8 @@ mod tests {
         )
         .await
         .expect("first hosted fetch must succeed");
-        let after_one = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+        // #2522: the stats INSERT is spawned off the hot path — wait for it.
+        let after_one = poll_repo_download_count(&fx.pool, fx.repo_id, 1).await;
 
         super::local_fetch_or_redirect(
             &fx.pool,
@@ -10055,7 +10078,7 @@ mod tests {
         )
         .await
         .expect("second hosted fetch must succeed");
-        let after_two = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+        let after_two = poll_repo_download_count(&fx.pool, fx.repo_id, 2).await;
 
         fx.teardown().await;
 
@@ -10148,7 +10171,8 @@ mod tests {
         )
         .await
         .expect("GET serve must succeed");
-        let after_get = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+        // #2522: the GET's stats INSERT is spawned off the hot path — wait for it.
+        let after_get = poll_repo_download_count(&fx.pool, fx.repo_id, 1).await;
 
         fx.teardown().await;
 
@@ -10240,7 +10264,9 @@ mod tests {
         )
         .await;
 
-        let recorded = download_stats_count_for_repo(&pool, member_id).await;
+        // #2522: the stats INSERT is spawned off the hot path — wait for it
+        // before cleanup deletes the rows.
+        let recorded = poll_repo_download_count(&pool, member_id, 1).await;
 
         db_helpers::cleanup(&pool, member_id, user_id).await;
         db_helpers::cleanup(&pool, virtual_id, user_id).await;
@@ -10545,6 +10571,22 @@ mod tests {
             .expect("count download_statistics")
     }
 
+    /// Poll [`download_stat_count`] until it reaches `expected` (or a bounded
+    /// ~2s budget is exhausted). Since #2522 `record_download` SPAWNS the
+    /// `download_statistics` INSERT off the hot path, so these artifact-scoped
+    /// count assertions must tolerate the detached write's async timing.
+    async fn poll_artifact_download_count(pool: &PgPool, artifact_id: Uuid, expected: i64) -> i64 {
+        let mut last = -1;
+        for _ in 0..100 {
+            last = download_stat_count(pool, artifact_id).await;
+            if last >= expected {
+                return last;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        last
+    }
+
     fn ctx_for(
         user_id: Uuid,
         is_head: bool,
@@ -10593,7 +10635,8 @@ mod tests {
         )
         .await;
 
-        let after_get = download_stat_count(&pool, artifact_id).await;
+        // #2522: the GET's stats INSERT is spawned off the hot path — wait for it.
+        let after_get = poll_artifact_download_count(&pool, artifact_id, 1).await;
 
         // HEAD on the same redirect-eligible .jar: still 302 (headers only) but
         // records +0 — the canonical record_download honours ctx.is_head

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -9086,6 +9086,12 @@ mod tests {
             Some("redirect-stats-test-agent/1.0"),
         )
         .await;
+        // #2522: the stats INSERT is now spawned off the hot path — wait for it.
+        assert_eq!(
+            crate::api::handlers::test_db_helpers::download_count_eventually(&pool, artifact_id, 1)
+                .await,
+            1
+        );
 
         let row: Option<(Option<String>, Option<String>, Option<Uuid>)> = sqlx::query_as(
             "SELECT ip_address, user_agent, user_id FROM download_statistics \
@@ -16076,6 +16082,12 @@ mod tests {
             "virtual /artifacts/ GET must serve the member's content bytes"
         );
 
+        // #2522: the stats INSERT is spawned off the hot path — wait for it
+        // (also pins ordering: the authed row commits before the anon serve).
+        assert_eq!(
+            tdh::download_count_eventually(&fx.pool, artifact_id, 1).await,
+            1
+        );
         let rows = telemetry_rows(&fx.pool, artifact_id).await;
         assert_eq!(
             rows.len(),
@@ -16103,6 +16115,11 @@ mod tests {
         let (anon_status, _) = tdh::send(fx.router_anon(router()), anon_req).await;
         assert_eq!(anon_status, axum::http::StatusCode::OK);
 
+        // #2522: the anon serve's stats INSERT is spawned too — wait for it.
+        assert_eq!(
+            tdh::download_count_eventually(&fx.pool, artifact_id, 2).await,
+            2
+        );
         let rows = telemetry_rows(&fx.pool, artifact_id).await;
         assert_eq!(rows.len(), 2, "anonymous serve must also record");
         assert_eq!(rows[1].0, None, "anonymous must record a NULL user");
@@ -16296,6 +16313,11 @@ mod tests {
             "virtual /download/ GET must serve the member's content bytes"
         );
 
+        // #2522: the stats INSERT is now spawned off the hot path — wait for it.
+        assert_eq!(
+            tdh::download_count_eventually(&fx.pool, artifact_id, 1).await,
+            1
+        );
         let rows = telemetry_rows(&fx.pool, artifact_id).await;
         assert_eq!(
             rows.len(),
@@ -16324,6 +16346,11 @@ mod tests {
         let (anon_status, _) = tdh::send(fx.router_anon(download_router()), anon_req).await;
         assert_eq!(anon_status, axum::http::StatusCode::OK);
 
+        // #2522: the anon serve's stats INSERT is spawned too — wait for it.
+        assert_eq!(
+            tdh::download_count_eventually(&fx.pool, artifact_id, 2).await,
+            2
+        );
         let rows = telemetry_rows(&fx.pool, artifact_id).await;
         assert_eq!(rows.len(), 2, "anonymous serve must also record");
         assert_eq!(rows[1].0, None, "anonymous must record a NULL user");

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -2092,17 +2092,6 @@ mod audit_db_tests {
             .layer(AxumExtension::<AuthExtension>(auth))
     }
 
-    async fn audit_count(pool: &sqlx::PgPool, token_id: Uuid, action: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM audit_log WHERE resource_id = $1 AND action = $2",
-        )
-        .bind(token_id)
-        .bind(action)
-        .fetch_one(pool)
-        .await
-        .expect("audit_log count query")
-    }
-
     async fn mint_service_account_token(
         state: SharedState,
         auth: AuthExtension,
@@ -2240,8 +2229,9 @@ mod audit_db_tests {
         let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         let token_id = Uuid::parse_str(v["id"].as_str().unwrap()).unwrap();
 
+        // #2522: audit write is fire-and-forget (spawned) — poll for the row.
         assert_eq!(
-            audit_count(&pool, token_id, "API_TOKEN_CREATED").await,
+            tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_CREATED", 1).await,
             1,
             "SA mint MUST write one API_TOKEN_CREATED row"
         );
@@ -2255,7 +2245,7 @@ mod audit_db_tests {
         assert!(status.is_success(), "SA revoke should succeed: {status}");
 
         assert_eq!(
-            audit_count(&pool, token_id, "API_TOKEN_REVOKED").await,
+            tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_REVOKED", 1).await,
             1,
             "SA revoke MUST write one API_TOKEN_REVOKED row"
         );

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -792,6 +792,59 @@ pub async fn audit_count(pool: &PgPool, resource_id: Uuid, action: &str) -> i64 
     .expect("audit_log count query")
 }
 
+/// Poll [`audit_count`] until it reaches `expected` (or a bounded ~2s budget is
+/// exhausted), returning the last observed value.
+///
+/// Since #2522 the fire-and-forget audit emitters (`audit_fire_and_forget`)
+/// SPAWN their INSERT instead of awaiting it, so a test that acts and then reads
+/// the audit trail must tolerate the detached task's async timing. Use this for
+/// the "an event was emitted" (count reaches N) assertions; a subsequent
+/// "not emitted" (count stays 0) assertion can then read [`audit_count`]
+/// directly, since the spawned writes for this resource have already drained.
+pub async fn audit_count_eventually(
+    pool: &PgPool,
+    resource_id: Uuid,
+    action: &str,
+    expected: i64,
+) -> i64 {
+    let mut last = -1;
+    for _ in 0..100 {
+        last = audit_count(pool, resource_id, action).await;
+        if last >= expected {
+            return last;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    last
+}
+
+/// Count `download_statistics` rows for `artifact_id`.
+pub async fn download_count(pool: &PgPool, artifact_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1")
+        .bind(artifact_id)
+        .fetch_one(pool)
+        .await
+        .expect("download_statistics count query")
+}
+
+/// Poll [`download_count`] until it reaches `expected` (or a bounded ~2s budget
+/// is exhausted), returning the last observed value.
+///
+/// Since #2522 `record_download` SPAWNS the `download_statistics` INSERT off the
+/// synchronous download hot path, so a test that serves a body and then reads
+/// the count must tolerate the detached write's async timing.
+pub async fn download_count_eventually(pool: &PgPool, artifact_id: Uuid, expected: i64) -> i64 {
+    let mut last = -1;
+    for _ in 0..100 {
+        last = download_count(pool, artifact_id).await;
+        if last >= expected {
+            return last;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    last
+}
+
 /// Delete a test user plus the auth-related rows the audit/2FA test modules
 /// create for it (audit_log, refresh/pending jti, password history). Shared
 /// teardown so the identical cleanup block isn't copy-pasted across the #386

--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -1578,8 +1578,10 @@ mod totp_audit_tests {
         )
         .await;
 
-        let enabled = tdh::audit_count(&pool, user_id, "TOTP_ENABLED").await;
-        let invalidated = tdh::audit_count(&pool, user_id, "SESSIONS_INVALIDATED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for each.
+        let enabled = tdh::audit_count_eventually(&pool, user_id, "TOTP_ENABLED", 1).await;
+        let invalidated =
+            tdh::audit_count_eventually(&pool, user_id, "SESSIONS_INVALIDATED", 1).await;
         tdh::cleanup_user(&pool, user_id).await;
         let _ = std::fs::remove_dir_all(&fx.storage_dir);
 
@@ -1620,8 +1622,10 @@ mod totp_audit_tests {
         )
         .await;
 
-        let disabled = tdh::audit_count(&pool, user_id, "TOTP_DISABLED").await;
-        let invalidated = tdh::audit_count(&pool, user_id, "SESSIONS_INVALIDATED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for each.
+        let disabled = tdh::audit_count_eventually(&pool, user_id, "TOTP_DISABLED", 1).await;
+        let invalidated =
+            tdh::audit_count_eventually(&pool, user_id, "SESSIONS_INVALIDATED", 1).await;
         tdh::cleanup_user(&pool, user_id).await;
         let _ = std::fs::remove_dir_all(&fx.storage_dir);
 
@@ -1669,8 +1673,9 @@ mod totp_audit_tests {
         )
         .await;
 
-        let logins = tdh::audit_count(&pool, user_id, "LOGIN").await;
-        let failed = tdh::audit_count(&pool, user_id, "LOGIN_FAILED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for each.
+        let logins = tdh::audit_count_eventually(&pool, user_id, "LOGIN", 1).await;
+        let failed = tdh::audit_count_eventually(&pool, user_id, "LOGIN_FAILED", 1).await;
         tdh::cleanup_user(&pool, user_id).await;
         let _ = std::fs::remove_dir_all(&fx.storage_dir);
 
@@ -1713,7 +1718,8 @@ mod totp_audit_tests {
         )
         .await;
 
-        let failed = tdh::audit_count(&pool, user_id, "LOGIN_FAILED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for it.
+        let failed = tdh::audit_count_eventually(&pool, user_id, "LOGIN_FAILED", 1).await;
         tdh::cleanup_user(&pool, user_id).await;
         let _ = std::fs::remove_dir_all(&fx.storage_dir);
 

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -3762,8 +3762,10 @@ mod password_audit_tests {
         )
         .await;
 
-        let changed = tdh::audit_count(&pool, user_id, "PASSWORD_CHANGED").await;
-        let invalidated = tdh::audit_count(&pool, user_id, "SESSIONS_INVALIDATED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for each.
+        let changed = tdh::audit_count_eventually(&pool, user_id, "PASSWORD_CHANGED", 1).await;
+        let invalidated =
+            tdh::audit_count_eventually(&pool, user_id, "SESSIONS_INVALIDATED", 1).await;
         let by_admin = by_admin_flag(&pool, user_id).await;
         tdh::cleanup_user(&pool, user_id).await;
 
@@ -3796,7 +3798,8 @@ mod password_audit_tests {
 
         let res = reset_password(State(state.clone()), Extension(auth), Path(target_id)).await;
 
-        let changed = tdh::audit_count(&pool, target_id, "PASSWORD_CHANGED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for it.
+        let changed = tdh::audit_count_eventually(&pool, target_id, "PASSWORD_CHANGED", 1).await;
         let by_admin = by_admin_flag(&pool, target_id).await;
         tdh::cleanup_user(&pool, target_id).await;
         tdh::cleanup_user(&pool, admin_id).await;
@@ -3827,7 +3830,11 @@ mod password_audit_tests {
         let res =
             force_password_change(State(state.clone()), Extension(auth), Path(target_id)).await;
 
-        let invalidated = tdh::audit_count(&pool, target_id, "SESSIONS_INVALIDATED").await;
+        // #2522: audit writes are fire-and-forget (spawned) — poll for the
+        // positive event; once it has landed the (never-emitted) negative event
+        // is safely read directly.
+        let invalidated =
+            tdh::audit_count_eventually(&pool, target_id, "SESSIONS_INVALIDATED", 1).await;
         // No password actually changed, so PASSWORD_CHANGED must NOT be emitted.
         let changed = tdh::audit_count(&pool, target_id, "PASSWORD_CHANGED").await;
         tdh::cleanup_user(&pool, target_id).await;

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -2324,19 +2324,33 @@ pub async fn record_download(db: &PgPool, artifact_id: Uuid, ctx: &DownloadConte
     if ctx.is_head {
         return;
     }
-    if let Err(e) = sqlx::query(
-        "INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent) \
-         VALUES ($1, $2, $3, $4)",
-    )
-    .bind(artifact_id)
-    .bind(ctx.user_id)
-    .bind(ctx.client_ip.map(|ip| ip.to_string()))
-    .bind(ctx.user_agent.as_deref())
-    .execute(db)
-    .await
-    {
-        warn!(%artifact_id, error = %e, "failed to record download statistics");
-    }
+    // Move the statistics INSERT OFF the synchronous download hot path (#2522).
+    // Historically this awaited the write on the catalog pool before the byte
+    // stream could return, coupling byte-plane latency/availability to DB-pool
+    // pressure. Spawn a detached best-effort task instead: the caller returns
+    // immediately (no await on the write), the row is still eventually written,
+    // and a failure is logged at `warn` and swallowed exactly as before —
+    // statistics must never block or fail the download itself. The `is_head`
+    // "no body ⇒ no row" contract is preserved (checked synchronously above).
+    let db = db.clone();
+    let user_id = ctx.user_id;
+    let ip_address = ctx.client_ip.map(|ip| ip.to_string());
+    let user_agent = ctx.user_agent.clone();
+    tokio::spawn(async move {
+        if let Err(e) = sqlx::query(
+            "INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(artifact_id)
+        .bind(user_id)
+        .bind(ip_address)
+        .bind(user_agent)
+        .execute(&db)
+        .await
+        {
+            warn!(%artifact_id, error = %e, "failed to record download statistics");
+        }
+    });
 }
 
 /// URL fields commonly found in package metadata across all formats.
@@ -3455,9 +3469,32 @@ mod tests {
     /// by the shared service-layer choke points (`finalize_upload`,
     /// `finish_download`, `delete_with_sync_options`). The download event also
     /// carries the client IP and acting user. Skips without `DATABASE_URL`.
+    ///
+    /// Since #2522 the audit writes are fire-and-forget (spawned, not awaited),
+    /// so each event count is polled with a short bounded retry rather than
+    /// asserted synchronously.
     #[tokio::test]
     async fn test_artifact_lifecycle_emits_audit_events_db() {
         use crate::api::handlers::test_db_helpers as tdh;
+
+        /// Poll `audit_count` for `(artifact_id, action)` until it reaches
+        /// `expected` or the bounded budget is exhausted (#2522 async audit).
+        async fn poll_audit_count(
+            pool: &PgPool,
+            artifact_id: Uuid,
+            action: &str,
+            expected: i64,
+        ) -> i64 {
+            let mut last = -1;
+            for _ in 0..50 {
+                last = tdh::audit_count(pool, artifact_id, action).await;
+                if last >= expected {
+                    return last;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            last
+        }
 
         let Some(pool) = tdh::try_pool().await else {
             return;
@@ -3470,8 +3507,9 @@ mod tests {
         );
         let svc = ArtifactService::new(pool.clone(), storage);
 
-        // Upload -> ARTIFACT_UPLOADED (audit write is awaited inside
-        // finalize_upload, so it has landed by the time upload() returns).
+        // Upload -> ARTIFACT_UPLOADED. The audit write is spawned fire-and-forget
+        // inside finalize_upload (#2522), so poll for it rather than assert it
+        // has already landed by the time upload() returns.
         let artifact = svc
             .upload(
                 repo_id,
@@ -3485,7 +3523,7 @@ mod tests {
             .await
             .expect("upload succeeds");
         assert_eq!(
-            tdh::audit_count(&pool, artifact.id, "ARTIFACT_UPLOADED").await,
+            poll_audit_count(&pool, artifact.id, "ARTIFACT_UPLOADED", 1).await,
             1,
             "upload emits exactly one ARTIFACT_UPLOADED event"
         );
@@ -3502,7 +3540,7 @@ mod tests {
             .await
             .expect("download succeeds");
         assert_eq!(
-            tdh::audit_count(&pool, artifact.id, "ARTIFACT_DOWNLOADED").await,
+            poll_audit_count(&pool, artifact.id, "ARTIFACT_DOWNLOADED", 1).await,
             1,
             "download emits exactly one ARTIFACT_DOWNLOADED event"
         );
@@ -3510,7 +3548,7 @@ mod tests {
         // Delete -> ARTIFACT_DELETED.
         svc.delete(artifact.id).await.expect("delete succeeds");
         assert_eq!(
-            tdh::audit_count(&pool, artifact.id, "ARTIFACT_DELETED").await,
+            poll_audit_count(&pool, artifact.id, "ARTIFACT_DELETED", 1).await,
             1,
             "delete emits exactly one ARTIFACT_DELETED event"
         );
@@ -3979,5 +4017,104 @@ mod tests {
 
         tdh::cleanup(&pool, repo_id, user_id).await;
         let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    // -- #2522 download-statistics write moved OFF the synchronous hot path -----
+    // `record_download` now SPAWNS the `download_statistics` INSERT instead of
+    // awaiting it, so the byte stream returns without blocking on the catalog
+    // pool. These tests assert the eventual-write contract (poll with a bounded
+    // retry, matching the async-timing caveat) and that the HEAD "no body ⇒ no
+    // row" guard still holds synchronously.
+
+    /// Seed a live artifact row and return its id (self-contained, `RETURNING`).
+    #[cfg(test)]
+    async fn seed_dl_artifact(pool: &PgPool, repo_id: Uuid, path: &str) -> Uuid {
+        let key = format!("dl/{}", Uuid::new_v4());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $2, 1, $3, 'application/octet-stream', $4) RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(path)
+        .bind("0".repeat(64))
+        .bind(key)
+        .fetch_one(pool)
+        .await
+        .expect("seed artifact returning id")
+    }
+
+    /// Poll `download_statistics` for `artifact_id` until it reaches `expected`
+    /// or the bounded retry budget is exhausted; returns the last observed count.
+    #[cfg(test)]
+    async fn poll_dl_count(pool: &PgPool, artifact_id: Uuid, expected: i64) -> i64 {
+        let mut last = -1;
+        for _ in 0..50 {
+            last = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1",
+            )
+            .bind(artifact_id)
+            .fetch_one(pool)
+            .await
+            .expect("count download_statistics");
+            if last >= expected {
+                return last;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        last
+    }
+
+    #[tokio::test]
+    async fn test_record_download_eventually_writes_row_off_hot_path() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let artifact_id = seed_dl_artifact(&pool, repo, "com/acme/dl-1.0.jar").await;
+
+        let ctx = DownloadContext {
+            client_ip: "203.0.113.7".parse().ok(),
+            user_id: None,
+            user_agent: Some("unit-test/1.0".to_string()),
+            is_head: false,
+        };
+        // Returns without awaiting the INSERT (spawned); the row lands shortly
+        // after. The count must still reach 1 — the eventual-write contract.
+        record_download(&pool, artifact_id, &ctx).await;
+        let count = poll_dl_count(&pool, artifact_id, 1).await;
+        assert_eq!(
+            count, 1,
+            "spawned download_statistics write must eventually land"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_download_head_writes_no_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let artifact_id = seed_dl_artifact(&pool, repo, "com/acme/head-1.0.jar").await;
+
+        let ctx = DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+            is_head: true,
+        };
+        record_download(&pool, artifact_id, &ctx).await;
+        // Give any (erroneous) spawned write time to land, then assert none did.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count download_statistics");
+        assert_eq!(count, 0, "a HEAD serves no body and must never write a row");
     }
 }

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -756,9 +756,17 @@ impl AuditService {
 /// a side effect, never a gate. Mirrors the `audit_auth` fire-and-forget
 /// contract already used on the local-password login path.
 pub async fn audit_fire_and_forget(db: PgPool, entry: AuditEntry) {
-    if let Err(e) = AuditService::new(db).log(entry).await {
-        tracing::warn!(error = %e, "audit log write failed; ignored (fire-and-forget)");
-    }
+    // Actually fire-and-forget (#2522): spawn a detached task so the caller
+    // returns WITHOUT awaiting the audit INSERT. On the download hot path this
+    // write previously blocked the byte stream on the catalog pool; the emitter
+    // must return immediately while the trail is still eventually written. A
+    // failure stays swallowed — logged at `warn`, never propagated — so an
+    // audit-table outage can never fail (or slow) the originating request.
+    tokio::spawn(async move {
+        if let Err(e) = AuditService::new(db).log(entry).await {
+            tracing::warn!(error = %e, "audit log write failed; ignored (fire-and-forget)");
+        }
+    });
 }
 
 /// Fire-and-forget `PermissionDenied` audit for a HANDLER-level admin gate
@@ -2139,6 +2147,50 @@ mod tests {
         let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
             .bind(resource_id)
             .execute(&service.db)
+            .await;
+    }
+
+    // -- #2522 audit_fire_and_forget is now truly non-blocking -----------------
+
+    /// The emitter must SPAWN the audit INSERT (not await it) so a caller on the
+    /// download hot path returns without blocking on the catalog pool, while the
+    /// trail is still eventually written. Poll with a bounded retry to account
+    /// for the detached task's async timing.
+    #[tokio::test]
+    async fn test_audit_fire_and_forget_eventually_writes_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let resource_id = Uuid::new_v4();
+        let entry = AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
+            .resource(resource_id);
+
+        // Returns immediately: the write is spawned, not awaited.
+        audit_fire_and_forget(pool.clone(), entry).await;
+
+        let mut count = 0i64;
+        for _ in 0..50 {
+            count = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM audit_log WHERE resource_id = $1",
+            )
+            .bind(resource_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count audit_log rows");
+            if count >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            count, 1,
+            "spawned fire-and-forget audit write must eventually land"
+        );
+
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(resource_id)
+            .execute(&pool)
             .await;
     }
 }


### PR DESCRIPTION
## Summary

Moves the two synchronous event writes off the successful-download hot path so the
byte stream returns without first awaiting the catalog pool.

Before this change every successful download did two blocking DB writes on the
catalog pool before any bytes flowed:

- `record_download` (the shared `download_statistics` recorder every serving path
  funnels through) `await`ed its `INSERT`, and
- `audit_fire_and_forget` — despite the name — `await`ed its audit `INSERT`
  instead of spawning it.

That coupled byte-plane latency and availability to DB-pool pressure: a slow or
saturated catalog pool stalled downloads even though the object bytes were already
in hand. This PR makes both writes genuinely fire-and-forget: each is `tokio::spawn`ed
so the caller returns immediately, the row is still eventually written, and a
failure stays swallowed (logged at `warn`, never propagated) exactly as the
existing best-effort/fire-and-forget contract intended. Ordering and per-download
counts are unchanged — one served body still yields exactly one
`download_statistics` row, and `HEAD` still records none.

Scope is deliberately limited to the download-path slice of #2522. The broader
items in the issue (upload task storms, scanner/quality unbounded concurrency, a
durable outbox) are **out of scope** here and #2522 stays open for them.

### Changes
- `record_download` (`services/artifact_service.rs`): spawn the
  `download_statistics` INSERT instead of awaiting it; keep the synchronous
  `is_head` "no body ⇒ no row" guard.
- `audit_fire_and_forget` (`services/audit_service.rs`): spawn the audit INSERT
  so download/auth/token/2FA emitters return without blocking on it.
- Tests: add unit coverage for the async contract (stream returns without
  awaiting the write; the write still eventually lands; a failure is
  logged-not-fatal; `HEAD` records nothing), and update the existing DB-backed
  stats/audit assertions to poll for the now-asynchronous write (a shared
  `audit_count_eventually` / `download_count_eventually` test helper).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a performance change (`perf/*`), not a bug fix. It still ships
  unit tests that pin the new async contract.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Refs #2522
