### PR TITLE
feat(backup): incremental backup from a given date to present (#2789)

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -250,6 +250,13 @@ pub struct CreateBackupRequest {
     /// also supplied the excluded ids are removed from that include list;
     /// otherwise every repository except the excluded ones is backed up.
     pub exclude_repositories: Option<Vec<Uuid>>,
+    /// Optional RFC3339 lower bound on artifact modification time (#2789).
+    ///
+    /// When set, the (typically incremental) backup includes only artifacts
+    /// whose `updated_at` is at or after this timestamp, capturing just the
+    /// changes made from the given date/time to now. When omitted every
+    /// artifact is included, so backup behavior is unchanged.
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
     /// Optional custom name/label for the backup archive (#2790).
     ///
     /// When provided it becomes the identifying part of the archive
@@ -424,6 +431,7 @@ pub async fn create_backup(
             backup_type,
             repository_ids: payload.repository_ids,
             exclude_repository_ids: payload.exclude_repositories,
+            since: payload.since,
             created_by: Some(auth.user_id),
             name: payload.name,
         })
@@ -1809,6 +1817,25 @@ mod tests {
         let json = r#"{"type": "full"}"#;
         let req: CreateBackupRequest = serde_json::from_str(json).unwrap();
         assert!(req.name.is_none());
+    }
+
+    #[test]
+    fn test_create_backup_request_since_defaults_none() {
+        // #2789: without `since` the backup keeps its default (all artifacts).
+        let json = r#"{"type": "incremental"}"#;
+        let req: CreateBackupRequest = serde_json::from_str(json).unwrap();
+        assert!(req.since.is_none());
+    }
+
+    #[test]
+    fn test_create_backup_request_parses_rfc3339_since() {
+        // #2789: an RFC3339 timestamp is accepted and parsed to a UTC instant.
+        let json = r#"{"type": "incremental", "since": "2026-01-15T12:30:00Z"}"#;
+        let req: CreateBackupRequest = serde_json::from_str(json).unwrap();
+        let expected = chrono::DateTime::parse_from_rfc3339("2026-01-15T12:30:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert_eq!(req.since, Some(expected));
     }
 
     #[test]

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -96,6 +96,14 @@ pub struct CreateBackupRequest {
     /// removed from it; otherwise every repository except the excluded ones
     /// is backed up.
     pub exclude_repository_ids: Option<Vec<Uuid>>,
+    /// Optional lower bound on artifact modification time (#2789).
+    ///
+    /// When set, only artifacts whose `updated_at >= since` are included in the
+    /// backup, letting operators capture just the changes made from a given
+    /// date/timestamp to now (an incremental "since this point" backup). When
+    /// `None` every artifact is included, so full and incremental backups behave
+    /// exactly as before.
+    pub since: Option<DateTime<Utc>>,
     pub created_by: Option<Uuid>,
     /// Optional operator-supplied name/label for the archive (#2790).
     ///
@@ -349,6 +357,18 @@ fn resolve_effective_repository_ids(
     }
 }
 
+/// Read the optional `since` cutoff (#2789) from a backup's stored metadata.
+///
+/// Returns `None` when no cutoff was recorded (the key is absent or JSON null),
+/// which preserves the historical "every artifact" behavior. A malformed value
+/// is treated as no cutoff rather than failing the backup.
+fn parse_since_filter(metadata: Option<&serde_json::Value>) -> Option<DateTime<Utc>> {
+    metadata
+        .and_then(|m| m.get("since"))
+        .filter(|v| !v.is_null())
+        .and_then(|v| serde_json::from_value::<DateTime<Utc>>(v.clone()).ok())
+}
+
 impl BackupService {
     pub fn new(db: PgPool, storage: Arc<StorageService>) -> Self {
         // Default: backup archives live in the same bucket as artifacts, so
@@ -411,6 +431,7 @@ impl BackupService {
             serde_json::json!({
                 "repository_ids": req.repository_ids,
                 "exclude_repository_ids": req.exclude_repository_ids,
+                "since": req.since,
                 "name": req.name,
             })
         )
@@ -555,13 +576,20 @@ impl BackupService {
             .effective_repository_filter(backup.metadata.as_ref())
             .await?;
 
+        // Optional "changes since" cutoff (#2789). When present only artifacts
+        // modified at-or-after this timestamp are dumped, so an incremental
+        // backup can capture just the delta from a given date to now. `None`
+        // keeps every artifact, preserving the historical behavior.
+        let since_filter = parse_since_filter(backup.metadata.as_ref());
+
         let mut table_data: Vec<(String, Vec<u8>)> = Vec::new();
         for table in &table_names {
             // The `artifacts` table is the only per-repository table exported,
             // so when a repository filter is in effect an excluded repository's
             // artifact rows are kept out of the dump too (not just its bytes).
             let json_data = if *table == "artifacts" {
-                self.export_artifacts(repository_filter.as_deref()).await?
+                self.export_artifacts(repository_filter.as_deref(), since_filter)
+                    .await?
             } else {
                 self.export_table(table).await?
             };
@@ -571,7 +599,7 @@ impl BackupService {
 
         // Fetch artifact storage keys and content
         let storage_keys = self
-            .artifact_storage_keys(repository_filter.as_deref())
+            .artifact_storage_keys(repository_filter.as_deref(), since_filter)
             .await?;
         let mut artifact_data: Vec<(String, Vec<u8>)> = Vec::new();
         for key in storage_keys {
@@ -688,48 +716,59 @@ impl BackupService {
     }
 
     /// List the artifact storage keys to include in a backup, honoring the
-    /// resolved repository filter (`None` => every artifact).
+    /// resolved repository filter (`None` => every repository) and the optional
+    /// `since` cutoff (#2789; `None` => every modification time). Both
+    /// predicates are null-guarded so passing `None`/`None` returns every
+    /// artifact exactly as before.
     async fn artifact_storage_keys(
         &self,
         repository_filter: Option<&[Uuid]>,
+        since: Option<DateTime<Utc>>,
     ) -> Result<Vec<String>> {
-        let keys: Vec<String> = if let Some(repo_ids) = repository_filter {
-            sqlx::query_scalar!(
-                "SELECT storage_key FROM artifacts WHERE repository_id = ANY($1)",
-                repo_ids
-            )
-            .fetch_all(&self.db)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?
-        } else {
-            sqlx::query_scalar!("SELECT storage_key FROM artifacts")
-                .fetch_all(&self.db)
-                .await
-                .map_err(|e| AppError::Database(e.to_string()))?
-        };
+        // Runtime (non-macro) query so no offline `.sqlx` prepare is needed and
+        // both optional predicates live in a single statement.
+        let repo_ids: Option<Vec<Uuid>> = repository_filter.map(|r| r.to_vec());
+        let keys: Vec<String> = sqlx::query_scalar(
+            r#"
+            SELECT storage_key FROM artifacts
+            WHERE ($1::uuid[] IS NULL OR repository_id = ANY($1))
+              AND ($2::timestamptz IS NULL OR updated_at >= $2)
+            "#,
+        )
+        .bind(repo_ids)
+        .bind(since)
+        .fetch_all(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(keys)
     }
 
     /// Export the `artifacts` table as a JSON array, honoring the resolved
-    /// repository filter (#2772).
+    /// repository filter (#2772) and the optional `since` cutoff (#2789).
     ///
-    /// When `repository_filter` is `None` this is identical to
-    /// `export_table("artifacts")`, so unfiltered backups are unchanged. When a
-    /// filter is present only the covered repositories' artifact rows are
-    /// dumped, keeping an excluded repository entirely out of the archive.
+    /// When both filters are `None` this returns every artifact row, identical
+    /// to `export_table("artifacts")`, so unfiltered backups are unchanged. A
+    /// repository filter keeps only the covered repositories' rows; a `since`
+    /// cutoff keeps only rows with `updated_at >= since`, so an incremental
+    /// backup dumps just the metadata changed after the given timestamp.
     async fn export_artifacts(
         &self,
         repository_filter: Option<&[Uuid]>,
+        since: Option<DateTime<Utc>>,
     ) -> Result<serde_json::Value> {
-        let Some(repo_ids) = repository_filter else {
-            return self.export_table("artifacts").await;
-        };
-
+        // Runtime (non-macro) query so no offline `.sqlx` prepare is needed and
+        // both optional predicates live in a single statement.
+        let repo_ids: Option<Vec<Uuid>> = repository_filter.map(|r| r.to_vec());
         let rows: Vec<serde_json::Value> = sqlx::query_scalar(
-            "SELECT row_to_json(t) FROM artifacts t WHERE repository_id = ANY($1)",
+            r#"
+            SELECT row_to_json(t) FROM artifacts t
+            WHERE ($1::uuid[] IS NULL OR repository_id = ANY($1))
+              AND ($2::timestamptz IS NULL OR updated_at >= $2)
+            "#,
         )
         .bind(repo_ids)
+        .bind(since)
         .fetch_all(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -1662,12 +1701,14 @@ mod tests {
             backup_type: BackupType::Full,
             repository_ids: Some(vec![Uuid::new_v4()]),
             exclude_repository_ids: None,
+            since: None,
             created_by: Some(Uuid::new_v4()),
             name: None,
         };
         assert_eq!(req.backup_type, BackupType::Full);
         assert!(req.repository_ids.is_some());
         assert!(req.created_by.is_some());
+        assert!(req.since.is_none());
     }
 
     #[test]
@@ -1676,12 +1717,31 @@ mod tests {
             backup_type: BackupType::Metadata,
             repository_ids: None,
             exclude_repository_ids: None,
+            since: None,
             created_by: None,
             name: None,
         };
         assert_eq!(req.backup_type, BackupType::Metadata);
         assert!(req.repository_ids.is_none());
         assert!(req.created_by.is_none());
+    }
+
+    #[test]
+    fn test_create_backup_request_with_since_cutoff() {
+        // #2789: an incremental "changes since" backup carries an RFC3339 cutoff.
+        let cutoff = DateTime::parse_from_rfc3339("2026-01-15T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let req = CreateBackupRequest {
+            backup_type: BackupType::Incremental,
+            repository_ids: None,
+            exclude_repository_ids: None,
+            since: Some(cutoff),
+            created_by: None,
+            name: None,
+        };
+        assert_eq!(req.backup_type, BackupType::Incremental);
+        assert_eq!(req.since, Some(cutoff));
     }
 
     // -----------------------------------------------------------------------
@@ -1929,6 +1989,50 @@ mod tests {
         assert_eq!(out, Some(vec![]));
     }
 
+    // -----------------------------------------------------------------------
+    // parse_since_filter tests (#2789 incremental "changes since" cutoff)
+    // -----------------------------------------------------------------------
+
+    /// Build the same metadata JSON that `create()` persists for a backup.
+    fn backup_metadata(since: Option<DateTime<Utc>>) -> serde_json::Value {
+        serde_json::json!({
+            "repository_ids": Option::<Vec<Uuid>>::None,
+            "exclude_repository_ids": Option::<Vec<Uuid>>::None,
+            "since": since,
+            "name": Option::<String>::None,
+        })
+    }
+
+    #[test]
+    fn test_parse_since_absent_metadata_is_none() {
+        // No metadata at all => no cutoff, back up every artifact (unchanged).
+        assert!(parse_since_filter(None).is_none());
+    }
+
+    #[test]
+    fn test_parse_since_unset_is_none() {
+        // A backup created without `since` stores JSON null => no cutoff.
+        let meta = backup_metadata(None);
+        assert!(parse_since_filter(Some(&meta)).is_none());
+    }
+
+    #[test]
+    fn test_parse_since_roundtrips_through_create_metadata() {
+        // The cutoff persisted by create() is read back verbatim by do_backup.
+        let cutoff = DateTime::parse_from_rfc3339("2026-01-15T12:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let meta = backup_metadata(Some(cutoff));
+        assert_eq!(parse_since_filter(Some(&meta)), Some(cutoff));
+    }
+
+    #[test]
+    fn test_parse_since_malformed_is_treated_as_none() {
+        // A non-timestamp value must not fail the backup; it means "no cutoff".
+        let meta = serde_json::json!({ "since": "not-a-timestamp" });
+        assert!(parse_since_filter(Some(&meta)).is_none());
+    }
+
     /// Verify every table in ALLOWED_EXPORT_TABLES is a known migration table.
     /// This prevents future mismatches by listing all valid tables.
     #[test]
@@ -1960,5 +2064,124 @@ mod tests {
                 table
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #2789: end-to-end "changes since" filtering against a real database.
+    // Skips cleanly when `DATABASE_URL` is unset (the CI coverage job seeds
+    // Postgres, so it is exercised there). Everything is scoped to a unique
+    // repository id so parallel test processes never see each other's rows.
+    // -----------------------------------------------------------------------
+
+    /// Build a backup service backed by `pool` with a throwaway filesystem
+    /// storage handle (the artifact-enumeration paths under test never read
+    /// bytes, so the backend is only needed to satisfy the constructor).
+    fn service_for(pool: PgPool) -> BackupService {
+        use crate::services::storage_service::FilesystemBackend;
+        let dir = std::env::temp_dir().join(format!("bk-since-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp storage dir");
+        let backend = Arc::new(FilesystemBackend::new(dir));
+        let storage = Arc::new(StorageService::new(backend));
+        BackupService::new(pool, storage)
+    }
+
+    /// Insert an artifact row with an explicit `updated_at` and return its key.
+    async fn insert_artifact_at(
+        pool: &PgPool,
+        repo_id: Uuid,
+        label: &str,
+        updated_at: DateTime<Utc>,
+    ) -> String {
+        let key = format!("since-test/{}-{}", label, Uuid::new_v4());
+        sqlx::query(
+            r#"
+            INSERT INTO artifacts
+                (repository_id, path, name, size_bytes, checksum_sha256,
+                 content_type, storage_key, updated_at)
+            VALUES ($1, $2, $3, 10, $4, 'application/octet-stream', $5, $6)
+            "#,
+        )
+        .bind(repo_id)
+        .bind(format!("path/{}", key))
+        .bind(label)
+        .bind("0".repeat(64))
+        .bind(&key)
+        .bind(updated_at)
+        .execute(pool)
+        .await
+        .expect("insert artifact");
+        key
+    }
+
+    #[tokio::test]
+    async fn test_since_filter_excludes_older_includes_newer_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+
+        let old_at = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let new_at = DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let cutoff = DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let old_key = insert_artifact_at(&pool, repo_id, "old", old_at).await;
+        let new_key = insert_artifact_at(&pool, repo_id, "new", new_at).await;
+
+        let service = service_for(pool.clone());
+        let repo_filter = [repo_id];
+
+        // With a `since` cutoff only the artifact modified after it is included.
+        let keys = service
+            .artifact_storage_keys(Some(&repo_filter), Some(cutoff))
+            .await
+            .expect("storage keys with since");
+        assert_eq!(
+            keys,
+            vec![new_key.clone()],
+            "since keeps only the newer key"
+        );
+        assert!(!keys.contains(&old_key), "older artifact is excluded");
+
+        // The exported metadata rows honor the same cutoff.
+        let exported = service
+            .export_artifacts(Some(&repo_filter), Some(cutoff))
+            .await
+            .expect("export with since");
+        let rows = exported.as_array().expect("array");
+        assert_eq!(rows.len(), 1, "only the newer artifact row is exported");
+        assert_eq!(rows[0]["storage_key"], serde_json::json!(new_key));
+
+        // Boundary: an artifact modified exactly at the cutoff is included
+        // (predicate is `updated_at >= since`).
+        let edge_key = insert_artifact_at(&pool, repo_id, "edge", cutoff).await;
+        let keys_edge = service
+            .artifact_storage_keys(Some(&repo_filter), Some(cutoff))
+            .await
+            .expect("storage keys with since (edge)");
+        assert!(
+            keys_edge.contains(&edge_key),
+            "artifact at exactly the cutoff is included"
+        );
+
+        // No cutoff (`None`) => every artifact in the repo, unchanged behavior.
+        let keys_all = service
+            .artifact_storage_keys(Some(&repo_filter), None)
+            .await
+            .expect("storage keys without since");
+        assert_eq!(keys_all.len(), 3, "unset since includes every artifact");
+
+        // Cleanup: dropping the repo cascades to its artifacts.
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -922,6 +922,7 @@ async fn execute_due_backup_schedules(db: &PgPool, config: &Config) -> crate::er
                 backup_type: schedule_row.backup_type,
                 repository_ids: schedule_row.include_repositories.clone(),
                 exclude_repository_ids: None, // schedules use include-lists today
+                since: None,                  // schedules back up every artifact (#2789)
                 created_by: None,             // system-initiated
                 name: None,                   // scheduled backups keep the default {uuid} name
             })


### PR DESCRIPTION
Closes #2789

## Summary

Part of the incremental-backups epic (#2788). Adds an optional `since` (RFC3339
timestamp) parameter to the create-backup API so operators can run an
incremental backup that captures only the changes made **from a given date to
now**.

When `since` is set, the backup includes only artifacts whose `updated_at >=
since` — both the artifact bytes and their rows in the `database/artifacts.json`
table dump inside the archive. When `since` is omitted the whole registry is
backed up, so existing full and incremental backups are unchanged (the feature
is additive).

The cutoff is carried the same way the recently-merged repository filters are:
`CreateBackupRequest` gains a `since` field, `create` persists it on the
backup's `metadata`, and `execute`/`do_backup` reads it back and threads it
through the artifact enumeration (`export_artifacts` + `artifact_storage_keys`),
ANDed with the existing repository include/exclude filter (#2772). Both artifact
queries use a single null-guarded predicate
(`($2::timestamptz IS NULL OR updated_at >= $2)`), so `None` returns every row
exactly as before.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added tests:
- `parse_since_filter` unit tests — absent metadata / unset (JSON null) / a value
  that round-trips through `create()`'s metadata / a malformed value treated as
  no cutoff.
- `test_since_filter_excludes_older_includes_newer_db` — a DB-backed test that
  inserts an older and a newer artifact plus a boundary artifact at exactly the
  cutoff; asserts the `since` query keeps only the newer (and the boundary,
  `updated_at >= since`), excludes the older, and that an unset cutoff returns
  every artifact. Skips cleanly when `DATABASE_URL` is unset (runs for real in
  CI).
- API-layer deserialization tests: `since` defaults to `None` and an RFC3339
  string parses to a UTC instant.
- Existing `CreateBackupRequest` construction tests updated for the new field,
  plus a new incremental-with-since construction test.

Manually validated on an isolated pool slot (fresh backend image): uploaded an
old + new artifact, backdated the old one, then ran incremental and full backups
with `since` — only the newer artifact appeared in the archive; a no-`since`
backup contained both.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations (existing `create_backup`
  path; the new field is on the annotated `CreateBackupRequest` body)
- [x] Request/response types have `#[derive(ToSchema)]` (`since` is documented on
  the `ToSchema` request struct)
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable) — no migration; `since` is stored
  in the existing `backups.metadata` JSON
- [ ] N/A - no API changes
