### PR TITLE
fix(docker): get docker-compose.local-dev.yml working again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,36 @@ gh workflow run e2e.yml -f profile=all -f include_stress=true
 
 Rust 1.75+: Follow standard conventions
 
+## Docker & Compose Files
+
+This repo ships multiple Dockerfiles (`docker/Dockerfile.backend`,
+`docker/Dockerfile.backend.dev`, `docker/Dockerfile.backend.alpine`, plus
+scanner/mock images) and multiple compose files
+(`docker-compose.yml`, `docker-compose.local-dev.yml`,
+`docker-compose.*-e2e.yml`, `docker-compose.test.yml`, etc.) that each
+independently encode assumptions about what the backend image provides (e.g.
+whether it has a shell, which packages install which files). These have
+drifted out of sync before: #2126 fixed production's `docker-compose.yml`
+after the hardened runtime image (#2059) dropped `/bin/sh`, but
+`docker-compose.local-dev.yml` carried an independent copy of the same
+`dtrack-init` pattern that nobody updated, so it silently reintroduced the
+exact bug #2126 had already fixed.
+
+**When changing any Dockerfile or compose file, check every other one for the
+same assumption.** Concretely:
+- If a Dockerfile's runtime image gains or loses a shell, package manager, or
+  any binary (e.g. `/bin/sh`, `curl`, `jq`, `protoc`), grep all other
+  Dockerfiles and compose files for the same pattern before assuming only the
+  one you're editing is affected.
+- If a compose file's `dtrack-init` (or any init container) is fixed to stop
+  reusing the hardened backend image through a shell, check every other
+  compose file for a service doing the same thing.
+- Prefer a regression test that scans *all* matching files (e.g. every
+  `docker-compose*.yml` at the repo root) over one hardcoded to the single
+  file you just fixed — see
+  `shipped_compose_does_not_run_hardened_image_through_a_shell` in
+  `backend/src/config.rs` for the pattern.
+
 ## Git & GitHub
 
 ### Branch Protection — NEVER push directly to main

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3965,21 +3965,20 @@ mod tests {
             .unwrap_or_else(|e| panic!("read {}: {e}", compose_path.display()))
     }
 
-    /// Assert that `dtrack-init` in the given compose file does not run the
-    /// hardened, shell-less backend image (#2059/#2084) — it must run a
-    /// shell-bearing image (alpine) instead, since its init script needs
-    /// sh+curl+jq.
-    fn assert_dtrack_init_uses_shell_bearing_image(compose: &str, file_name: &str) {
-        let dtrack_init = compose_service_block(compose, "dtrack-init");
-        assert!(
-            !dtrack_init.is_empty(),
-            "dtrack-init service not found in {file_name}"
-        );
-        assert!(
-            !dtrack_init.contains("artifact-keeper-backend"),
-            "dtrack-init in {file_name} must not run the shell-less backend image \
-             (#2084). Offending block:\n{dtrack_init}"
-        );
+    /// List every top-level `docker-compose*.yml` file at the repo root. Used
+    /// so the regression guard below automatically covers any compose file
+    /// added in future, instead of a hardcoded list that can silently miss
+    /// one the way `docker-compose.local-dev.yml` was missed after #2126.
+    /// Test-only.
+    fn discover_compose_files(repo_root: &std::path::Path) -> Vec<String> {
+        let mut files: Vec<String> = std::fs::read_dir(repo_root)
+            .expect("read repo root")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with("docker-compose") && name.ends_with(".yml"))
+            .collect();
+        files.sort();
+        files
     }
 
     /// Regression guard for #2084: the hardened runtime image (#2059) ships no
@@ -3990,18 +3989,47 @@ mod tests {
     /// `exec: "/bin/sh": no such file or directory`.
     ///
     /// #2126 fixed this in `docker-compose.yml` only. `docker-compose.local-
-    /// dev.yml` carries an independent copy of the `dtrack-init` service that
-    /// pulls the same hardened `ghcr.io/.../artifact-keeper-backend` image and
-    /// drifted back into the identical broken pattern because nothing checked
-    /// it, so it is covered here too. Its `backend` service is exempt from the
-    /// shell-entrypoint check: unlike `docker-compose.yml`, it builds its own
-    /// dev image (`docker/Dockerfile.backend.dev`, based on
-    /// `rust:*-bookworm`), which does ship a shell.
+    /// dev.yml` carried an independent copy of the `dtrack-init` service that
+    /// pulled the same hardened `ghcr.io/.../artifact-keeper-backend` image
+    /// and drifted back into the identical broken pattern because nothing
+    /// checked it. Rather than hardcode that one other file, every
+    /// `docker-compose*.yml` at the repo root is scanned for a `dtrack-init`
+    /// service, so a future compose file can't reintroduce this silently.
+    ///
+    /// `docker-compose.yml`'s `backend` service additionally may never use a
+    /// shell entrypoint: unlike every other compose file's `backend`/`backend-
+    /// peer-*` services (which either build their own shell-bearing dev image
+    /// or run the hardened image with no entrypoint override), it is the only
+    /// one this repo has ever wrapped in `/bin/sh -c`.
     #[test]
     fn shipped_compose_does_not_run_hardened_image_through_a_shell() {
         let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("backend crate has a parent directory (repo root)");
+
+        let compose_files = discover_compose_files(repo_root);
+        assert!(
+            compose_files.iter().any(|f| f == "docker-compose.yml")
+                && compose_files
+                    .iter()
+                    .any(|f| f == "docker-compose.local-dev.yml"),
+            "expected to discover both docker-compose.yml and \
+             docker-compose.local-dev.yml among the repo's compose files, \
+             found: {compose_files:?}"
+        );
+
+        for file_name in &compose_files {
+            let compose = read_compose(repo_root, file_name);
+            let dtrack_init = compose_service_block(&compose, "dtrack-init");
+            if dtrack_init.is_empty() {
+                continue;
+            }
+            assert!(
+                !dtrack_init.contains("artifact-keeper-backend"),
+                "dtrack-init in {file_name} must not run the shell-less backend \
+                 image (#2084). Offending block:\n{dtrack_init}"
+            );
+        }
 
         let prod_compose = read_compose(repo_root, "docker-compose.yml");
         let backend = compose_service_block(&prod_compose, "backend");
@@ -4013,13 +4041,6 @@ mod tests {
             !backend.contains("/bin/sh") && !backend.contains("/bin/bash"),
             "backend service must not use a shell entrypoint; the runtime image \
              has no shell (#2059/#2084). Offending block:\n{backend}"
-        );
-        assert_dtrack_init_uses_shell_bearing_image(&prod_compose, "docker-compose.yml");
-
-        let local_dev_compose = read_compose(repo_root, "docker-compose.local-dev.yml");
-        assert_dtrack_init_uses_shell_bearing_image(
-            &local_dev_compose,
-            "docker-compose.local-dev.yml",
         );
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3956,22 +3956,55 @@ mod tests {
         out
     }
 
+    /// Read a compose file relative to the repo root, panicking with the path
+    /// on failure so a missing/renamed file fails loudly instead of silently
+    /// passing an empty-string check. Test-only.
+    fn read_compose(repo_root: &std::path::Path, file_name: &str) -> String {
+        let compose_path = repo_root.join(file_name);
+        std::fs::read_to_string(&compose_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", compose_path.display()))
+    }
+
+    /// Assert that `dtrack-init` in the given compose file does not run the
+    /// hardened, shell-less backend image (#2059/#2084) — it must run a
+    /// shell-bearing image (alpine) instead, since its init script needs
+    /// sh+curl+jq.
+    fn assert_dtrack_init_uses_shell_bearing_image(compose: &str, file_name: &str) {
+        let dtrack_init = compose_service_block(compose, "dtrack-init");
+        assert!(
+            !dtrack_init.is_empty(),
+            "dtrack-init service not found in {file_name}"
+        );
+        assert!(
+            !dtrack_init.contains("artifact-keeper-backend"),
+            "dtrack-init in {file_name} must not run the shell-less backend image \
+             (#2084). Offending block:\n{dtrack_init}"
+        );
+    }
+
     /// Regression guard for #2084: the hardened runtime image (#2059) ships no
     /// `/bin/sh`, so no compose service that runs that image may be launched
     /// through a shell. On `main` the `backend` service used
     /// `entrypoint: ["/bin/sh","-c", <wait-for-DT-key>]` and `dtrack-init` ran
     /// the backend image via `/bin/sh`; both broke `docker compose up` with
     /// `exec: "/bin/sh": no such file or directory`.
+    ///
+    /// #2126 fixed this in `docker-compose.yml` only. `docker-compose.local-
+    /// dev.yml` carries an independent copy of the `dtrack-init` service that
+    /// pulls the same hardened `ghcr.io/.../artifact-keeper-backend` image and
+    /// drifted back into the identical broken pattern because nothing checked
+    /// it, so it is covered here too. Its `backend` service is exempt from the
+    /// shell-entrypoint check: unlike `docker-compose.yml`, it builds its own
+    /// dev image (`docker/Dockerfile.backend.dev`, based on
+    /// `rust:*-bookworm`), which does ship a shell.
     #[test]
     fn shipped_compose_does_not_run_hardened_image_through_a_shell() {
         let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("backend crate has a parent directory (repo root)");
-        let compose_path = repo_root.join("docker-compose.yml");
-        let compose = std::fs::read_to_string(&compose_path)
-            .unwrap_or_else(|e| panic!("read {}: {e}", compose_path.display()));
 
-        let backend = compose_service_block(&compose, "backend");
+        let prod_compose = read_compose(repo_root, "docker-compose.yml");
+        let backend = compose_service_block(&prod_compose, "backend");
         assert!(
             !backend.is_empty(),
             "backend service not found in docker-compose.yml"
@@ -3981,18 +4014,12 @@ mod tests {
             "backend service must not use a shell entrypoint; the runtime image \
              has no shell (#2059/#2084). Offending block:\n{backend}"
         );
+        assert_dtrack_init_uses_shell_bearing_image(&prod_compose, "docker-compose.yml");
 
-        // dtrack-init may legitimately use a shell, but not on the shell-less
-        // backend image — it must run a shell-bearing image instead.
-        let dtrack_init = compose_service_block(&compose, "dtrack-init");
-        assert!(
-            !dtrack_init.is_empty(),
-            "dtrack-init service not found in docker-compose.yml"
-        );
-        assert!(
-            !dtrack_init.contains("artifact-keeper-backend"),
-            "dtrack-init must not run the shell-less backend image (#2084). \
-             Offending block:\n{dtrack_init}"
+        let local_dev_compose = read_compose(repo_root, "docker-compose.local-dev.yml");
+        assert_dtrack_init_uses_shell_bearing_image(
+            &local_dev_compose,
+            "docker-compose.local-dev.yml",
         );
     }
 }

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -128,8 +128,12 @@ services:
       - "4318:4318"
     restart: unless-stopped
 
+  # Runs on a small shell-bearing image (alpine) rather than the backend
+  # image: the hardened runtime image (issue #2059) has no /bin/sh — nor the
+  # `jq` that init-dtrack.sh needs — so it can't host this bootstrap script
+  # (issue #2084). Mirrors the dtrack-init fix in docker-compose.yml.
   dtrack-init:
-    image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
+    image: alpine:3.23
     container_name: artifact-keeper-dev-dtrack-init
     depends_on:
       postgres:
@@ -142,7 +146,11 @@ services:
     environment:
       DTRACK_INIT_FORCE_ROTATE: ${DTRACK_INIT_FORCE_ROTATE:-false}
       DEPENDENCY_TRACK_ADMIN_PASSWORD: ${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}
-    entrypoint: ["/bin/sh", "/init-dtrack.sh"]
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache curl jq >/dev/null 2>&1
+        exec /bin/sh /init-dtrack.sh
     restart: "no"
     healthcheck:
       disable: true
@@ -186,17 +194,21 @@ services:
     entrypoint:
       - /bin/sh
       - -c
-      - |
-        if [ -f /shared/dtrack-api-key ] && [ -s /shared/dtrack-api-key ]; then
-          export DEPENDENCY_TRACK_API_KEY="$$(cat /shared/dtrack-api-key)"
-        fi
-        cargo watch -x 'run --bin artifact-keeper'
+      - cargo watch -x 'run --bin artifact-keeper'
     environment:
+      # Reduce peak rustc memory for this large workspace so the compile
+      # doesn't get OOM-killed inside the podman VM. line-tables-only keeps
+      # enough debug info for stack traces/backtraces without full DWARF, and
+      # capping parallel jobs avoids stacking multiple heavy crates (wasmtime,
+      # git2, sqlx, tonic) in memory at once. Dev-container only; does not
+      # affect native builds, CI, or other contributors.
+      CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
+      CARGO_BUILD_JOBS: "3"
       DATABASE_URL: postgresql://registry:registry@postgres:5432/artifact_registry
       STORAGE_PATH: /data/storage
       BACKUP_PATH: /data/backups
       PLUGINS_DIR: /data/plugins
-      JWT_SECRET: dev-secret-change-in-production
+      JWT_SECRET: dev-secret-change-in-production-please
       ADMIN_PASSWORD: admin
       RUST_LOG: info,artifact_keeper=debug
       LOG_FORMAT: ${LOG_FORMAT:-pretty}
@@ -208,6 +220,7 @@ services:
       SCAN_WORKSPACE_PATH: /scan-workspace
       OPENSEARCH_URL: http://opensearch:9200
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
+      DEPENDENCY_TRACK_API_KEY_FILE: /shared/dtrack-api-key
       DEPENDENCY_TRACK_ENABLED: "true"
       ALLOW_HTTP_INTEGRATIONS: "1"
       # Webhooks v2 signing-secret encryption key. 32 bytes, base64 encoded.

--- a/docker/Dockerfile.backend.dev
+++ b/docker/Dockerfile.backend.dev
@@ -5,6 +5,7 @@ FROM rust:1.97-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     liblzma-dev \
+    libprotobuf-dev \
     libssl-dev \
     pkg-config \
     protobuf-compiler \


### PR DESCRIPTION
## Summary
- `docker-compose.local-dev.yml` was broken end to end for `backend`/`web` (confirmed via `podman compose -f docker-compose.local-dev.yml up`). Root causes:
  - `dtrack-init` reused the hardened production backend image, which has no `/bin/sh` (#2059), but its init script needs sh+curl+jq. Since `backend`/`web` transitively depend on `dtrack-init` completing, this blocked the whole stack. This is the exact bug #2126 fixed in `docker-compose.yml` — `docker-compose.local-dev.yml` carried an independent, never-updated copy of the same broken pattern. Fixed by switching `dtrack-init` to `alpine:3.23`, mirroring `docker-compose.yml`.
  - Simplified the `backend` entrypoint to use the `DEPENDENCY_TRACK_API_KEY_FILE` convention (added in #2126) instead of a shell wrapper reading the key file.
  - `docker/Dockerfile.backend.dev` installed `protoc` via Debian's `protobuf-compiler`, which doesn't ship the `google/protobuf/*.proto` well-known types (unlike production's Dockerfile, which vendors the official protoc release). Added `libprotobuf-dev`, which supplies them at protoc's default include path.
  - Backend's dev compile was getting OOM-killed under memory-constrained Podman VMs (this is a large workspace: wasmtime, git2, sqlx, tonic all in one crate, built with full debug info). Added `CARGO_PROFILE_DEV_DEBUG=line-tables-only` and `CARGO_BUILD_JOBS=3` to the backend service, scoped to this compose file only.
  - The default `JWT_SECRET` in the compose file was 31 characters, one short of the backend's 32-character minimum, so it always failed config validation. Padded it.
- The existing #2084 regression test (`shipped_compose_does_not_run_hardened_image_through_a_shell`) only parsed `docker-compose.yml`, which is exactly why it didn't catch `docker-compose.local-dev.yml` drifting back into the same bug. Generalized it to discover every `docker-compose*.yml` at the repo root and check each one's `dtrack-init` service, so a future compose file can't reintroduce this unnoticed.
- Audited every other Dockerfile and compose file in the repo for both bug patterns (hardened image run through a shell; protoc missing well-known types from a split-off package). Nothing else was affected — details in the third commit's message.
- Added a `CLAUDE.md` rule: changing one Dockerfile/compose file's assumptions about the runtime image must prompt checking every sibling file for the same assumption, since that's exactly how this regressed.

Not part of this diff, but required for other local-dev users: a real `AK_WEBHOOK_SECRET_KEY` must be set via a gitignored `.env` at the repo root (compose only auto-loads `.env`, not `.env.local-dev`, and the default is intentionally invalid). Podman machine users on memory-constrained hosts may also need `podman machine set --memory 11264` or similar.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2911