### PR TITLE
Fix conda-forge and Hugging Face pull-through proxies; preserve Content-Length on compressed upstreams

### DIFF
--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -1567,23 +1567,32 @@ async fn serve_repodata(
         return Ok(cacheable_response(body, ct, headers));
     }
 
-    // For remote repos, proxy repodata from upstream
+    // For remote repos, proxy repodata from upstream. Real conda-forge
+    // repodata.json.zst commonly runs 20-30 MiB (e.g. noarch/osx-arm64), well
+    // past the 8 MiB DEFAULT_METADATA_MAX_BYTES ceiling used by most other
+    // formats' metadata proxying, so this uses the LARGE tier (128 MiB) the
+    // same way debian/npm/maven/pypi do for their oversized index documents.
+    //
+    // A fetch failure here must propagate to the client instead of silently
+    // falling through to `build_repodata` below: that fallback only reflects
+    // artifacts already cached in our own DB, so masking a real upstream
+    // failure (cap exceeded, upstream down, etc.) behind it would serve a
+    // valid-looking but empty/incomplete index and make the client believe
+    // there are no packages, rather than surfacing the actual problem.
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let upstream_path = format!("{}/{}", subdir, encoding.upstream_filename());
-                if let Ok((content, _ct)) = proxy_helpers::proxy_fetch_capped(
+                let (content, _ct) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     repo_key,
                     upstream_url,
                     &upstream_path,
-                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                    proxy_helpers::LARGE_METADATA_MAX_BYTES,
                 )
-                .await
-                {
-                    return Ok(cacheable_response(content.to_vec(), ct, headers));
-                }
+                .await?;
+                return Ok(cacheable_response(content.to_vec(), ct, headers));
             }
         }
     }
@@ -1894,11 +1903,36 @@ fn group_artifacts_by_name<'a>(
     by_name
 }
 
+/// CEP-16 sharded repodata is only built from artifacts already present in
+/// our own DB (see [`list_conda_artifacts`]) - it never proxies an upstream's
+/// real shard index. For a Local/hosted repo that's exactly right: our DB is
+/// the source of truth. For a Remote repo it's not: an upstream like
+/// conda-forge that has not yet been mirrored into our DB would otherwise get
+/// a syntactically valid but semantically empty (or incomplete) shard index
+/// served with 200, which a CEP-16-aware client treats as authoritative and
+/// will not fall back from - silently hiding every package that hasn't
+/// already been cached. Until sharded repodata is actually proxied from the
+/// upstream, Remote repos must 404 here so clients (pixi, conda) take the
+/// documented fallback to `repodata.json`, which IS proxied.
+#[allow(clippy::result_large_err)]
+fn reject_unsupported_remote_sharding(repo: &RepoInfo) -> Result<(), Response> {
+    if repo.repo_type == RepositoryType::Remote {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Sharded repodata (CEP-16) is not available for remote/proxy conda repositories; \
+             use repodata.json",
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
 async fn sharded_repodata_index(
     State(state): State<SharedState>,
     Path((repo_key, subdir)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
+    reject_unsupported_remote_sharding(&repo)?;
     let all_artifacts = list_conda_artifacts(&state.db, repo.id).await?;
     let subdir_artifacts = artifacts_for_subdir(&all_artifacts, &subdir);
     let by_name = group_artifacts_by_name(&subdir_artifacts);
@@ -1950,6 +1984,7 @@ async fn sharded_repodata_shard(
     }
 
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
+    reject_unsupported_remote_sharding(&repo)?;
     let all_artifacts = list_conda_artifacts(&state.db, repo.id).await?;
     let subdir_artifacts = artifacts_for_subdir(&all_artifacts, &subdir);
     let by_name = group_artifacts_by_name(&subdir_artifacts);
@@ -8827,5 +8862,219 @@ mod tests {
 
         assertions.await;
         fx.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Remote conda-forge repodata proxy: cap ceiling + failure propagation,
+    // and CEP-16 sharded repodata scoping. A Remote conda repo's real
+    // repodata.json.zst (e.g. conda-forge's noarch/osx-arm64 channels)
+    // commonly runs 20-30 MiB, well past the 8 MiB DEFAULT_METADATA_MAX_BYTES
+    // tier most other formats' metadata proxying uses. The old code silently
+    // fell through to `build_repodata` (DB-only) whenever the capped fetch
+    // failed for ANY reason, serving a valid-looking but empty 200 instead of
+    // the real upstream index, or an error. These tests pin the fix: the
+    // LARGE tier makes the real-sized fetch succeed, and any other upstream
+    // failure now surfaces to the client instead of being masked.
+    // -----------------------------------------------------------------------
+
+    /// Insert a Remote conda repo pointing at `upstream_url`, marked public so
+    /// anonymous test requests pass `check_read_access`. Returns its id/key.
+    async fn insert_public_remote_conda_repo(
+        pool: &sqlx::PgPool,
+        upstream_url: &str,
+    ) -> (uuid::Uuid, String, std::path::PathBuf) {
+        let (repo_id, repo_key, storage_dir) =
+            crate::api::handlers::test_db_helpers::create_repo(pool, "remote", "conda").await;
+        sqlx::query("UPDATE repositories SET upstream_url = $1, is_public = true WHERE id = $2")
+            .bind(upstream_url)
+            .bind(repo_id)
+            .execute(pool)
+            .await
+            .expect("point repo at upstream and make it public");
+        (repo_id, repo_key, storage_dir)
+    }
+
+    async fn cleanup_conda_repo(pool: &sqlx::PgPool, repo_id: uuid::Uuid) {
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+    }
+
+    // A 9 MiB repodata.json.zst -- above the old 8 MiB DEFAULT ceiling that
+    // used to make the capped fetch fail and silently fall back to an empty
+    // `build_repodata` -- is now fetched and served in full (LARGE tier).
+    #[tokio::test]
+    async fn remote_repodata_above_default_cap_is_served_in_full() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let body = vec![0x5au8; 9 * 1024 * 1024];
+        assert!(
+            body.len() > proxy_helpers::DEFAULT_METADATA_MAX_BYTES
+                && body.len() < proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            "fixture must straddle DEFAULT and LARGE so success implies the LARGE tier",
+        );
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/noarch/repodata.json.zst"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("conda-cap-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (repo_id, repo_key, _dir) = insert_public_remote_conda_repo(&pool, &server.uri()).await;
+
+        let app = tdh::router_anon(router(), state);
+        let (status, resp_body) = tdh::send(
+            app,
+            tdh::get(format!("/{repo_key}/noarch/repodata.json.zst")),
+        )
+        .await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a repodata.json.zst above the old 8 MiB cap must now succeed"
+        );
+        assert_eq!(
+            resp_body.len(),
+            body.len(),
+            "the full upstream body must be served, not truncated"
+        );
+    }
+
+    // A genuine upstream failure (a 500 that folds to 502 via map_proxy_error)
+    // must surface to the client instead of being swallowed into a silent
+    // fallback that serves an empty, DB-only repodata.json with 200 (the
+    // conda-forge-discovery-blocking bug this fixes).
+    #[tokio::test]
+    async fn remote_repodata_upstream_failure_surfaces_not_empty_200() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/noarch/repodata.json.zst"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("conda-502-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (repo_id, repo_key, _dir) = insert_public_remote_conda_repo(&pool, &server.uri()).await;
+
+        let app = tdh::router_anon(router(), state);
+        let (status, resp_body) = tdh::send(
+            app,
+            tdh::get(format!("/{repo_key}/noarch/repodata.json.zst")),
+        )
+        .await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            status.is_server_error(),
+            "a genuine upstream failure must surface as a server error, got {status} with body {:?}",
+            String::from_utf8_lossy(&resp_body),
+        );
+    }
+
+    // CEP-16 sharded repodata is only ever built from artifacts already in our
+    // own DB (never proxied from upstream). For a Remote repo with nothing
+    // cached yet, the old code served a syntactically valid but semantically
+    // empty shard index with 200 -- which a CEP-16-aware client treats as
+    // authoritative and will NOT fall back from, hiding every upstream
+    // package. The endpoint must 404 for Remote repos instead, so clients
+    // take the documented fallback to repodata.json.
+    #[tokio::test]
+    async fn remote_repo_sharded_index_404s_instead_of_empty_200() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let tmp = std::env::temp_dir().join(format!("conda-shard-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (repo_id, repo_key, _dir) =
+            insert_public_remote_conda_repo(&pool, "https://upstream.example.test").await;
+
+        let app = tdh::router_anon(router(), state);
+        let (status, _body) = tdh::send(
+            app,
+            tdh::get(format!("/{repo_key}/noarch/repodata_shards.msgpack.zst")),
+        )
+        .await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "sharded repodata for a Remote conda repo must 404, not serve an empty 200"
+        );
+    }
+
+    // Preserve existing behavior for Local/hosted conda repos: the shard index
+    // is (and remains) built from the repo's own DB artifacts and returns 200.
+    #[tokio::test]
+    async fn local_repo_sharded_index_still_returns_200() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, _storage_dir) = tdh::create_repo(&pool, "local", "conda").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("make repo public");
+
+        let tmp = std::env::temp_dir().join(format!("conda-local-shard-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+
+        let app = tdh::router_anon(router(), state);
+        let (status, _body) = tdh::send(
+            app,
+            tdh::get(format!("/{repo_key}/noarch/repodata_shards.msgpack.zst")),
+        )
+        .await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a Local/hosted conda repo's shard index must still serve 200"
+        );
     }
 }

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -406,9 +406,44 @@ fn gzip_compress(data: &[u8]) -> Vec<u8> {
 }
 
 /// Build a cacheable response with ETag and Cache-Control headers.
-fn cacheable_response(body: Vec<u8>, content_type: &str, headers: &HeaderMap) -> Response {
+///
+/// Takes `impl Into<Bytes>` so a proxied upstream body (already a [`Bytes`])
+/// rides into the response without the extra whole-body `to_vec()` copy the
+/// remote branches used to make, while locally generated `Vec<u8>` documents
+/// convert for free (#2915).
+async fn cacheable_response(
+    body: impl Into<Bytes>,
+    content_type: &str,
+    headers: &HeaderMap,
+) -> Response {
+    cacheable_response_coded(body, content_type, None, headers).await
+}
+
+/// [`cacheable_response`] for a body that may ALREADY carry a content coding.
+///
+/// `upstream_content_encoding` is the `Content-Encoding` the body arrived with
+/// (proxied Remote metadata). Two things follow from it (#2915):
+///
+///  1. It must be forwarded verbatim. The proxy's HTTP client no longer lets
+///     reqwest decode upstream bodies (see `http_client::base_client_builder`),
+///     so an undeclared coded body would have the client write compressed bytes
+///     to disk as if they were JSON.
+///  2. Our own gzip pass below MUST be skipped. Re-gzipping a body that is
+///     already `Content-Encoding: gzip` (as some channel mirrors serve
+///     `repodata.json`) produces doubly-gzipped bytes declared as singly
+///     gzipped — a body no client can read.
+///
+/// `None` means "identity body, compress at will" and is what every locally
+/// generated document passes.
+async fn cacheable_response_coded(
+    body: impl Into<Bytes>,
+    content_type: &str,
+    upstream_content_encoding: Option<&str>,
+    headers: &HeaderMap,
+) -> Response {
     use crate::api::handlers::cache_headers;
 
+    let body: Bytes = body.into();
     let etag = compute_etag(&body);
 
     if let Some(not_modified) = check_conditional_request(headers, &etag) {
@@ -417,29 +452,55 @@ fn cacheable_response(body: Vec<u8>, content_type: &str, headers: &HeaderMap) ->
 
     // Conda-specific: serve gzip-compressed JSON responses when the client
     // advertises gzip (Conda clients commonly don't support zstd/bz2 for
-    // repodata, so gzip is a useful middle ground).
-    if content_type == "application/json" && accepts_gzip(headers) {
-        let compressed = gzip_compress(&body);
-        return Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, content_type)
-            .header(CONTENT_ENCODING, "gzip")
-            .header(CONTENT_LENGTH, compressed.len().to_string())
-            .header(ETAG, &etag)
-            .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL)
-            .header("Vary", "Accept-Encoding")
-            .body(Body::from(compressed))
-            .unwrap();
+    // repodata, so gzip is a useful middle ground). Never for an
+    // already-content-coded body — see the doc comment above.
+    if content_type == "application/json"
+        && upstream_content_encoding.is_none()
+        && accepts_gzip(headers)
+    {
+        // #2915: repodata documents reach tens of MiB (conda-forge's
+        // linux-64/noarch channels), and gzipping one is a CPU-bound
+        // multi-hundred-millisecond stall. Run it on the blocking pool so it
+        // cannot block the tokio worker (and with it every other request that
+        // worker is driving). `Bytes` clones are refcount bumps, so handing the
+        // body to the blocking task costs nothing.
+        let to_compress = body.clone();
+        match tokio::task::spawn_blocking(move || gzip_compress(&to_compress)).await {
+            Ok(compressed) => {
+                return Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, content_type)
+                    .header(CONTENT_ENCODING, "gzip")
+                    .header(CONTENT_LENGTH, compressed.len().to_string())
+                    .header(ETAG, &etag)
+                    .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL)
+                    .header("Vary", "Accept-Encoding")
+                    .body(Body::from(compressed))
+                    .unwrap();
+            }
+            // A join error means the blocking task panicked or the runtime is
+            // shutting down. Compression is an optimization, not a correctness
+            // requirement: fall through and serve the identity body rather than
+            // failing a request that has all its bytes in hand.
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "conda gzip offload failed; serving uncompressed body"
+                );
+            }
+        }
     }
 
-    Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type)
         .header(CONTENT_LENGTH, body.len().to_string())
         .header(ETAG, &etag)
-        .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL)
-        .body(Body::from(body))
-        .unwrap()
+        .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL);
+    if let Some(encoding) = upstream_content_encoding {
+        builder = builder.header(CONTENT_ENCODING, encoding);
+    }
+    builder.body(Body::from(body)).unwrap()
 }
 
 // ---------------------------------------------------------------------------
@@ -1188,29 +1249,52 @@ async fn channeldata_json(
         let body = serde_json::to_string_pretty(&channeldata)
             .unwrap()
             .into_bytes();
-        return Ok(cacheable_response(body, "application/json", &headers));
+        return Ok(cacheable_response(body, "application/json", &headers).await);
     }
 
-    // For remote repos, proxy channeldata from upstream
+    // For remote repos, proxy channeldata from upstream.
+    //
+    // #2915: two problems this branch used to have, both fixed the same way
+    // `serve_repodata` fixed them:
+    //
+    //  * The 8 MiB DEFAULT tier is far too small — conda-forge's
+    //    `channeldata.json` is a single document describing every package in
+    //    the channel and comfortably exceeds it — so the capped fetch ALWAYS
+    //    errored for the channel this endpoint matters most for.
+    //  * The error was then swallowed by `if let Ok(..)`, falling through to
+    //    the DB-only document below. For a freshly created Remote repo that is
+    //    an EMPTY channeldata served with 200, which a client reads as
+    //    authoritative ("this channel has no packages") instead of as the
+    //    upstream failure it actually is. Propagate with `?`.
+    //
+    // The LARGE tier is reserved against the process-wide buffered-metadata
+    // budget (#2684) because this endpoint is anonymously reachable on a public
+    // repo: the per-request cap bounds ONE buffer at 128 MiB, and only the
+    // budget bounds the SUM of concurrent buffers.
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
-                if let Ok((content, _ct)) = proxy_helpers::proxy_fetch_capped(
-                    proxy,
-                    repo.id,
-                    &repo_key,
-                    upstream_url,
-                    "channeldata.json",
-                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                let (content, _ct, upstream_encoding, _budget_permit) =
+                    proxy_helpers::proxy_fetch_capped_budgeted_with_encoding(
+                        proxy,
+                        repo.id,
+                        &repo_key,
+                        upstream_url,
+                        "channeldata.json",
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
+                    )
+                    .await?;
+                // `_budget_permit` is held until this function returns, i.e.
+                // across response construction (including the gzip pass), which
+                // is the window where the buffer is resident AND being copied.
+                // Same lifetime as the debian dists path (#2684).
+                return Ok(cacheable_response_coded(
+                    content,
+                    "application/json",
+                    upstream_encoding.as_deref(),
+                    &headers,
                 )
-                .await
-                {
-                    return Ok(cacheable_response(
-                        content.to_vec(),
-                        "application/json",
-                        &headers,
-                    ));
-                }
+                .await);
             }
         }
     }
@@ -1384,7 +1468,7 @@ async fn channeldata_json(
         .unwrap()
         .into_bytes();
 
-    Ok(cacheable_response(body, "application/json", &headers))
+    Ok(cacheable_response(body, "application/json", &headers).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1410,7 +1494,7 @@ async fn notices_json(
     });
 
     let body = serde_json::to_vec_pretty(&notices).unwrap();
-    Ok(cacheable_response(body, "application/json", &headers))
+    Ok(cacheable_response(body, "application/json", &headers).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1460,7 +1544,7 @@ async fn run_exports_json(
     });
 
     let body = serde_json::to_vec_pretty(&response).unwrap();
-    Ok(cacheable_response(body, "application/json", &headers))
+    Ok(cacheable_response(body, "application/json", &headers).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1491,7 +1575,7 @@ async fn patch_instructions_json(
     });
 
     let body = serde_json::to_vec_pretty(&response).unwrap();
-    Ok(cacheable_response(body, "application/json", &headers))
+    Ok(cacheable_response(body, "application/json", &headers).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1564,7 +1648,7 @@ async fn serve_repodata(
         )
         .await?;
         let body = encoding.encode(&repodata)?;
-        return Ok(cacheable_response(body, ct, headers));
+        return Ok(cacheable_response(body, ct, headers).await);
     }
 
     // For remote repos, proxy repodata from upstream. Real conda-forge
@@ -1579,27 +1663,46 @@ async fn serve_repodata(
     // failure (cap exceeded, upstream down, etc.) behind it would serve a
     // valid-looking but empty/incomplete index and make the client believe
     // there are no packages, rather than surfacing the actual problem.
+    //
+    // #2915: the 128 MiB buffer is reserved against the process-wide
+    // buffered-metadata budget (#2684) rather than taken unbudgeted. This
+    // endpoint is anonymously reachable on a public repo and re-buffers on every
+    // request (cache hits included), so the per-request cap alone bounds one
+    // buffer while N concurrent requests could still drive resident memory to
+    // N * 128 MiB; the budget bounds the sum. The buffered `Bytes` is then moved
+    // straight into the response instead of being copied via `to_vec()`.
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let upstream_path = format!("{}/{}", subdir, encoding.upstream_filename());
-                let (content, _ct) = proxy_helpers::proxy_fetch_capped(
-                    proxy,
-                    repo.id,
-                    repo_key,
-                    upstream_url,
-                    &upstream_path,
-                    proxy_helpers::LARGE_METADATA_MAX_BYTES,
+                let (content, _ct, upstream_encoding, _budget_permit) =
+                    proxy_helpers::proxy_fetch_capped_budgeted_with_encoding(
+                        proxy,
+                        repo.id,
+                        repo_key,
+                        upstream_url,
+                        &upstream_path,
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
+                    )
+                    .await?;
+                // `_budget_permit` is held until this function returns, i.e.
+                // across response construction (including the gzip pass) — the
+                // window where the buffer is both resident and being read.
+                // Matches the debian dists path (#2684).
+                return Ok(cacheable_response_coded(
+                    content,
+                    ct,
+                    upstream_encoding.as_deref(),
+                    headers,
                 )
-                .await?;
-                return Ok(cacheable_response(content.to_vec(), ct, headers));
+                .await);
             }
         }
     }
 
     let repodata = build_repodata(&state.db, repo.id, repo_key, subdir, false).await?;
     let body = encoding.encode(&repodata)?;
-    Ok(cacheable_response(body, ct, headers))
+    Ok(cacheable_response(body, ct, headers).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1732,12 +1835,31 @@ async fn repodata_json_zst(
 ///
 /// Supports HTTP Range requests (`Accept-Ranges: bytes`) so clients can
 /// fetch only newly appended lines on subsequent requests.
+///
+/// Local repos only (#2915). The bootstrap JLAP's footer advertises `latest` =
+/// the BLAKE2b hash of the document [`build_repodata`] produces from our own DB
+/// rows, and that is only the document `repodata.json` actually serves for a
+/// Local repo. For a Remote repo `repodata.json` serves the UPSTREAM document,
+/// and for a Virtual repo the aggregation of its members' — so the advertised
+/// hash can never match what the client holds, the client concludes its cached
+/// index is stale on every single run, and it refetches the full
+/// `repodata.json` anyway (having paid for a JLAP round trip first). 404ing is
+/// the documented "no JLAP available" signal and sends the client straight to
+/// the full fetch, which is the outcome it would have reached regardless.
 async fn repodata_json_jlap(
     State(state): State<SharedState>,
     headers: HeaderMap,
     Path((repo_key, subdir)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
+    if repo.repo_type != RepositoryType::Local {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "JLAP incremental repodata is only available for local/hosted conda repositories; \
+             fetch repodata.json",
+        )
+            .into_response());
+    }
     let repodata = build_repodata(&state.db, repo.id, &repo_key, &subdir, false).await?;
 
     // Serialize repodata identically to how repodata_json serves it
@@ -1873,7 +1995,7 @@ async fn current_repodata_json(
         .unwrap()
         .into_bytes();
 
-    Ok(cacheable_response(body, "application/json", &headers))
+    Ok(cacheable_response(body, "application/json", &headers).await)
 }
 
 // ---------------------------------------------------------------------------
@@ -1904,22 +2026,38 @@ fn group_artifacts_by_name<'a>(
 }
 
 /// CEP-16 sharded repodata is only built from artifacts already present in
-/// our own DB (see [`list_conda_artifacts`]) - it never proxies an upstream's
-/// real shard index. For a Local/hosted repo that's exactly right: our DB is
-/// the source of truth. For a Remote repo it's not: an upstream like
-/// conda-forge that has not yet been mirrored into our DB would otherwise get
-/// a syntactically valid but semantically empty (or incomplete) shard index
-/// served with 200, which a CEP-16-aware client treats as authoritative and
-/// will not fall back from - silently hiding every package that hasn't
-/// already been cached. Until sharded repodata is actually proxied from the
-/// upstream, Remote repos must 404 here so clients (pixi, conda) take the
-/// documented fallback to `repodata.json`, which IS proxied.
+/// our own DB, scoped to *this* repository's id (see [`list_conda_artifacts`]) -
+/// it never proxies an upstream's real shard index and never aggregates
+/// members. For a Local repo that's exactly right: our DB is the source of
+/// truth. For anything else it isn't, and the failure mode is the same in every
+/// case - a syntactically valid but semantically empty (or incomplete) shard
+/// index served with 200, which a CEP-16-aware client treats as authoritative
+/// and will NOT fall back from, silently hiding every package:
+///
+///   * **Remote**: an upstream like conda-forge that has not yet been mirrored
+///     into our DB has no rows here at all.
+///   * **Virtual** (#2915): `list_conda_artifacts` is scoped to the virtual
+///     repo's own id, and a virtual repo owns no artifacts - its MEMBERS do. So
+///     a virtual conda repo always served an empty shard index, even though
+///     `repodata.json` for the same repo is correctly aggregated by
+///     [`build_virtual_repodata`].
+///   * **Staging / anything else**: a staging repo's own rows would in fact be
+///     authoritative, but 404ing is the conservative direction (the client
+///     falls back to `repodata.json`, which is complete for a hosted repo, so
+///     the only cost is the CEP-16 bandwidth saving). Failing closed also
+///     covers a `repo_type` this code does not know about — `RepoInfo::repo_type`
+///     is a raw string and `resolve_repo_by_key` yields an empty one when the
+///     column read fails.
+///
+/// Until sharded repodata is actually proxied/aggregated, only Local repos may
+/// answer here; everyone else 404s so clients (pixi, conda) take the documented
+/// fallback to `repodata.json`.
 #[allow(clippy::result_large_err)]
-fn reject_unsupported_remote_sharding(repo: &RepoInfo) -> Result<(), Response> {
-    if repo.repo_type == RepositoryType::Remote {
+fn reject_unsupported_sharding_repo_type(repo: &RepoInfo) -> Result<(), Response> {
+    if repo.repo_type != RepositoryType::Local {
         return Err((
             StatusCode::NOT_FOUND,
-            "Sharded repodata (CEP-16) is not available for remote/proxy conda repositories; \
+            "Sharded repodata (CEP-16) is only available for local/hosted conda repositories; \
              use repodata.json",
         )
             .into_response());
@@ -1932,7 +2070,7 @@ async fn sharded_repodata_index(
     Path((repo_key, subdir)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
-    reject_unsupported_remote_sharding(&repo)?;
+    reject_unsupported_sharding_repo_type(&repo)?;
     let all_artifacts = list_conda_artifacts(&state.db, repo.id).await?;
     let subdir_artifacts = artifacts_for_subdir(&all_artifacts, &subdir);
     let by_name = group_artifacts_by_name(&subdir_artifacts);
@@ -1984,7 +2122,7 @@ async fn sharded_repodata_shard(
     }
 
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
-    reject_unsupported_remote_sharding(&repo)?;
+    reject_unsupported_sharding_repo_type(&repo)?;
     let all_artifacts = list_conda_artifacts(&state.db, repo.id).await?;
     let subdir_artifacts = artifacts_for_subdir(&all_artifacts, &subdir);
     let by_name = group_artifacts_by_name(&subdir_artifacts);
@@ -2458,6 +2596,21 @@ async fn build_virtual_channeldata(
 // GET /conda/{repo_key}/{subdir}/{filename} - Download package
 // ---------------------------------------------------------------------------
 
+/// `Content-Type` for a conda package download.
+///
+/// `.tar.bz2` is a tarball; `.conda` (a zip container) and anything else get the
+/// generic binary type. Shared by the hosted, Remote-proxied and Virtual arms of
+/// [`download_package`] so all three advertise the same type for the same
+/// filename — the Remote arm uses it as the fallback for when upstream omits a
+/// `Content-Type` of its own.
+fn conda_package_content_type(filename: &str) -> &'static str {
+    if filename.ends_with(".tar.bz2") {
+        "application/x-tar"
+    } else {
+        "application/octet-stream"
+    }
+}
+
 async fn download_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -2499,23 +2652,39 @@ async fn download_package(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("{}/{}", subdir, filename);
-                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
+                    // #2915 BLOCKER: this is the PACKAGE path, not a metadata
+                    // path, and it used to go through the buffered
+                    // `proxy_fetch_capped` at the 8 MiB metadata ceiling. Real
+                    // conda packages dwarf that (`python` ~30 MiB, `scipy`
+                    // ~17 MiB, `pytorch` far more), so the cap turned every
+                    // meaningful package download into a 502 — and the ones that
+                    // did fit were still buffered whole in memory, which is the
+                    // OOM pattern #895/#1608 removed from every other format's
+                    // package download.
+                    //
+                    // Stream instead, exactly as `try_remote_or_virtual_download`
+                    // does for rpm/hex/cran/huggingface and as debian's pool
+                    // handler does for `.deb`: the body is teed from upstream to
+                    // the client and into the proxy cache without ever being
+                    // fully resident. The quarantine gating is unchanged — it
+                    // lives inside `ProxyService` (`check_quarantine_until` on
+                    // both the fresh-fetch and cache-hit paths) and
+                    // `map_proxy_error` still turns a hold into 409 / a rejected
+                    // artifact into 403 for the streaming path too.
+                    //
+                    // `Content-Disposition` is now emitted (the buffered arm
+                    // omitted it) so a proxied package matches what the hosted
+                    // and Virtual arms below already serve.
+                    return proxy_helpers::proxy_fetch_streaming_with_disposition(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
-                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                        conda_package_content_type(&filename),
+                        Some(&filename),
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
 
@@ -2543,14 +2712,11 @@ async fn download_package(
                 )
                 .await?;
 
-                let ct = if filename.ends_with(".conda") {
-                    "application/octet-stream"
-                } else if filename.ends_with(".tar.bz2") {
-                    "application/x-tar"
-                } else {
-                    "application/octet-stream"
-                };
-                return proxy_helpers::stream_fetch_result(result, ct, Some(&filename));
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    conda_package_content_type(&filename),
+                    Some(&filename),
+                );
             }
 
             return Err(not_found);
@@ -2577,17 +2743,9 @@ async fn download_package(
     // Record download
     crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
-    let content_type = if filename.ends_with(".conda") {
-        "application/octet-stream"
-    } else if filename.ends_with(".tar.bz2") {
-        "application/x-tar"
-    } else {
-        "application/octet-stream"
-    };
-
     Ok(Response::builder()
         .status(StatusCode::OK)
-        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_TYPE, conda_package_content_type(&filename))
         .header(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
@@ -5964,11 +6122,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_cacheable_response_includes_etag() {
+    #[tokio::test]
+    async fn test_cacheable_response_includes_etag() {
         let body = b"repodata json content".to_vec();
         let headers = HeaderMap::new();
-        let resp = cacheable_response(body.clone(), "application/json", &headers);
+        let resp = cacheable_response(body.clone(), "application/json", &headers).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(
@@ -5985,24 +6143,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_cacheable_response_304_on_matching_etag() {
+    #[tokio::test]
+    async fn test_cacheable_response_304_on_matching_etag() {
         let body = b"repodata json content".to_vec();
         let etag = compute_etag(&body);
         let mut headers = HeaderMap::new();
         headers.insert(IF_NONE_MATCH, etag.parse().unwrap());
 
-        let resp = cacheable_response(body, "application/json", &headers);
+        let resp = cacheable_response(body, "application/json", &headers).await;
         assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
     }
 
-    #[test]
-    fn test_cacheable_response_200_on_stale_etag() {
+    #[tokio::test]
+    async fn test_cacheable_response_200_on_stale_etag() {
         let body = b"updated repodata json content".to_vec();
         let mut headers = HeaderMap::new();
         headers.insert(IF_NONE_MATCH, "W/\"stale_etag_value\"".parse().unwrap());
 
-        let resp = cacheable_response(body, "application/json", &headers);
+        let resp = cacheable_response(body, "application/json", &headers).await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -7724,13 +7882,13 @@ mod tests {
         assert_eq!(decompressed, original);
     }
 
-    #[test]
-    fn test_cacheable_response_gzip_when_accepted() {
+    #[tokio::test]
+    async fn test_cacheable_response_gzip_when_accepted() {
         let body = serde_json::to_vec(&serde_json::json!({"test": true})).unwrap();
         let mut headers = HeaderMap::new();
         headers.insert(ACCEPT_ENCODING, "gzip, deflate".parse().unwrap());
 
-        let resp = cacheable_response(body, "application/json", &headers);
+        let resp = cacheable_response(body, "application/json", &headers).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
@@ -7747,24 +7905,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_cacheable_response_no_gzip_for_binary() {
+    #[tokio::test]
+    async fn test_cacheable_response_no_gzip_for_binary() {
         let body = vec![0u8; 100];
         let mut headers = HeaderMap::new();
         headers.insert(ACCEPT_ENCODING, "gzip, deflate".parse().unwrap());
 
-        let resp = cacheable_response(body, "application/x-bzip2", &headers);
+        let resp = cacheable_response(body, "application/x-bzip2", &headers).await;
 
         // Binary content types should not be gzip-encoded
         assert!(resp.headers().get(CONTENT_ENCODING).is_none());
     }
 
-    #[test]
-    fn test_cacheable_response_no_gzip_without_accept() {
+    #[tokio::test]
+    async fn test_cacheable_response_no_gzip_without_accept() {
         let body = serde_json::to_vec(&serde_json::json!({"test": true})).unwrap();
         let headers = HeaderMap::new();
 
-        let resp = cacheable_response(body, "application/json", &headers);
+        let resp = cacheable_response(body, "application/json", &headers).await;
 
         // No Accept-Encoding means no gzip
         assert!(resp.headers().get(CONTENT_ENCODING).is_none());
@@ -8949,16 +9107,21 @@ mod tests {
             StatusCode::OK,
             "a repodata.json.zst above the old 8 MiB cap must now succeed"
         );
+        // Byte equality, not just length: a truncated-at-the-cap body and a
+        // correctly proxied one can only be told apart by content.
         assert_eq!(
+            &resp_body[..],
+            &body[..],
+            "the full upstream body must be served verbatim (got {} bytes, want {})",
             resp_body.len(),
             body.len(),
-            "the full upstream body must be served, not truncated"
         );
     }
 
-    // A genuine upstream failure (a 500 that folds to 502 via map_proxy_error)
-    // must surface to the client instead of being swallowed into a silent
-    // fallback that serves an empty, DB-only repodata.json with 200 (the
+    // A genuine upstream failure (a 500, which `validate_upstream_status` folds
+    // to `ServiceUnavailable` and `map_proxy_error` renders as 503) must surface
+    // to the client instead of being swallowed into a silent fallback that
+    // serves an empty, DB-only repodata.json with 200 (the
     // conda-forge-discovery-blocking bug this fixes).
     #[tokio::test]
     async fn remote_repodata_upstream_failure_surfaces_not_empty_200() {
@@ -8993,10 +9156,17 @@ mod tests {
         cleanup_conda_repo(&pool, repo_id).await;
         let _ = std::fs::remove_dir_all(&tmp);
 
-        assert!(
-            status.is_server_error(),
-            "a genuine upstream failure must surface as a server error, got {status} with body {:?}",
+        // Concrete status, not merely "some 5xx": #1445 fixes upstream 5xx at
+        // 503 Service Unavailable (never a raw 502, never the masked 200).
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "an upstream 5xx must surface as 503, got {status} with body {:?}",
             String::from_utf8_lossy(&resp_body),
+        );
+        assert!(
+            !String::from_utf8_lossy(&resp_body).contains("repodata_version"),
+            "the failure response must not be a fabricated repodata document"
         );
     }
 
@@ -9075,6 +9245,401 @@ mod tests {
             status,
             StatusCode::OK,
             "a Local/hosted conda repo's shard index must still serve 200"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2915 follow-ups to the #2914 proxy work above.
+    //
+    // 1. The PACKAGE download path for a Remote repo was routed through the
+    //    buffered 8 MiB *metadata* helper, so every real conda package 502'd.
+    // 2. `channeldata.json` kept the exact fail-open that was removed from
+    //    `serve_repodata`: an 8 MiB cap the real document exceeds, plus an
+    //    `if let Ok(..)` that turned the resulting error into an empty 200.
+    // 3. The CEP-16 / JLAP guards only covered Remote, so Virtual repos --
+    //    whose artifacts belong to their MEMBERS, never to the virtual repo id
+    //    `list_conda_artifacts` is scoped to -- still served empty 200s.
+    // -----------------------------------------------------------------------
+
+    /// Wire a `SharedState` whose proxy cache lives in a fresh temp dir. The
+    /// returned `TempDir` must outlive the request (dropping it deletes the
+    /// cache the proxy is writing through).
+    fn state_with_proxy_cache(pool: &sqlx::PgPool) -> (crate::api::SharedState, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("proxy cache tempdir");
+        let root = dir.path().to_str().expect("utf8 tempdir path");
+        let proxy =
+            crate::api::handlers::test_db_helpers::build_proxy_service_with_fs(pool.clone(), root);
+        let state = crate::api::handlers::test_db_helpers::build_state_with_proxy(
+            pool.clone(),
+            root,
+            proxy,
+        );
+        (state, dir)
+    }
+
+    /// A 64-hex shard hash that matches no shard. Needed because
+    /// `sharded_repodata_shard` validates the hash FORMAT before it resolves the
+    /// repository, so a malformed hash 400s and never reaches the repo-type
+    /// guard under test.
+    fn well_formed_shard_hash() -> String {
+        "ab".repeat(32)
+    }
+
+    // #2915 BLOCKER regression: a Remote conda package download must stream the
+    // whole upstream body. The old code buffered it through
+    // `proxy_fetch_capped(.., DEFAULT_METADATA_MAX_BYTES)`, so anything past
+    // 8 MiB -- i.e. essentially every package anyone installs (python ~30 MiB,
+    // scipy ~17 MiB) -- came back 502. This fixture is deliberately larger than
+    // that ceiling, so it FAILS on the pre-fix code, and asserts byte equality
+    // so a truncated body cannot pass either.
+    #[tokio::test]
+    async fn remote_package_download_above_metadata_cap_is_served_in_full() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // Non-uniform bytes so a byte-equality assertion is meaningful (a
+        // constant fill would match any equally sized garbage body).
+        let pkg: Vec<u8> = (0..(9 * 1024 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        assert!(
+            pkg.len() > proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            "fixture must exceed the metadata cap the buffered path used"
+        );
+        let filename = "python-3.12.0-h30d4d87_0.conda";
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/osx-arm64/{filename}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(pkg.clone()))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = state_with_proxy_cache(&pool);
+        let (repo_id, repo_key, _dir) = insert_public_remote_conda_repo(&pool, &server.uri()).await;
+
+        let app = tdh::router_anon(router(), state);
+        let (status, resp_body) =
+            tdh::send(app, tdh::get(format!("/{repo_key}/osx-arm64/{filename}"))).await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a >8 MiB remote conda package must download, not 502; body was {:?}",
+            String::from_utf8_lossy(&resp_body[..resp_body.len().min(200)]),
+        );
+        assert_eq!(
+            &resp_body[..],
+            &pkg[..],
+            "the streamed package must be byte-identical to upstream (got {} bytes, want {})",
+            resp_body.len(),
+            pkg.len(),
+        );
+    }
+
+    // #2915 (4): an upstream `channeldata.json` failure must surface. The old
+    // `if let Ok(..)` swallowed it and fell through to the DB-only document,
+    // which for a fresh Remote repo is an EMPTY channel description served 200 --
+    // indistinguishable, to a client, from "this channel really has no packages".
+    #[tokio::test]
+    async fn remote_channeldata_upstream_failure_surfaces_instead_of_empty_200() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/channeldata.json"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = state_with_proxy_cache(&pool);
+        let (repo_id, repo_key, _dir) = insert_public_remote_conda_repo(&pool, &server.uri()).await;
+
+        let app = tdh::router_anon(router(), state);
+        let (status, resp_body) =
+            tdh::send(app, tdh::get(format!("/{repo_key}/channeldata.json"))).await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "an upstream 5xx on channeldata.json must surface as 503, got {status}"
+        );
+        assert!(
+            !String::from_utf8_lossy(&resp_body).contains("channeldata_version"),
+            "the failure response must not be a fabricated (empty) channeldata document"
+        );
+    }
+
+    // #2915 (4): conda-forge's `channeldata.json` is a single document covering
+    // every package in the channel and comfortably exceeds the 8 MiB DEFAULT
+    // tier the old code used, so the fetch ALWAYS failed for the channel this
+    // endpoint matters most for. It must now be fetched at the LARGE tier and
+    // served verbatim.
+    #[tokio::test]
+    async fn remote_channeldata_above_default_cap_is_served_in_full() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // A real (if degenerate) JSON document above the DEFAULT cap and below
+        // the LARGE one, so success implies the LARGE tier specifically.
+        let body = format!(
+            "{{\"channeldata_version\":1,\"packages\":{{}},\"_pad\":\"{}\"}}",
+            "p".repeat(9 * 1024 * 1024)
+        )
+        .into_bytes();
+        assert!(
+            body.len() > proxy_helpers::DEFAULT_METADATA_MAX_BYTES
+                && body.len() < proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            "fixture must straddle DEFAULT and LARGE"
+        );
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/channeldata.json"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body.clone())
+                    .insert_header("content-type", "application/json"),
+            )
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = state_with_proxy_cache(&pool);
+        let (repo_id, repo_key, _dir) = insert_public_remote_conda_repo(&pool, &server.uri()).await;
+
+        let app = tdh::router_anon(router(), state);
+        // No `Accept-Encoding`, so `cacheable_response` serves the identity body
+        // and the comparison below is against the upstream bytes directly.
+        let (status, resp_body) =
+            tdh::send(app, tdh::get(format!("/{repo_key}/channeldata.json"))).await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a channeldata.json above the old 8 MiB cap must now succeed"
+        );
+        assert_eq!(
+            &resp_body[..],
+            &body[..],
+            "the full upstream channeldata must be served verbatim (got {} bytes, want {})",
+            resp_body.len(),
+            body.len(),
+        );
+    }
+
+    // #2915 (5): the shard ENDPOINT needs the same repo-type guard the index
+    // endpoint got -- a Remote repo has no shard rows of its own, so without the
+    // guard it answers 404 "Shard not found" for a reason that has nothing to do
+    // with the repository being unsupported, and the index/shard pair disagree
+    // about whether CEP-16 exists here.
+    #[tokio::test]
+    async fn remote_repo_sharded_shard_404s() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (state, _cache) = state_with_proxy_cache(&pool);
+        let (repo_id, repo_key, _dir) =
+            insert_public_remote_conda_repo(&pool, "https://upstream.example.test").await;
+
+        let app = tdh::router_anon(router(), state);
+        let hash = well_formed_shard_hash();
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{repo_key}/noarch/shards/{hash}.msgpack.zst")),
+        )
+        .await;
+
+        cleanup_conda_repo(&pool, repo_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "a CEP-16 shard fetch against a Remote conda repo must 404"
+        );
+        assert!(
+            String::from_utf8_lossy(&body).contains("local/hosted"),
+            "the 404 must come from the repo-type guard, not the shard lookup; got {:?}",
+            String::from_utf8_lossy(&body),
+        );
+    }
+
+    // The Local counterpart: a hosted repo's own DB rows ARE authoritative, so a
+    // shard whose content hash the client asks for is still served with 200 and
+    // the exact shard bytes.
+    #[tokio::test]
+    async fn local_repo_sharded_shard_still_returns_200() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "conda").await else {
+            return;
+        };
+        let repo = fx.repo_info("local", None);
+        let pkg_path = "linux-64/zlib-1.3-h4ab18f5_1.conda";
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            pkg_path,
+            pkg_path,
+            "zlib",
+            "1.3",
+            "application/octet-stream",
+            Bytes::from_static(b"conda package payload"),
+            fx.user_id,
+        )
+        .await;
+
+        let assertions = async {
+            // Recompute the content-addressed shard hash exactly as the index
+            // endpoint advertises it, so the request is one a real CEP-16 client
+            // would make after reading the index.
+            let all = list_conda_artifacts(&fx.pool, fx.repo_id)
+                .await
+                .expect("list conda artifacts");
+            let subdir_artifacts = artifacts_for_subdir(&all, "linux-64");
+            let by_name = group_artifacts_by_name(&subdir_artifacts);
+            let artifacts = by_name.get("zlib").expect("seeded package must shard");
+            let shard = build_shard("linux-64", artifacts);
+            let shard_compressed = serialize_msgpack_zst(&shard).expect("serialize shard");
+            let mut hasher = Sha256::new();
+            hasher.update(&shard_compressed);
+            let hash = format!("{:x}", hasher.finalize());
+
+            let app = fx.router_anon(router());
+            let (status, body) = tdh::send(
+                app,
+                tdh::get(format!(
+                    "/{key}/linux-64/shards/{hash}.msgpack.zst",
+                    key = fx.repo_key
+                )),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "a Local conda repo must still serve its own CEP-16 shards"
+            );
+            assert_eq!(
+                &body[..],
+                &shard_compressed[..],
+                "the served shard must be the content-addressed bytes"
+            );
+        };
+
+        assertions.await;
+        fx.teardown().await;
+    }
+
+    // #2915 (5): a Virtual conda repo owns no artifacts -- its MEMBERS do -- and
+    // both sharded endpoints plus the JLAP endpoint are built from
+    // `list_conda_artifacts(repo.id)` / `build_repodata(repo.id)`, i.e. from the
+    // virtual repo's own (always empty) rows. `repodata.json` is correctly
+    // aggregated by `build_virtual_repodata`, so all three of these must 404 and
+    // send the client there instead of serving an authoritative-looking empty
+    // index (CEP-16) or an unmatchable `latest` hash (JLAP).
+    #[tokio::test]
+    async fn virtual_repo_404s_on_sharded_and_jlap_endpoints() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "virtual", "conda").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("make repo public");
+        let (state, _cache) = state_with_proxy_cache(&pool);
+
+        let hash = well_formed_shard_hash();
+        let endpoints = [
+            format!("/{repo_key}/noarch/repodata_shards.msgpack.zst"),
+            format!("/{repo_key}/noarch/shards/{hash}.msgpack.zst"),
+            format!("/{repo_key}/noarch/repodata.json.jlap"),
+        ];
+        let mut results = Vec::new();
+        for uri in &endpoints {
+            let app = tdh::router_anon(router(), state.clone());
+            let (status, _body) = tdh::send(app, tdh::get(uri.clone())).await;
+            results.push((uri.clone(), status));
+        }
+
+        cleanup_conda_repo(&pool, repo_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        for (uri, status) in results {
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "{uri} must 404 for a Virtual conda repo instead of serving an empty document"
+            );
+        }
+    }
+
+    // #2915 (3): `cacheable_response` must not add its own gzip on top of a body
+    // that already arrived content-coded, and must declare the coding it did
+    // arrive with. Double-gzipping while advertising `Content-Encoding: gzip`
+    // once produces a body no client can decode.
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test module exempt — buffering a 22-byte gzipped JSON
+    // body in an assertion is not an artifact path (#1608).
+    #[tokio::test]
+    async fn cacheable_response_does_not_recompress_already_coded_body() {
+        let already_gzipped = gzip_compress(br#"{"repodata_version":1}"#);
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT_ENCODING, "gzip, deflate".parse().unwrap());
+
+        let resp = cacheable_response_coded(
+            already_gzipped.clone(),
+            "application/json",
+            Some("gzip"),
+            &headers,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(CONTENT_ENCODING)
+                .and_then(|v| v.to_str().ok()),
+            Some("gzip"),
+            "the upstream coding must be forwarded verbatim, exactly once"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(already_gzipped.len().to_string().as_str()),
+            "the body must be passed through untouched, not gzipped a second time"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        assert_eq!(
+            &body[..],
+            &already_gzipped[..],
+            "an already-coded body must be served byte-for-byte"
         );
     }
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1758,7 +1758,7 @@ async fn resolve_pool_expected_checksum(
         if !is_matching_packages_index(&cache_path, component, &arch) {
             continue;
         }
-        let Ok(Some((bytes, _))) = proxy
+        let Ok(Some((bytes, _, _))) = proxy
             .get_cached_artifact_by_path(repo_key, &cache_path)
             .await
         else {

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -68,6 +68,19 @@ pub fn router() -> Router<SharedState> {
             "/:repo_key/api/models/:namespace/:name",
             get(model_info_namespaced),
         )
+        // Model info at a specific revision: bare model id. `huggingface_hub`
+        // requests this variant whenever a revision is known (the CLI/
+        // `snapshot_download` default is "main"), so without this route the
+        // client 404s before it ever reaches `download_file`.
+        .route(
+            "/:repo_key/api/models/:model_id/revision/:revision",
+            get(model_info_revision),
+        )
+        // Model info at a specific revision: namespaced model id.
+        .route(
+            "/:repo_key/api/models/:namespace/:name/revision/:revision",
+            get(model_info_revision_namespaced),
+        )
         // Upload file to model: bare model id
         .route(
             "/:repo_key/api/models/:model_id/upload/:revision",
@@ -192,26 +205,64 @@ async fn model_info(
     State(state): State<SharedState>,
     Path((repo_key, model_id)): Path<(String, String)>,
 ) -> Result<Response, Response> {
-    model_info_impl(state, repo_key, model_id).await
+    model_info_impl(state, repo_key, model_id, None).await
 }
 
 async fn model_info_namespaced(
     State(state): State<SharedState>,
     Path((repo_key, namespace, name)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
-    model_info_impl(state, repo_key, format!("{namespace}/{name}")).await
+    model_info_impl(state, repo_key, format!("{namespace}/{name}"), None).await
+}
+
+async fn model_info_revision(
+    State(state): State<SharedState>,
+    Path((repo_key, model_id, revision)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    model_info_impl(state, repo_key, model_id, Some(revision)).await
+}
+
+async fn model_info_revision_namespaced(
+    State(state): State<SharedState>,
+    Path((repo_key, namespace, name, revision)): Path<(String, String, String, String)>,
+) -> Result<Response, Response> {
+    model_info_impl(
+        state,
+        repo_key,
+        format!("{namespace}/{name}"),
+        Some(revision),
+    )
+    .await
 }
 
 async fn model_info_impl(
     state: SharedState,
     repo_key: String,
     model_id: String,
+    revision: Option<String>,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
 
-    let artifact = proxy_helpers::find_artifact_by_name_lowercase(&state.db, repo.id, &model_id)
-        .await?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Model not found").into_response())?;
+    let artifact =
+        proxy_helpers::find_artifact_by_name_lowercase(&state.db, repo.id, &model_id).await?;
+
+    // Not cached locally: for a Remote repo, proxy the upstream Hugging Face
+    // model-info JSON instead of 404ing immediately. This mirrors the
+    // pull-through `download_file_impl` already does for file downloads
+    // (via `try_remote_or_virtual_download`) - without it, `hf download`
+    // never gets past the initial file-listing call for any model that
+    // hasn't already been cached by a prior download.
+    let artifact = match artifact {
+        Some(a) => a,
+        None => {
+            if let Some(resp) =
+                proxy_model_info(&state, &repo, &model_id, revision.as_deref()).await?
+            {
+                return Ok(resp);
+            }
+            return Err((StatusCode::NOT_FOUND, "Model not found").into_response());
+        }
+    };
 
     let siblings = sqlx::query!(
         r#"
@@ -257,6 +308,64 @@ async fn model_info_impl(
     });
 
     Ok(super::json_response(&json))
+}
+
+/// Proxy the upstream Hugging Face model-info JSON for a Remote repo.
+///
+/// Returns `Ok(None)` when the repo isn't a Remote repo (or has no
+/// `upstream_url`/proxy service wired up), so the caller falls through to its
+/// existing 404. Returns `Err` for a genuine upstream failure (404, 5xx,
+/// path-traversal rejection, ...) via `proxy_helpers::proxy_fetch_capped` -
+/// never a silently-empty 200.
+///
+/// The upstream path mirrors the real `huggingface_hub` client request:
+/// `api/models/{model_id}` with no revision, or
+/// `api/models/{model_id}/revision/{revision}` when one is given.
+/// `proxy_fetch_capped` runs the request through `ProxyService`'s existing
+/// cache-path validator (rejects `..` segments etc.), so no separate
+/// traversal guard is needed here - `model_id` flows into that same
+/// validated path exactly as it already does for `download_file_impl`'s
+/// `resolve/{revision}/{filename}` upstream path.
+async fn proxy_model_info(
+    state: &SharedState,
+    repo: &RepoInfo,
+    model_id: &str,
+    revision: Option<&str>,
+) -> Result<Option<Response>, Response> {
+    if proxy_helpers::classify_remote_or_virtual(&repo.repo_type)
+        != proxy_helpers::RemoteOrVirtualAction::Remote
+    {
+        return Ok(None);
+    }
+    let Some(upstream_url) = repo.upstream_url.as_deref() else {
+        return Ok(None);
+    };
+    let Some(proxy) = state.proxy_service.as_deref() else {
+        return Ok(None);
+    };
+
+    let upstream_path = match revision {
+        Some(rev) => format!("api/models/{model_id}/revision/{rev}"),
+        None => format!("api/models/{model_id}"),
+    };
+
+    let (bytes, _content_type) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        &repo.key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await?;
+
+    Ok(Some(
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(bytes))
+            .unwrap(),
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -1104,5 +1213,251 @@ mod tests {
             status
         );
         f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Model-info `/revision/{revision}` routes and upstream pull-through.
+    //
+    // `hf download <org/model>` calls
+    // `GET /api/models/{model_id}/revision/{revision}` to list a model's
+    // files before downloading them. Before this fix there was no route for
+    // that path at all (bare or namespaced), and even with a route,
+    // `model_info_impl` never consulted the upstream Hugging Face API for an
+    // uncached model - both gaps 404'd a fresh `hf download` immediately.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_revision_route_serves_local() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            "huggingface/gpt2/main/config.json",
+            "gpt2/main/config.json",
+            "gpt2",
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"x\":1}"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/api/models/gpt2/revision/main", f.repo_key)),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the bare /revision/ route must exist and reach model_info_impl"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["modelId"], "gpt2");
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_revision_route_serves_local_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        let model_id = "sentence-transformers/all-MiniLM-L6-v2";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            &format!("huggingface/{model_id}/main/config.json"),
+            &format!("{model_id}/main/config.json"),
+            model_id,
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"x\":1}"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/api/models/{}/revision/main",
+                f.repo_key, model_id
+            )),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the namespaced /revision/ route must exist and reach model_info_impl"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["modelId"], model_id);
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_proxies_upstream_for_uncached_remote_model() {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let upstream_json = serde_json::json!({
+            "modelId": "sentence-transformers/all-MiniLM-L6-v2",
+            "sha": "deadbeef",
+            "siblings": [{"rfilename": "config.json"}, {"rfilename": "pytorch_model.bin"}],
+        });
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&upstream_json))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main",
+                f.repo_key
+            )),
+        )
+        .await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "an uncached model on a Remote repo must be proxied from upstream, not 404"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["modelId"], "sentence-transformers/all-MiniLM-L6-v2");
+        assert_eq!(json["siblings"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_proxies_upstream_bare_no_revision() {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let upstream_json = serde_json::json!({"modelId": "gpt2", "siblings": []});
+        Mock::given(method("GET"))
+            .and(wm_path("/api/models/gpt2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&upstream_json))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) =
+            tdh::send(app, tdh::get(format!("/{}/api/models/gpt2", f.repo_key))).await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the no-revision variant must also proxy upstream for an uncached model"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["modelId"], "gpt2");
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_upstream_404_surfaces_not_empty_200() {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/api/models/does-not-exist/revision/main"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, _body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/api/models/does-not-exist/revision/main",
+                f.repo_key
+            )),
+        )
+        .await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "a genuine upstream 404 must surface as 404, not a silent empty 200"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_cached_model_skips_upstream_proxy() {
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        // No mock registered: if the handler tried to hit upstream for a
+        // cached model, wiremock would return its default 404 and the test
+        // would fail below, proving the DB path was bypassed.
+        let server = MockServer::start().await;
+        Mock::given(wiremock::matchers::any())
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let repo = f.repo_info("remote", Some(&server.uri()));
+        tdh::seed_artifact(
+            &state,
+            &f.pool,
+            &repo,
+            "huggingface/gpt2/main/config.json",
+            "gpt2/main/config.json",
+            "gpt2",
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"cached\":true}"),
+            f.user_id,
+        )
+        .await;
+
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) =
+            tdh::send(app, tdh::get(format!("/{}/api/models/gpt2", f.repo_key))).await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a model already cached in the DB must be served from there, not upstream"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["modelId"], "gpt2");
     }
 }

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -8,6 +8,14 @@
 //!   GET  /huggingface/{repo_key}/{model_id}/resolve/{revision}/{filename}     - Download file
 //!   POST /huggingface/{repo_key}/api/models/{model_id}/upload/{revision}      - Upload file
 //!   GET  /huggingface/{repo_key}/api/models/{model_id}/tree/{revision}        - List files
+//!
+//! `{model_id}` above is written as a single placeholder, but real Hugging
+//! Face model IDs are almost always namespaced (`org/name`, e.g.
+//! `sentence-transformers/all-MiniLM-L6-v2`). Axum's `:param` segments cannot
+//! contain a literal `/`, so every route that carries a model ID is
+//! registered twice: once with a single `:model_id` segment (bare IDs like
+//! `gpt2`) and once with `:namespace/:name` (two segments, rejoined into
+//! `"namespace/name"` inside the handler). See `router()` below.
 
 use axum::body::Body;
 use axum::extract::{Path, State};
@@ -53,22 +61,42 @@ pub fn router() -> Router<SharedState> {
     Router::new()
         // List models
         .route("/:repo_key/api/models", get(list_models))
-        // Model info
+        // Model info: bare model id (e.g. "gpt2")
         .route("/:repo_key/api/models/:model_id", get(model_info))
-        // Upload file to model
+        // Model info: namespaced model id (e.g. "org/name")
+        .route(
+            "/:repo_key/api/models/:namespace/:name",
+            get(model_info_namespaced),
+        )
+        // Upload file to model: bare model id
         .route(
             "/:repo_key/api/models/:model_id/upload/:revision",
             post(upload_file),
         )
-        // List files in model (tree)
+        // Upload file to model: namespaced model id
+        .route(
+            "/:repo_key/api/models/:namespace/:name/upload/:revision",
+            post(upload_file_namespaced),
+        )
+        // List files in model (tree): bare model id
         .route(
             "/:repo_key/api/models/:model_id/tree/:revision",
             get(list_files),
         )
-        // Download file from model
+        // List files in model (tree): namespaced model id
+        .route(
+            "/:repo_key/api/models/:namespace/:name/tree/:revision",
+            get(list_files_namespaced),
+        )
+        // Download file from model: bare model id
         .route(
             "/:repo_key/:model_id/resolve/:revision/*filename",
             get(download_file),
+        )
+        // Download file from model: namespaced model id
+        .route(
+            "/:repo_key/:namespace/:name/resolve/:revision/*filename",
+            get(download_file_namespaced),
         )
 }
 
@@ -164,6 +192,21 @@ async fn model_info(
     State(state): State<SharedState>,
     Path((repo_key, model_id)): Path<(String, String)>,
 ) -> Result<Response, Response> {
+    model_info_impl(state, repo_key, model_id).await
+}
+
+async fn model_info_namespaced(
+    State(state): State<SharedState>,
+    Path((repo_key, namespace, name)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    model_info_impl(state, repo_key, format!("{namespace}/{name}")).await
+}
+
+async fn model_info_impl(
+    state: SharedState,
+    repo_key: String,
+    model_id: String,
+) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
 
     let artifact = proxy_helpers::find_artifact_by_name_lowercase(&state.db, repo.id, &model_id)
@@ -223,6 +266,39 @@ async fn model_info(
 async fn download_file(
     State(state): State<SharedState>,
     Path((repo_key, model_id, revision, filename)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
+) -> Result<Response, Response> {
+    download_file_impl(state, repo_key, model_id, revision, filename, ctx).await
+}
+
+async fn download_file_namespaced(
+    State(state): State<SharedState>,
+    Path((repo_key, namespace, name, revision, filename)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
+) -> Result<Response, Response> {
+    download_file_impl(
+        state,
+        repo_key,
+        format!("{namespace}/{name}"),
+        revision,
+        filename,
+        ctx,
+    )
+    .await
+}
+
+async fn download_file_impl(
+    state: SharedState,
+    repo_key: String,
+    model_id: String,
+    revision: String,
+    filename: String,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
@@ -291,6 +367,37 @@ async fn upload_file(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, model_id, revision)): Path<(String, String, String)>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, Response> {
+    upload_file_impl(state, auth, repo_key, model_id, revision, headers, body).await
+}
+
+async fn upload_file_namespaced(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((repo_key, namespace, name, revision)): Path<(String, String, String, String)>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, Response> {
+    upload_file_impl(
+        state,
+        auth,
+        repo_key,
+        format!("{namespace}/{name}"),
+        revision,
+        headers,
+        body,
+    )
+    .await
+}
+
+async fn upload_file_impl(
+    state: SharedState,
+    auth: Option<AuthExtension>,
+    repo_key: String,
+    model_id: String,
+    revision: String,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, Response> {
@@ -426,6 +533,22 @@ async fn upload_file(
 async fn list_files(
     State(state): State<SharedState>,
     Path((repo_key, model_id, revision)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    list_files_impl(state, repo_key, model_id, revision).await
+}
+
+async fn list_files_namespaced(
+    State(state): State<SharedState>,
+    Path((repo_key, namespace, name, revision)): Path<(String, String, String, String)>,
+) -> Result<Response, Response> {
+    list_files_impl(state, repo_key, format!("{namespace}/{name}"), revision).await
+}
+
+async fn list_files_impl(
+    state: SharedState,
+    repo_key: String,
+    model_id: String,
+    revision: String,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
 
@@ -783,6 +906,194 @@ mod tests {
         let req = axum::http::Request::builder()
             .method("POST")
             .uri(format!("/{}/api/models/my-model/upload/main", f.repo_key))
+            .header("x-filename", "weights.bin")
+            .body(axum::body::Body::from(vec![0u8; 16]))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert!(
+            status == StatusCode::OK || status == StatusCode::CREATED,
+            "got {}",
+            status
+        );
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Namespaced model id ("org/name") routing.
+    //
+    // Real Hugging Face model IDs are almost always namespaced (e.g.
+    // "sentence-transformers/all-MiniLM-L6-v2"). Axum's single-segment
+    // `:model_id` placeholder cannot match a value containing `/`, so these
+    // tests exercise the `:namespace/:name` router variants added to fix
+    // that 404.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_huggingface_resolve_serves_local_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        let model_id = "sentence-transformers/all-MiniLM-L6-v2";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            &format!("huggingface/{model_id}/main/config.json"),
+            &format!("{model_id}/main/config.json"),
+            model_id,
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"x\":1}"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/{}/resolve/main/config.json",
+                f.repo_key, model_id
+            )),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"{\"x\":1}");
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_resolve_404_when_missing_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let app = f.router_anon(super::router());
+        let (status, _) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/missing-org/missing-model/resolve/main/missing.bin",
+                f.repo_key
+            )),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        let model_id = "sentence-transformers/all-MiniLM-L6-v2";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            &format!("huggingface/{model_id}/main/config.json"),
+            &format!("{model_id}/main/config.json"),
+            model_id,
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"x\":1}"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/api/models/{}", f.repo_key, model_id)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["modelId"], model_id);
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_model_info_404_when_missing_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let app = f.router_anon(super::router());
+        let (status, _) = tdh::send(
+            app,
+            tdh::get(format!("/{}/api/models/missing-org/missing", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_tree_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        let model_id = "sentence-transformers/all-MiniLM-L6-v2";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            &format!("huggingface/{model_id}/main/config.json"),
+            &format!("{model_id}/main/config.json"),
+            model_id,
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"x\":1}"),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/api/models/{}/tree/main", f.repo_key, model_id)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json[0]["path"], "config.json");
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_upload_unauthenticated_401_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let app = f.router_anon(super::router());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/api/models/my-org/my-model/upload/main",
+                f.repo_key
+            ))
+            .header("x-filename", "file.bin")
+            .body(axum::body::Body::from("data"))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_huggingface_upload_succeeds_for_local_namespaced() {
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let app = f.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/api/models/my-org/my-model/upload/main",
+                f.repo_key
+            ))
             .header("x-filename", "weights.bin")
             .body(axum::body::Body::from(vec![0u8; 16]))
             .unwrap();

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -368,6 +368,52 @@ async fn proxy_model_info(
     ))
 }
 
+/// Fetch the commit sha upstream reports for `(model_id, revision)`, via the
+/// same model-info pull-through [`proxy_model_info`] proxies
+/// (`api/models/{model_id}/revision/{revision}`), parsing the JSON `"sha"`
+/// field. Used by [`download_file_impl`] to inject `X-Repo-Commit` on the
+/// resolve response for Remote repos: `huggingface_hub`'s HEAD-based
+/// metadata check hard-requires that header, and it only ever exists on the
+/// upstream 302/307 hop that the shared reqwest client's auto-follow
+/// swallows (see `hf-deepdive-report.md`), so recovering it from the
+/// separately-proxied model-info document sidesteps the redirect problem
+/// entirely.
+///
+/// Returns `None` when the repo isn't Remote, has no upstream/proxy wired
+/// up, or the upstream call fails or doesn't parse - this is best-effort
+/// metadata, never worth failing the file download over. The metadata
+/// fetch flows through `ProxyService`'s existing cache, so steady-state
+/// cost is a cache read, identical on fresh and cached file serves.
+async fn fetch_upstream_commit_sha(
+    state: &SharedState,
+    repo: &RepoInfo,
+    model_id: &str,
+    revision: &str,
+) -> Option<String> {
+    if proxy_helpers::classify_remote_or_virtual(&repo.repo_type)
+        != proxy_helpers::RemoteOrVirtualAction::Remote
+    {
+        return None;
+    }
+    let upstream_url = repo.upstream_url.as_deref()?;
+    let proxy = state.proxy_service.as_deref()?;
+
+    let upstream_path = format!("api/models/{model_id}/revision/{revision}");
+    let (bytes, _content_type) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        &repo.key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    .ok()?;
+
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("sha")?.as_str().map(str::to_string)
+}
+
 // ---------------------------------------------------------------------------
 // GET /huggingface/{repo_key}/{model_id}/resolve/{revision}/{filename} — Download file
 // ---------------------------------------------------------------------------
@@ -436,7 +482,7 @@ async fn download_file_impl(
         Ok(a) => a,
         Err(not_found) => {
             let upstream_path = format!("{}/resolve/{}/{}", model_id, revision, filename);
-            if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
+            if let Some(mut resp) = proxy_helpers::try_remote_or_virtual_download(
                 &state,
                 &repo,
                 &ctx,
@@ -450,6 +496,18 @@ async fn download_file_impl(
             )
             .await?
             {
+                // `huggingface_hub`'s HEAD-based metadata check hard-requires
+                // `X-Repo-Commit` (see hf-deepdive-report.md); Remote-repo
+                // responses need it injected here since the upstream redirect
+                // hop that would otherwise carry it is swallowed by the
+                // shared reqwest client's auto-follow.
+                if let Some(sha) =
+                    fetch_upstream_commit_sha(&state, &repo, &model_id, &revision).await
+                {
+                    if let Ok(value) = axum::http::HeaderValue::from_str(&sha) {
+                        resp.headers_mut().insert("x-repo-commit", value);
+                    }
+                }
                 return Ok(resp);
             }
             return Err(not_found);
@@ -1345,6 +1403,122 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["modelId"], "sentence-transformers/all-MiniLM-L6-v2");
         assert_eq!(json["siblings"].as_array().unwrap().len(), 2);
+    }
+
+    /// `huggingface_hub`'s HEAD-based metadata check hard-requires an ETag
+    /// (`X-Linked-Etag` or plain `ETag`) on the resolve response, or it raises
+    /// `FileMetadataError` -> `LocalEntryNotFoundError` (see
+    /// hf-deepdive-report.md). The proxy response builder must forward
+    /// whatever ETag upstream sent rather than synthesizing a bare 200 with
+    /// only Content-Type/Content-Length.
+    #[tokio::test]
+    async fn test_huggingface_resolve_carries_upstream_etag_header() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"72b987e498d7e3a1\"")
+                    .set_body_bytes(b"{\"hidden_size\": 384}".to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let resp = app
+            .oneshot(tdh::get(format!(
+                "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+                f.repo_key
+            )))
+            .await
+            .expect("resolve oneshot");
+
+        f.teardown().await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let etag = resp
+            .headers()
+            .get(axum::http::header::ETAG)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(
+            etag,
+            Some("\"72b987e498d7e3a1\""),
+            "the proxy must forward the upstream ETag so huggingface_hub's \
+             HEAD-based metadata check (which hard-requires an ETag) succeeds"
+        );
+    }
+
+    /// `huggingface_hub`'s HEAD-based metadata check also hard-requires
+    /// `X-Repo-Commit`, which only ever exists on the upstream redirect hop
+    /// that the shared reqwest client's auto-follow swallows (see
+    /// hf-deepdive-report.md). The handler recovers it from the model-info
+    /// pull-through instead (`api/models/{model_id}/revision/{revision}`,
+    /// parsing the `"sha"` field) and injects it as `X-Repo-Commit` on the
+    /// resolve response.
+    #[tokio::test]
+    async fn test_huggingface_resolve_carries_x_repo_commit_from_model_info() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "modelId": "sentence-transformers/all-MiniLM-L6-v2",
+                "sha": "1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf",
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(b"{\"hidden_size\": 384}".to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let resp = app
+            .oneshot(tdh::get(format!(
+                "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+                f.repo_key
+            )))
+            .await
+            .expect("resolve oneshot");
+
+        f.teardown().await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let commit = resp
+            .headers()
+            .get("x-repo-commit")
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(
+            commit,
+            Some("1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf"),
+            "the resolve response must carry X-Repo-Commit sourced from the \
+             model-info sha, since huggingface_hub's HEAD-based metadata check \
+             hard-requires it"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -19,8 +19,8 @@
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::header::CONTENT_TYPE;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::header::{CONTENT_TYPE, ETAG};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Extension;
@@ -28,11 +28,13 @@ use axum::Router;
 use bytes::Bytes;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
+use std::time::Duration;
 use tracing::info;
 
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
+use crate::services::proxy_service::UPSTREAM_COMMIT_HEADER;
 
 // ---------------------------------------------------------------------------
 // Limits
@@ -52,6 +54,145 @@ const MAX_REVISION_LEN: usize = 255;
 /// so the artifact path must stay within 2036 to keep the storage key under
 /// the column limit.
 const MAX_PATH_LEN: usize = 2036;
+
+/// Total deadline for the best-effort model-info fallback in
+/// [`fetch_upstream_commit_sha`] (#2915).
+///
+/// The shared upstream client sets only `connect_timeout` and a per-frame
+/// `read_timeout` (see `services::http_client`), so a model-info endpoint that
+/// trickles bytes has no *total* bound and can stall a file download far longer
+/// than the download itself would take. This fallback exists purely to recover
+/// a metadata header, so it gets its own hard ceiling and gives up quietly
+/// rather than holding the client's file response hostage.
+const COMMIT_SHA_FALLBACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+// ---------------------------------------------------------------------------
+// Read-path input validation
+// ---------------------------------------------------------------------------
+
+/// Validate a `model_id` (and optionally a `revision`) taken from a request
+/// path, on **every** route rather than only on upload (#2915).
+///
+/// The length ceilings are database-shaped: `artifacts.name` is VARCHAR(512)
+/// and `artifacts.version` is VARCHAR(255), so an over-long value on a write
+/// would fail with an opaque constraint error, and on a read it is simply a
+/// value no stored row can ever match. Rejecting both at the boundary keeps the
+/// error message the same on every route.
+///
+/// The `..` and NUL rejections mirror `npm::validate_package_name`: axum has
+/// already percent-decoded these captures exactly once by the time a handler
+/// sees them, so `%2e%2e` (from a doubly-encoded `%252e%252e`) arrives decoded
+/// and a substring test on the decoded value is the check that actually bites.
+/// Substrings like `foo..bar` are rejected too — Hugging Face model IDs and git
+/// ref names do not contain `..` (git explicitly forbids it in ref names), so
+/// there is no legitimate value to lose.
+///
+/// The `filename` capture is deliberately not checked here: it is a `*filename`
+/// wildcard whose only use is the exact-match local lookup and the upstream
+/// path, and the latter is validated where the proxy-cache key is derived (see
+/// [`proxy_model_info`]).
+#[allow(clippy::result_large_err)]
+fn validate_model_coordinates(model_id: &str, revision: Option<&str>) -> Result<(), Response> {
+    validate_path_component("Model ID", model_id, MAX_MODEL_ID_LEN)?;
+    if let Some(revision) = revision {
+        validate_path_component("Revision", revision, MAX_REVISION_LEN)?;
+    }
+    Ok(())
+}
+
+/// Shared body of [`validate_model_coordinates`], applied once per captured
+/// component so both carry identical rules and identical error wording.
+#[allow(clippy::result_large_err)]
+fn validate_path_component(label: &str, value: &str, max_len: usize) -> Result<(), Response> {
+    if value.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, format!("{label} cannot be empty")).into_response());
+    }
+    if value.len() > max_len {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "{} exceeds maximum length of {} characters (got {})",
+                label,
+                max_len,
+                value.len()
+            ),
+        )
+            .into_response());
+    }
+    if value.contains('\0') {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("{label} contains null bytes"),
+        )
+            .into_response());
+    }
+    if value.contains("..") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("{label} contains path traversal"),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Percent-encode a decoded revision so it occupies exactly one segment of an
+/// upstream Hugging Face path (#2915).
+///
+/// `hf download --revision refs/pr/1` puts `resolve/refs%2Fpr%2F1/<file>` on
+/// the wire; axum decodes that capture once, so the handler holds
+/// `refs/pr/1`. Concatenating the decoded value straight into
+/// `{model_id}/resolve/{revision}/{filename}` produced
+/// `…/resolve/refs/pr/1/config.json`, which is a shape the Hub's API does not
+/// serve — the download 404'd (or worse, resolved a different file) and the
+/// model-info request built the same way silently returned nothing, so
+/// `X-Repo-Commit` went missing too.
+///
+/// Re-encoding rather than rejecting is deliberate: `refs/pr/N` and
+/// `refs/convert/parquet` are ordinary Hub revisions that `huggingface_hub`
+/// itself emits (`hf_hub_url` builds them with `quote(revision, safe="")`), so
+/// rejecting slash-bearing revisions would drop a supported client feature to
+/// fix a spelling bug. `urlencoding::encode` matches `quote(safe="")` — it
+/// leaves `A-Za-z0-9-_.~` alone, so ordinary revisions (`main`, a 40-hex sha,
+/// `v1.0`) pass through byte-identical and no existing cache key moves.
+fn encode_upstream_revision(revision: &str) -> String {
+    urlencoding::encode(revision).into_owned()
+}
+
+/// The `X-Repo-Commit` / model-info `sha` value served for a Local/hosted (or
+/// Virtual local-member) Hugging Face repository (#2915).
+///
+/// These repositories have no git history, so there is no real commit to
+/// report — but `huggingface_hub` hard-requires the header on a resolve and
+/// then *names the snapshot directory after it*
+/// (`<cache>/models--org--name/snapshots/<commit>/`). That makes two
+/// properties load-bearing, and neither is "be a real commit":
+///
+///   * **Stable per `(model_id, revision)`.** `snapshot_download` takes the
+///     commit from model-info and computes the snapshot directory from it, then
+///     downloads each file and files it under the commit *that file's* resolve
+///     reported. A value that varied per file would scatter one model across
+///     several snapshot directories and the directory `snapshot_download`
+///     returns would come back incomplete. Deriving it from the coordinates
+///     alone — not from any file's bytes — makes every file of a revision agree
+///     by construction, with no extra query.
+///   * **40 lowercase hex characters.** `huggingface_hub` matches candidate
+///     commit hashes against `^[0-9a-f]{40}$` before it will treat a revision
+///     as already-resolved, so a 64-character digest silently disables that
+///     fast path.
+///
+/// Per-file content identity is carried by the ETag instead (the artifact's
+/// `checksum_sha256`), which is what `huggingface_hub` keys its blob store on —
+/// so re-uploading a file at the same revision still invalidates the client's
+/// copy even though this value does not move.
+fn local_repo_commit_sha(model_id: &str, revision: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(model_id.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(revision.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    digest[..40].to_string()
+}
 
 // ---------------------------------------------------------------------------
 // Router
@@ -242,6 +383,7 @@ async fn model_info_impl(
     revision: Option<String>,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
+    validate_model_coordinates(&model_id, revision.as_deref())?;
 
     let artifact =
         proxy_helpers::find_artifact_by_name_lowercase(&state.db, repo.id, &model_id).await?;
@@ -298,9 +440,22 @@ async fn model_info_impl(
         .unwrap_or("")
         .to_string();
 
+    // `sha` must be the SAME value the resolve route reports in
+    // `X-Repo-Commit` for this `(model_id, revision)`, or `snapshot_download`
+    // computes its snapshot directory from one value and files the downloaded
+    // blobs under the other (#2915 - see `local_repo_commit_sha`). It used to
+    // be this artifact's `checksum_sha256`, which is per-FILE and 64 hex
+    // characters: it disagreed with every sibling in the same revision and was
+    // never a commit identifier in the first place. Per-file content identity
+    // is still exposed - as the resolve ETag, where `huggingface_hub` looks for
+    // it.
+    let commit_revision = revision
+        .as_deref()
+        .or(artifact.version.as_deref())
+        .unwrap_or("main");
     let json = serde_json::json!({
         "modelId": model_id,
-        "sha": artifact.checksum_sha256,
+        "sha": local_repo_commit_sha(&model_id, commit_revision),
         "lastModified": artifact.version.clone().unwrap_or_default(),
         "pipeline_tag": pipeline_tag,
         "tags": [],
@@ -320,17 +475,90 @@ async fn model_info_impl(
 ///
 /// The upstream path mirrors the real `huggingface_hub` client request:
 /// `api/models/{model_id}` with no revision, or
-/// `api/models/{model_id}/revision/{revision}` when one is given.
-/// `proxy_fetch_capped` runs the request through `ProxyService`'s existing
-/// cache-path validator (rejects `..` segments etc.), so no separate
-/// traversal guard is needed here - `model_id` flows into that same
-/// validated path exactly as it already does for `download_file_impl`'s
-/// `resolve/{revision}/{filename}` upstream path.
+/// `api/models/{model_id}/revision/{revision}` when one is given, with the
+/// revision put back into its single-segment wire spelling by
+/// [`encode_upstream_revision`].
+///
+/// Two independent things check that path for traversal, and it is worth being
+/// precise about which is which because only the first belongs to this module:
+///
+///   * The caller has already run [`validate_model_coordinates`] on `model_id`
+///     and `revision`, which rejects `..` and NUL in the *decoded* values that
+///     reach the handler. That is this file's own guarantee and the one the
+///     read-path tests pin.
+///   * `proxy_fetch_capped` then derives a proxy-cache key from the assembled
+///     path, and that derivation validates it inside `ProxyService`
+///     (`validate_cache_path`: empty/NUL/backslash/dot segments, including the
+///     percent-encoded dot spellings `%2e`, `.%2e`, `%2e.` and `%2e%2e` that the
+///     `url` crate folds back into dot segments when it parses the fetch URL).
+///
+/// An earlier version of this comment claimed the second check alone made a
+/// local guard unnecessary. That was wrong at the time: the validator then
+/// compared segments against `..` literally, and axum decodes a captured
+/// parameter exactly once, so a request spelled `%252e%252e` arrived here as the
+/// literal `%2e%2e`, passed the comparison, and was only collapsed into a dot
+/// segment later by the URL parser. The validator has since been hardened to
+/// reject the encoded spellings as well, but it lives in another module and can
+/// change without this one, so it is relied on here as defence in depth rather
+/// than as the guarantee.
 async fn proxy_model_info(
     state: &SharedState,
     repo: &RepoInfo,
     model_id: &str,
     revision: Option<&str>,
+) -> Result<Option<Response>, Response> {
+    let upstream_path = match revision {
+        Some(rev) => format!(
+            "api/models/{model_id}/revision/{}",
+            encode_upstream_revision(rev)
+        ),
+        None => format!("api/models/{model_id}"),
+    };
+    proxy_hf_metadata_json(state, repo, &upstream_path).await
+}
+
+/// Proxy the upstream Hugging Face file-tree JSON for a Remote repo (#2915).
+///
+/// `list_files_impl` answers from the local `artifacts` table, and a Remote
+/// repository intentionally keeps no `artifacts` rows for proxied content
+/// (#1278) - so its prefix query matched nothing and the endpoint returned `[]`
+/// with 200 for every uncached model. That is the same fail-open this PR removed
+/// from `model_info`, left standing on the sibling endpoint: a client cannot
+/// tell "this revision has no files" from "this backend never asked upstream".
+///
+/// Same contract as [`proxy_model_info`]: `Ok(None)` for a non-Remote repo so
+/// the caller keeps its existing behaviour, `Err` for a real upstream failure.
+///
+/// Only the first page is proxied. The Hub paginates large trees with a `Link:
+/// rel="next"` header, which `proxy_fetch_capped` does not follow, so a model
+/// with more entries than one page holds is reported short here. `hf download`
+/// does not use this endpoint (it lists files from model-info `siblings`), so
+/// that limitation is not on the download path.
+async fn proxy_model_tree(
+    state: &SharedState,
+    repo: &RepoInfo,
+    model_id: &str,
+    revision: &str,
+) -> Result<Option<Response>, Response> {
+    let upstream_path = format!(
+        "api/models/{model_id}/tree/{}",
+        encode_upstream_revision(revision)
+    );
+    proxy_hf_metadata_json(state, repo, &upstream_path).await
+}
+
+/// Shared body of [`proxy_model_info`] and [`proxy_model_tree`]: fetch a
+/// buffered JSON metadata document from a Remote repo's upstream and hand it
+/// back verbatim.
+///
+/// Keeping the Remote/upstream/proxy-wired guards and the capped fetch in one
+/// place is what makes the two endpoints propagate upstream failures
+/// identically - the fail-open the tree endpoint had was precisely a matter of
+/// its not sharing this code.
+async fn proxy_hf_metadata_json(
+    state: &SharedState,
+    repo: &RepoInfo,
+    upstream_path: &str,
 ) -> Result<Option<Response>, Response> {
     if proxy_helpers::classify_remote_or_virtual(&repo.repo_type)
         != proxy_helpers::RemoteOrVirtualAction::Remote
@@ -344,17 +572,12 @@ async fn proxy_model_info(
         return Ok(None);
     };
 
-    let upstream_path = match revision {
-        Some(rev) => format!("api/models/{model_id}/revision/{rev}"),
-        None => format!("api/models/{model_id}"),
-    };
-
     let (bytes, _content_type) = proxy_helpers::proxy_fetch_capped(
         proxy,
         repo.id,
         &repo.key,
         upstream_url,
-        &upstream_path,
+        upstream_path,
         proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
     )
     .await?;
@@ -368,22 +591,37 @@ async fn proxy_model_info(
     ))
 }
 
-/// Fetch the commit sha upstream reports for `(model_id, revision)`, via the
-/// same model-info pull-through [`proxy_model_info`] proxies
-/// (`api/models/{model_id}/revision/{revision}`), parsing the JSON `"sha"`
-/// field. Used by [`download_file_impl`] to inject `X-Repo-Commit` on the
-/// resolve response for Remote repos: `huggingface_hub`'s HEAD-based
-/// metadata check hard-requires that header, and it only ever exists on the
-/// upstream 302/307 hop that the shared reqwest client's auto-follow
-/// swallows (see `hf-deepdive-report.md`), so recovering it from the
-/// separately-proxied model-info document sidesteps the redirect problem
-/// entirely.
+/// Last-resort recovery of upstream's commit sha for `(model_id, revision)`,
+/// read out of the model-info document's `"sha"` field.
 ///
-/// Returns `None` when the repo isn't Remote, has no upstream/proxy wired
-/// up, or the upstream call fails or doesn't parse - this is best-effort
-/// metadata, never worth failing the file download over. The metadata
-/// fetch flows through `ProxyService`'s existing cache, so steady-state
-/// cost is a cache read, identical on fresh and cached file serves.
+/// **This is a fallback, and only a fallback.** `ProxyService` now captures
+/// upstream's own `X-Repo-Commit` response header, stores it in the cache
+/// sidecar next to the bytes it describes, and replays it on cache hits and
+/// stale-if-error serves; `build_streaming_response_with_disposition` emits it.
+/// So the ordinary Remote resolve already carries the header, bound to the exact
+/// bytes being served, and [`ensure_resolve_metadata_headers`] calls this
+/// function *only* when that header is absent.
+///
+/// Why it is still worth keeping (#2915): the Hub serves LFS objects as a 302 to
+/// its CDN and puts `X-Repo-Commit` (and `X-Linked-Etag`) on the *redirect*,
+/// while the shared reqwest client follows redirects itself and only exposes the
+/// final hop's headers. Model weights are exactly the files that take that path,
+/// so dropping this fallback would leave `hf download` without a commit header
+/// on the one file type it most needs one for. The genuinely correct fix is to
+/// capture the header from the intermediate hop in `ProxyService`; until that
+/// exists, this recovers the value from a document the Hub serves without a
+/// redirect.
+///
+/// It is deliberately weaker than the forwarded header and must never be
+/// preferred to it: model-info is a *separate* observation of a mutable ref, so
+/// if `main` advances between the two calls this reports a commit that does not
+/// contain the bytes just served - and `huggingface_hub` would then file those
+/// bytes under the wrong snapshot directory.
+///
+/// Returns `None` when the repo isn't Remote, has no upstream/proxy wired up, or
+/// the fetch fails, times out, or doesn't parse. Never propagates an error:
+/// losing a metadata header degrades `hf download` to its
+/// no-header path, whereas failing the request loses the file.
 async fn fetch_upstream_commit_sha(
     state: &SharedState,
     repo: &RepoInfo,
@@ -398,20 +636,196 @@ async fn fetch_upstream_commit_sha(
     let upstream_url = repo.upstream_url.as_deref()?;
     let proxy = state.proxy_service.as_deref()?;
 
-    let upstream_path = format!("api/models/{model_id}/revision/{revision}");
-    let (bytes, _content_type) = proxy_helpers::proxy_fetch_capped(
+    let upstream_path = format!(
+        "api/models/{model_id}/revision/{}",
+        encode_upstream_revision(revision)
+    );
+    let fetch = proxy_helpers::proxy_fetch_capped(
         proxy,
         repo.id,
         &repo.key,
         upstream_url,
         &upstream_path,
         proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-    )
-    .await
-    .ok()?;
+    );
+
+    // Own deadline, not the shared client's: see `COMMIT_SHA_FALLBACK_TIMEOUT`.
+    let bytes = match tokio::time::timeout(COMMIT_SHA_FALLBACK_TIMEOUT, fetch).await {
+        Ok(Ok((bytes, _content_type))) => bytes,
+        Ok(Err(_response)) => {
+            tracing::debug!(
+                repo_key = %repo.key,
+                model_id,
+                revision,
+                "upstream model-info lookup failed; serving the file without X-Repo-Commit"
+            );
+            return None;
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                repo_key = %repo.key,
+                model_id,
+                revision,
+                timeout_secs = COMMIT_SHA_FALLBACK_TIMEOUT.as_secs(),
+                "upstream model-info lookup exceeded its deadline; serving the file \
+                 without X-Repo-Commit"
+            );
+            return None;
+        }
+    };
 
     let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
     json.get("sha")?.as_str().map(str::to_string)
+}
+
+/// Give a resolve response the two headers `huggingface_hub`'s HEAD-based
+/// metadata probe refuses to work without - an ETag and `X-Repo-Commit` - when
+/// the arm that produced it did not already supply them (#2915).
+///
+/// Both are only *added*, never overwritten, so anything the upstream (or an
+/// upstream-backed cache entry) already said wins. What "missing" means differs
+/// per repository type:
+///
+///   * **Remote.** The bytes are upstream's, so an ETag is upstream's to state
+///     and is never synthesized here - inventing one would let a client cache a
+///     proxied object under an identity this backend made up. Only the commit is
+///     recoverable, via [`fetch_upstream_commit_sha`].
+///   * **Virtual.** A Remote member's serve already carries both. A *local*
+///     member's serve comes back with neither, because it is assembled from
+///     stored bytes rather than an HTTP response - so it gets the local
+///     treatment below, keyed on the member row that actually won the
+///     member-priority race.
+///   * **Hosted.** Handled by the caller directly (it already holds the
+///     artifact row), not through this function.
+async fn ensure_resolve_metadata_headers(
+    state: &SharedState,
+    repo: &RepoInfo,
+    model_id: &str,
+    revision: &str,
+    artifact_path: &str,
+    resp: &mut Response,
+) {
+    let needs_commit = !resp.headers().contains_key(UPSTREAM_COMMIT_HEADER);
+    let needs_etag = !resp.headers().contains_key(ETAG);
+    if !needs_commit && !needs_etag {
+        return;
+    }
+
+    if proxy_helpers::classify_remote_or_virtual(&repo.repo_type)
+        == proxy_helpers::RemoteOrVirtualAction::Remote
+    {
+        if needs_commit {
+            if let Some(sha) = fetch_upstream_commit_sha(state, repo, model_id, revision).await {
+                insert_header_if_valid(resp, UPSTREAM_COMMIT_HEADER, &sha);
+            }
+        }
+        return;
+    }
+
+    // Virtual: only a local member's bytes get local metadata. If no local
+    // member owns this path the serve came from a Remote member, and whatever
+    // that member's upstream said (possibly nothing) is the honest answer.
+    let Some(checksum) = virtual_member_checksum(&state.db, repo.id, artifact_path).await else {
+        return;
+    };
+    apply_local_metadata_headers(resp, Some(&checksum), model_id, revision);
+}
+
+/// Set the ETag and `X-Repo-Commit` for bytes this instance stores itself
+/// (a hosted artifact, or a Virtual repo's local-member artifact).
+///
+/// The ETag is the artifact's stored `checksum_sha256`, quoted as RFC 9110
+/// requires - `huggingface_hub` names its local blob file after this value, so a
+/// content hash is exactly the right identity and an unquoted one would be an
+/// invalid entity-tag. `X-Repo-Commit` comes from [`local_repo_commit_sha`].
+///
+/// The checksum is trimmed first: `artifacts.checksum_sha256` is `CHAR(64)`, so
+/// Postgres blank-pads anything shorter than 64 characters on read and the raw
+/// value would produce an entity-tag with trailing spaces inside the quotes.
+/// A real SHA-256 fills the column exactly, but nothing enforces that at the
+/// type level.
+///
+/// Neither header is overwritten if already present, and both go through
+/// [`insert_header_if_valid`].
+fn apply_local_metadata_headers(
+    resp: &mut Response,
+    checksum_sha256: Option<&str>,
+    model_id: &str,
+    revision: &str,
+) {
+    if !resp.headers().contains_key(ETAG) {
+        if let Some(checksum) = checksum_sha256.map(str::trim).filter(|c| !c.is_empty()) {
+            insert_header_if_valid(resp, ETAG.as_str(), &format!("\"{checksum}\""));
+        }
+    }
+    if !resp.headers().contains_key(UPSTREAM_COMMIT_HEADER) {
+        insert_header_if_valid(
+            resp,
+            UPSTREAM_COMMIT_HEADER,
+            &local_repo_commit_sha(model_id, revision),
+        );
+    }
+}
+
+/// Insert `name: value` on `resp`, dropping the header if `value` cannot be a
+/// header value at all.
+///
+/// Every value routed through here is derived from data (a stored checksum, an
+/// upstream JSON field), so `HeaderValue::from_str` is checked rather than
+/// unwrapped: its rejection of CR/LF is what stops an upstream `"sha"` from
+/// splicing extra headers into our response, and a value we cannot represent is
+/// worth losing a metadata header over, not the download.
+fn insert_header_if_valid(resp: &mut Response, name: &str, value: &str) {
+    if let Ok(value) = HeaderValue::from_str(value) {
+        if let Ok(name) = axum::http::HeaderName::from_bytes(name.as_bytes()) {
+            resp.headers_mut().insert(name, value);
+        }
+    }
+}
+
+/// `checksum_sha256` of the artifact a Virtual repository's local member served
+/// for `artifact_path`, or `None` when no local member owns it.
+///
+/// Resolves the same row `resolve_virtual_download` finalizes on - first
+/// non-Remote member by `virtual_repo_members.priority` holding a live artifact
+/// at the exact path - so the ETag describes the bytes that were actually sent.
+/// Mirrors `proxy_helpers::virtual_local_winner_artifact_id`, which re-derives
+/// the same row for download attribution.
+///
+/// Best-effort like that helper: a database error logs and yields `None` so the
+/// download proceeds without the header.
+async fn virtual_member_checksum(
+    db: &PgPool,
+    virtual_repo_id: uuid::Uuid,
+    artifact_path: &str,
+) -> Option<String> {
+    match sqlx::query_scalar::<_, Option<String>>(
+        "SELECT a.checksum_sha256 FROM artifacts a \
+         JOIN virtual_repo_members vrm ON vrm.member_repo_id = a.repository_id \
+         JOIN repositories r ON r.id = a.repository_id \
+         WHERE vrm.virtual_repo_id = $1 \
+           AND r.repo_type != 'remote' \
+           AND a.path = $2 \
+           AND a.is_deleted = false \
+         ORDER BY vrm.priority \
+         LIMIT 1",
+    )
+    .bind(virtual_repo_id)
+    .bind(artifact_path)
+    .fetch_optional(db)
+    .await
+    {
+        Ok(checksum) => checksum.flatten(),
+        Err(e) => {
+            tracing::warn!(
+                %virtual_repo_id,
+                artifact_path,
+                error = %e,
+                "failed to resolve virtual member checksum; serving without an ETag"
+            );
+            None
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -457,73 +871,100 @@ async fn download_file_impl(
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
+    validate_model_coordinates(&model_id, Some(&revision))?;
 
     let filename = filename.trim_start_matches('/');
     let artifact_path = format!("{}/{}/{}", model_id, revision, filename);
 
-    let artifact = sqlx::query!(
-        r#"
-        SELECT id, path, storage_key, size_bytes
-        FROM artifacts
-        WHERE repository_id = $1
-          AND is_deleted = false
-          AND path = $2
-        LIMIT 1
-        "#,
-        repo.id,
-        artifact_path
+    // Runtime query rather than `sqlx::query!` so `checksum_sha256` can be read
+    // alongside the storage key in a single round trip; this is the same
+    // runtime-query + `try_get` shape
+    // `proxy_helpers::find_artifact_by_name_lowercase` uses. The checksum feeds
+    // the resolve ETag below (#2915).
+    use sqlx::Row;
+    let artifact = sqlx::query(
+        "SELECT id, storage_key, checksum_sha256 FROM artifacts \
+         WHERE repository_id = $1 \
+           AND is_deleted = false \
+           AND path = $2 \
+         LIMIT 1",
     )
+    .bind(repo.id)
+    .bind(&artifact_path)
     .fetch_optional(&state.db)
     .await
-    .map_err(super::db_err)?
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "File not found").into_response());
+    .map_err(super::db_err)?;
 
-    let artifact = match artifact {
-        Ok(a) => a,
-        Err(not_found) => {
-            let upstream_path = format!("{}/resolve/{}/{}", model_id, revision, filename);
-            if let Some(mut resp) = proxy_helpers::try_remote_or_virtual_download(
+    let Some(artifact) = artifact else {
+        // The revision is re-encoded here: axum handed us the decoded value, and
+        // the Hub expects it as one segment (`refs%2Fpr%2F1`). See
+        // `encode_upstream_revision`.
+        let upstream_path = format!(
+            "{}/resolve/{}/{}",
+            model_id,
+            encode_upstream_revision(&revision),
+            filename
+        );
+        if let Some(mut resp) = proxy_helpers::try_remote_or_virtual_download(
+            &state,
+            &repo,
+            &ctx,
+            proxy_helpers::DownloadResponseOpts {
+                upstream_path: &upstream_path,
+                virtual_lookup: proxy_helpers::VirtualLookup::ExactPath(&artifact_path),
+                default_content_type: "application/octet-stream",
+                content_disposition_filename: None,
+                suppress_upstream_proxy: false,
+            },
+        )
+        .await?
+        {
+            // Remote serves normally arrive with upstream's own ETag and
+            // `X-Repo-Commit` already forwarded by the streaming response
+            // builder; Virtual local-member serves arrive with neither. This
+            // fills only what is actually missing - and, for Remote, only after
+            // the file response exists, so the fallback round trip can be skipped
+            // entirely whenever the header came through.
+            ensure_resolve_metadata_headers(
                 &state,
                 &repo,
-                &ctx,
-                proxy_helpers::DownloadResponseOpts {
-                    upstream_path: &upstream_path,
-                    virtual_lookup: proxy_helpers::VirtualLookup::ExactPath(&artifact_path),
-                    default_content_type: "application/octet-stream",
-                    content_disposition_filename: None,
-                    suppress_upstream_proxy: false,
-                },
+                &model_id,
+                &revision,
+                &artifact_path,
+                &mut resp,
             )
-            .await?
-            {
-                // `huggingface_hub`'s HEAD-based metadata check hard-requires
-                // `X-Repo-Commit` (see hf-deepdive-report.md); Remote-repo
-                // responses need it injected here since the upstream redirect
-                // hop that would otherwise carry it is swallowed by the
-                // shared reqwest client's auto-follow.
-                if let Some(sha) =
-                    fetch_upstream_commit_sha(&state, &repo, &model_id, &revision).await
-                {
-                    if let Ok(value) = axum::http::HeaderValue::from_str(&sha) {
-                        resp.headers_mut().insert("x-repo-commit", value);
-                    }
-                }
-                return Ok(resp);
-            }
-            return Err(not_found);
+            .await;
+            return Ok(resp);
         }
+        return Err((StatusCode::NOT_FOUND, "File not found").into_response());
     };
 
-    proxy_helpers::serve_local_artifact(
+    let artifact_id: uuid::Uuid = artifact.try_get("id").map_err(super::db_err)?;
+    let storage_key: String = artifact.try_get("storage_key").map_err(super::db_err)?;
+    let checksum: Option<String> = artifact
+        .try_get::<Option<String>, _>("checksum_sha256")
+        .ok()
+        .flatten();
+
+    let mut resp = proxy_helpers::serve_local_artifact(
         &state,
         &repo,
-        artifact.id,
-        &artifact.storage_key,
+        artifact_id,
+        &storage_key,
         "application/octet-stream",
         Some(filename),
         &ctx,
     )
-    .await
+    .await?;
+
+    // A hosted serve is built by `proxy_helpers::build_download_response`, which
+    // emits only Content-Type/Content-Length/Content-Disposition - so `hf
+    // download` against a Local or hosted HF repo failed its HEAD metadata probe
+    // outright, on content this instance owns. Adding the two headers here
+    // rather than in `build_download_response` keeps the HF-specific commit
+    // semantics out of the shared, format-agnostic builder (#2915).
+    apply_local_metadata_headers(&mut resp, checksum.as_deref(), &model_id, &revision);
+    Ok(resp)
 }
 
 // ---------------------------------------------------------------------------
@@ -578,31 +1019,10 @@ async fn upload_file_impl(
         return Err((StatusCode::BAD_REQUEST, "Empty file body").into_response());
     }
 
-    // Validate model_id length: the `name` database column is VARCHAR(512)
-    if model_id.len() > MAX_MODEL_ID_LEN {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Model ID exceeds maximum length of {} characters (got {})",
-                MAX_MODEL_ID_LEN,
-                model_id.len()
-            ),
-        )
-            .into_response());
-    }
-
-    // Validate revision length: the `version` database column is VARCHAR(255)
-    if revision.len() > MAX_REVISION_LEN {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Revision exceeds maximum length of {} characters (got {})",
-                MAX_REVISION_LEN,
-                revision.len()
-            ),
-        )
-            .into_response());
-    }
+    // Length ceilings (`name` is VARCHAR(512), `version` is VARCHAR(255)) plus
+    // the traversal/NUL rejections, from the one helper the read paths also use
+    // so upload and download can never diverge on what they accept (#2915).
+    validate_model_coordinates(&model_id, Some(&revision))?;
 
     // Extract filename from X-Filename or Content-Disposition header.
     let filename = filename_from_headers(&headers);
@@ -718,8 +1138,18 @@ async fn list_files_impl(
     revision: String,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
+    validate_model_coordinates(&model_id, Some(&revision))?;
 
-    let path_prefix = super::escape_path_prefix(&[&model_id, &revision]);
+    // Two prefixes, deliberately: the LIKE pattern is escaped so `%`/`_`/`\` in
+    // a model ID or revision cannot widen the match, while the prefix stripped
+    // off each returned path must be the LITERAL one. Using the escaped form for
+    // both meant any model ID containing `_` (`bert_base_uncased`, and plenty of
+    // real Hub IDs) produced a pattern of `bert\_base_uncased/main/`, which
+    // `strip_prefix` could not match - so `unwrap_or` fell through and the
+    // endpoint reported every entry under its full stored path instead of the
+    // path relative to the revision.
+    let like_prefix = super::escape_path_prefix(&[&model_id, &revision]);
+    let path_prefix = format!("{}/{}/", model_id, revision);
 
     let artifacts = sqlx::query!(
         r#"
@@ -731,11 +1161,22 @@ async fn list_files_impl(
         ORDER BY path
         "#,
         repo.id,
-        path_prefix
+        like_prefix
     )
     .fetch_all(&state.db)
     .await
     .map_err(super::db_err)?;
+
+    // Remote pull-through. Nothing local means one of two very different things
+    // for a Remote repo, and answering `[]` with 200 conflated them - see
+    // `proxy_model_tree`. Gating on emptiness (rather than on repo type) keeps
+    // artifacts that were promoted into a Remote repo authoritative, exactly as
+    // `model_info_impl` does.
+    if artifacts.is_empty() {
+        if let Some(resp) = proxy_model_tree(&state, &repo, &model_id, &revision).await? {
+            return Ok(resp);
+        }
+    }
 
     let files: Vec<serde_json::Value> = artifacts
         .iter()
@@ -1130,13 +1571,24 @@ mod tests {
         f.teardown().await;
     }
 
+    /// The namespaced resolve route must 404 through `download_file_impl`, not
+    /// through axum's router fallback.
+    ///
+    /// This distinction is the whole point of the assertion on the body. Before
+    /// the namespaced routes existed, `/{repo}/org/model/resolve/main/f.bin`
+    /// matched NO route, so axum's fallback produced a bodyless 404 and a
+    /// status-only assertion passed on code that had no feature at all. Pinning
+    /// the handler's own error string means this test can only pass when the
+    /// request actually reached `download_file_impl` (#2915).
     #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
     async fn test_huggingface_resolve_404_when_missing_namespaced() {
         let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
             return;
         };
         let app = f.router_anon(super::router());
-        let (status, _) = tdh::send(
+        let (status, body) = tdh::send(
             app,
             tdh::get(format!(
                 "/{}/missing-org/missing-model/resolve/main/missing.bin",
@@ -1145,6 +1597,12 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap_or_default(),
+            "File not found",
+            "the 404 must be `download_file_impl`'s own, proving the namespaced \
+             route was matched rather than falling through to axum's router fallback"
+        );
         f.teardown().await;
     }
 
@@ -1181,18 +1639,31 @@ mod tests {
         f.teardown().await;
     }
 
+    /// Namespaced model-info sibling of
+    /// `test_huggingface_resolve_404_when_missing_namespaced`: assert the
+    /// handler's own 404 body so "no route registered" (axum's bodyless
+    /// fallback, which is what the pre-fix code produced here) cannot be
+    /// mistaken for "route present, model genuinely absent" (#2915).
     #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
     async fn test_huggingface_model_info_404_when_missing_namespaced() {
         let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
             return;
         };
         let app = f.router_anon(super::router());
-        let (status, _) = tdh::send(
+        let (status, body) = tdh::send(
             app,
             tdh::get(format!("/{}/api/models/missing-org/missing", f.repo_key)),
         )
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap_or_default(),
+            "Model not found",
+            "the 404 must be `model_info_impl`'s own, proving the namespaced \
+             route was matched rather than falling through to axum's router fallback"
+        );
         f.teardown().await;
     }
 
@@ -1545,11 +2016,21 @@ mod tests {
     /// `Content-Encoding: gzip` body regardless of what `Accept-Encoding`
     /// the client sent, exactly reproducing the header-loss this proxy must
     /// not exhibit.
+    ///
+    /// #2915 tightened the assertions. The original test checked only the status
+    /// and `Content-Length`, never the body — so it passed while the client
+    /// received a gzip blob labelled as identity-encoded and wrote compressed
+    /// bytes to disk under a `.md` name. Now that `Content-Encoding` is forwarded
+    /// alongside the coded length, this asserts the pair a client actually needs
+    /// to make sense of the transfer: the declared encoding, and that the coded
+    /// bytes really do inflate back to the original document.
     #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
     async fn test_huggingface_resolve_survives_upstream_gzip_content_length() {
         use flate2::write::GzEncoder;
         use flate2::Compression;
-        use std::io::Write;
+        use std::io::{Read, Write};
         use tower::ServiceExt;
         use wiremock::matchers::{method, path as wm_path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1590,18 +2071,47 @@ mod tests {
         f.teardown().await;
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let content_length = resp
-            .headers()
+        let headers = resp.headers().clone();
+        let content_length = headers
             .get(axum::http::header::CONTENT_LENGTH)
-            .and_then(|v| v.to_str().ok());
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
         assert_eq!(
-            content_length,
+            content_length.as_deref(),
             Some(compressed.len().to_string().as_str()),
             "the proxy's upstream HTTP client must not silently auto-decode \
              a gzip-encoded upstream response (which would strip \
              Content-Length before this proxy's header-capture code ever \
              sees it): huggingface_hub's HEAD-based metadata check \
              hard-requires a Content-Length or it raises FileMetadataError"
+        );
+        assert_eq!(
+            headers
+                .get(axum::http::header::CONTENT_ENCODING)
+                .and_then(|v| v.to_str().ok()),
+            Some("gzip"),
+            "the coded length above is only interpretable alongside the coding \
+             that produced it: without Content-Encoding the client reads \
+             `compressed.len()` bytes and stores them as if they were the file"
+        );
+
+        let served = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect resolve body");
+        assert_eq!(
+            &served[..],
+            &compressed[..],
+            "the body must be the still-coded upstream bytes, matching the \
+             advertised Content-Length"
+        );
+        let mut inflated = Vec::new();
+        flate2::read::GzDecoder::new(&served[..])
+            .read_to_end(&mut inflated)
+            .expect("served body must be valid gzip");
+        assert_eq!(
+            inflated, body,
+            "a client that honours the declared gzip encoding must recover the \
+             original document byte for byte"
         );
     }
 
@@ -1637,7 +2147,18 @@ mod tests {
         assert_eq!(json["modelId"], "gpt2");
     }
 
+    /// A genuine upstream 404 must surface as a 404, not a silent empty 200.
+    ///
+    /// The `.expect(1)` and the body assertion together are what make this test
+    /// meaningful. `/{repo}/api/models/does-not-exist/revision/main` matched no
+    /// route before this PR, so axum's fallback returned a bodyless 404 without
+    /// upstream ever being contacted and a status-only assertion passed either
+    /// way. Requiring exactly one upstream call proves the pull-through ran, and
+    /// pinning `map_proxy_error`'s wording proves the 404 came back from it
+    /// (#2915).
     #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
     async fn test_huggingface_model_info_upstream_404_surfaces_not_empty_200() {
         use wiremock::matchers::{method, path as wm_path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1649,12 +2170,16 @@ mod tests {
         Mock::given(method("GET"))
             .and(wm_path("/api/models/does-not-exist/revision/main"))
             .respond_with(ResponseTemplate::new(404))
+            // Proof the handler consulted upstream at all: without a Remote
+            // pull-through this counter stays at 0 and the mock's verification
+            // fails when `server` drops.
+            .expect(1)
             .mount(&server)
             .await;
 
         let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
         let app = tdh::router_anon(super::router(), state);
-        let (status, _body) = tdh::send(
+        let (status, body) = tdh::send(
             app,
             tdh::get(format!(
                 "/{}/api/models/does-not-exist/revision/main",
@@ -1669,6 +2194,12 @@ mod tests {
             status,
             StatusCode::NOT_FOUND,
             "a genuine upstream 404 must surface as 404, not a silent empty 200"
+        );
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap_or_default(),
+            "Artifact not found upstream",
+            "the 404 must be the proxy's mapped upstream error, not axum's \
+             bodyless router fallback"
         );
     }
 
@@ -1717,5 +2248,751 @@ mod tests {
         );
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["modelId"], "gpt2");
+    }
+
+    // -----------------------------------------------------------------------
+    // #2914 / #2915: read-path input validation and upstream path spelling.
+    //
+    // These are pure-function tests for the boundary checks and the revision
+    // re-encoding; the DB-backed behaviour they feed is covered further down.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_model_coordinates_accepts_real_hub_shapes() {
+        for (model_id, revision) in [
+            ("gpt2", "main"),
+            ("sentence-transformers/all-MiniLM-L6-v2", "main"),
+            (
+                "sentence-transformers/all-MiniLM-L6-v2",
+                "1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf",
+            ),
+            // Slash-bearing Hub revisions must pass validation - they are
+            // re-encoded for upstream, not rejected (see
+            // `encode_upstream_revision`).
+            ("openai/whisper-large-v3", "refs/pr/1"),
+            ("openai/whisper-large-v3", "refs/convert/parquet"),
+            // A dot inside a name/tag is ordinary; only `..` is traversal.
+            ("stabilityai/sd.turbo", "v1.0"),
+        ] {
+            assert!(
+                validate_model_coordinates(model_id, Some(revision)).is_ok(),
+                "{model_id}@{revision} is a legitimate Hub coordinate"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_model_coordinates_rejects_traversal_and_overlong() {
+        // axum percent-decodes a captured parameter exactly once, so a request
+        // spelled `%252e%252e` reaches the handler as the literal `%2e%2e` and a
+        // doubly-encoded `%2e%2e` reaches it as `..`. The decoded-value check is
+        // therefore the one that has to catch traversal.
+        for (model_id, revision) in [
+            ("../../etc/passwd", "main"),
+            ("org/..", "main"),
+            ("gpt2", "../main"),
+            ("gpt2", "refs/../../secret"),
+        ] {
+            let err = validate_model_coordinates(model_id, Some(revision));
+            assert!(
+                err.is_err(),
+                "{model_id}@{revision} must be rejected at the handler boundary"
+            );
+        }
+        assert!(validate_model_coordinates(&"a".repeat(MAX_MODEL_ID_LEN + 1), None).is_err());
+        assert!(
+            validate_model_coordinates("gpt2", Some(&"v".repeat(MAX_REVISION_LEN + 1))).is_err()
+        );
+        assert!(validate_model_coordinates("gpt2\0", None).is_err());
+    }
+
+    #[test]
+    fn test_encode_upstream_revision_matches_hub_wire_spelling() {
+        // `huggingface_hub` builds resolve URLs with `quote(revision, safe="")`,
+        // so `refs/pr/1` travels as one segment. Ordinary revisions must pass
+        // through byte-identical, or every existing proxy-cache key would move.
+        assert_eq!(encode_upstream_revision("main"), "main");
+        assert_eq!(
+            encode_upstream_revision("1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf"),
+            "1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf"
+        );
+        assert_eq!(encode_upstream_revision("v1.0"), "v1.0");
+        assert_eq!(encode_upstream_revision("my-branch_x"), "my-branch_x");
+        assert_eq!(encode_upstream_revision("refs/pr/1"), "refs%2Fpr%2F1");
+        assert_eq!(
+            encode_upstream_revision("refs/convert/parquet"),
+            "refs%2Fconvert%2Fparquet"
+        );
+    }
+
+    #[test]
+    fn test_local_repo_commit_sha_is_stable_40_hex_per_coordinate() {
+        let a = local_repo_commit_sha("gpt2", "main");
+        assert_eq!(a.len(), 40, "huggingface_hub matches ^[0-9a-f]{{40}}$");
+        assert!(a
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+        // Stable: every file of a revision must report the same commit or
+        // `snapshot_download` scatters one model across snapshot directories.
+        assert_eq!(a, local_repo_commit_sha("gpt2", "main"));
+        // Distinct per coordinate, and the separator keeps the two components
+        // from running together (`("a/b", "c")` must not equal `("a", "b/c")`).
+        assert_ne!(a, local_repo_commit_sha("gpt2", "dev"));
+        assert_ne!(a, local_repo_commit_sha("gpt-2", "main"));
+        assert_ne!(
+            local_repo_commit_sha("a/b", "c"),
+            local_repo_commit_sha("a", "b/c")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2914 / #2915: the metadata headers `hf download` cannot work without.
+    //
+    // `huggingface_hub` probes every file with HEAD before downloading it
+    // (`get_hf_file_metadata`) and raises `FileMetadataError` ->
+    // `LocalEntryNotFoundError` unless that response carries an ETag, a
+    // Content-Length and `X-Repo-Commit`. `X-Repo-Commit` is now captured from
+    // upstream's own response header by `ProxyService`, stored in the cache
+    // sidecar beside the bytes it describes, and replayed on cache hits - so
+    // these tests pin both the forwarded path and the fallbacks around it.
+    // -----------------------------------------------------------------------
+
+    /// A **HEAD** resolve must return the full metadata header set and no body.
+    ///
+    /// Every other resolve test in this module issues a GET, so the exact
+    /// request shape the bug reports came from had no coverage at all. axum
+    /// dispatches HEAD to the `get(...)` handler and strips the body from the
+    /// response afterwards, which is precisely the contract `huggingface_hub`
+    /// depends on: headers as if it were a GET, zero bytes transferred.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    async fn test_huggingface_resolve_head_carries_etag_length_and_commit() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let payload = b"{\"hidden_size\": 384}".to_vec();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"72b987e498d7e3a1\"")
+                    .insert_header("x-repo-commit", "1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf")
+                    .set_body_bytes(payload.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let req = axum::http::Request::builder()
+            .method("HEAD")
+            .uri(format!(
+                "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+                f.repo_key
+            ))
+            .body(Body::empty())
+            .expect("build HEAD request");
+        let resp = app.oneshot(req).await.expect("HEAD resolve must respond");
+
+        f.teardown().await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let headers = resp.headers().clone();
+        assert_eq!(
+            headers.get(ETAG).and_then(|v| v.to_str().ok()),
+            Some("\"72b987e498d7e3a1\""),
+            "huggingface_hub names its local blob file after the ETag and fails \
+             the metadata probe outright without one"
+        );
+        assert_eq!(
+            headers
+                .get(axum::http::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(payload.len().to_string().as_str()),
+            "HEAD must still advertise the body size it would have sent"
+        );
+        assert_eq!(
+            headers
+                .get(UPSTREAM_COMMIT_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some("1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf"),
+            "X-Repo-Commit names the snapshot directory huggingface_hub stores \
+             the file under"
+        );
+
+        let collected = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect HEAD body");
+        assert!(
+            collected.is_empty(),
+            "a HEAD probe must transfer no bytes, got {}",
+            collected.len()
+        );
+    }
+
+    /// `X-Repo-Commit` comes from the resolve response's OWN header when upstream
+    /// sends one, and the model-info endpoint is not touched in that case.
+    ///
+    /// This is the path that matters most: a header captured from the same
+    /// response as the bytes is bound to those bytes, whereas the model-info
+    /// `sha` is a second, independent observation of a mutable ref and can
+    /// describe a different commit entirely. The `.expect(0)` on the model-info
+    /// mock is the load-bearing assertion — the old code fetched model-info on
+    /// *every* Remote resolve, and did it after the file response had already
+    /// been opened, so an idle file socket waited on a full extra round trip
+    /// before the client saw a byte.
+    #[tokio::test]
+    async fn test_huggingface_resolve_prefers_forwarded_commit_header() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"72b987e498d7e3a1\"")
+                    .insert_header("x-repo-commit", "aaaabbbbccccddddeeeeffff0000111122223333")
+                    .set_body_bytes(b"{\"hidden_size\": 384}".to_vec()),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sha": "9999999999999999999999999999999999999999",
+            })))
+            // The forwarded header must make this request unnecessary. A single
+            // call here would also mean the returned commit could disagree with
+            // the bytes served.
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let resp = app
+            .oneshot(tdh::get(format!(
+                "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+                f.repo_key
+            )))
+            .await
+            .expect("resolve oneshot");
+
+        f.teardown().await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(UPSTREAM_COMMIT_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some("aaaabbbbccccddddeeeeffff0000111122223333"),
+            "the commit must be the one upstream sent with these bytes, not the \
+             one a separate model-info call would report"
+        );
+    }
+
+    /// A second request for the same file must serve the identical ETag and
+    /// `X-Repo-Commit` from the proxy cache, without touching upstream.
+    ///
+    /// `.expect(1)` is what makes this a cache-hit test rather than a repeat of
+    /// the test above: both headers now travel through the cache sidecar
+    /// (`CacheMetadata::upstream_commit_sha`), so a warm serve that lost either
+    /// one would leave `huggingface_hub` unable to validate a file it had
+    /// already downloaded once.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    async fn test_huggingface_resolve_cache_hit_replays_etag_and_commit() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        // Distinct enough in size that `wait_for_cache_commit`'s size gate
+        // cannot be satisfied by some other object in the cache directory.
+        let payload = b"{\"hidden_size\": 384, \"num_layers\": 6}\n".repeat(64);
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"72b987e498d7e3a1\"")
+                    .insert_header("x-repo-commit", "1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf")
+                    .set_body_bytes(payload.clone()),
+            )
+            // Cache-hit proof: one upstream fetch across the two requests below.
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (state, cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let uri = format!(
+            "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            f.repo_key
+        );
+
+        let mut seen: Vec<(Option<String>, Option<String>)> = Vec::new();
+        for attempt in 0..2 {
+            // The streaming write-back tees into the cache as the body drains
+            // and only the metadata sidecar makes the next lookup a hit, so wait
+            // for the commit instead of racing it.
+            if attempt == 1 {
+                tdh::wait_for_cache_commit(cache.path(), payload.len() as u64).await;
+            }
+            let app = tdh::router_anon(super::router(), state.clone());
+            let resp = app
+                .oneshot(tdh::get(uri.clone()))
+                .await
+                .expect("resolve oneshot");
+            assert_eq!(resp.status(), StatusCode::OK, "attempt {attempt}");
+            let headers = resp.headers().clone();
+            seen.push((
+                headers
+                    .get(ETAG)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string),
+                headers
+                    .get(UPSTREAM_COMMIT_HEADER)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string),
+            ));
+            // Drain so the tee can finish writing the cache entry.
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("collect resolve body");
+            assert_eq!(&body[..], &payload[..], "attempt {attempt} body");
+        }
+
+        f.teardown().await;
+
+        assert_eq!(
+            seen[0],
+            (
+                Some("\"72b987e498d7e3a1\"".to_string()),
+                Some("1110a243c5cd318b8688b1e73b6ba0b9c7d6f6cf".to_string())
+            ),
+            "cold serve must forward upstream's ETag and X-Repo-Commit"
+        );
+        assert_eq!(
+            seen[1], seen[0],
+            "the warm serve must replay the SAME ETag and X-Repo-Commit from the \
+             cache sidecar; the mock's expect(1) proves it came from cache"
+        );
+    }
+
+    /// The model-info fallback is best-effort: a broken model-info endpoint must
+    /// cost the download its `X-Repo-Commit` header, never the file.
+    ///
+    /// Upstream here answers the resolve without a commit header (the shape the
+    /// Hub produces when it 302s an LFS object to its CDN and the header stays on
+    /// the redirect the HTTP client follows internally), and answers model-info
+    /// with a 500. The `.expect(1)` pins that the fallback really was attempted;
+    /// the body assertion pins that its failure changed nothing about the bytes.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    async fn test_huggingface_resolve_survives_model_info_failure() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let payload = b"{\"hidden_size\": 384}".to_vec();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"72b987e498d7e3a1\"")
+                    .set_body_bytes(payload.clone()),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/api/models/sentence-transformers/all-MiniLM-L6-v2/revision/main",
+            ))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let resp = app
+            .oneshot(tdh::get(format!(
+                "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json",
+                f.repo_key
+            )))
+            .await
+            .expect("resolve oneshot");
+
+        f.teardown().await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a failing metadata lookup must not fail the file download"
+        );
+        assert!(
+            resp.headers().get(UPSTREAM_COMMIT_HEADER).is_none(),
+            "with no forwarded header and a broken model-info endpoint there is \
+             no commit to report, and inventing one would mislabel the bytes"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect resolve body");
+        assert_eq!(&body[..], &payload[..]);
+    }
+
+    /// A Local/hosted HF repo's resolve must carry an ETag and `X-Repo-Commit`
+    /// too, and the commit must agree with the `sha` model-info reports.
+    ///
+    /// Hosted serves go through `proxy_helpers::build_download_response`, which
+    /// emits only Content-Type/Content-Length/Content-Disposition — so
+    /// `hf download` failed its metadata probe against content this instance
+    /// owns, not just against proxied content. The cross-endpoint equality is the
+    /// real assertion: `snapshot_download` computes its snapshot directory from
+    /// model-info's `sha` and then files each downloaded file under the commit
+    /// that file's resolve reported, so the two disagreeing yields a snapshot
+    /// directory with nothing in it.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    async fn test_huggingface_local_resolve_carries_etag_and_commit() {
+        use tower::ServiceExt;
+
+        let Some(f) = tdh::Fixture::setup("local", "huggingface").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+        let model_id = "sentence-transformers/all-MiniLM-L6-v2";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            &format!("huggingface/{model_id}/main/config.json"),
+            &format!("{model_id}/main/config.json"),
+            model_id,
+            "main",
+            "application/json",
+            bytes::Bytes::from_static(b"{\"hidden_size\": 384}"),
+            f.user_id,
+        )
+        .await;
+
+        let resolve = f
+            .router_anon(super::router())
+            .oneshot(tdh::get(format!(
+                "/{}/{}/resolve/main/config.json",
+                f.repo_key, model_id
+            )))
+            .await
+            .expect("resolve oneshot");
+        assert_eq!(resolve.status(), StatusCode::OK);
+        let headers = resolve.headers().clone();
+
+        let (info_status, info_body) = tdh::send(
+            f.router_anon(super::router()),
+            tdh::get(format!(
+                "/{}/api/models/{}/revision/main",
+                f.repo_key, model_id
+            )),
+        )
+        .await;
+
+        f.teardown().await;
+
+        // `tdh::seed_artifact` stores "test-seed" as the checksum; the point is
+        // that the ETag is the stored per-file content hash, quoted as RFC 9110
+        // requires for an entity-tag. The absence of interior padding also pins
+        // the `CHAR(64)` blank-padding trim - Postgres returns "test-seed" plus
+        // 55 spaces for this column.
+        assert_eq!(
+            headers.get(ETAG).and_then(|v| v.to_str().ok()),
+            Some("\"test-seed\""),
+            "a hosted resolve must expose the artifact's stored checksum as a \
+             quoted ETag"
+        );
+        let commit = headers
+            .get(UPSTREAM_COMMIT_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .expect("hosted resolve must carry X-Repo-Commit")
+            .to_string();
+        assert_eq!(commit.len(), 40, "huggingface_hub matches ^[0-9a-f]{{40}}$");
+        assert!(commit
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+
+        assert_eq!(info_status, StatusCode::OK);
+        let info: serde_json::Value = serde_json::from_slice(&info_body).unwrap();
+        assert_eq!(
+            info["sha"].as_str(),
+            Some(commit.as_str()),
+            "model-info's sha and the resolve's X-Repo-Commit must be the same \
+             value or snapshot_download's directory and its file placement diverge"
+        );
+    }
+
+    /// `hf download --revision refs/pr/1` must reach upstream with the revision
+    /// spelled as one percent-encoded segment.
+    ///
+    /// The client puts `resolve/refs%2Fpr%2F1/<file>` on the wire; axum decodes
+    /// that capture once, so the handler holds `refs/pr/1` and a naive
+    /// `format!` produced `…/resolve/refs/pr/1/config.json` upstream — a shape
+    /// the Hub's API does not serve. The wiremock path matcher compares against
+    /// the still-encoded URL path, so an exact match here is proof the outbound
+    /// request carries the spelling `huggingface_hub` itself generates. The
+    /// `X-Repo-Commit` assertion is the second half of the same bug: the
+    /// model-info path was mis-spelled the same way, so the header went missing
+    /// too.
+    #[tokio::test]
+    async fn test_huggingface_resolve_reencodes_slash_bearing_revision() {
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/openai/whisper-large-v3/resolve/refs%2Fpr%2F1/config.json",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"5f2c1d0e\"")
+                    .insert_header("x-repo-commit", "77778888999900001111222233334444aaaabbbb")
+                    .set_body_bytes(b"{\"num_mel_bins\": 128}".to_vec()),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let resp = app
+            .oneshot(tdh::get(format!(
+                "/{}/openai/whisper-large-v3/resolve/refs%2Fpr%2F1/config.json",
+                f.repo_key
+            )))
+            .await
+            .expect("resolve oneshot");
+
+        f.teardown().await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a `refs/pr/N` revision is an ordinary Hub revision and must resolve, \
+             not 404 against a mis-spelled upstream path"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(UPSTREAM_COMMIT_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some("77778888999900001111222233334444aaaabbbb")
+        );
+    }
+
+    /// A Virtual repo's local-member serve sources its ETag from the member row
+    /// that actually won the member-priority race.
+    ///
+    /// `virtual_member_checksum` swallows database errors by design (a missing
+    /// header must never fail a download), which means a wrong column or join in
+    /// its SQL would degrade silently to "no ETag" rather than surfacing. This
+    /// drives the query directly against a real virtual/member pair so that
+    /// cannot happen unnoticed, and pins the two answers the calling code
+    /// branches on: the winner's checksum, and `None` when no local member owns
+    /// the path (which is how a Remote member's serve keeps whatever its own
+    /// upstream said).
+    #[tokio::test]
+    async fn test_virtual_member_checksum_resolves_priority_winner() {
+        let Some(f) = tdh::Fixture::setup("virtual", "huggingface").await else {
+            return;
+        };
+        let (member_id, _member_key, member_dir) =
+            tdh::create_repo(&f.pool, "local", "huggingface").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(f.repo_id)
+        .bind(member_id)
+        .execute(&f.pool)
+        .await
+        .expect("link virtual member");
+
+        let artifact_path = "sentence-transformers/all-MiniLM-L6-v2/main/config.json";
+        // A full 64-hex digest, so the assertion also shows that a real checksum
+        // needs no `CHAR(64)` padding trim.
+        let checksum = "b".repeat(64);
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (id, repository_id, name, version, path, storage_key, size_bytes, \
+              checksum_sha256, content_type, is_deleted) \
+             VALUES (gen_random_uuid(),$1,$2,'main',$3,$4,20,$5,'application/json',false)",
+        )
+        .bind(member_id)
+        .bind("sentence-transformers/all-MiniLM-L6-v2")
+        .bind(artifact_path)
+        .bind(format!("huggingface/{artifact_path}"))
+        .bind(&checksum)
+        .execute(&f.pool)
+        .await
+        .expect("insert member artifact");
+
+        let found = virtual_member_checksum(&f.pool, f.repo_id, artifact_path).await;
+        let missing = virtual_member_checksum(
+            &f.pool,
+            f.repo_id,
+            "sentence-transformers/all-MiniLM-L6-v2/main/absent.json",
+        )
+        .await;
+
+        tdh::cleanup(&f.pool, member_id, f.user_id).await;
+        let _ = std::fs::remove_dir_all(&member_dir);
+        f.teardown().await;
+
+        assert_eq!(
+            found.as_deref().map(str::trim),
+            Some(checksum.as_str()),
+            "the ETag must come from the local member that owns the path"
+        );
+        assert!(
+            missing.is_none(),
+            "no local member owning the path means the bytes came from a Remote \
+             member, whose own upstream metadata must stand unaltered"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2915: `/api/models/{id}/tree/{revision}` Remote pull-through.
+    //
+    // `list_files_impl` answers from the local `artifacts` table by path prefix.
+    // A Remote repo keeps no `artifacts` rows for proxied content (#1278), so
+    // that query matched nothing and the endpoint returned `[]` with 200 for
+    // every uncached model - the same fail-open this PR removed from
+    // `model_info`, left standing on the sibling endpoint.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_huggingface_tree_proxies_upstream_for_remote_repo() {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/api/models/sentence-transformers/all-MiniLM-L6-v2/tree/main",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"type": "file", "oid": "abc", "size": 612, "path": "config.json"},
+                {"type": "file", "oid": "def", "size": 90868376, "path": "model.safetensors"},
+            ])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/api/models/sentence-transformers/all-MiniLM-L6-v2/tree/main",
+                f.repo_key
+            )),
+        )
+        .await;
+
+        f.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entries = json
+            .as_array()
+            .expect("the tree endpoint must return a JSON array");
+        assert_eq!(
+            entries.len(),
+            2,
+            "an uncached model on a Remote repo must report upstream's tree, not \
+             an empty list"
+        );
+        assert_eq!(entries[1]["path"], "model.safetensors");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    async fn test_huggingface_tree_upstream_failure_surfaces_not_empty_200() {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/api/models/does-not-exist/tree/main"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/api/models/does-not-exist/tree/main",
+                f.repo_key
+            )),
+        )
+        .await;
+
+        f.teardown().await;
+
+        // #1445 folds an upstream 5xx into 503 in `map_proxy_error`; what matters
+        // here is that the failure is visible at all rather than being flattened
+        // into an authoritative-looking empty listing.
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a real upstream failure must surface as an error, not `[]` with 200"
+        );
+        assert_ne!(
+            std::str::from_utf8(&body).unwrap_or_default(),
+            "[]",
+            "an empty list would tell the client the revision has no files"
+        );
     }
 }

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -1521,6 +1521,90 @@ mod tests {
         );
     }
 
+    /// REPRO (act2-fix-hf4): live testing against huggingface.co showed a
+    /// cold-cache HEAD on a nested file (`1_Pooling/config.json`) succeeds,
+    /// but `hf download` still failed on OTHER files in the same repo
+    /// (`README.md`) with `FileMetadataError("Distant resource does not have
+    /// a Content-Length.")`. Root cause, confirmed by `cargo tree -i
+    /// reqwest@0.13.4 -e features`: this crate's `Cargo.toml` requests only
+    /// `["json", "stream", "form"]`, but Cargo unifies features for a single
+    /// resolved `reqwest` version across the whole build, and the
+    /// `opensearch` dependency (full-text search) pulls in `reqwest` with
+    /// its `gzip` feature — silently switching EVERY `reqwest::Client` in
+    /// this binary, including the shared upstream client from
+    /// `http_client::base_client_builder()`, into auto content-negotiation
+    /// mode. That makes the client add `Accept-Encoding: gzip` to outbound
+    /// requests and, whenever upstream compresses the response (HF's
+    /// CloudFront does this for text/JSON responses above a size
+    /// threshold — verified live: small nested configs stay under it,
+    /// `README.md` does not), transparently decode the body AND strip both
+    /// `Content-Encoding` and `Content-Length` from `response.headers()`
+    /// before this proxy's header-capture code
+    /// (`extract_streaming_headers`) ever sees them. This test does not
+    /// depend on live negotiation: it mounts a mock that returns a
+    /// `Content-Encoding: gzip` body regardless of what `Accept-Encoding`
+    /// the client sent, exactly reproducing the header-loss this proxy must
+    /// not exhibit.
+    #[tokio::test]
+    async fn test_huggingface_resolve_survives_upstream_gzip_content_length() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+        use tower::ServiceExt;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+
+        let body = b"# sentence-transformers model card\n".repeat(200);
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&body).expect("gzip encode");
+        let compressed = encoder.finish().expect("gzip finish");
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(
+                "/sentence-transformers/all-MiniLM-L6-v2/resolve/main/README.md",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-encoding", "gzip")
+                    .insert_header("etag", "\"152b56c8ff5229192e0b1f405f5bf07699854738\"")
+                    .set_body_bytes(compressed.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let resp = app
+            .oneshot(tdh::get(format!(
+                "/{}/sentence-transformers/all-MiniLM-L6-v2/resolve/main/README.md",
+                f.repo_key
+            )))
+            .await
+            .expect("resolve oneshot");
+
+        f.teardown().await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let content_length = resp
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok());
+        assert_eq!(
+            content_length,
+            Some(compressed.len().to_string().as_str()),
+            "the proxy's upstream HTTP client must not silently auto-decode \
+             a gzip-encoded upstream response (which would strip \
+             Content-Length before this proxy's header-capture code ever \
+             sees it): huggingface_hub's HEAD-based metadata check \
+             hard-requires a Content-Length or it raises FileMetadataError"
+        );
+    }
+
     #[tokio::test]
     async fn test_huggingface_model_info_proxies_upstream_bare_no_revision() {
         use wiremock::matchers::{method, path as wm_path};

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -420,6 +420,7 @@ async fn maven_local_fetch_snapshot(
         // Local snapshot artifact resolved: surface its id so a virtual
         // maven-snapshot member download is recorded exactly once (#2260).
         artifact_id: Some(resolved.id),
+        etag: None,
     })
 }
 

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -414,6 +414,8 @@ async fn maven_local_fetch_snapshot(
 
     let ct = content_type_for_path(path).to_string();
     Ok(proxy_helpers::StreamingFetchResult {
+        commit_sha: None,
+        content_encoding: None,
         body: stream,
         content_type: Some(ct),
         content_length: None,

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -180,6 +180,8 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
             let storage = state.storage_for_repo_or_500(location)?;
             if let Ok(stream) = storage.get_stream(&scoped_key).await {
                 return Ok(StreamingFetchResult {
+                    commit_sha: None,
+                    content_encoding: None,
                     body: stream,
                     content_type: None,
                     content_length: None,
@@ -212,6 +214,8 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
             }
         })?;
         return Ok(StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: stream,
             content_type: None,
             content_length: None,
@@ -345,6 +349,8 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
         }
     })?;
     Ok(StreamingFetchResult {
+        commit_sha: None,
+        content_encoding: None,
         body: stream,
         content_type: None,
         content_length: None,

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -185,6 +185,7 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
                     content_length: None,
                     // Row-less companion object: not anchored to an artifact row.
                     artifact_id: None,
+                    etag: None,
                 });
             }
         }
@@ -216,6 +217,7 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
             content_length: None,
             // Cloud flat-key legacy object: not anchored to our artifact row.
             artifact_id: None,
+            etag: None,
         });
     }
 
@@ -348,6 +350,7 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
         content_length: None,
         // Remote proxy-cache stream: not our artifact row (#1278), unrecorded.
         artifact_id: None,
+        etag: None,
     })
 }
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2713,6 +2713,7 @@ async fn npm_local_fetch(
         // Local artifact resolved: surface its id so a virtual npm-member
         // download is recorded exactly once at the streaming resolver (#2260).
         artifact_id: Some(artifact.id),
+        etag: None,
     })
 }
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2707,6 +2707,8 @@ async fn npm_local_fetch(
         };
 
     Ok(proxy_helpers::StreamingFetchResult {
+        commit_sha: None,
+        content_encoding: None,
         body,
         content_type: Some(artifact.content_type.clone()),
         content_length: Some(artifact.size_bytes as u64),

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -656,6 +656,34 @@ pub async fn proxy_fetch_capped_budgeted(
     Ok((content, content_type, permit))
 }
 
+/// As [`proxy_fetch_capped_budgeted`], but also reports the upstream
+/// `Content-Encoding` for handlers that forward the buffered bytes to the client
+/// and must declare the coding — see
+/// [`proxy_fetch_capped_with_cache_key_and_accept_encoded`].
+pub async fn proxy_fetch_capped_budgeted_with_encoding(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>, Option<String>, OwnedSemaphorePermit), Response> {
+    let permit = proxy_metadata_budget().reserve(max).await;
+    let (content, content_type, content_encoding) =
+        proxy_fetch_capped_with_cache_key_and_accept_encoded(
+            proxy_service,
+            repo_id,
+            repo_key,
+            upstream_url,
+            path,
+            path,
+            None,
+            max,
+        )
+        .await?;
+    Ok((content, content_type, content_encoding, permit))
+}
+
 /// Budget-reserving sibling of [`proxy_fetch_capped_with_cache_key_and_accept`]
 /// (#2684). See [`proxy_fetch_capped_budgeted`] for the reservation semantics;
 /// used by the PyPI simple-index proxy, which negotiates the PEP 691 JSON
@@ -893,6 +921,28 @@ pub(crate) fn build_streaming_response_with_disposition(
     if let Some(ref etag) = result.etag {
         builder = builder.header("etag", etag);
     }
+    // The proxy no longer decodes upstream bodies (see
+    // `http_client::base_client_builder`), so a content-coded body must be
+    // declared as such or the client silently writes compressed bytes to disk.
+    // `content_length` above is the coded length, which is what the client needs
+    // to read the transfer.
+    if let Some(ref encoding) = result.content_encoding {
+        builder = builder.header("content-encoding", encoding);
+    }
+    // Upstream's `X-Repo-Commit`, forwarded with the bytes it describes.
+    // `huggingface_hub` requires it on a resolve and names the snapshot directory
+    // from it, so it must be the commit these bytes came from — which is why it
+    // travels through the cache sidecar rather than being looked up separately.
+    // `HeaderValue` parsing rejects CR/LF, so an upstream cannot inject a header
+    // here; a malformed value is dropped rather than failing the download.
+    if let Some(ref sha) = result.commit_sha {
+        if let Ok(value) = axum::http::HeaderValue::from_str(sha) {
+            builder = builder.header(
+                crate::services::proxy_service::UPSTREAM_COMMIT_HEADER,
+                value,
+            );
+        }
+    }
     if let Some(fname) = filename {
         builder = builder.header("content-disposition", content_disposition_attachment(fname));
     }
@@ -1085,11 +1135,13 @@ pub async fn proxy_check_cache(
     repo_key: &str,
     path: &str,
 ) -> Option<(Bytes, Option<String>)> {
+    // Callers here parse the cached body rather than forwarding it, so the
+    // upstream coding is not part of this helper's contract.
     match proxy_service
         .get_cached_artifact_by_path(repo_key, path)
         .await
     {
-        Ok(result) => result,
+        Ok(result) => result.map(|(content, content_type, _encoding)| (content, content_type)),
         Err(e) => {
             tracing::debug!(
                 "Cache lookup failed for {}/{}, treating as miss: {}",
@@ -1325,6 +1377,37 @@ pub async fn proxy_fetch_capped_with_cache_key_and_accept(
     accept: Option<&str>,
     max: usize,
 ) -> Result<(Bytes, Option<String>), Response> {
+    let (content, content_type, _encoding) = proxy_fetch_capped_with_cache_key_and_accept_encoded(
+        proxy_service,
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        cache_path,
+        accept,
+        max,
+    )
+    .await?;
+    Ok((content, content_type))
+}
+
+/// As [`proxy_fetch_capped_with_cache_key_and_accept`], but also reports the
+/// upstream `Content-Encoding` so a handler that forwards the buffered bytes can
+/// declare the coding. Needed because the shared HTTP client no longer lets
+/// reqwest decode upstream bodies, so a buffered metadata document may arrive
+/// content coded (object stores return a stored coding regardless of
+/// `Accept-Encoding`).
+#[allow(clippy::too_many_arguments)]
+pub async fn proxy_fetch_capped_with_cache_key_and_accept_encoded(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    accept: Option<&str>,
+    max: usize,
+) -> Result<(Bytes, Option<String>, Option<String>), Response> {
     with_proxy_repo(
         repo_id,
         repo_key,
@@ -2261,7 +2344,7 @@ where
             // (warm path never fans out) while a held entry is skipped rather
             // than served raw. A fresh hit is transformed into the response.
             match proxy.cached_metadata_if_servable(member, path).await {
-                Ok(Some((bytes, _ct))) => match transform(bytes, member.key.clone()).await {
+                Ok(Some((bytes, _ct, _enc))) => match transform(bytes, member.key.clone()).await {
                     Ok(response) => (MemberCacheClass::DefiniteHit, Some(response)),
                     // The cached bytes failed to transform (e.g. corrupt cached
                     // metadata). Don't treat the member as a definite miss —
@@ -2711,6 +2794,8 @@ async fn read_local_stream(
         Err(e) => return Err(map_storage_err(e)),
     };
     Ok(StreamingFetchResult {
+        commit_sha: None,
+        content_encoding: None,
         body,
         content_type: Some(artifact.content_type.clone()),
         content_length: Some(artifact.size_bytes as u64),
@@ -5330,6 +5415,8 @@ mod tests {
 
     fn empty_stream_result() -> StreamingFetchResult {
         StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: Box::pin(futures::stream::empty()),
             content_type: None,
             content_length: Some(0),
@@ -8899,6 +8986,8 @@ mod tests {
     #[test]
     fn test_build_streaming_response_uses_upstream_content_type_when_set() {
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: Some("application/java-archive".to_string()),
             content_length: None,
@@ -8920,6 +9009,8 @@ mod tests {
     #[test]
     fn test_build_streaming_response_falls_back_to_default_when_upstream_omits() {
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: None,
             content_length: None,
@@ -8943,6 +9034,8 @@ mod tests {
     #[test]
     fn test_build_streaming_response_sets_content_length_when_upstream_advertises_it() {
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(12345),
@@ -8967,6 +9060,8 @@ mod tests {
         // Chunked-transfer-encoding case: upstream omits Content-Length,
         // outbound response also omits it so axum falls back to TE: chunked.
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: Some("application/octet-stream".to_string()),
             content_length: None,
@@ -8985,6 +9080,8 @@ mod tests {
     #[test]
     fn test_build_streaming_response_status_is_200() {
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: None,
             content_length: None,
@@ -9002,6 +9099,8 @@ mod tests {
         // string as-is, not lowercase / normalize / sniff.
         let weird = "application/vnd.android.package-archive";
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: None,
             content_length: None,
@@ -9024,6 +9123,8 @@ mod tests {
         // underlying builder: upstream content-type wins, content-length is set
         // when known, and a filename produces a Content-Disposition.
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: Some("application/zip".to_string()),
             content_length: Some(1234),
@@ -9053,6 +9154,8 @@ mod tests {
         // No upstream content-type, no length, no filename: default type is
         // used and neither content-length nor content-disposition is emitted.
         let result = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: empty_body(),
             content_type: None,
             content_length: None,
@@ -9547,6 +9650,8 @@ mod tests {
         async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
             if key.ends_with("__cache_meta__.json") {
                 let meta = crate::services::proxy_service::CacheMetadata {
+                    upstream_commit_sha: None,
+                    content_encoding: None,
                     cached_at: Utc::now(),
                     upstream_etag: None,
                     storage_etag: None,
@@ -9733,6 +9838,8 @@ mod tests {
         async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
             if key.ends_with("__cache_meta__.json") {
                 let meta = crate::services::proxy_service::CacheMetadata {
+                    upstream_commit_sha: None,
+                    content_encoding: None,
                     cached_at: Utc::now(),
                     upstream_etag: None,
                     storage_etag: None,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -890,6 +890,9 @@ pub(crate) fn build_streaming_response_with_disposition(
     if let Some(len) = result.content_length {
         builder = builder.header("content-length", len);
     }
+    if let Some(ref etag) = result.etag {
+        builder = builder.header("etag", etag);
+    }
     if let Some(fname) = filename {
         builder = builder.header("content-disposition", content_disposition_attachment(fname));
     }
@@ -2714,6 +2717,7 @@ async fn read_local_stream(
         // Local artifact row resolved: surface its id so the virtual-member
         // streaming resolver can record the download exactly once (#2260).
         artifact_id: Some(artifact.id),
+        etag: None,
     })
 }
 
@@ -5330,6 +5334,7 @@ mod tests {
             content_type: None,
             content_length: Some(0),
             artifact_id: None,
+            etag: None,
         }
     }
 
@@ -8898,6 +8903,7 @@ mod tests {
             content_type: Some("application/java-archive".to_string()),
             content_length: None,
             artifact_id: None,
+            etag: None,
         };
         let response = build_streaming_response(result, "application/octet-stream")
             .expect("response build must succeed");
@@ -8918,6 +8924,7 @@ mod tests {
             content_type: None,
             content_length: None,
             artifact_id: None,
+            etag: None,
         };
         let response =
             build_streaming_response(result, "text/xml").expect("response build must succeed");
@@ -8940,6 +8947,7 @@ mod tests {
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(12345),
             artifact_id: None,
+            etag: None,
         };
         let response = build_streaming_response(result, "application/octet-stream").unwrap();
         assert_eq!(
@@ -8963,6 +8971,7 @@ mod tests {
             content_type: Some("application/octet-stream".to_string()),
             content_length: None,
             artifact_id: None,
+            etag: None,
         };
         let response = build_streaming_response(result, "application/octet-stream").unwrap();
         assert!(
@@ -8980,6 +8989,7 @@ mod tests {
             content_type: None,
             content_length: None,
             artifact_id: None,
+            etag: None,
         };
         let response = build_streaming_response(result, "application/octet-stream").unwrap();
         assert_eq!(response.status(), StatusCode::OK);
@@ -8996,6 +9006,7 @@ mod tests {
             content_type: None,
             content_length: None,
             artifact_id: None,
+            etag: None,
         };
         let response = build_streaming_response(result, weird).unwrap();
         assert_eq!(
@@ -9017,6 +9028,7 @@ mod tests {
             content_type: Some("application/zip".to_string()),
             content_length: Some(1234),
             artifact_id: None,
+            etag: None,
         };
         let response = stream_fetch_result(result, "application/octet-stream", Some("pkg.whl"))
             .expect("stream_fetch_result must build a response");
@@ -9045,6 +9057,7 @@ mod tests {
             content_type: None,
             content_length: None,
             artifact_id: None,
+            etag: None,
         };
         let response = stream_fetch_result(result, "application/octet-stream", None)
             .expect("stream_fetch_result must build a response");

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -4496,6 +4496,8 @@ mod tests {
         len: Option<u64>,
     ) -> crate::services::proxy_service::StreamingFetchResult {
         crate::services::proxy_service::StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: futures::stream::once(async move { Ok(Bytes::from_static(content)) }).boxed(),
             content_type: None,
             content_length: len,
@@ -4611,6 +4613,8 @@ mod tests {
         content: &'static [u8],
     ) -> crate::services::proxy_service::StreamingFetchResult {
         crate::services::proxy_service::StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: futures::stream::once(async move { Ok(Bytes::from_static(content)) }).boxed(),
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(content.len() as u64),
@@ -5013,6 +5017,8 @@ mod tests {
         content_length: Option<u64>,
     ) -> crate::services::proxy_service::StreamingFetchResult {
         crate::services::proxy_service::StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: futures::stream::iter(chunks.into_iter().map(|c| Ok(Bytes::from_static(c))))
                 .boxed(),
             content_type: Some("application/octet-stream".to_string()),
@@ -7705,6 +7711,8 @@ mod tests {
         let data_len = wheel_data.len() as u64;
         let stream = stream::once(async move { Ok::<Bytes, crate::error::AppError>(wheel_data) });
         let result = crate::services::proxy_service::StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: Box::pin(stream),
             content_type: Some("application/zip".to_string()),
             content_length: Some(data_len),

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -4500,6 +4500,7 @@ mod tests {
             content_type: None,
             content_length: len,
             artifact_id: None,
+            etag: None,
         }
     }
 
@@ -4614,6 +4615,7 @@ mod tests {
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(content.len() as u64),
             artifact_id: None,
+            etag: None,
         }
     }
 
@@ -5016,6 +5018,7 @@ mod tests {
             content_type: Some("application/octet-stream".to_string()),
             content_length,
             artifact_id: None,
+            etag: None,
         }
     }
 
@@ -7706,6 +7709,7 @@ mod tests {
             content_type: Some("application/zip".to_string()),
             content_length: Some(data_len),
             artifact_id: None,
+            etag: None,
         };
 
         let response = build_streaming_file_response("numpy-1.0-py3-none-any.whl", result);

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -84,12 +84,38 @@ pub fn base_client_builder() -> ClientBuilder {
         // "another dependency enabled it" scenario: they stop the
         // auto-negotiation (no automatic `Accept-Encoding`, no automatic
         // decode) regardless of which decompression features happen to be
-        // compiled in, so upstream serves identity and every proxied
-        // format's Content-Length survives intact.
+        // compiled in, so every proxied format's Content-Length survives
+        // intact.
+        //
+        // Only `gzip` is actually in the resolved feature set today; the other
+        // three are defensive, so a future dependency enabling brotli/zstd
+        // cannot silently re-introduce the same bug.
         .no_gzip()
         .no_brotli()
         .no_deflate()
-        .no_zstd();
+        .no_zstd()
+        // Disabling the codecs makes reqwest/tower-http send *no*
+        // `Accept-Encoding` at all, and RFC 9110 §12.5.3 reads an absent
+        // header as "any content coding is acceptable" — the opposite of what
+        // this client can handle now that nothing decodes. Advertise identity
+        // explicitly so a compliant upstream does not elect a coding we would
+        // then pass through to the client. This is belt-and-braces with the
+        // `content_encoding` plumbing in `proxy_service`: object stores
+        // (notably S3) return a stored `Content-Encoding` regardless of what
+        // the request advertised, so the header must still be forwarded
+        // faithfully when it does appear.
+        //
+        // Composes with tower-http's decompression layer, which only inserts
+        // `Accept-Encoding` when the entry is vacant — this explicit value
+        // wins.
+        .default_headers({
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                reqwest::header::ACCEPT_ENCODING,
+                reqwest::header::HeaderValue::from_static("identity"),
+            );
+            headers
+        });
 
     apply_custom_ca_cert(builder)
 }

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -61,7 +61,35 @@ pub fn base_client_builder() -> ClientBuilder {
 
     let builder = reqwest::Client::builder()
         .redirect(ssrf_redirect_policy())
-        .dns_resolver(crate::services::ssrf_dns::ssrf_guard_resolver());
+        .dns_resolver(crate::services::ssrf_dns::ssrf_guard_resolver())
+        // This crate's own `Cargo.toml` requests only `["json", "stream",
+        // "form"]`, but Cargo unifies features for a single resolved
+        // `reqwest` version across the whole build: the `opensearch` crate
+        // (full-text search) pulls in `reqwest` with its `gzip` feature
+        // enabled, which silently switches EVERY `reqwest::Client` in this
+        // binary — including this one — into auto content-negotiation mode.
+        // That makes the client add `Accept-Encoding: gzip` to outbound
+        // upstream requests and, on any response upstream compresses,
+        // transparently decode the body AND strip both `Content-Encoding`
+        // and `Content-Length` from `response.headers()` before this proxy's
+        // header-capture code ever sees them. A CDN that compresses
+        // responses above a size threshold (observed live against
+        // huggingface.co's CloudFront) then reaches the client with no
+        // Content-Length, which `huggingface_hub`'s HEAD-based metadata
+        // check hard-requires (`FileMetadataError: Distant resource does not
+        // have a Content-Length`) — small responses stay under the
+        // threshold and are unaffected, which is why this only shows up on
+        // larger upstream files. `no_gzip`/`no_brotli`/`no_deflate`/
+        // `no_zstd` are documented by reqwest to exist for exactly this
+        // "another dependency enabled it" scenario: they stop the
+        // auto-negotiation (no automatic `Accept-Encoding`, no automatic
+        // decode) regardless of which decompression features happen to be
+        // compiled in, so upstream serves identity and every proxied
+        // format's Content-Length survives intact.
+        .no_gzip()
+        .no_brotli()
+        .no_deflate()
+        .no_zstd();
 
     apply_custom_ca_cert(builder)
 }

--- a/backend/src/services/proxy_hydration.rs
+++ b/backend/src/services/proxy_hydration.rs
@@ -343,6 +343,11 @@ pub struct StreamHandle {
 pub struct StreamHeaders {
     pub content_type: Option<String>,
     pub content_length: Option<u64>,
+    /// Upstream `ETag` (or, for a cache hit, the sidecar's `upstream_etag`),
+    /// forwarded verbatim to the client so `huggingface_hub`'s HEAD-based
+    /// metadata check (which requires an ETag) succeeds. Generic ETag
+    /// forwarding on every proxied stream, not HF-specific.
+    pub etag: Option<String>,
 }
 
 /// One item on a per-key streaming broadcast channel.
@@ -1192,6 +1197,7 @@ mod tests {
         StreamHeaders {
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(11),
+            etag: None,
         }
     }
 
@@ -1407,6 +1413,7 @@ mod tests {
                 headers: StreamHeaders {
                     content_type: None,
                     content_length: Some(0),
+                    etag: None,
                 },
             })
         })

--- a/backend/src/services/proxy_hydration.rs
+++ b/backend/src/services/proxy_hydration.rs
@@ -348,6 +348,15 @@ pub struct StreamHeaders {
     /// metadata check (which requires an ETag) succeeds. Generic ETag
     /// forwarding on every proxied stream, not HF-specific.
     pub etag: Option<String>,
+    /// Upstream `Content-Encoding` when the streamed bytes are content coded.
+    /// Must reach every follower with the body: the proxy no longer decodes
+    /// upstream responses, so dropping this serves compressed bytes labelled as
+    /// identity.
+    pub content_encoding: Option<String>,
+    /// Upstream `X-Repo-Commit` for the streamed bytes, so every follower labels
+    /// the body with the commit it actually came from rather than whatever a
+    /// separately-cached metadata document happens to say.
+    pub commit_sha: Option<String>,
 }
 
 /// One item on a per-key streaming broadcast channel.
@@ -1195,6 +1204,8 @@ mod tests {
 
     fn test_headers() -> StreamHeaders {
         StreamHeaders {
+            commit_sha: None,
+            content_encoding: None,
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(11),
             etag: None,
@@ -1411,6 +1422,8 @@ mod tests {
             Ok(StreamHandle {
                 body: body_of(&[]),
                 headers: StreamHeaders {
+                    commit_sha: None,
+                    content_encoding: None,
                     content_type: None,
                     content_length: Some(0),
                     etag: None,

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -89,6 +89,25 @@ pub(crate) struct UpstreamResponse {
     /// `Last-Modified` header from upstream, persisted into the cache sidecar
     /// so a later conditional revalidation can send `If-Modified-Since` (#1611).
     pub(crate) last_modified: Option<String>,
+    /// `Content-Encoding` from upstream, when it sent one.
+    ///
+    /// Since the base HTTP client disables reqwest's transparent decompression
+    /// (see `http_client::base_client_builder`), a content-coded body now
+    /// arrives here still coded — so the coding MUST be carried alongside the
+    /// bytes and re-emitted, or the client receives compressed data labelled as
+    /// identity. Object stores return a stored `Content-Encoding` regardless of
+    /// the request's `Accept-Encoding`, so this is reachable even though the
+    /// client advertises identity.
+    pub(crate) content_encoding: Option<String>,
+    /// Upstream's `X-Repo-Commit`, when it sent one.
+    ///
+    /// Hugging Face's resolve endpoint returns the commit the served bytes came
+    /// from, and `huggingface_hub` uses it to name the snapshot directory. It has
+    /// to travel *with* the bytes — persisted in the cache sidecar and replayed on
+    /// a hit — because deriving it from a separately-cached model-info document
+    /// lets the proxy serve commit A's bytes while asserting commit B, defeating
+    /// the client's own commit pinning.
+    pub(crate) commit_sha: Option<String>,
     pub(crate) effective_url: String,
     pub(crate) link: Option<String>,
 }
@@ -101,6 +120,10 @@ struct UpstreamStream {
     body: BoxStream<'static, Result<Bytes>>,
     content_type: Option<String>,
     etag: Option<String>,
+    /// `Content-Encoding` from upstream — see [`UpstreamResponse::content_encoding`].
+    content_encoding: Option<String>,
+    /// `X-Repo-Commit` from upstream — see [`UpstreamResponse::commit_sha`].
+    commit_sha: Option<String>,
     /// `Content-Length` from upstream, if it sent one. Lets the proxy
     /// decide whether to bypass the cache entirely for huge objects
     /// (a future enhancement; currently informational only).
@@ -132,6 +155,16 @@ pub struct StreamingFetchResult {
     /// Forwarded verbatim on the outbound response so clients that require
     /// an ETag on the resolve HEAD (e.g. `huggingface_hub`) get one.
     pub etag: Option<String>,
+    /// Upstream `Content-Encoding` when the cached/streamed bytes are content
+    /// coded — see [`UpstreamResponse::content_encoding`]. Must be forwarded
+    /// with the body on every serve (fresh, cache hit, stale-if-error) or the
+    /// client cannot decode what it receives.
+    pub content_encoding: Option<String>,
+    /// Upstream `X-Repo-Commit` for the bytes being served — see
+    /// [`UpstreamResponse::commit_sha`]. Forwarded on fresh fetches and replayed
+    /// from the sidecar on cache hits, so the header always describes the body it
+    /// arrives with.
+    pub commit_sha: Option<String>,
 }
 
 impl From<StreamHandle> for StreamingFetchResult {
@@ -146,6 +179,8 @@ impl From<StreamHandle> for StreamingFetchResult {
             // Remote/cache stream: not a local artifact row, so unrecorded.
             artifact_id: None,
             etag: handle.headers.etag,
+            content_encoding: handle.headers.content_encoding,
+            commit_sha: handle.headers.commit_sha,
         }
     }
 }
@@ -185,6 +220,12 @@ impl StreamingFetchResult {
 struct CacheMetadataTemplate {
     content_type: Option<String>,
     etag: Option<String>,
+    /// `Content-Encoding` of the bytes being persisted, recorded so a later
+    /// cache hit re-emits it — see [`UpstreamResponse::content_encoding`].
+    content_encoding: Option<String>,
+    /// Upstream `X-Repo-Commit` for the bytes being persisted — see
+    /// [`UpstreamResponse::commit_sha`].
+    commit_sha: Option<String>,
     /// `Last-Modified` from upstream (#1611). `None` on the streaming path,
     /// which does not currently surface the header into the tee template.
     last_modified: Option<String>,
@@ -450,14 +491,44 @@ fn validate_upstream_status(status: StatusCode, url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Extract `(content_type, etag, content_length)` from an upstream
-/// response's headers. Extracted from
+/// Whether a single path segment is a dot segment, in the same sense the WHATWG
+/// URL parser uses when it normalizes a path.
+///
+/// Covers the literal `.` and `..` plus every percent-encoded spelling the URL
+/// parser folds into them (`%2e`, `.%2e`, `%2e.`, `%2e%2e`), case-insensitively.
+/// Used by [`ProxyService::validate_cache_path`] so a doubly-encoded request
+/// cannot smuggle a dot segment past validation and have the URL parser decode it
+/// back into one afterwards.
+fn is_dot_segment(segment: &str) -> bool {
+    let lower = segment.to_ascii_lowercase();
+    matches!(lower.as_str(), "." | "%2e")
+        || matches!(lower.as_str(), ".." | ".%2e" | "%2e." | "%2e%2e")
+}
+
+/// Upstream response header carrying the commit an artifact was resolved from.
+/// Hugging Face's resolve endpoint sets it; the proxy forwards it generically.
+pub(crate) const UPSTREAM_COMMIT_HEADER: &str = "x-repo-commit";
+
+/// The upstream response headers this proxy forwards or persists.
+///
+/// A named struct rather than a tuple because it has outgrown positional
+/// destructuring; every field is optional because upstreams vary.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct UpstreamHeaders {
+    pub(crate) content_type: Option<String>,
+    pub(crate) etag: Option<String>,
+    pub(crate) content_length: Option<u64>,
+    /// See [`UpstreamResponse::content_encoding`].
+    pub(crate) content_encoding: Option<String>,
+    /// See [`UpstreamResponse::commit_sha`].
+    pub(crate) commit_sha: Option<String>,
+}
+
+/// Extract the forwardable headers from an upstream response. Extracted from
 /// [`ProxyService::read_upstream_response_streaming`] so the header-
 /// parsing rules (in particular the `Content-Length` parse-and-coerce
 /// to `u64`) can be unit-tested without a real `reqwest::Response`.
-fn extract_streaming_headers(
-    headers: &reqwest::header::HeaderMap,
-) -> (Option<String>, Option<String>, Option<u64>) {
+fn extract_streaming_headers(headers: &reqwest::header::HeaderMap) -> UpstreamHeaders {
     let content_type = headers
         .get(CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
@@ -470,7 +541,21 @@ fn extract_streaming_headers(
         .get(CONTENT_LENGTH)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<u64>().ok());
-    (content_type, etag, content_length)
+    let content_encoding = headers
+        .get(reqwest::header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    let commit_sha = headers
+        .get(UPSTREAM_COMMIT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    UpstreamHeaders {
+        content_type,
+        etag,
+        content_length,
+        content_encoding,
+        commit_sha,
+    }
 }
 
 /// Whether a freshly streamed proxy-cache write should be committed or
@@ -632,6 +717,27 @@ pub struct CacheMetadata {
     pub expires_at: DateTime<Utc>,
     /// Content type from upstream
     pub content_type: Option<String>,
+    /// `Content-Encoding` of the bytes stored under the body key, when they are
+    /// content coded.
+    ///
+    /// The proxy no longer decompresses upstream bodies (see
+    /// `http_client::base_client_builder`), so a coded body is cached coded and
+    /// the coding has to be replayed on every cache hit — otherwise a hit
+    /// serves compressed bytes labelled as identity. `size_bytes` and
+    /// `checksum_sha256` describe the stored (still coded) bytes.
+    ///
+    /// `None` means identity, which is also the right reading for sidecars
+    /// written before this field existed: on those entries reqwest had already
+    /// decompressed the body before it was stored. `#[serde(default)]`
+    /// preserves wire-compat with them.
+    #[serde(default)]
+    pub content_encoding: Option<String>,
+    /// Upstream `X-Repo-Commit` recorded with these bytes — see
+    /// [`UpstreamResponse::commit_sha`]. `None` for entries written before this
+    /// field existed (`#[serde(default)]` preserves wire-compat) or when upstream
+    /// sent no such header.
+    #[serde(default)]
+    pub upstream_commit_sha: Option<String>,
     /// Size of the cached content
     pub size_bytes: i64,
     /// SHA-256 checksum of cached content
@@ -687,8 +793,9 @@ fn parse_http_date(value: &str) -> Option<DateTime<Utc>> {
 /// the three actions the caller cares about: serve a body, return 404, or fetch
 /// upstream.
 enum CacheReadOutcome {
-    /// Serve this cached (or freshly revalidated) body + content type.
-    Hit(Bytes, Option<String>),
+    /// Serve this cached (or freshly revalidated) body, content type, and
+    /// content coding.
+    Hit(Bytes, Option<String>, Option<String>),
     /// A negative-cached upstream 404 is still within its TTL: respond 404.
     NegativeHit,
     /// No usable entry; the caller must fetch from upstream.
@@ -847,6 +954,13 @@ impl CacheKeys {
 /// Wraps the same `Arc<StorageService>` handle [`ProxyService`] already uses
 /// for these operations, so reads and writes target the global default
 /// backend exactly as before (#1278).
+/// A buffered cache read: `(body, content_type, content_encoding)`.
+///
+/// `content_encoding` rides along because the proxy no longer decodes upstream
+/// bodies, so a cached body may be content coded and the coding has to be
+/// replayed to the client — see [`UpstreamResponse::content_encoding`].
+pub(crate) type CachedBody = (Bytes, Option<String>, Option<String>);
+
 pub(crate) struct CacheStore {
     storage: Arc<StorageService>,
 }
@@ -894,7 +1008,7 @@ impl CacheStore {
         cache_key: &str,
         metadata_key: &str,
         allow_stale: bool,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
+    ) -> Result<Option<CachedBody>> {
         // Per-branch proxy-cache observability (#1263 follow-up / PR #1284).
         // Only the FRESH lookup (`allow_stale == false`) is counted: that is
         // the single per-request cache-read decision the original PR
@@ -983,7 +1097,11 @@ impl CacheStore {
                     tracing::debug!(cache_key = %cache_key, "Proxy cache hit");
                     record_proxy_cache_lookup(repo_label, "hit");
                 }
-                Ok(Some((content, metadata.content_type)))
+                Ok(Some((
+                    content,
+                    metadata.content_type,
+                    metadata.content_encoding,
+                )))
             }
             Err(AppError::NotFound(_)) => {
                 if !allow_stale {
@@ -1180,6 +1298,10 @@ impl CachePersister {
         content_type: Option<String>,
         etag: Option<String>,
         last_modified: Option<String>,
+        // Coding the buffered bytes are in, recorded so a cache hit replays it.
+        content_encoding: Option<String>,
+        // Upstream X-Repo-Commit for these bytes, recorded for the same reason.
+        commit_sha: Option<String>,
         ttl_secs: i64,
         repository_id: Uuid,
         artifact_path: &str,
@@ -1223,6 +1345,8 @@ impl CachePersister {
             upstream_etag: etag,
             storage_etag,
             last_modified,
+            content_encoding,
+            upstream_commit_sha: commit_sha,
             negative_cached_until: None,
             // Package Age Policy hold resolved by the caller (#1770): recorded
             // on the sidecar (NOT the `artifacts` table, per #1278) so every
@@ -1421,6 +1545,8 @@ impl CachePersister {
                             upstream_etag: template.etag,
                             storage_etag,
                             last_modified: template.last_modified,
+                            content_encoding: template.content_encoding,
+                            upstream_commit_sha: template.commit_sha,
                             negative_cached_until: None,
                             // The streaming leader refuses to open upstream at all
                             // while the repo's Package Age Policy is enabled
@@ -1781,6 +1907,18 @@ impl UpstreamClient {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
+        let content_encoding = response
+            .headers()
+            .get(reqwest::header::CONTENT_ENCODING)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let commit_sha = response
+            .headers()
+            .get(UPSTREAM_COMMIT_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
         let link = response
             .headers()
             .get("link")
@@ -1827,6 +1965,8 @@ impl UpstreamClient {
             content_type,
             etag,
             last_modified,
+            content_encoding,
+            commit_sha,
             effective_url,
             link,
         })
@@ -1992,7 +2132,7 @@ impl UpstreamClient {
         url: &str,
     ) -> Result<UpstreamStream> {
         validate_upstream_status(response.status(), url)?;
-        let (content_type, etag, content_length) = extract_streaming_headers(response.headers());
+        let headers = extract_streaming_headers(response.headers());
 
         let body = response.bytes_stream().map(|r| {
             r.map_err(|e| {
@@ -2005,9 +2145,11 @@ impl UpstreamClient {
 
         Ok(UpstreamStream {
             body: Box::pin(body),
-            content_type,
-            etag,
-            content_length,
+            content_type: headers.content_type,
+            etag: headers.etag,
+            content_encoding: headers.content_encoding,
+            commit_sha: headers.commit_sha,
+            content_length: headers.content_length,
         })
     }
 
@@ -2337,12 +2479,32 @@ impl ProxyService {
 
     /// Byte-ceiling-aware sibling of [`Self::fetch_artifact`] (#1608 Phase 4b /
     /// #2181). Bounds the buffered upstream metadata read at `max` bytes.
+    /// As [`Self::fetch_artifact_capped_with_encoding`], but drops the upstream
+    /// `Content-Encoding`. Kept for the many callers that parse the body
+    /// themselves (index/packument/manifest parsers) rather than forwarding it,
+    /// so they are unaffected by the coding plumbing.
     pub async fn fetch_artifact_capped(
         &self,
         repo: &Repository,
         path: &str,
         max: usize,
     ) -> Result<(Bytes, Option<String>)> {
+        let (content, content_type, _encoding) = self
+            .fetch_artifact_capped_with_encoding(repo, path, max)
+            .await?;
+        Ok((content, content_type))
+    }
+
+    /// Buffered capped fetch that also reports the upstream `Content-Encoding`,
+    /// for handlers that pass the buffered bytes through to the client and must
+    /// therefore declare the coding — see
+    /// [`UpstreamResponse::content_encoding`].
+    pub async fn fetch_artifact_capped_with_encoding(
+        &self,
+        repo: &Repository,
+        path: &str,
+        max: usize,
+    ) -> Result<CachedBody> {
         self.fetch_artifact_with_cache_path_and_accept_capped(repo, path, path, None, max)
             .await
     }
@@ -2356,8 +2518,10 @@ impl ProxyService {
         accept: Option<&str>,
         max: usize,
     ) -> Result<(Bytes, Option<String>)> {
-        self.fetch_artifact_with_cache_path_and_accept_capped(repo, path, path, accept, max)
-            .await
+        let (content, content_type, _encoding) = self
+            .fetch_artifact_with_cache_path_and_accept_capped(repo, path, path, accept, max)
+            .await?;
+        Ok((content, content_type))
     }
 
     /// Byte-ceiling-aware sibling of
@@ -2369,10 +2533,12 @@ impl ProxyService {
         cache_path: &str,
         max: usize,
     ) -> Result<(Bytes, Option<String>)> {
-        self.fetch_artifact_with_cache_path_and_accept_capped(
-            repo, fetch_path, cache_path, None, max,
-        )
-        .await
+        let (content, content_type, _encoding) = self
+            .fetch_artifact_with_cache_path_and_accept_capped(
+                repo, fetch_path, cache_path, None, max,
+            )
+            .await?;
+        Ok((content, content_type))
     }
 
     /// Variant of [`Self::fetch_artifact`] that forwards a client-supplied
@@ -2410,7 +2576,7 @@ impl ProxyService {
         &self,
         repo_key: &str,
         path: &str,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
+    ) -> Result<Option<CachedBody>> {
         let cache_key = Self::cache_storage_key(repo_key, path)?;
         let metadata_key = Self::cache_metadata_key(repo_key, path)?;
         self.get_cached_artifact(&cache_key, &metadata_key).await
@@ -2552,14 +2718,16 @@ impl ProxyService {
         cache_path: &str,
         accept: Option<&str>,
     ) -> Result<(Bytes, Option<String>)> {
-        self.fetch_artifact_with_cache_path_and_accept_capped(
-            repo,
-            fetch_path,
-            cache_path,
-            accept,
-            DEFAULT_METADATA_MAX_BYTES,
-        )
-        .await
+        let (content, content_type, _encoding) = self
+            .fetch_artifact_with_cache_path_and_accept_capped(
+                repo,
+                fetch_path,
+                cache_path,
+                accept,
+                DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await?;
+        Ok((content, content_type))
     }
 
     /// Byte-ceiling-aware sibling of
@@ -2569,6 +2737,11 @@ impl ProxyService {
     /// written to the proxy cache. Callers pass the per-format ceiling
     /// ([`DEFAULT_METADATA_MAX_BYTES`] or [`LARGE_METADATA_MAX_BYTES`]); the
     /// non-capped wrappers delegate here with the 8 MiB default.
+    ///
+    /// Returns `(body, content_type, content_encoding)`. The coding is part of the
+    /// result because reqwest no longer decodes upstream bodies, so a buffered
+    /// metadata document may itself be content coded and the handler has to
+    /// declare that when it serves the bytes on.
     pub async fn fetch_artifact_with_cache_path_and_accept_capped(
         &self,
         repo: &Repository,
@@ -2576,7 +2749,7 @@ impl ProxyService {
         cache_path: &str,
         accept: Option<&str>,
         max: usize,
-    ) -> Result<(Bytes, Option<String>)> {
+    ) -> Result<CachedBody> {
         let upstream_url = Self::remote_target(repo)?;
 
         // Cache keys use the caller-supplied cache_path
@@ -2593,7 +2766,9 @@ impl ProxyService {
             .read_cached_with_revalidation(repo, fetch_path, cache_path, &cache_key, &metadata_key)
             .await?
         {
-            CacheReadOutcome::Hit(content, content_type) => return Ok((content, content_type)),
+            CacheReadOutcome::Hit(content, content_type, content_encoding) => {
+                return Ok((content, content_type, content_encoding))
+            }
             CacheReadOutcome::NegativeHit => {
                 return Err(AppError::NotFound(format!(
                     "Upstream returned 404 (negative-cached) for {}",
@@ -2650,6 +2825,10 @@ impl ProxyService {
 
                 match upstream_result {
                     Ok(resp) => {
+                        // Captured before the cache write consumes `resp`, so the
+                        // coding can also be returned to the caller that serves
+                        // these freshly-fetched bytes.
+                        let upstream_encoding = resp.content_encoding.clone();
                         // #1611: mutability-aware TTL (immutable -> forever).
                         let cache_ttl = self.cache_ttl_for_path(repo, cache_path).await;
                         // Package Age Policy (#1770): resolve the hold window
@@ -2758,6 +2937,8 @@ impl ProxyService {
                                 resp.content_type.clone(),
                                 resp.etag,
                                 resp.last_modified,
+                                upstream_encoding.clone(),
+                                resp.commit_sha,
                                 cache_ttl,
                                 repo.id,
                                 cache_path,
@@ -2799,7 +2980,7 @@ impl ProxyService {
                         // the best-effort cache write above failed.
                         check_quarantine_until(quarantine_until)?;
 
-                        Ok((resp.content, resp.content_type))
+                        Ok((resp.content, resp.content_type, upstream_encoding))
                     }
                     Err(upstream_err) => {
                         // #1611 negative caching: a definitive upstream 404 is
@@ -2814,7 +2995,7 @@ impl ProxyService {
                         }
                         // Transient error (5xx / timeout / transport): RFC 5861
                         // stale-if-error — serve the stale body we already hold.
-                        if let Ok(Some((stale_content, stale_content_type))) = self
+                        if let Ok(Some((stale_content, stale_content_type, stale_content_encoding))) = self
                             .get_stale_cached_artifact(&cache_key, &metadata_key)
                             .await
                         {
@@ -2823,7 +3004,7 @@ impl ProxyService {
                                 full_url,
                                 upstream_err
                             );
-                            Ok((stale_content, stale_content_type))
+                            Ok((stale_content, stale_content_type, stale_content_encoding))
                         } else {
                             Err(upstream_err)
                         }
@@ -3188,6 +3369,10 @@ impl ProxyService {
                 // Proxy-cache stream: not our artifact row (#1278), unrecorded.
                 artifact_id: None,
                 etag: metadata.upstream_etag.clone(),
+                // Replay the coding the bytes were stored under, or a hit serves
+                // compressed data labelled as identity.
+                content_encoding: metadata.content_encoding.clone(),
+                commit_sha: metadata.upstream_commit_sha.clone(),
             })),
             Err(AppError::NotFound(_)) => {
                 tracing::debug!(
@@ -3275,6 +3460,8 @@ impl ProxyService {
             content_type: upstream.content_type.clone(),
             content_length: upstream.content_length,
             etag: upstream.etag.clone(),
+            content_encoding: upstream.content_encoding.clone(),
+            commit_sha: upstream.commit_sha.clone(),
         };
 
         let body = self.cache_persister.tee_stream(
@@ -3284,6 +3471,8 @@ impl ProxyService {
             CacheMetadataTemplate {
                 content_type: upstream.content_type,
                 etag: upstream.etag,
+                content_encoding: upstream.content_encoding,
+                commit_sha: upstream.commit_sha,
                 last_modified: None,
                 ttl_secs: cache_ttl,
                 expected_checksum,
@@ -3336,6 +3525,10 @@ impl ProxyService {
                 content_type: metadata.as_ref().and_then(|m| m.content_type.clone()),
                 content_length: metadata.as_ref().map(|m| m.size_bytes as u64),
                 etag: metadata.as_ref().and_then(|m| m.upstream_etag.clone()),
+                content_encoding: metadata.as_ref().and_then(|m| m.content_encoding.clone()),
+                commit_sha: metadata
+                    .as_ref()
+                    .and_then(|m| m.upstream_commit_sha.clone()),
             };
             return Ok(StreamHandle { body, headers });
         }
@@ -3685,6 +3878,8 @@ impl ProxyService {
                 resp.content_type.clone(),
                 resp.etag,
                 resp.last_modified,
+                resp.content_encoding,
+                resp.commit_sha,
                 dists_ttl_secs,
                 repo.id,
                 path,
@@ -4398,11 +4593,23 @@ impl ProxyService {
             ));
         }
 
-        // Reject any path segment that is exactly `..` or `.`. Substrings
-        // like `..foo` or `foo..bar` are fine (they are just bytes inside a
+        // Reject any path segment that is a dot segment. Substrings like
+        // `..foo` or `foo..bar` are fine (they are just bytes inside a
         // filename) and reflect legitimate package names.
+        //
+        // The percent-encoded spellings have to be rejected too, and this is a
+        // real escape rather than a theoretical one. axum percent-decodes a
+        // captured path parameter exactly once, so a request carrying `%252e%252e`
+        // reaches a handler as the literal `%2e%2e` — which is not equal to `..`
+        // and so passed this check — and the `url` crate then collapses
+        // `%2e%2e` as a dot segment when the fetch URL is parsed (WHATWG URL
+        // §"double-dot path segment" treats `..`, `.%2e`, `%2e.` and `%2e%2e`
+        // case-insensitively as equivalent). The upstream request would then
+        // resolve above the repository's configured base path, carrying the
+        // operator's stored upstream credential with it. Match the same set the
+        // URL parser does.
         for segment in trimmed.split('/') {
-            if segment == ".." || segment == "." {
+            if is_dot_segment(segment) {
                 return Err(AppError::Validation(format!(
                     "Proxy cache path must not contain `{}` segment",
                     segment
@@ -4438,7 +4645,7 @@ impl ProxyService {
         &self,
         cache_key: &str,
         metadata_key: &str,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
+    ) -> Result<Option<CachedBody>> {
         self.get_cached(cache_key, metadata_key, false).await
     }
 
@@ -4487,9 +4694,11 @@ impl ProxyService {
                 // upstream. `get_cached_artifact` re-verifies checksum + body
                 // presence; a missing/poisoned body degrades to Miss (B6).
                 match self.get_cached_artifact(cache_key, metadata_key).await? {
-                    Some((content, content_type)) => {
-                        Ok(CacheReadOutcome::Hit(content, content_type))
-                    }
+                    Some((content, content_type, content_encoding)) => Ok(CacheReadOutcome::Hit(
+                        content,
+                        content_type,
+                        content_encoding,
+                    )),
                     None => Ok(CacheReadOutcome::Miss),
                 }
             }
@@ -4531,7 +4740,7 @@ impl ProxyService {
         &self,
         repo: &Repository,
         cache_path: &str,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
+    ) -> Result<Option<CachedBody>> {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
         let mutability = cache_classifier::classify(&repo.format, cache_path);
@@ -4586,20 +4795,28 @@ impl ProxyService {
                     .get_stale_cached_artifact(cache_key, metadata_key)
                     .await
                 {
-                    Ok(Some((content, content_type))) => {
+                    Ok(Some((content, content_type, content_encoding))) => {
                         tracing::debug!(cache_key = %cache_key, "304 revalidation: extended TTL, serving cached body");
-                        Ok(CacheReadOutcome::Hit(content, content_type))
+                        Ok(CacheReadOutcome::Hit(
+                            content,
+                            content_type,
+                            content_encoding,
+                        ))
                     }
                     // Body vanished between probe and read: refill.
                     _ => Ok(CacheReadOutcome::Miss),
                 }
             }
             RevalidationVerdict::ServeStaleIfError => {
-                if let Ok(Some((content, content_type))) = self
+                if let Ok(Some((content, content_type, content_encoding))) = self
                     .get_stale_cached_artifact(cache_key, metadata_key)
                     .await
                 {
-                    return Ok(CacheReadOutcome::Hit(content, content_type));
+                    return Ok(CacheReadOutcome::Hit(
+                        content,
+                        content_type,
+                        content_encoding,
+                    ));
                 }
                 Ok(CacheReadOutcome::Miss)
             }
@@ -4709,6 +4926,8 @@ impl ProxyService {
         let now = Utc::now();
         let neg_ttl = chrono::Duration::seconds(cache_classifier::NEGATIVE_CACHE_TTL_SECS);
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -4759,7 +4978,7 @@ impl ProxyService {
         cache_key: &str,
         metadata_key: &str,
         allow_stale: bool,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
+    ) -> Result<Option<CachedBody>> {
         self.cache_store
             .get(cache_key, metadata_key, allow_stale)
             .await
@@ -4864,6 +5083,10 @@ impl ProxyService {
         content_type: Option<String>,
         etag: Option<String>,
         last_modified: Option<String>,
+        // Coding the buffered bytes are in, recorded so a cache hit replays it.
+        content_encoding: Option<String>,
+        // Upstream X-Repo-Commit for these bytes, recorded for the same reason.
+        commit_sha: Option<String>,
         ttl_secs: i64,
         repository_id: Uuid,
         artifact_path: &str,
@@ -4877,6 +5100,8 @@ impl ProxyService {
                 content_type,
                 etag,
                 last_modified,
+                content_encoding,
+                commit_sha,
                 ttl_secs,
                 repository_id,
                 artifact_path,
@@ -5038,7 +5263,7 @@ impl ProxyService {
         &self,
         cache_key: &str,
         metadata_key: &str,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
+    ) -> Result<Option<CachedBody>> {
         self.get_cached(cache_key, metadata_key, true).await
     }
 
@@ -5397,6 +5622,8 @@ mod tests {
     fn test_sidecar_round_trips_quarantine_until() {
         let until = Utc::now() + chrono::Duration::minutes(120);
         let meta = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: Utc::now(),
             upstream_etag: None,
             storage_etag: None,
@@ -6080,6 +6307,8 @@ mod tests {
     #[test]
     fn test_cache_metadata_serialization() {
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: Utc::now(),
             upstream_etag: Some("\"abc123\"".to_string()),
             storage_etag: None,
@@ -6104,6 +6333,8 @@ mod tests {
     fn test_cache_metadata_serialization_no_etag() {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -6129,6 +6360,8 @@ mod tests {
         let now = Utc::now();
         let expires = now + chrono::Duration::seconds(DEFAULT_CACHE_TTL_SECS);
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: Some("\"etag-value\"".to_string()),
             storage_etag: Some("\"storage-etag\"".to_string()),
@@ -6151,6 +6384,8 @@ mod tests {
     #[test]
     fn test_cache_metadata_large_size() {
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: Utc::now(),
             upstream_etag: None,
             storage_etag: None,
@@ -6194,6 +6429,8 @@ mod tests {
 
         // Expired cache entry
         let expired_metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now - chrono::Duration::hours(25),
             upstream_etag: None,
             storage_etag: None,
@@ -6212,6 +6449,8 @@ mod tests {
 
         // Valid cache entry
         let valid_metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -6434,6 +6673,8 @@ mod tests {
     fn test_expired_metadata_is_stale() {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now - chrono::Duration::hours(25),
             upstream_etag: Some("\"old-etag\"".to_string()),
             storage_etag: None,
@@ -6458,6 +6699,8 @@ mod tests {
     fn test_valid_metadata_is_not_stale() {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -6478,6 +6721,8 @@ mod tests {
     fn test_just_expired_metadata_is_stale() {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now - chrono::Duration::seconds(DEFAULT_CACHE_TTL_SECS + 1),
             upstream_etag: None,
             storage_etag: None,
@@ -7196,6 +7441,8 @@ mod tests {
     /// behavior on the storage HEAD.
     fn fresh_metadata_bytes_with_storage_etag(storage_etag: Option<String>) -> Bytes {
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: Utc::now(),
             upstream_etag: None,
             storage_etag,
@@ -7212,6 +7459,8 @@ mod tests {
 
     fn expired_metadata_bytes() -> Bytes {
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: Utc::now() - chrono::Duration::hours(2),
             upstream_etag: None,
             storage_etag: None,
@@ -7231,6 +7480,8 @@ mod tests {
     /// through the held / elapsed / no-hold states.
     fn metadata_bytes_with_quarantine(quarantine_until: Option<DateTime<Utc>>) -> Bytes {
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: Utc::now(),
             upstream_etag: None,
             storage_etag: None,
@@ -8236,6 +8487,8 @@ mod tests {
 
     fn template() -> CacheMetadataTemplate {
         CacheMetadataTemplate {
+            commit_sha: None,
+            content_encoding: None,
             content_type: Some("application/octet-stream".to_string()),
             etag: None,
             last_modified: None,
@@ -8572,6 +8825,8 @@ mod tests {
 
         let upstream = upstream_chunks(vec![b"payload"]);
         let template = CacheMetadataTemplate {
+            commit_sha: None,
+            content_encoding: None,
             content_type: Some("application/x-deb".to_string()),
             etag: Some("\"abc123\"".to_string()),
             last_modified: None,
@@ -8799,6 +9054,8 @@ mod tests {
                 content,
                 Some("application/octet-stream".to_string()),
                 etag,
+                None,
+                None,
                 None,
                 3600,
                 Uuid::nil(),
@@ -9268,6 +9525,8 @@ mod tests {
         cached_at: chrono::DateTime<chrono::Utc>,
     ) -> Bytes {
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at,
             upstream_etag: None,
             storage_etag: None,
@@ -9293,6 +9552,8 @@ mod tests {
     fn test_build_cached_entry_maps_fields_and_extracts_name() {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -9321,6 +9582,8 @@ mod tests {
     fn test_build_cached_entry_defaults_missing_content_type() {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -9646,6 +9909,73 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // validate_cache_path: dot-segment rejection, including the percent-encoded
+    // spellings the URL parser folds back into dot segments.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_cache_path_rejects_literal_dot_segments() {
+        for path in ["a/../b", "../etc/passwd", "a/./b", "..", "."] {
+            assert!(
+                ProxyService::validate_cache_path(path).is_err(),
+                "must reject {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_cache_path_rejects_encoded_dot_segments() {
+        // Regression: axum percent-decodes a captured path parameter exactly
+        // once, so a request carrying `%252e%252e` reaches the handler as the
+        // literal `%2e%2e`. That is not equal to `..`, so it used to pass this
+        // validator — and the `url` crate then collapsed it as a dot segment
+        // when the upstream URL was parsed, resolving the fetch above the
+        // repository's configured base path with the operator's upstream
+        // credential attached. Every spelling the URL parser folds must be
+        // rejected here, case-insensitively.
+        for path in [
+            "api/models/%2e%2e/x",
+            "api/models/%2E%2E/x",
+            "api/models/.%2e/x",
+            "api/models/%2e./x",
+            "api/models/%2e/x",
+            "a/%2E/b",
+        ] {
+            assert!(
+                ProxyService::validate_cache_path(path).is_err(),
+                "must reject {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_cache_path_allows_dots_inside_a_segment() {
+        // Real package filenames are full of dots and must not be caught.
+        for path in [
+            "simple/click/click-8.0.0-py3-none-any.whl",
+            "a/..foo/b",
+            "a/foo..bar/b",
+            "noarch/repodata.json.zst",
+            "a/%2ebar/b",
+        ] {
+            assert!(
+                ProxyService::validate_cache_path(path).is_ok(),
+                "must allow {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_dot_segment_matches_url_parser_set() {
+        for s in [".", "..", "%2e", "%2E", "%2e%2e", "%2E%2e", ".%2e", "%2e."] {
+            assert!(is_dot_segment(s), "{s} is a dot segment");
+        }
+        for s in ["", "a", "...", "%2ea", "a%2e", "..a", "foo.bar", "%252e"] {
+            assert!(!is_dot_segment(s), "{s} is not a dot segment");
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // extract_streaming_headers: pure header parsing. Verifies the
     // Content-Length parse-or-skip behaviour and the etag/content-type
     // round-trip without a reqwest::Response. #895.
@@ -9654,12 +9984,75 @@ mod tests {
     use reqwest::header::{HeaderMap, HeaderValue};
 
     #[test]
+    fn test_extract_streaming_headers_captures_encoding_and_commit() {
+        // Both of these must survive header capture: with reqwest's transparent
+        // decompression disabled, a coded body is only decodable by the client if
+        // the coding is forwarded, and `X-Repo-Commit` has to travel with the
+        // bytes it describes rather than being looked up separately.
+        let mut h = HeaderMap::new();
+        h.insert(
+            reqwest::header::CONTENT_ENCODING,
+            HeaderValue::from_static("gzip"),
+        );
+        h.insert(UPSTREAM_COMMIT_HEADER, HeaderValue::from_static("abc123"));
+        let got = extract_streaming_headers(&h);
+        assert_eq!(got.content_encoding.as_deref(), Some("gzip"));
+        assert_eq!(got.commit_sha.as_deref(), Some("abc123"));
+
+        // Absent headers stay absent rather than defaulting to a coding.
+        let empty = extract_streaming_headers(&HeaderMap::new());
+        assert!(empty.content_encoding.is_none());
+        assert!(empty.commit_sha.is_none());
+    }
+
+    #[test]
+    fn test_cache_metadata_round_trips_encoding_and_commit() {
+        // A cache hit rebuilds the response from the sidecar, so both fields have
+        // to serialize; and pre-existing sidecars (written without them) must
+        // still deserialize, reading as "identity, no commit".
+        let now = Utc::now();
+        let metadata = CacheMetadata {
+            cached_at: now,
+            upstream_etag: Some("\"e\"".to_string()),
+            storage_etag: None,
+            last_modified: None,
+            content_encoding: Some("gzip".to_string()),
+            upstream_commit_sha: Some("deadbeef".to_string()),
+            negative_cached_until: None,
+            quarantine_until: None,
+            expires_at: now + chrono::Duration::seconds(60),
+            content_type: Some("application/json".to_string()),
+            size_bytes: 3,
+            checksum_sha256: "abc".to_string(),
+        };
+        let json = serde_json::to_string(&metadata).expect("serialize");
+        let back: CacheMetadata = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.content_encoding.as_deref(), Some("gzip"));
+        assert_eq!(back.upstream_commit_sha.as_deref(), Some("deadbeef"));
+
+        let legacy = serde_json::json!({
+            "cached_at": now,
+            "upstream_etag": null,
+            "expires_at": now + chrono::Duration::seconds(60),
+            "content_type": "application/json",
+            "size_bytes": 3,
+            "checksum_sha256": "abc",
+        });
+        let legacy: CacheMetadata =
+            serde_json::from_value(legacy).expect("pre-existing sidecar must still load");
+        assert!(legacy.content_encoding.is_none());
+        assert!(legacy.upstream_commit_sha.is_none());
+    }
+
+    #[test]
     fn test_extract_streaming_headers_full_set() {
         let mut h = HeaderMap::new();
         h.insert(CONTENT_TYPE, HeaderValue::from_static("application/x-deb"));
         h.insert(ETAG, HeaderValue::from_static("\"abc123\""));
         h.insert(CONTENT_LENGTH, HeaderValue::from_static("12345"));
-        let (ct, etag, len) = extract_streaming_headers(&h);
+        let h = extract_streaming_headers(&h);
+        let (ct, etag, len) = (h.content_type, h.etag, h.content_length);
+        let _ = (&ct, &etag, &len);
         assert_eq!(ct.as_deref(), Some("application/x-deb"));
         assert_eq!(etag.as_deref(), Some("\"abc123\""));
         assert_eq!(len, Some(12345));
@@ -9668,7 +10061,9 @@ mod tests {
     #[test]
     fn test_extract_streaming_headers_empty() {
         let h = HeaderMap::new();
-        let (ct, etag, len) = extract_streaming_headers(&h);
+        let h = extract_streaming_headers(&h);
+        let (ct, etag, len) = (h.content_type, h.etag, h.content_length);
+        let _ = (&ct, &etag, &len);
         assert!(ct.is_none());
         assert!(etag.is_none());
         assert!(len.is_none());
@@ -9682,7 +10077,9 @@ mod tests {
         // back to chunked transfer encoding.
         let mut h = HeaderMap::new();
         h.insert(CONTENT_LENGTH, HeaderValue::from_static("not-a-number"));
-        let (_, _, len) = extract_streaming_headers(&h);
+        let h = extract_streaming_headers(&h);
+        let (ct, etag, len) = (h.content_type, h.etag, h.content_length);
+        let _ = (&ct, &etag, &len);
         assert!(len.is_none());
     }
 
@@ -9694,7 +10091,9 @@ mod tests {
         let mut h = HeaderMap::new();
         let bad = HeaderValue::from_bytes(b"\xff\xfe").unwrap();
         h.insert(ETAG, bad);
-        let (_, etag, _) = extract_streaming_headers(&h);
+        let h = extract_streaming_headers(&h);
+        let (ct, etag, len) = (h.content_type, h.etag, h.content_length);
+        let _ = (&ct, &etag, &len);
         assert!(etag.is_none());
     }
 
@@ -9707,6 +10106,8 @@ mod tests {
     fn test_streaming_fetch_result_carries_content_length() {
         let dummy: BoxStream<'static, Result<Bytes>> = Box::pin(futures::stream::iter(vec![]));
         let r = StreamingFetchResult {
+            commit_sha: None,
+            content_encoding: None,
             body: dummy,
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(12345),
@@ -10187,7 +10588,7 @@ mod tests {
             .expect("prime cache from upstream");
         assert_eq!(&body[..], b"INDEX-BODY");
         match proxy.cached_metadata_if_servable(&repo, "index.json").await {
-            Ok(Some((bytes, _))) => assert_eq!(&bytes[..], b"INDEX-BODY"),
+            Ok(Some((bytes, _, _))) => assert_eq!(&bytes[..], b"INDEX-BODY"),
             other => panic!("fresh cached entry must be servable, got {other:?}"),
         }
 
@@ -10511,6 +10912,8 @@ mod tests {
                 Some("application/gzip".to_string()),
                 None,
                 None,
+                None,
+                None,
                 DEFAULT_CACHE_TTL_SECS,
                 Uuid::new_v4(),
                 cache_path,
@@ -10530,7 +10933,7 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
 
-        let (got, got_ct) = lookup.expect(
+        let (got, got_ct, _got_enc) = lookup.expect(
             "cache_artifact MUST persist bytes that the very next call to \
              get_cached_artifact_by_path can read back. The reproducer in \
              #1445(A) (`cached artifacts should contain abbrev after npm \
@@ -10694,7 +11097,8 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
 
-        let (cached_content, _) = cached.expect("a matching content-addressed body MUST be cached");
+        let (cached_content, _, _) =
+            cached.expect("a matching content-addressed body MUST be cached");
         assert_eq!(&cached_content[..], body.as_ref());
     }
 
@@ -11127,6 +11531,8 @@ mod tests {
             now + chrono::Duration::hours(1)
         };
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now - chrono::Duration::hours(2),
             upstream_etag: None,
             storage_etag: None,
@@ -11283,7 +11689,7 @@ mod tests {
             KeyResponse::Bytes(Bytes::from_static(body)),
         );
         let out = svc.get_cached(BODY_KEY, META_KEY, true).await.unwrap();
-        let (content, ct) = out.expect("stale read must serve an expired entry");
+        let (content, ct, _enc) = out.expect("stale read must serve an expired entry");
         assert_eq!(&content[..], body);
         assert_eq!(ct.as_deref(), Some("application/octet-stream"));
     }
@@ -12568,6 +12974,8 @@ mod tests {
     ) {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now - chrono::Duration::hours(2),
             upstream_etag: upstream_etag.map(String::from),
             storage_etag: None,
@@ -12839,6 +13247,8 @@ mod tests {
     ) {
         let now = Utc::now();
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -12859,6 +13269,8 @@ mod tests {
         let now = Utc::now();
         let neg_ttl = chrono::Duration::seconds(cache_classifier::NEGATIVE_CACHE_TTL_SECS);
         let metadata = CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: None,
             storage_etag: None,
@@ -14008,6 +14420,8 @@ mod tests {
                 Some("text/plain".to_string()),
                 Some("\"etag-1\"".to_string()),
                 None,
+                None,
+                None,
                 3600,
                 Uuid::new_v4(),
                 "some/path",
@@ -14042,6 +14456,8 @@ mod tests {
     fn sample_cache_metadata(etag: &str) -> CacheMetadata {
         let now = Utc::now();
         CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
             cached_at: now,
             upstream_etag: Some(etag.to_string()),
             storage_etag: None,

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -127,6 +127,11 @@ pub struct StreamingFetchResult {
     /// recording keys off this field so a local-member serve is counted
     /// exactly once, at the shared local-serve choke point (#2260).
     pub artifact_id: Option<Uuid>,
+    /// Upstream `ETag` when known (fresh fetch, cache hit, or stale-if-error
+    /// serve). `None` for local artifact reads, which have no upstream ETag.
+    /// Forwarded verbatim on the outbound response so clients that require
+    /// an ETag on the resolve HEAD (e.g. `huggingface_hub`) get one.
+    pub etag: Option<String>,
 }
 
 impl From<StreamHandle> for StreamingFetchResult {
@@ -140,6 +145,7 @@ impl From<StreamHandle> for StreamingFetchResult {
             content_length: handle.headers.content_length,
             // Remote/cache stream: not a local artifact row, so unrecorded.
             artifact_id: None,
+            etag: handle.headers.etag,
         }
     }
 }
@@ -149,6 +155,7 @@ impl std::fmt::Debug for StreamingFetchResult {
         f.debug_struct("StreamingFetchResult")
             .field("content_type", &self.content_type)
             .field("content_length", &self.content_length)
+            .field("etag", &self.etag)
             .field("body", &"<stream>")
             .finish()
     }
@@ -3180,6 +3187,7 @@ impl ProxyService {
                 content_length: Some(metadata.size_bytes as u64),
                 // Proxy-cache stream: not our artifact row (#1278), unrecorded.
                 artifact_id: None,
+                etag: metadata.upstream_etag.clone(),
             })),
             Err(AppError::NotFound(_)) => {
                 tracing::debug!(
@@ -3266,6 +3274,7 @@ impl ProxyService {
         let headers = StreamHeaders {
             content_type: upstream.content_type.clone(),
             content_length: upstream.content_length,
+            etag: upstream.etag.clone(),
         };
 
         let body = self.cache_persister.tee_stream(
@@ -3326,6 +3335,7 @@ impl ProxyService {
             let headers = StreamHeaders {
                 content_type: metadata.as_ref().and_then(|m| m.content_type.clone()),
                 content_length: metadata.as_ref().map(|m| m.size_bytes as u64),
+                etag: metadata.as_ref().and_then(|m| m.upstream_etag.clone()),
             };
             return Ok(StreamHandle { body, headers });
         }
@@ -9701,6 +9711,7 @@ mod tests {
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(12345),
             artifact_id: None,
+            etag: None,
         };
         assert_eq!(r.content_length, Some(12345));
         assert_eq!(r.content_type.as_deref(), Some("application/octet-stream"));


### PR DESCRIPTION
## Summary

Makes the conda-forge and Hugging Face pull-through proxies work against real upstreams, and fixes a binary-wide reqwest bug that stripped Content-Length from compressed upstream responses. Found while validating a developer onboarding path (pip, conda/pixi, Hugging Face, NuGet all pointed at Artifact Keeper). Closes #2914.

1. HF namespaced (org/name) model routing.
2. conda Remote repodata served in full (128 MiB tier, budget-reserved) with real upstream failures propagated instead of masked as an empty index; sharded-repodata endpoint 404s for non-hosted repos so clients fall back to repodata.json.
3. HF model-info and tree listings are now real upstream pull-throughs for Remote repos.
4. Upstream `ETag`, `Content-Encoding` and `X-Repo-Commit` are forwarded on resolve responses (huggingface_hub's HEAD metadata check requires an ETag, a size, and a commit).
5. Disable reqwest auto-decompression (`no_gzip`/`no_brotli`/`no_deflate`/`no_zstd`) on the base HTTP client. The `opensearch` crate enables reqwest's `gzip` feature, which Cargo unifies across the binary, silently switching every client into content-negotiation that decodes compressed responses and drops Content-Encoding and Content-Length before the proxy captures them.
6. conda Remote **package** downloads stream instead of buffering at the 8 MiB metadata tier.

## Content-Encoding is now carried end to end

Turning off reqwest's decompression removed the only component in the process that handled `Content-Encoding`, and nothing took over: a coded body was served and cached labelled as identity. Before, such a response reached the client with correct bytes and no Content-Length; after commit 5 alone it would have reached the client with *wrong bytes* and a correct Content-Length. Object stores return a stored `Content-Encoding` regardless of the request's `Accept-Encoding`, so this needed no hostile upstream — an S3-hosted channel mirror or `nginx gzip_static always` was enough, and conda would have re-gzipped on top of it.

The coding is now captured on both the buffered and streaming paths, persisted in the cache sidecar (`CacheMetadata::content_encoding`, `#[serde(default)]` for wire-compat — absent means identity, which is correct for entries written while reqwest was still decoding), and replayed on cache hits and stale-if-error serves. The base client also advertises `Accept-Encoding: identity` explicitly, because sending *no* `Accept-Encoding` means "any content coding is acceptable" per RFC 9110 §12.5.3 — the opposite of what a client that cannot decode should say.

`fetch_artifact_capped` keeps its existing `(Bytes, Option<String>)` shape so the ~8 callers that parse bodies themselves are untouched; a `_with_encoding` sibling serves the handlers that forward bytes onward.

## Behavior changes worth a reviewer's attention

- **conda `repodata.json` / `channeldata.json` now fail closed.** A real upstream failure surfaces (503 on a 5xx) instead of a DB-only empty index with 200. A single failing channel can now fail a solve that previously "succeeded" against a silently empty index. The proxy's own RFC 5861 stale-if-error window still covers transient upstream errors.
- **Sharded-repodata and JLAP 404 for all non-hosted repo types**, not just Remote. Virtual was the real fail-open (a virtual repo owns no artifacts, so it served an authoritative empty CEP-16 index that a client will not fall back from). Extending it to Staging is conservative rather than a bug fix — Staging is hosted, so its shard index would have been correct; the guard is written to fail closed on an unreadable `repo_type` and the rationale is in its doc comment so a reviewer can dissent knowingly.
- **`GET /api/models/{id}` `"sha"` changed for hosted repos** from the artifact's `checksum_sha256` to a stable per-`(model_id, revision)` commit id. `snapshot_download` takes the snapshot directory from model-info's `sha` and files each blob under the commit its own resolve reported, so the two must agree or the download produces an empty directory. The old value was per-file and 64 chars, and was never a commit identifier. No existing test asserted it.
- Upstream `ETag` is never synthesized for Remote artifacts — inventing one would let clients cache proxied bytes under an identity we made up. Hosted/Virtual local serves use the stored `checksum_sha256`.

## Verification

All four developer flows verified end to end through a locally built image: pip download, `pixi install` resolving conda-forge + PyPI, `hf download` of a namespaced model (pulls the full model, 30 files, ~1 GB, through the proxy), and `dotnet restore`.

Targets `main`. **Expect merge conflicts with #2913 (merged after this branch was cut)**: `proxy_helpers.rs`'s `RepoInfo` gained `curation_enabled`/`curation_default_action`, and the conda/HF test fixtures gained fields. #2913's curation enforcement is PyPI-only, so no conda/HF path needs a curation gate.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Each fix has a test that fails on the pre-fix code. Two were verified by reverting the fix and observing the failure:

- conda package download above the 8 MiB tier — fails with `502 … Upstream metadata response exceeded the 8388608-byte limit`.
- Scan-policy-style wiring aside, the gzip test now asserts the coding is forwarded **and** that the body inflates to the original bytes, rather than only asserting Content-Length.

Also added: conda `channeldata.json` fail-closed and large-body serve; sharded-shard and JLAP guards for Remote, Local and Virtual; a **HEAD** request carrying the full `etag`/`content-length`/`x-repo-commit` trio (no test issued a HEAD before, though the bug being fixed is huggingface_hub's HEAD probe); a second cache-hit request replaying the same ETag and commit with the mock `.expect(1)` proving it came from cache; forwarded-header preference with the model-info mock `.expect(0)`; model-info failure not failing the download; tree pull-through and its upstream failure surfacing; hosted ETag + commit with `model_info.sha == resolve x-repo-commit`; slash-bearing revision re-encoding; and `validate_cache_path` unit tests for the literal and encoded dot-segment sets.

Three pre-existing namespaced-404 tests passed unchanged at the merge base (their URIs matched no route, so axum's fallback already produced the 404). They now assert the handler's own error body and `.expect(1)` on the upstream mock, so they fail at base.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests — full `cargo test --lib`: **14,122 passed, 2 failed**, both pre-existing and environment-specific (`test_hex_same_version_case_variants_advertise_one_downloadable_release_db` fails identically at the merge base and passes in CI; `test_large_object_client_builder_does_not_apply_total_timeout` fails with a loopback TCP connect timeout, verified identical with this PR's `http_client.rs` change reverted)

## API Changes
- [x] N/A — no new OpenAPI-documented endpoints. `huggingface.rs` and `conda.rs` carry no `#[utoipa::path]` annotations at all and are not registered in `ApiDoc`, consistent with every other format handler. (The previous revision of this description checked the utoipa/ToSchema boxes and named "HF revision routes"; that was wrong — those annotations do not exist.)
- [x] `cargo test --lib test_openapi_spec_is_valid` passes (nothing was added to the spec)
- [x] N/A - no migration
- [x] `cargo sqlx prepare --check --workspace` clean — no new checked macro queries

## Known follow-ups (not blocking)

- **LFS commit header.** The Hub serves LFS objects as a 302 to its CDN with `X-Repo-Commit` on the *redirect*, and reqwest follows redirects internally, exposing only the final hop's headers. So for model weights the forwarded header is unavailable and a bounded 2s model-info fallback is used instead — strictly weaker, since model-info is a second observation of a mutable ref. Capturing intermediate-hop headers needs `Policy::none()` plus a manual redirect loop that re-runs the SSRF check per hop; once that lands the fallback can be deleted outright.
- **The buffered-download audit found two more instances of the conda bug class outside this PR**, filed separately: `cargo.rs`'s Remote crate download buffers at 8 MiB (so any crate over that 502s — crates.io's default publish ceiling is 10 MiB), and nuget's flatcontainer cache-repair path both buffers at 8 MiB and builds its upstream URL without `PackageBaseAddress` discovery. Maven, goproxy and the other ~25 formats were checked and stream correctly.
- **Budget-reservation gaps** beyond conda: `debian.rs` has two unbudgeted 128 MiB buffered dists paths (missed when its siblings were budgeted), `protobuf.rs` buffers 128 MiB unbudgeted and its Virtual arm collects with no cap at all, and `pub_registry.rs` is the last caller of the uncapped `proxy_fetch`.
- conda's Remote `repodata.json` (identity, not `.zst`) can exceed the 128 MiB tier for a large channel; modern clients request `.zst` first and are unaffected.
- Only the first page of `/api/models/{id}/tree/{rev}` is proxied (`Link: rel="next"` is not followed). `hf download` does not use this endpoint.
- `GET /pypi//simple/` (empty repo-key segment) returns 500 rather than 404 — matchit matches the empty param and the middleware's early return skips inserting the auth extension. Not exploitable; no repository can hold the empty key.
- No end-to-end router test for a Virtual HF repo's local-member resolve headers; the new member-priority checksum SQL is covered directly instead.
