### PR TITLE
fix: omit empty shasums_url/shasums_signature_url from provider download response

### DIFF
--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -943,8 +943,6 @@ async fn download_provider(
         "filename": filename,
         "download_url": download_url,
         "shasum": artifact.checksum_sha256,
-        "shasums_url": "",
-        "shasums_signature_url": "",
         "signing_keys": {
             "gpg_public_keys": []
         },


### PR DESCRIPTION
## Summary
- `download_provider` always sent `shasums_url`/`shasums_signature_url` as `""`, which per RFC 3986 self-resolves to the same download-info URL when Terraform follows it, causing `terraform init` to fail with `checksum list has no SHA-256 hash for ...`
- Omit both fields when no SHASUMS file is served; Terraform falls back to the per-package `shasum` field for verification

Fixes #2933

## Test plan
- [x] `cargo build --lib` succeeds
- [x] `cargo test --lib terraform::` — 104 passed, 0 failed