### PR TITLE
fix(maven): backport flat-key attribution ledger-first ordering to 1.6.x (#2943)

### DIFF
--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -10,9 +10,9 @@
 //! closed.
 //!
 //! This module resolves the single owning repository of a flat key from the
-//! catalog (live artifact rows, parent-artifact metadata `files[]`, and the
-//! `maven_flat_object_owner` attribution table backfilled by migration 163 and
-//! qualified by storage backend in migration 168), and uses that to:
+//! catalog (live artifact rows, the `maven_flat_object_owner` attribution
+//! table backfilled by migration 163 and qualified by storage backend in
+//! migration 168, and parent-artifact metadata `files[]`), and uses that to:
 //!
 //! * gate reads -- serve a legacy flat object only to its genuine owner
 //!   ([`flat_key_readable`]); and
@@ -117,11 +117,25 @@ async fn query_layer(
 }
 
 /// Resolve the owner of a flat key on `storage_backend` directly (without
-/// checksum-suffix stripping): (a) a live `artifacts` row, then (b) a live
-/// parent artifact whose metadata `files[]` references the key, then (c) the
-/// `maven_flat_object_owner` table -- each restricted to the same backend. A
-/// layer that names two or more repositories is ambiguous and resolves to
-/// `None` (no tenant may read it) rather than arbitrarily picking one owner.
+/// checksum-suffix stripping): (a) a live `artifacts` row, then (b) the
+/// `maven_flat_object_owner` table, then (c) a live parent artifact whose
+/// metadata `files[]` references the key -- each restricted to the same
+/// backend. A layer that names two or more repositories is ambiguous and
+/// resolves to `None` (no tenant may read it) rather than arbitrarily picking
+/// one owner.
+///
+/// The attribution table is consulted *before* the metadata-files derivation
+/// (#2942), for two reasons:
+///
+/// * Correctness: the table is the claims ledger -- write-time
+///   first-writer-wins claims ([`claim_flat_key_on_write`]), the 163/170
+///   backfills, and operator repairs all record ownership there, and
+///   [`guard_flat_key_writable`] enforces against it. An explicit claim must
+///   outrank an attribution *derived* from another repository's metadata, or
+///   the read path could disagree with the write guard about who owns a key.
+/// * Cost: the table lookup is a primary-key probe, while the metadata
+///   derivation scans `artifact_metadata`; on deployments with a populated
+///   ledger the derivation now runs only for keys the table has never seen.
 async fn resolve_direct(
     db: &PgPool,
     storage_backend: &str,
@@ -129,8 +143,8 @@ async fn resolve_direct(
 ) -> Result<Option<Uuid>> {
     for sql in [
         OWNER_BY_ARTIFACT_ROW_SQL,
-        OWNER_BY_METADATA_FILES_SQL,
         OWNER_BY_ATTRIBUTION_TABLE_SQL,
+        OWNER_BY_METADATA_FILES_SQL,
     ] {
         match query_layer(db, sql, storage_backend, storage_key).await? {
             LayerResult::Absent => continue,
@@ -146,8 +160,8 @@ async fn resolve_direct(
 /// (unowned, or ambiguous across repositories on that backend). The backend is
 /// part of the object's physical identity: the same flat key on two different
 /// backends names two distinct objects with independent owners (#2671).
-/// Resolution order: (a) live `artifacts` row, (b) live parent artifact metadata
-/// `files[]`, (c) `maven_flat_object_owner` table, and if the key is a
+/// Resolution order: (a) live `artifacts` row, (b) `maven_flat_object_owner`
+/// table, (c) live parent artifact metadata `files[]`, and if the key is a
 /// checksum/signature sidecar, (d) strip the suffix and resolve the base key the
 /// same way.
 pub async fn attributed_owner(
@@ -741,5 +755,69 @@ mod tests {
             "snake_case files[] entry must keep attributing after the fix"
         );
         tdh::cleanup(&pool, repo, Uuid::nil()).await;
+    }
+
+    /// The attribution table is the claims ledger: an explicit claim (write-time
+    /// first-writer-wins, backfill, or operator repair) must outrank an
+    /// attribution *derived* from another repository's metadata `files[]`, so
+    /// the read path always agrees with `guard_flat_key_writable`, which
+    /// enforces against the recorded claim (#2942).
+    ///
+    /// This test FAILS under the pre-fix layer order (metadata derivation
+    /// consulted first would attribute the key to the parent's repository) and
+    /// PASSES with the table consulted first.
+    #[tokio::test]
+    async fn test_attribution_table_claim_outranks_metadata_derivation() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (claimant, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let (deriver, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        set_repo_backend(&pool, claimant, "s3").await;
+        set_repo_backend(&pool, deriver, "s3").await;
+        let gav = Uuid::new_v4();
+        let parent_key = format!("maven/com/acme/prec/{gav}/prec-1.0.jar");
+        let contested_key = format!("maven/com/acme/prec/{gav}/prec-1.0.pom");
+        // `deriver`'s parent metadata lists the contested key...
+        seed_parent_with_files_entry(
+            &pool,
+            deriver,
+            "com/acme/prec/1.0/prec-1.0.jar",
+            &parent_key,
+            "storageKey",
+            &contested_key,
+        )
+        .await;
+        // ...but `claimant` holds the recorded claim.
+        sqlx::query(
+            "INSERT INTO maven_flat_object_owner \
+             (storage_backend, storage_key, repository_id, source) \
+             VALUES ('s3', $1, $2, 'write_claim')",
+        )
+        .bind(&contested_key)
+        .bind(claimant)
+        .execute(&pool)
+        .await
+        .expect("seed claim");
+
+        assert_eq!(
+            attributed_owner(&pool, "s3", &contested_key)
+                .await
+                .expect("query"),
+            Some(claimant),
+            "a recorded claim must outrank metadata-derived attribution"
+        );
+        assert!(
+            flat_key_readable(&pool, claimant, "s3", &contested_key).await,
+            "the claimant reads its claimed key"
+        );
+        assert!(
+            !flat_key_readable(&pool, deriver, "s3", &contested_key).await,
+            "the deriving repository must not read a key claimed by another"
+        );
+
+        clear_claims(&pool, &[claimant, deriver]).await;
+        tdh::cleanup(&pool, deriver, Uuid::nil()).await;
+        tdh::cleanup(&pool, claimant, Uuid::nil()).await;
     }
 }


### PR DESCRIPTION
## Summary

Backports the tenant-isolation **layer-reorder** (the security-relevant part)
from #2943 to `release/1.6.x`. In `backend/src/services/maven_flat_attribution.rs`,
`resolve_direct` now consults the `maven_flat_object_owner` claims ledger
**before** the parent-artifact metadata `files[]` derivation:

```
[ artifacts row, attribution table (ledger), metadata files[] ]
```

instead of the previous `[ artifacts row, metadata files[], attribution table ]`.

The attribution table is the claims ledger: write-time first-writer-wins claims,
the migration 163/170 backfills, and operator repairs all record ownership there,
and `guard_flat_key_writable` enforces against it. A recorded claim must outrank
an attribution *derived* from another repository's metadata, otherwise the read
path can disagree with the write guard about who owns a flat key — a
tenant-isolation attribution-consistency defect on shared cloud namespaces
(S3/GCS/Azure). This aligns read-side resolution with the write guard.

Credit to **@ThaSami** for the original fix in #2943.

## What is and isn't backported (the split)

The performance optimization from #2943 — the `jsonb_path_ops` GIN index
(migration 179) and the `@>` containment rewrite of `OWNER_BY_METADATA_FILES_SQL`
— is **intentionally NOT backported**: a write-blocking in-transaction index
build is heavier than appropriate for a patch release, and the reorder is the
security-relevant part (independent of the SQL form). `release/1.6.x` keeps its
existing `EXISTS` / `jsonb_array_elements` metadata SQL exactly as-is; a
red-team verification confirmed both SQL forms resolve identically, so the
reorder is correct against either. 1.6.x users get the isolation fix; the
indexed fast-path ships in 1.7.0 via #2943 on `main`.

Diff is the array-order swap + doc-comments explaining ledger-first ordering
+ one regression test. No migration, no SQL rewrite.

## Main-first trace-back

Fixed on `main` via #2943 / commit `05dc4042e` (closes #2942). This PR carries
the security portion of that change back to the 1.6.x patch line.

Refs #2942.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Ports `test_attribution_table_claim_outranks_metadata_derivation` from #2943,
adapted to 1.6.x's test helpers (`tdh`, `seed_parent_with_files_entry`,
`set_repo_backend`, `clear_claims`, all present on the branch). A parent's
metadata `files[]` lists a contested key while another repository holds the
recorded ledger claim; the test asserts the claimant owns and reads the key and
the deriving repository does not. It **fails** under the pre-reorder order
(resolves to the deriving repo) and **passes** with the ledger consulted first —
confirmed locally in both directions.

## Test Checklist
- [x] Unit tests added/updated (1 ported regression test)
- [ ] Integration tests added/updated (if applicable) — N/A; covered by the module test
- [ ] E2E tests added/updated (if applicable) — N/A
- [x] Manually tested locally (module suite: 12 passed; ported test flips RED→GREEN on a throwaway Postgres with 1.6.x migrations applied)
- [x] No regressions in existing tests

## API Changes
- [x] N/A — no API changes (read-side attribution ordering only)

## Notes

- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `docker build -f docker/Dockerfile.backend` succeeds; the patched image boots healthy (`/health` → 200) on an isolated pool slot.
- No behavior change for filesystem backends (they short-circuit before consulting the catalog) or for keys attributed by a single layer; the reorder only changes precedence when a key is *both* claimed in the ledger and derivable from another repo's metadata.
