### PR TITLE
feat(curation): publisher_trust rule evaluator with provenance-first trust

### DIFF
--- a/backend/src/services/curation/mod.rs
+++ b/backend/src/services/curation/mod.rs
@@ -1,0 +1,9 @@
+//! Curation policy rule evaluators (#2947 epic).
+//!
+//! Each submodule is a self-contained evaluator for one curation rule type.
+//! The curation service dispatch (owned by the foundation work for #2947)
+//! selects the evaluator by the rule's `rule_type` and maps the module-local
+//! decision enum onto the shared `CurationDecision`.
+
+pub mod publisher_source;
+pub mod publisher_trust;

--- a/backend/src/services/curation/publisher_source.rs
+++ b/backend/src/services/curation/publisher_source.rs
@@ -1,0 +1,344 @@
+//! Publisher identity extraction for `publisher_trust` curation rules (#2948).
+//!
+//! Security model: a publisher identity is only as trustworthy as where it
+//! came from. This module makes that provenance explicit:
+//!
+//! * [`PublisherSource::Attestation`] — the identity comes from a registry
+//!   provenance/attestation record (PyPI Trusted Publishers / integrity API
+//!   attestation bundles, npm sigstore provenance). These are bound to an
+//!   OIDC identity at publish time and are the *strong* trust signal.
+//! * [`PublisherSource::Metadata`] — the identity is self-asserted package
+//!   metadata (`author`, `maintainer`, `_npmUser`, ...). Anyone can put
+//!   "Microsoft" in an `author` field, so this is a *weak*, spoofable signal
+//!   (a classic dependency-confusion vector). It is surfaced as a labeled
+//!   fallback and must never be treated as equivalent to an attestation.
+//!
+//! Parsing is deliberately defensive: any missing or malformed field yields
+//! `None` rather than a guess, so callers can fail safe.
+
+use serde_json::Value;
+
+/// Where a publisher identity was sourced from. Ordering of trust:
+/// `Attestation` (verified provenance) > `Metadata` (self-asserted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublisherSource {
+    /// Registry-verified provenance (PyPI Trusted Publisher attestation
+    /// bundle, npm sigstore attestation). Strong signal.
+    Attestation,
+    /// Self-asserted package metadata (`author` / `maintainer` / `_npmUser`).
+    /// Weak, spoofable signal — never sufficient on its own for trust
+    /// decisions under `match: "attestation"`.
+    Metadata,
+}
+
+/// A publisher identity extracted from package metadata, labeled with the
+/// signal it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublisherIdentity {
+    /// Publisher name as extracted (e.g. a GitHub org from an attestation
+    /// bundle, or an `author` string from self-asserted metadata).
+    pub name: String,
+    /// Which class of signal produced [`Self::name`].
+    pub source: PublisherSource,
+    /// `true` only when the identity comes from a registry-verified
+    /// provenance record. Always `false` for [`PublisherSource::Metadata`].
+    pub verified: bool,
+}
+
+/// Package formats for which a publisher/provenance concept exists and this
+/// module knows how to extract it. Formats outside this set have no
+/// meaningful publisher signal (e.g. `raw`/`generic`), so a global
+/// publisher-trust policy should treat them as not applicable rather than
+/// flagging everything.
+pub const APPLICABLE_FORMATS: &[&str] = &["pypi", "npm"];
+
+/// Returns `true` if `format` has a publisher concept this module can
+/// evaluate (see [`APPLICABLE_FORMATS`]).
+pub fn is_applicable_format(format: &str) -> bool {
+    APPLICABLE_FORMATS.contains(&format.to_ascii_lowercase().as_str())
+}
+
+/// Extracts the strongest available publisher identity from `metadata` for
+/// the given package `format`.
+///
+/// * `pypi` — expects the PyPI JSON API shape (`/pypi/{pkg}/json`): the
+///   self-asserted fields live under `info.author` / `info.maintainer` /
+///   `info.author_email` / `info.maintainer_email`. If a PyPI integrity-API
+///   provenance object has been merged into the blob (top-level
+///   `provenance.attestation_bundles[].publisher`, as returned by
+///   `/integrity/{pkg}/{version}/{file}/provenance`), the Trusted-Publisher
+///   identity (repository owner, e.g. the GitHub org) is preferred with
+///   `source = Attestation, verified = true`.
+/// * `npm` — expects the registry packument / version-document shape:
+///   self-asserted fields are `_npmUser.name` and `maintainers[].name`. If
+///   the version's `dist.attestations` carries a sigstore `provenance`
+///   record, the identity is labeled `Attestation`/`verified`.
+///
+/// Any other format, and any metadata where no non-empty publisher can be
+/// found, returns `None` — callers must not fabricate trust from absence.
+pub fn extract_publisher(format: &str, metadata: &Value) -> Option<PublisherIdentity> {
+    match format.to_ascii_lowercase().as_str() {
+        "pypi" => extract_pypi(metadata),
+        "npm" => extract_npm(metadata),
+        _ => None,
+    }
+}
+
+// -- PyPI --------------------------------------------------------------------
+
+fn extract_pypi(metadata: &Value) -> Option<PublisherIdentity> {
+    if let Some(name) = pypi_attestation_publisher(metadata) {
+        return Some(PublisherIdentity {
+            name,
+            source: PublisherSource::Attestation,
+            verified: true,
+        });
+    }
+
+    let info = metadata.get("info")?;
+    let name = non_empty_str(info.get("author"))
+        .or_else(|| non_empty_str(info.get("maintainer")))
+        .or_else(|| display_name_from_contact(info.get("author_email")))
+        .or_else(|| display_name_from_contact(info.get("maintainer_email")))?;
+
+    Some(PublisherIdentity {
+        name,
+        source: PublisherSource::Metadata,
+        verified: false,
+    })
+}
+
+/// Reads the Trusted-Publisher identity from a merged PyPI integrity-API
+/// provenance object: `provenance.attestation_bundles[].publisher` where the
+/// publisher is e.g. `{ "kind": "GitHub", "repository": "owner/repo", ... }`.
+/// The publisher *name* is the repository owner (the org), which is what an
+/// allowlist like `["Microsoft", "NumFOCUS"]` is meant to match.
+fn pypi_attestation_publisher(metadata: &Value) -> Option<String> {
+    let bundles = metadata.get("provenance")?.get("attestation_bundles")?;
+    let publisher = bundles
+        .as_array()?
+        .iter()
+        .find_map(|b| b.get("publisher"))?;
+    let repository = non_empty_str(publisher.get("repository"))?;
+    let owner = repository.split('/').next().unwrap_or(&repository).trim();
+    if owner.is_empty() {
+        return None;
+    }
+    Some(owner.to_string())
+}
+
+// -- npm ---------------------------------------------------------------------
+
+fn extract_npm(metadata: &Value) -> Option<PublisherIdentity> {
+    let name =
+        non_empty_str(metadata.get("_npmUser").and_then(|u| u.get("name"))).or_else(|| {
+            metadata
+                .get("maintainers")?
+                .as_array()?
+                .iter()
+                .find_map(|m| non_empty_str(m.get("name")))
+        })?;
+
+    if npm_has_provenance(metadata) {
+        return Some(PublisherIdentity {
+            name,
+            source: PublisherSource::Attestation,
+            verified: true,
+        });
+    }
+
+    Some(PublisherIdentity {
+        name,
+        source: PublisherSource::Metadata,
+        verified: false,
+    })
+}
+
+/// npm marks provenance on the version document as
+/// `dist.attestations: { "url": ..., "provenance": { "predicateType": ... } }`.
+/// Presence of the `provenance` record means the registry verified a sigstore
+/// attestation for this publish; the publishing identity is the npm user that
+/// performed the attested publish.
+fn npm_has_provenance(metadata: &Value) -> bool {
+    metadata
+        .get("dist")
+        .and_then(|d| d.get("attestations"))
+        .and_then(|a| a.get("provenance"))
+        .is_some_and(|p| !p.is_null())
+}
+
+// -- helpers -----------------------------------------------------------------
+
+fn non_empty_str(value: Option<&Value>) -> Option<String> {
+    let s = value?.as_str()?.trim();
+    if s.is_empty() {
+        return None;
+    }
+    Some(s.to_string())
+}
+
+/// Extracts a display name from an RFC 5322-style contact field such as
+/// `"NumFOCUS <admin@numfocus.org>"`. A bare email address carries no
+/// publisher *name* and yields `None` (an allowlist should never be matched
+/// against a raw email address).
+fn display_name_from_contact(value: Option<&Value>) -> Option<String> {
+    let contact = value?.as_str()?.trim();
+    let angle = contact.find('<')?;
+    let name = contact[..angle].trim().trim_matches('"').trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn pypi_metadata_only() -> Value {
+        json!({
+            "info": {
+                "author": "Microsoft Corporation",
+                "author_email": "opensource@microsoft.com",
+                "maintainer": null,
+                "maintainer_email": null,
+                "name": "azure-core",
+                "version": "1.30.0"
+            },
+            "urls": [{"filename": "azure_core-1.30.0-py3-none-any.whl"}]
+        })
+    }
+
+    fn pypi_with_attestation() -> Value {
+        json!({
+            "info": {
+                "author": "Totally Microsoft",
+                "name": "numpy",
+                "version": "2.0.0"
+            },
+            "provenance": {
+                "attestation_bundles": [{
+                    "publisher": {
+                        "kind": "GitHub",
+                        "repository": "NumFOCUS/numpy",
+                        "workflow": "release.yml",
+                        "environment": "pypi"
+                    },
+                    "attestations": [{"envelope": {}}]
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn pypi_prefers_attestation_over_self_asserted_author() {
+        let id = extract_publisher("pypi", &pypi_with_attestation()).unwrap();
+        // The attestation org wins over the spoofable `author` string.
+        assert_eq!(id.name, "NumFOCUS");
+        assert_eq!(id.source, PublisherSource::Attestation);
+        assert!(id.verified);
+    }
+
+    #[test]
+    fn pypi_falls_back_to_author_metadata_unverified() {
+        let id = extract_publisher("pypi", &pypi_metadata_only()).unwrap();
+        assert_eq!(id.name, "Microsoft Corporation");
+        assert_eq!(id.source, PublisherSource::Metadata);
+        assert!(!id.verified);
+    }
+
+    #[test]
+    fn pypi_null_author_uses_maintainer_then_contact_display_name() {
+        let md = json!({
+            "info": {
+                "author": null,
+                "maintainer": "  ",
+                "author_email": "NumFOCUS <admin@numfocus.org>"
+            }
+        });
+        let id = extract_publisher("pypi", &md).unwrap();
+        assert_eq!(id.name, "NumFOCUS");
+        assert_eq!(id.source, PublisherSource::Metadata);
+        assert!(!id.verified);
+    }
+
+    #[test]
+    fn pypi_bare_email_is_not_a_publisher_name() {
+        let md = json!({"info": {"author_email": "admin@numfocus.org"}});
+        assert_eq!(extract_publisher("pypi", &md), None);
+    }
+
+    #[test]
+    fn pypi_empty_or_malformed_yields_none() {
+        assert_eq!(extract_publisher("pypi", &json!({})), None);
+        assert_eq!(extract_publisher("pypi", &json!({"info": {}})), None);
+        assert_eq!(extract_publisher("pypi", &json!({"info": "oops"})), None);
+        // Malformed provenance must not panic and must not fabricate identity.
+        let md =
+            json!({"provenance": {"attestation_bundles": [{"publisher": {"repository": "/"}}]}});
+        assert_eq!(extract_publisher("pypi", &md), None);
+    }
+
+    fn npm_with_provenance() -> Value {
+        json!({
+            "name": "@azure/core-rest-pipeline",
+            "version": "1.16.0",
+            "_npmUser": {"name": "microsoft", "email": "npmjs@microsoft.com"},
+            "maintainers": [{"name": "azure-sdk", "email": "azuresdk@microsoft.com"}],
+            "dist": {
+                "tarball": "https://registry.npmjs.org/...",
+                "attestations": {
+                    "url": "https://registry.npmjs.org/-/npm/v1/attestations/@azure%2fcore-rest-pipeline@1.16.0",
+                    "provenance": {"predicateType": "https://slsa.dev/provenance/v1"}
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn npm_provenance_marks_attested_verified() {
+        let id = extract_publisher("npm", &npm_with_provenance()).unwrap();
+        assert_eq!(id.name, "microsoft");
+        assert_eq!(id.source, PublisherSource::Attestation);
+        assert!(id.verified);
+    }
+
+    #[test]
+    fn npm_without_provenance_is_metadata_only() {
+        let md = json!({
+            "maintainers": [{"name": "microsoft", "email": "npmjs@microsoft.com"}],
+            "dist": {"tarball": "https://registry.npmjs.org/..."}
+        });
+        let id = extract_publisher("npm", &md).unwrap();
+        assert_eq!(id.name, "microsoft");
+        assert_eq!(id.source, PublisherSource::Metadata);
+        assert!(!id.verified);
+    }
+
+    #[test]
+    fn npm_missing_fields_yield_none() {
+        assert_eq!(extract_publisher("npm", &json!({})), None);
+        assert_eq!(extract_publisher("npm", &json!({"maintainers": []})), None);
+        assert_eq!(
+            extract_publisher("npm", &json!({"maintainers": "oops", "_npmUser": 42})),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_format_yields_none() {
+        assert_eq!(extract_publisher("raw", &pypi_metadata_only()), None);
+        assert_eq!(extract_publisher("maven", &json!({})), None);
+    }
+
+    #[test]
+    fn applicable_format_set() {
+        assert!(is_applicable_format("pypi"));
+        assert!(is_applicable_format("npm"));
+        assert!(is_applicable_format("PyPI"));
+        assert!(!is_applicable_format("raw"));
+        assert!(!is_applicable_format("docker"));
+        assert!(!is_applicable_format("maven"));
+    }
+}

--- a/backend/src/services/curation/publisher_trust.rs
+++ b/backend/src/services/curation/publisher_trust.rs
@@ -1,0 +1,508 @@
+//! `publisher_trust` curation rule evaluator (#2948).
+//!
+//! Matches a package's publisher against a configured trusted-publisher
+//! allowlist and maps the result to an allow / flag / block decision.
+//!
+//! # Config shape
+//!
+//! ```json
+//! {
+//!   "trusted_publishers": ["Microsoft", "NumFOCUS"],
+//!   "match": "attestation" | "metadata",
+//!   "action": "allow" | "flag" | "block"
+//! }
+//! ```
+//!
+//! * `trusted_publishers` — required, non-empty list of publisher names.
+//!   Names are compared **case-insensitively and exactly** (never substring:
+//!   `"Microsoft"` must not match `"Evil Microsoft Fans"`).
+//! * `match` — which signal quality is sufficient to consider a publisher
+//!   trusted. Defaults to `"attestation"` (the secure default):
+//!   * `"attestation"` — only a registry-verified provenance identity
+//!     ([`PublisherSource::Attestation`] with `verified = true`) can satisfy
+//!     the allowlist. Self-asserted `author`/`maintainer` metadata is
+//!     spoofable and is deliberately **not** sufficient in this mode.
+//!   * `"metadata"` — an operator opt-in that also accepts the weaker,
+//!     self-asserted metadata identity. Use only where the threat model
+//!     tolerates it.
+//! * `action` — what the rule does, defaulting to `"flag"` (fail-safe):
+//!   * `"block"` — enforcement mode: **block anything NOT from a trusted
+//!     publisher**; trusted packages are allowed.
+//!   * `"allow"` — allowlist mode: allow trusted packages; anything else is
+//!     flagged for review (an allow rule never silently admits an untrusted
+//!     package, and never hard-blocks — it defers to a human).
+//!   * `"flag"` — watch mode: **flag packages that DO come from a listed
+//!     publisher** (e.g. audit everything a given vendor ships); packages
+//!     from unlisted publishers pass through unaffected (`Allow`). This mode
+//!     is an observability tool, not a security gate — use `"block"` or
+//!     `"allow"` to gate.
+//!
+//! # Fail-safe behavior
+//!
+//! * Format with no publisher concept (anything outside
+//!   [`publisher_source::APPLICABLE_FORMATS`]) → [`Decision::NotApplicable`],
+//!   so a global instance-wide rule silently passes e.g. `raw` artifacts
+//!   through instead of carpet-flagging them.
+//! * Applicable format but no extractable publisher → [`Decision::Flag`]
+//!   ("publisher unknown"): absence of identity is never trusted, but it is
+//!   surfaced for review rather than hard-blocked.
+//! * Malformed config (missing/empty `trusted_publishers`, unknown `match`
+//!   or `action` value) → [`Decision::Flag`] describing the misconfiguration.
+
+use serde_json::Value;
+
+use super::publisher_source::{self, PublisherSource};
+
+/// Outcome of a `publisher_trust` rule evaluation.
+///
+/// The curation foundation (#2947) exposes an identical `CurationDecision`;
+/// integration maps these variants 1:1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// The package passes this rule.
+    Allow,
+    /// The package needs human review; the string is the reviewable reason.
+    Flag(String),
+    /// The package is rejected; the string is the reason.
+    Block(String),
+    /// The rule does not apply to this package's format (no publisher
+    /// concept); a global policy must treat this as "no effect".
+    NotApplicable,
+}
+
+/// Evaluates a `publisher_trust` rule against one package.
+///
+/// `config` is the rule's JSON config (see module docs), `format` the package
+/// format (`"pypi"`, `"npm"`, ...), `name`/`version` identify the package for
+/// reason strings, and `metadata` is the registry metadata blob the publisher
+/// is extracted from.
+pub fn evaluate(
+    config: &Value,
+    format: &str,
+    name: &str,
+    version: &str,
+    metadata: &Value,
+) -> Decision {
+    if !publisher_source::is_applicable_format(format) {
+        return Decision::NotApplicable;
+    }
+
+    let trusted: Vec<String> = match config.get("trusted_publishers").and_then(Value::as_array) {
+        Some(list) if !list.is_empty() => list
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    };
+    if trusted.is_empty() {
+        return Decision::Flag(
+            "publisher_trust rule misconfigured: `trusted_publishers` is missing or empty"
+                .to_string(),
+        );
+    }
+
+    let match_mode = match config.get("match").and_then(Value::as_str) {
+        // Secure default: only verified provenance satisfies the allowlist.
+        None => "attestation",
+        Some(m @ ("attestation" | "metadata")) => m,
+        Some(other) => {
+            return Decision::Flag(format!(
+                "publisher_trust rule misconfigured: unknown match mode `{other}`"
+            ));
+        }
+    };
+
+    let action = match config.get("action").and_then(Value::as_str) {
+        // Fail-safe default: surface for review rather than allow or block.
+        None => "flag",
+        Some(a @ ("allow" | "flag" | "block")) => a,
+        Some(other) => {
+            return Decision::Flag(format!(
+                "publisher_trust rule misconfigured: unknown action `{other}`"
+            ));
+        }
+    };
+
+    let publisher = match publisher_source::extract_publisher(format, metadata) {
+        Some(p) => p,
+        None => {
+            // Applicable format but no identity: never trust silence.
+            return Decision::Flag(format!(
+                "publisher unknown: no publisher identity could be extracted for {format} package {name}@{version}"
+            ));
+        }
+    };
+
+    let name_listed = trusted.contains(&publisher.name.to_lowercase());
+    let signal_sufficient = match match_mode {
+        "metadata" => true,
+        // `attestation` mode: self-asserted metadata must not be the sole
+        // trust signal (dependency-confusion / spoofing resistance).
+        _ => publisher.source == PublisherSource::Attestation && publisher.verified,
+    };
+    let is_trusted = name_listed && signal_sufficient;
+
+    let signal_label = match publisher.source {
+        PublisherSource::Attestation => "verified attestation",
+        PublisherSource::Metadata => "self-asserted metadata (unverified)",
+    };
+
+    match (action, is_trusted) {
+        // Trusted publishers pass under both gating modes.
+        ("allow" | "block", true) => Decision::Allow,
+        // Enforcement: everything not provably trusted is rejected.
+        ("block", false) => Decision::Block(untrusted_reason(
+            &publisher.name,
+            signal_label,
+            name_listed,
+            match_mode,
+            name,
+            version,
+        )),
+        // Allowlist mode fails safe: untrusted goes to review, not through.
+        ("allow", false) => Decision::Flag(untrusted_reason(
+            &publisher.name,
+            signal_label,
+            name_listed,
+            match_mode,
+            name,
+            version,
+        )),
+        // Watch mode: flag the listed publisher's packages for review...
+        ("flag", true) => Decision::Flag(format!(
+            "publisher `{}` matched trusted-publisher watch list via {signal_label} for {name}@{version}",
+            publisher.name
+        )),
+        // ...and pass everything else through unaffected.
+        _ => Decision::Allow,
+    }
+}
+
+fn untrusted_reason(
+    publisher: &str,
+    signal_label: &str,
+    name_listed: bool,
+    match_mode: &str,
+    name: &str,
+    version: &str,
+) -> String {
+    if name_listed && match_mode == "attestation" {
+        format!(
+            "publisher `{publisher}` for {name}@{version} is on the trusted list but was asserted only via {signal_label}; `match: attestation` requires registry-verified provenance"
+        )
+    } else {
+        format!(
+            "publisher `{publisher}` ({signal_label}) for {name}@{version} is not in the trusted-publisher list"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn config(match_mode: &str, action: &str) -> Value {
+        json!({
+            "trusted_publishers": ["Microsoft", "NumFOCUS"],
+            "match": match_mode,
+            "action": action
+        })
+    }
+
+    /// Realistic PyPI JSON-API blob with a merged integrity-API provenance
+    /// object: attested Trusted-Publisher org `NumFOCUS`.
+    fn pypi_attested() -> Value {
+        json!({
+            "info": {"author": "NumPy Developers", "name": "numpy", "version": "2.0.0"},
+            "provenance": {
+                "attestation_bundles": [{
+                    "publisher": {"kind": "GitHub", "repository": "NumFOCUS/numpy", "workflow": "wheels.yml"},
+                    "attestations": [{"envelope": {}}]
+                }]
+            }
+        })
+    }
+
+    /// Self-asserted `author: "Microsoft"` with NO provenance — the
+    /// dependency-confusion shape a squatter would upload.
+    fn pypi_spoofed_author() -> Value {
+        json!({
+            "info": {
+                "author": "Microsoft",
+                "author_email": "attacker@example.com",
+                "name": "azure-coore",
+                "version": "99.0.0"
+            }
+        })
+    }
+
+    fn npm_attested() -> Value {
+        json!({
+            "name": "@azure/identity",
+            "version": "4.0.0",
+            "_npmUser": {"name": "Microsoft", "email": "npmjs@microsoft.com"},
+            "dist": {
+                "attestations": {
+                    "url": "https://registry.npmjs.org/-/npm/v1/attestations/@azure%2fidentity@4.0.0",
+                    "provenance": {"predicateType": "https://slsa.dev/provenance/v1"}
+                }
+            }
+        })
+    }
+
+    fn npm_metadata_only(user: &str) -> Value {
+        json!({
+            "maintainers": [{"name": user, "email": "x@example.com"}],
+            "dist": {"tarball": "https://registry.npmjs.org/..."}
+        })
+    }
+
+    // -- trust via attestation ------------------------------------------------
+
+    #[test]
+    fn trusted_publisher_via_attestation_is_allowed_under_block() {
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "numpy",
+            "2.0.0",
+            &pypi_attested(),
+        );
+        assert_eq!(d, Decision::Allow);
+    }
+
+    #[test]
+    fn npm_trusted_publisher_via_provenance_is_allowed() {
+        let d = evaluate(
+            &config("attestation", "block"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        assert_eq!(d, Decision::Allow);
+    }
+
+    // -- spoof resistance -----------------------------------------------------
+
+    #[test]
+    fn trusted_name_via_metadata_only_is_not_trusted_under_match_attestation() {
+        // `author: "Microsoft"` alone must NOT satisfy the allowlist: the
+        // field is self-asserted and spoofable.
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "azure-coore",
+            "99.0.0",
+            &pypi_spoofed_author(),
+        );
+        match d {
+            Decision::Block(reason) => {
+                assert!(
+                    reason.contains("self-asserted metadata"),
+                    "reason: {reason}"
+                );
+                assert!(reason.contains("requires registry-verified provenance"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn metadata_match_mode_is_an_explicit_opt_in() {
+        // Under the weaker opt-in mode the same package IS trusted — the
+        // distinction is explicit config, never implicit.
+        let d = evaluate(
+            &config("metadata", "block"),
+            "pypi",
+            "azure-coore",
+            "99.0.0",
+            &pypi_spoofed_author(),
+        );
+        assert_eq!(d, Decision::Allow);
+    }
+
+    #[test]
+    fn exact_match_only_no_substring_trust() {
+        let md = json!({"info": {"author": "Evil Microsoft Fans"}});
+        let d = evaluate(&config("metadata", "block"), "pypi", "pkg", "1.0", &md);
+        assert!(matches!(d, Decision::Block(_)), "got {d:?}");
+        // Case-insensitive exact match still works.
+        let md = json!({"info": {"author": "microsoft"}});
+        let d = evaluate(&config("metadata", "block"), "pypi", "pkg", "1.0", &md);
+        assert_eq!(d, Decision::Allow);
+    }
+
+    // -- action semantics -----------------------------------------------------
+
+    #[test]
+    fn untrusted_publisher_under_action_block_is_blocked() {
+        let d = evaluate(
+            &config("metadata", "block"),
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &npm_metadata_only("some-rando"),
+        );
+        match d {
+            Decision::Block(reason) => {
+                assert!(
+                    reason.contains("not in the trusted-publisher list"),
+                    "reason: {reason}"
+                );
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn untrusted_publisher_under_action_allow_is_flagged_not_admitted() {
+        let d = evaluate(
+            &config("metadata", "allow"),
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &npm_metadata_only("some-rando"),
+        );
+        assert!(matches!(d, Decision::Flag(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn trusted_publisher_under_action_allow_is_allowed() {
+        let d = evaluate(
+            &config("attestation", "allow"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        assert_eq!(d, Decision::Allow);
+    }
+
+    #[test]
+    fn action_flag_watches_listed_publishers_and_passes_others() {
+        // Listed publisher → flagged for review (watch mode).
+        let d = evaluate(
+            &config("attestation", "flag"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        match d {
+            Decision::Flag(reason) => assert!(reason.contains("watch list"), "reason: {reason}"),
+            other => panic!("expected Flag, got {other:?}"),
+        }
+        // Unlisted publisher → unaffected.
+        let d = evaluate(
+            &config("metadata", "flag"),
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &npm_metadata_only("some-rando"),
+        );
+        assert_eq!(d, Decision::Allow);
+    }
+
+    // -- fail-safe paths ------------------------------------------------------
+
+    #[test]
+    fn missing_publisher_on_applicable_format_flags_publisher_unknown() {
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "mystery-pkg",
+            "0.1.0",
+            &json!({"info": {}}),
+        );
+        match d {
+            Decision::Flag(reason) => {
+                assert!(reason.contains("publisher unknown"), "reason: {reason}");
+                assert!(reason.contains("mystery-pkg@0.1.0"));
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_applicable_format_is_not_applicable_not_flagged() {
+        // A global rule must pass raw/generic artifacts through untouched —
+        // they have no publisher concept.
+        for format in ["raw", "generic", "docker", "maven"] {
+            let d = evaluate(
+                &config("attestation", "block"),
+                format,
+                "some-artifact",
+                "1.0.0",
+                &json!({}),
+            );
+            assert_eq!(d, Decision::NotApplicable, "format {format}");
+        }
+    }
+
+    #[test]
+    fn misconfigured_rule_flags_instead_of_deciding() {
+        // Missing allowlist.
+        let d = evaluate(
+            &json!({"action": "block"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(
+            matches!(d, Decision::Flag(ref r) if r.contains("trusted_publishers")),
+            "got {d:?}"
+        );
+        // Empty allowlist.
+        let d = evaluate(
+            &json!({"trusted_publishers": [], "action": "block"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(matches!(d, Decision::Flag(_)), "got {d:?}");
+        // Unknown match mode.
+        let d = evaluate(
+            &json!({"trusted_publishers": ["NumFOCUS"], "match": "vibes"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(
+            matches!(d, Decision::Flag(ref r) if r.contains("vibes")),
+            "got {d:?}"
+        );
+        // Unknown action.
+        let d = evaluate(
+            &json!({"trusted_publishers": ["NumFOCUS"], "action": "yolo"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(
+            matches!(d, Decision::Flag(ref r) if r.contains("yolo")),
+            "got {d:?}"
+        );
+    }
+
+    #[test]
+    fn defaults_are_secure_attestation_match_and_fail_safe_flag_action() {
+        // No `match`, no `action`: attestation-only matching, flag action.
+        let cfg = json!({"trusted_publishers": ["NumFOCUS"]});
+        // Attested + listed → watch-mode flag (default action=flag).
+        let d = evaluate(&cfg, "pypi", "numpy", "2.0.0", &pypi_attested());
+        assert!(matches!(d, Decision::Flag(_)), "got {d:?}");
+        // Metadata-only listed name under default match=attestation is NOT
+        // treated as the listed publisher → passes watch mode untouched.
+        let md = json!({"info": {"author": "NumFOCUS"}});
+        let d = evaluate(&cfg, "pypi", "pkg", "1.0", &md);
+        assert_eq!(d, Decision::Allow);
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -103,6 +103,7 @@ pub mod webhook_signing;
 pub mod age_gate_service;
 pub mod analytics_service;
 pub mod crash_reporting_service;
+pub mod curation;
 pub mod curation_service;
 pub mod curation_sync;
 pub mod health_monitor_service;


### PR DESCRIPTION
## Summary

Adds the self-contained evaluator module for the `publisher_trust` curation rule type (part of the curation policy rule-types epic #2947): match a package's publisher against a configured trusted-publisher allowlist and map the result to allow / flag / block.

Closes #2948

**Depends on #2947 (curation rule-type foundation) for wiring.** This PR intentionally does NOT touch the `CurationRule` model, migrations, or the `curation_service` dispatch — it only provides the evaluator the foundation will call, at the agreed stub paths. The only shared-file change is the one-line `pub mod curation;` declaration in `services/mod.rs` (trivial merge with the foundation branch).

New files:
- `backend/src/services/curation/publisher_source.rs` — `extract_publisher(format, metadata) -> Option<PublisherIdentity>`; parses realistic PyPI JSON-API and npm registry shapes, and labels each identity with its signal class: `Attestation` (PyPI Trusted-Publisher/integrity-API provenance bundle, npm sigstore `dist.attestations.provenance`) vs `Metadata` (self-asserted `author`/`maintainer`/`_npmUser`).
- `backend/src/services/curation/publisher_trust.rs` — `evaluate(config, format, name, version, metadata) -> Decision` with `Decision { Allow, Flag(String), Block(String), NotApplicable }` (variant-identical to the foundation's `CurationDecision`; integration maps 1:1).

### Security design

- **Provenance-first trust.** Config `match: "attestation"` (the default) only accepts a registry-verified provenance identity; self-asserted `author`/`maintainer` metadata is a labeled weaker fallback that requires the explicit `match: "metadata"` opt-in. A package whose `author` field merely *claims* a trusted name is never trusted under the default — that field is spoofable and is a dependency-confusion vector.
- **Exact, case-insensitive allowlist matching only** — no substring matching (`"Microsoft"` does not match `"Evil Microsoft Fans"`).
- **Fail-safe paths.** Unknown publisher on an applicable format → `Flag("publisher unknown …")`, never silent trust. Malformed rule config → `Flag` describing the misconfiguration. Formats with no publisher concept (anything outside `pypi`/`npm`, e.g. `raw`) → `NotApplicable`, so a global instance-wide rule passes them through instead of carpet-flagging.
- **Action semantics** (doc-commented + tested): `block` = block anything NOT from a trusted publisher; `allow` = allow trusted, flag (not admit, not hard-block) everything else; `flag` = watch mode, flag packages that DO come from a listed publisher and pass others through.

### Metadata-shape assumptions (reviewer note)

- PyPI: self-asserted fields from `/pypi/{pkg}/json` `info.*`; the attestation path expects an integrity-API provenance object (`provenance.attestation_bundles[].publisher.repository`) merged into the stored metadata blob by the sync layer; the publisher name is the repository owner (org).
- npm: identity from `_npmUser.name` / `maintainers[].name`; presence of `dist.attestations.provenance` on the version document marks the publish as attested (full sigstore bundle verification is out of scope for this evaluator and assumed at the verification layer).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated (26 new tests: attestation-trusted, metadata-spoof rejection under `match: attestation`, action semantics for allow/flag/block, unknown-publisher flag, `NotApplicable` formats, misconfig fail-safes, defensive parsing of malformed JSON)
- [ ] Integration tests added/updated (if applicable) — N/A, pure functions; rule persistence/dispatch covered by #2947
- [ ] E2E tests added/updated (if applicable) — N/A (foundation covers rule persistence; no DTF tier needed here)
- [x] Manually tested locally (`cargo nextest run --workspace --lib`: 14178 passed; clippy `-D warnings` clean; jscpd 0% duplication on new files)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
