### PR TITLE
feat(curation): popularity + typo-squat rule evaluator and download-count sources

### DIFF
--- a/backend/src/services/curation/mod.rs
+++ b/backend/src/services/curation/mod.rs
@@ -1,0 +1,17 @@
+//! Curation rule-type evaluators.
+//!
+//! Each rule type lives in its own submodule and exposes a self-contained
+//! `evaluate` entry point plus whatever data sources it needs. The curation
+//! foundation (`rule_type` discriminator + `config` JSONB dispatch on
+//! `curation_rules`, epic #2947) calls into these evaluators; the evaluators
+//! themselves stay free of database and model dependencies so they can be
+//! unit-tested in isolation.
+//!
+//! Currently implemented:
+//! - [`popularity`] — download-count threshold + typo-squat detection
+//!   (issue #2949), backed by [`popularity_source`] (pluggable download-count
+//!   providers) and [`typosquat`] (lexical-distance matching).
+
+pub mod popularity;
+pub mod popularity_source;
+pub mod typosquat;

--- a/backend/src/services/curation/popularity.rs
+++ b/backend/src/services/curation/popularity.rs
@@ -1,0 +1,344 @@
+//! `popularity` curation rule evaluator (#2949): download-count threshold +
+//! typo-squat detection.
+//!
+//! # Decision semantics
+//!
+//! - **Not applicable** — popularity rules run as instance-wide policy, but
+//!   only some ecosystems have a public download-count source (currently
+//!   PyPI via pypistats.org and npm via the npm downloads API, plus their
+//!   registry-compatible aliases). For any other format `evaluate` returns
+//!   [`Decision::NotApplicable`] so a global rule silently passes raw/
+//!   generic/private-only formats through instead of flagging everything.
+//! - **Below threshold** — a known download count under `min_downloads`
+//!   applies the configured `action` (`"flag"` default, `"block"` opt-in).
+//!   Flag-first is deliberate: legitimately new packages have low counts.
+//! - **Typo-squat** — a name within `max_distance` (1–2) edits of a popular
+//!   package, while not itself popular, is *flagged* for review. The signal
+//!   is advisory (never a block from this check alone): lexical proximity has
+//!   false positives by construction.
+//! - **Unknown popularity** — a source outage/rate limit/unlisted package
+//!   yields `Flag("popularity unknown…")`, never Block, regardless of
+//!   `action`. Fail-open on the data source, fail-safe on the decision: the
+//!   package stays reviewable but an upstream stats outage can never
+//!   hard-block installs.
+//!
+//! When both the threshold and the typo-squat signal fire, the strongest
+//! outcome wins (Block > Flag) and the reasons are combined.
+
+use super::popularity_source::{ecosystem_for_format, PopularityResult, PopularitySource};
+use super::typosquat::{default_popular_packages, is_typosquat};
+
+/// Evaluation outcome for a single package against one `popularity` rule.
+///
+/// Variants mirror the curation foundation's `CurationDecision` (#2947); the
+/// integration layer maps 1:1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// Package passes this rule.
+    Allow,
+    /// Package should be held for human review, with a reason.
+    Flag(String),
+    /// Package should be rejected, with a reason.
+    Block(String),
+    /// This rule cannot meaningfully evaluate the package's format (no
+    /// popularity data source exists); it must have no effect.
+    NotApplicable,
+}
+
+/// Default lexical distance for typo-squat matching.
+const DEFAULT_MAX_DISTANCE: u64 = 2;
+/// Ceiling for the configurable distance. Beyond 2 edits the false-positive
+/// rate on short names makes the signal noise.
+const MAX_DISTANCE_CEILING: u64 = 2;
+
+/// Evaluate the `popularity` rule for one package.
+///
+/// `config` is the rule's JSONB config:
+///
+/// ```json
+/// {
+///   "min_downloads": 500,
+///   "window": "month",
+///   "typosquat_check": true,
+///   "max_distance": 2,
+///   "action": "flag",
+///   "popular_packages": ["requests", "..."]
+/// }
+/// ```
+///
+/// All keys are optional: `min_downloads` defaults to 0 (threshold check
+/// disabled), `typosquat_check` to `true`, `max_distance` to 2 (clamped to
+/// 1–2), `action` to `"flag"` (anything other than `"block"` means flag),
+/// and `popular_packages` to the built-in per-ecosystem seed list. `window`
+/// is currently informational — both supported sources report last-month
+/// counts.
+///
+/// `version` is accepted for signature-compatibility with the dispatch seam;
+/// popularity is a package-level signal, so it does not influence the
+/// decision today.
+pub async fn evaluate(
+    config: &serde_json::Value,
+    format: &str,
+    name: &str,
+    version: &str,
+    source: &dyn PopularitySource,
+) -> Decision {
+    let _ = version; // package-level signal; see doc comment.
+
+    let Some(ecosystem) = ecosystem_for_format(format) else {
+        return Decision::NotApplicable;
+    };
+
+    let min_downloads = config
+        .get("min_downloads")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let typosquat_check = config
+        .get("typosquat_check")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    let max_distance = config
+        .get("max_distance")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_MAX_DISTANCE)
+        .clamp(1, MAX_DISTANCE_CEILING) as usize;
+    let block_action = config
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .map(|a| a.eq_ignore_ascii_case("block"))
+        .unwrap_or(false);
+
+    let popular: Vec<String> = match config
+        .get("popular_packages")
+        .and_then(serde_json::Value::as_array)
+    {
+        Some(list) => list
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        None => default_popular_packages(ecosystem)
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    };
+
+    let downloads = source.downloads(format, name).await;
+
+    let mut block_reasons: Vec<String> = Vec::new();
+    let mut flag_reasons: Vec<String> = Vec::new();
+
+    match downloads {
+        PopularityResult::Known(d) if min_downloads > 0 && d < min_downloads => {
+            let reason = format!(
+                "package '{name}' has {d} recent downloads, below the configured minimum of {min_downloads}"
+            );
+            if block_action {
+                block_reasons.push(reason);
+            } else {
+                flag_reasons.push(reason);
+            }
+        }
+        PopularityResult::Known(_) => {}
+        PopularityResult::Unknown => {
+            // Fail-open on the data source, fail-safe on the decision: a
+            // stats outage or unlisted package is reviewable, never a block.
+            flag_reasons.push(format!(
+                "popularity unknown for package '{name}' (download-count source unavailable or package not listed)"
+            ));
+        }
+    }
+
+    if typosquat_check {
+        if let Some(target) = is_typosquat(name, &popular, max_distance) {
+            // Advisory signal only: lexical proximity alone never blocks.
+            flag_reasons.push(format!(
+                "name '{name}' is within edit distance {max_distance} of popular package '{target}' (possible typo-squat)"
+            ));
+        }
+    }
+
+    if !block_reasons.is_empty() {
+        block_reasons.extend(flag_reasons);
+        Decision::Block(block_reasons.join("; "))
+    } else if !flag_reasons.is_empty() {
+        Decision::Flag(flag_reasons.join("; "))
+    } else {
+        Decision::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::popularity_source::FakePopularitySource;
+    use super::*;
+
+    fn config(json: serde_json::Value) -> serde_json::Value {
+        json
+    }
+
+    #[tokio::test]
+    async fn below_threshold_flags_by_default() {
+        let source = FakePopularitySource::new().with("pypi", "obscure-pkg", 42);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        let decision = evaluate(&cfg, "pypi", "obscure-pkg", "1.0.0", &source).await;
+        match decision {
+            Decision::Flag(reason) => {
+                assert!(
+                    reason.contains("42"),
+                    "reason should include the count: {reason}"
+                );
+                assert!(
+                    reason.contains("500"),
+                    "reason should include the threshold: {reason}"
+                );
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn below_threshold_blocks_when_opted_in() {
+        let source = FakePopularitySource::new().with("npm", "obscure-pkg", 3);
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
+        let decision = evaluate(&cfg, "npm", "obscure-pkg", "0.0.1", &source).await;
+        match decision {
+            Decision::Block(reason) => assert!(reason.contains("below the configured minimum")),
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn above_threshold_allows() {
+        let source = FakePopularitySource::new().with("pypi", "healthy-pkg", 10_000);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "healthy-pkg", "2.1.0", &source).await,
+            Decision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_threshold_disables_count_check() {
+        let source = FakePopularitySource::new().with("npm", "tiny-pkg", 1);
+        let cfg = config(serde_json::json!({"typosquat_check": false}));
+        assert_eq!(
+            evaluate(&cfg, "npm", "tiny-pkg", "1.0.0", &source).await,
+            Decision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn typosquat_flags_and_names_the_target() {
+        // `reqeusts` is popular-ish by count but one transposition from
+        // `requests`: the advisory typo-squat flag fires on its own.
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 900);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "max_distance": 2}));
+        let decision = evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await;
+        match decision {
+            Decision::Flag(reason) => {
+                assert!(
+                    reason.contains("requests"),
+                    "should name the target: {reason}"
+                );
+                assert!(reason.contains("typo-squat"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn typosquat_is_advisory_even_with_block_action() {
+        // action=block applies to the threshold check only; a typo-squat
+        // match on an above-threshold package stays a Flag.
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 9_999_999);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "action": "block"}));
+        match evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await {
+            Decision::Flag(reason) => assert!(reason.contains("typo-squat")),
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn typosquat_respects_custom_popular_list_and_toggle() {
+        let source = FakePopularitySource::new().with("npm", "lodahs", 700);
+        // Custom list without lodash: no match.
+        let cfg = config(serde_json::json!({
+            "min_downloads": 500,
+            "popular_packages": ["express", "react"]
+        }));
+        assert_eq!(
+            evaluate(&cfg, "npm", "lodahs", "4.0.0", &source).await,
+            Decision::Allow
+        );
+        // Toggle off: no match even against the default list.
+        let cfg = config(serde_json::json!({"min_downloads": 500, "typosquat_check": false}));
+        assert_eq!(
+            evaluate(&cfg, "npm", "lodahs", "4.0.0", &source).await,
+            Decision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_popularity_flags_never_blocks() {
+        let source = FakePopularitySource::new(); // everything Unknown
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
+        match evaluate(&cfg, "pypi", "brand-new-pkg", "0.1.0", &source).await {
+            Decision::Flag(reason) => {
+                assert!(reason.contains("popularity unknown"), "{reason}");
+            }
+            other => panic!("expected Flag (fail-open on source outage), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn inapplicable_format_returns_not_applicable() {
+        // Global policy over a format with no download-count source must have
+        // no effect — even though the fake would return Unknown (which for an
+        // applicable format means Flag).
+        let source = FakePopularitySource::new();
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
+        for format in ["generic", "docker", "maven", "rpm", "helm"] {
+            assert_eq!(
+                evaluate(&cfg, format, "anything", "1.0.0", &source).await,
+                Decision::NotApplicable,
+                "format {format} should be NotApplicable"
+            );
+        }
+        // And the source was never consulted for inapplicable formats.
+        assert_eq!(source.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn block_and_typosquat_reasons_combine() {
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 5);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "action": "block"}));
+        match evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await {
+            Decision::Block(reason) => {
+                assert!(reason.contains("below the configured minimum"), "{reason}");
+                assert!(reason.contains("typo-squat"), "{reason}");
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_config_allows_popular_known_package() {
+        let source = FakePopularitySource::new().with("npm", "some-lib", 123);
+        assert_eq!(
+            evaluate(&serde_json::json!({}), "npm", "some-lib", "1.0.0", &source).await,
+            Decision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn max_distance_is_clamped_to_ceiling() {
+        // Distance 3 name; configured max_distance=5 clamps to 2 → no flag.
+        let source = FakePopularitySource::new().with("pypi", "reqzzzts", 10_000);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "max_distance": 5}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "reqzzzts", "1.0.0", &source).await,
+            Decision::Allow
+        );
+    }
+}

--- a/backend/src/services/curation/popularity_source.rs
+++ b/backend/src/services/curation/popularity_source.rs
@@ -1,0 +1,483 @@
+//! Pluggable download-count ("popularity") data sources for the `popularity`
+//! curation rule (#2949).
+//!
+//! The contract is deliberately narrow: given an ecosystem format and a
+//! package name, return either a **known** download count for the recent
+//! window or [`PopularityResult::Unknown`]. A source must NEVER fabricate a
+//! count — any transport error, non-2xx status, unparseable body, timeout, or
+//! unsupported ecosystem degrades to `Unknown`. The policy layer
+//! ([`super::popularity::evaluate`]) maps `Unknown` to a *flag-for-review*
+//! decision, never a hard block, so a data-source outage cannot break
+//! legitimate installs.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+/// Outcome of a download-count lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopularityResult {
+    /// The source returned an authoritative recent download count.
+    Known(u64),
+    /// The count could not be determined (source outage, rate limit,
+    /// unknown package, unsupported ecosystem). Callers must treat this as
+    /// "no data", not "zero downloads".
+    Unknown,
+}
+
+/// A provider of recent download counts for packages in an ecosystem.
+#[async_trait]
+pub trait PopularitySource: Send + Sync {
+    /// Return the recent (last-month) download count for `name` in the
+    /// ecosystem identified by `format` (e.g. `"pypi"`, `"npm"`), or
+    /// [`PopularityResult::Unknown`] when no authoritative answer exists.
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult;
+}
+
+/// Default total-request timeout for popularity lookups. These are small JSON
+/// responses from public APIs; a short hard deadline keeps a slow upstream
+/// from stalling curation evaluation.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default TTL for cached `Known` results.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// TTL for cached `Unknown` results. Deliberately shorter than the positive
+/// TTL: it shields an unavailable upstream from a request storm while still
+/// retrying soon after an outage or a freshly published package.
+const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Map a repository format (including registry-compatible aliases) to the
+/// upstream download-count ecosystem it belongs to.
+///
+/// Returns `None` for formats without a public download-count API; the
+/// evaluator treats those as not applicable rather than unpopular.
+pub fn ecosystem_for_format(format: &str) -> Option<&'static str> {
+    match format.to_ascii_lowercase().as_str() {
+        // Poetry/conda repos serve packages published on PyPI.
+        "pypi" | "poetry" => Some("pypi"),
+        // Yarn and pnpm resolve against the npm registry.
+        "npm" | "yarn" | "pnpm" => Some("npm"),
+        _ => None,
+    }
+}
+
+/// Real download-count source backed by public registry statistics APIs:
+///
+/// - **PyPI** → `GET https://pypistats.org/api/packages/{name}/recent`
+///   (last-month total from the `data.last_month` field)
+/// - **npm** → `GET https://api.npmjs.org/downloads/point/last-month/{name}`
+///   (the `downloads` field)
+///
+/// All failures — timeouts, non-2xx (including 429 rate limiting), malformed
+/// bodies — degrade to [`PopularityResult::Unknown`]. Wrap in
+/// [`CachedPopularitySource`] (see [`HttpPopularitySource::cached`]) for
+/// production use so repeated evaluations of the same package do not hammer
+/// the public APIs.
+pub struct HttpPopularitySource {
+    client: reqwest::Client,
+    pypistats_base: String,
+    npm_base: String,
+}
+
+impl HttpPopularitySource {
+    /// Build a source using the repo-standard SSRF-guarded HTTP client with a
+    /// short total-request timeout.
+    pub fn new() -> Self {
+        let client = crate::services::http_client::base_client_builder()
+            .timeout(DEFAULT_REQUEST_TIMEOUT)
+            .connect_timeout(Duration::from_secs(3))
+            .build()
+            .expect("failed to build popularity HTTP client");
+        Self {
+            client,
+            pypistats_base: "https://pypistats.org".to_string(),
+            npm_base: "https://api.npmjs.org".to_string(),
+        }
+    }
+
+    /// Override the upstream base URLs (tests / air-gapped mirrors).
+    pub fn with_base_urls(mut self, pypistats_base: &str, npm_base: &str) -> Self {
+        self.pypistats_base = pypistats_base.trim_end_matches('/').to_string();
+        self.npm_base = npm_base.trim_end_matches('/').to_string();
+        self
+    }
+
+    /// Wrap this source in an in-memory TTL cache with the default TTL.
+    pub fn cached(self) -> CachedPopularitySource<Self> {
+        CachedPopularitySource::new(self, DEFAULT_CACHE_TTL)
+    }
+
+    async fn fetch_json(&self, url: &str) -> Option<serde_json::Value> {
+        let resp = match self.client.get(url).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(url, error = %e, "popularity lookup failed");
+                return None;
+            }
+        };
+        if !resp.status().is_success() {
+            tracing::debug!(url, status = %resp.status(), "popularity lookup non-success");
+            return None;
+        }
+        match resp.json::<serde_json::Value>().await {
+            Ok(v) => Some(v),
+            Err(e) => {
+                tracing::debug!(url, error = %e, "popularity response not valid JSON");
+                None
+            }
+        }
+    }
+}
+
+impl Default for HttpPopularitySource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract the last-month total from a pypistats.org `/recent` response body:
+/// `{"data": {"last_day": .., "last_month": N, "last_week": ..}, ...}`.
+pub fn parse_pypistats_recent(body: &serde_json::Value) -> PopularityResult {
+    match body
+        .get("data")
+        .and_then(|d| d.get("last_month"))
+        .and_then(serde_json::Value::as_u64)
+    {
+        Some(n) => PopularityResult::Known(n),
+        None => PopularityResult::Unknown,
+    }
+}
+
+/// Extract the download count from an npm point-downloads response body:
+/// `{"downloads": N, "start": .., "end": .., "package": ..}`.
+pub fn parse_npm_point(body: &serde_json::Value) -> PopularityResult {
+    match body.get("downloads").and_then(serde_json::Value::as_u64) {
+        Some(n) => PopularityResult::Known(n),
+        None => PopularityResult::Unknown,
+    }
+}
+
+/// Percent-encode a package name for safe use as a single path segment.
+/// Keeps unreserved characters plus `@` untouched for readability of scoped
+/// npm names in logs; encodes `/` (scoped-package separator) and everything
+/// else that could alter the request path.
+fn encode_path_segment(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for b in name.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'@' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[async_trait]
+impl PopularitySource for HttpPopularitySource {
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult {
+        let Some(ecosystem) = ecosystem_for_format(format) else {
+            return PopularityResult::Unknown;
+        };
+        match ecosystem {
+            "pypi" => {
+                // PEP 503 normalization: lowercase, runs of -_. become -.
+                let normalized = normalize_pypi_name(name);
+                let url = format!(
+                    "{}/api/packages/{}/recent",
+                    self.pypistats_base,
+                    encode_path_segment(&normalized)
+                );
+                match self.fetch_json(&url).await {
+                    Some(body) => parse_pypistats_recent(&body),
+                    None => PopularityResult::Unknown,
+                }
+            }
+            "npm" => {
+                let url = format!(
+                    "{}/downloads/point/last-month/{}",
+                    self.npm_base,
+                    encode_path_segment(name)
+                );
+                match self.fetch_json(&url).await {
+                    Some(body) => parse_npm_point(&body),
+                    None => PopularityResult::Unknown,
+                }
+            }
+            _ => PopularityResult::Unknown,
+        }
+    }
+}
+
+/// Normalize a PyPI project name per PEP 503 (lowercase; runs of `-`, `_`,
+/// `.` collapse to a single `-`), which is what pypistats.org expects.
+pub fn normalize_pypi_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_sep = false;
+    for c in name.chars() {
+        if matches!(c, '-' | '_' | '.') {
+            if !prev_sep {
+                out.push('-');
+            }
+            prev_sep = true;
+        } else {
+            out.push(c.to_ascii_lowercase());
+            prev_sep = false;
+        }
+    }
+    out
+}
+
+/// In-memory TTL cache decorator over any [`PopularitySource`].
+///
+/// `Known` results are cached for the configured TTL; `Unknown` results are
+/// cached for the shorter [`NEGATIVE_CACHE_TTL`] so a source outage is not
+/// amplified into a request storm but recovery is picked up quickly.
+pub struct CachedPopularitySource<S: PopularitySource> {
+    inner: S,
+    ttl: Duration,
+    cache: Mutex<HashMap<(String, String), (Instant, PopularityResult)>>,
+}
+
+impl<S: PopularitySource> CachedPopularitySource<S> {
+    /// Wrap `inner` with a positive-result TTL of `ttl`.
+    pub fn new(inner: S, ttl: Duration) -> Self {
+        Self {
+            inner,
+            ttl,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl<S: PopularitySource> PopularitySource for CachedPopularitySource<S> {
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult {
+        let key = (format.to_string(), name.to_string());
+        if let Ok(cache) = self.cache.lock() {
+            if let Some((at, result)) = cache.get(&key) {
+                let ttl = match result {
+                    PopularityResult::Known(_) => self.ttl,
+                    PopularityResult::Unknown => NEGATIVE_CACHE_TTL.min(self.ttl),
+                };
+                if at.elapsed() < ttl {
+                    return *result;
+                }
+            }
+        }
+        let result = self.inner.downloads(format, name).await;
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.insert(key, (Instant::now(), result));
+        }
+        result
+    }
+}
+
+/// Deterministic in-memory test double. Returns `Known` for seeded
+/// `(format, name)` pairs and `Unknown` otherwise, and counts lookups so
+/// tests can assert caching behavior.
+#[derive(Default)]
+pub struct FakePopularitySource {
+    counts: HashMap<(String, String), u64>,
+    calls: AtomicUsize,
+}
+
+impl FakePopularitySource {
+    /// Empty fake: every lookup returns `Unknown`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed a known download count for `(format, name)`.
+    pub fn with(mut self, format: &str, name: &str, downloads: u64) -> Self {
+        self.counts
+            .insert((format.to_string(), name.to_string()), downloads);
+        self
+    }
+
+    /// Number of `downloads` calls made against this fake.
+    pub fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl PopularitySource for FakePopularitySource {
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        match self.counts.get(&(format.to_string(), name.to_string())) {
+            Some(n) => PopularityResult::Known(*n),
+            None => PopularityResult::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pypistats_recent_body() {
+        let body = serde_json::json!({
+            "data": {"last_day": 100, "last_month": 12345, "last_week": 900},
+            "package": "requests",
+            "type": "recent_downloads"
+        });
+        assert_eq!(
+            parse_pypistats_recent(&body),
+            PopularityResult::Known(12345)
+        );
+    }
+
+    #[test]
+    fn parses_npm_point_body() {
+        let body = serde_json::json!({
+            "downloads": 987654,
+            "start": "2026-06-01",
+            "end": "2026-06-30",
+            "package": "lodash"
+        });
+        assert_eq!(parse_npm_point(&body), PopularityResult::Known(987654));
+    }
+
+    #[test]
+    fn malformed_bodies_degrade_to_unknown() {
+        assert_eq!(
+            parse_pypistats_recent(&serde_json::json!({"error": "not found"})),
+            PopularityResult::Unknown
+        );
+        assert_eq!(
+            parse_npm_point(&serde_json::json!({"error": "package not found"})),
+            PopularityResult::Unknown
+        );
+        // Negative / non-integer counts are not trusted.
+        assert_eq!(
+            parse_npm_point(&serde_json::json!({"downloads": -5})),
+            PopularityResult::Unknown
+        );
+    }
+
+    #[test]
+    fn ecosystem_mapping_covers_aliases_and_rejects_others() {
+        assert_eq!(ecosystem_for_format("pypi"), Some("pypi"));
+        assert_eq!(ecosystem_for_format("poetry"), Some("pypi"));
+        assert_eq!(ecosystem_for_format("npm"), Some("npm"));
+        assert_eq!(ecosystem_for_format("yarn"), Some("npm"));
+        assert_eq!(ecosystem_for_format("pnpm"), Some("npm"));
+        assert_eq!(ecosystem_for_format("NPM"), Some("npm"));
+        assert_eq!(ecosystem_for_format("generic"), None);
+        assert_eq!(ecosystem_for_format("docker"), None);
+        assert_eq!(ecosystem_for_format("maven"), None);
+    }
+
+    #[test]
+    fn pypi_name_normalization_is_pep503() {
+        assert_eq!(normalize_pypi_name("Django"), "django");
+        assert_eq!(
+            normalize_pypi_name("typing_extensions"),
+            "typing-extensions"
+        );
+        assert_eq!(normalize_pypi_name("zope.interface"), "zope-interface");
+        assert_eq!(normalize_pypi_name("a--b__c"), "a-b-c");
+    }
+
+    #[test]
+    fn path_segment_encoding_escapes_separators() {
+        assert_eq!(encode_path_segment("@scope/pkg"), "@scope%2Fpkg");
+        assert_eq!(encode_path_segment("simple-name"), "simple-name");
+        assert_eq!(encode_path_segment("a b"), "a%20b");
+    }
+
+    #[tokio::test]
+    async fn fake_source_returns_seeded_counts_and_unknown() {
+        let fake = FakePopularitySource::new().with("pypi", "requests", 1_000_000);
+        assert_eq!(
+            fake.downloads("pypi", "requests").await,
+            PopularityResult::Known(1_000_000)
+        );
+        assert_eq!(
+            fake.downloads("pypi", "not-seeded").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(fake.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn cache_serves_repeat_lookups_without_inner_calls() {
+        let fake = FakePopularitySource::new().with("npm", "lodash", 50_000_000);
+        let cached = CachedPopularitySource::new(fake, Duration::from_secs(60));
+        assert_eq!(
+            cached.downloads("npm", "lodash").await,
+            PopularityResult::Known(50_000_000)
+        );
+        assert_eq!(
+            cached.downloads("npm", "lodash").await,
+            PopularityResult::Known(50_000_000)
+        );
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_expires_after_ttl() {
+        let fake = FakePopularitySource::new().with("npm", "react", 40_000_000);
+        let cached = CachedPopularitySource::new(fake, Duration::from_millis(10));
+        assert_eq!(
+            cached.downloads("npm", "react").await,
+            PopularityResult::Known(40_000_000)
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(
+            cached.downloads("npm", "react").await,
+            PopularityResult::Known(40_000_000)
+        );
+        assert_eq!(cached.inner.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn unknown_results_are_negatively_cached_within_short_ttl() {
+        let fake = FakePopularitySource::new();
+        // Positive TTL shorter than NEGATIVE_CACHE_TTL: min() applies, so the
+        // Unknown entry is still fresh on the second lookup.
+        let cached = CachedPopularitySource::new(fake, Duration::from_secs(30));
+        assert_eq!(
+            cached.downloads("pypi", "ghost-pkg").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(
+            cached.downloads("pypi", "ghost-pkg").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn http_source_unsupported_format_is_unknown_without_network() {
+        // No network I/O happens for a format outside the ecosystem map.
+        let source =
+            HttpPopularitySource::new().with_base_urls("http://127.0.0.1:1", "http://127.0.0.1:1");
+        assert_eq!(
+            source.downloads("generic", "whatever").await,
+            PopularityResult::Unknown
+        );
+    }
+
+    #[tokio::test]
+    async fn http_source_degrades_to_unknown_on_connection_error() {
+        // Unroutable base URL: the request errors and the source degrades.
+        let source =
+            HttpPopularitySource::new().with_base_urls("http://127.0.0.1:1", "http://127.0.0.1:1");
+        assert_eq!(
+            source.downloads("pypi", "requests").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(
+            source.downloads("npm", "lodash").await,
+            PopularityResult::Unknown
+        );
+    }
+}

--- a/backend/src/services/curation/typosquat.rs
+++ b/backend/src/services/curation/typosquat.rs
@@ -1,0 +1,265 @@
+//! Lexical typo-squat detection for the `popularity` curation rule (#2949).
+//!
+//! A classic supply-chain attack registers a package whose name is one or two
+//! keystrokes away from a heavily downloaded package (`reqeusts` vs
+//! `requests`). This module provides the string-distance primitive
+//! ([`damerau_levenshtein`], optimal-string-alignment variant, which counts
+//! adjacent transpositions as a single edit), a nearest-neighbor search over a
+//! popular-package list, and a small built-in seed list of top packages per
+//! ecosystem. The seed list is a default only — rules can supply their own
+//! list via config.
+
+/// Damerau-Levenshtein distance (optimal string alignment variant): the
+/// minimum number of single-character insertions, deletions, substitutions,
+/// and adjacent transpositions needed to turn `a` into `b`.
+///
+/// Operates on Unicode scalar values, not bytes.
+pub fn damerau_levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+
+    // Three rolling rows: two-back (for transpositions), previous, current.
+    let mut prev_prev: Vec<usize> = vec![0; n + 1];
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr: Vec<usize> = vec![0; n + 1];
+
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            let mut d = (prev[j] + 1) // deletion
+                .min(curr[j - 1] + 1) // insertion
+                .min(prev[j - 1] + cost); // substitution
+            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                d = d.min(prev_prev[j - 2] + 1); // adjacent transposition
+            }
+            curr[j] = d;
+        }
+        std::mem::swap(&mut prev_prev, &mut prev);
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
+/// Find the popular package name closest to `name` (case-insensitive) and its
+/// distance. Returns `None` for an empty popular list. Ties resolve to the
+/// first entry in list order.
+pub fn nearest_popular(name: &str, popular: &[String]) -> Option<(String, usize)> {
+    let name_lc = name.to_lowercase();
+    let mut best: Option<(String, usize)> = None;
+    for candidate in popular {
+        let d = damerau_levenshtein(&name_lc, &candidate.to_lowercase());
+        match &best {
+            Some((_, best_d)) if *best_d <= d => {}
+            _ => best = Some((candidate.clone(), d)),
+        }
+    }
+    best
+}
+
+/// Return `Some(target)` when `name` looks like a typo-squat of a popular
+/// package: within `max_distance` edits (but not identical) of an entry in
+/// `popular`, while `name` itself is NOT in the popular list.
+///
+/// The self-exclusion matters: `request` (a real, once-hugely-popular npm
+/// package) is distance 1 from `requests`, so a curated popular list that
+/// contains both must not flag either.
+pub fn is_typosquat(name: &str, popular: &[String], max_distance: usize) -> Option<String> {
+    let name_lc = name.to_lowercase();
+    // A package that IS popular by name is never a squat of another entry.
+    if popular.iter().any(|p| p.to_lowercase() == name_lc) {
+        return None;
+    }
+    let (target, distance) = nearest_popular(name, popular)?;
+    if distance >= 1 && distance <= max_distance {
+        Some(target)
+    } else {
+        None
+    }
+}
+
+/// Built-in seed list of heavily downloaded package names per ecosystem
+/// (`"pypi"` / `"npm"`). A pragmatic default so the rule is useful out of the
+/// box; rules can replace it with a curated list via the `popular_packages`
+/// config key. Unknown ecosystems get an empty list.
+pub fn default_popular_packages(ecosystem: &str) -> &'static [&'static str] {
+    match ecosystem {
+        "pypi" => &[
+            "requests",
+            "urllib3",
+            "boto3",
+            "botocore",
+            "numpy",
+            "pandas",
+            "setuptools",
+            "certifi",
+            "idna",
+            "charset-normalizer",
+            "typing-extensions",
+            "python-dateutil",
+            "six",
+            "pyyaml",
+            "cryptography",
+            "packaging",
+            "pip",
+            "wheel",
+            "s3transfer",
+            "attrs",
+            "click",
+            "jinja2",
+            "markupsafe",
+            "pydantic",
+            "sqlalchemy",
+            "aiohttp",
+            "flask",
+            "django",
+            "pytest",
+            "scipy",
+            "matplotlib",
+            "pillow",
+            "rich",
+            "httpx",
+            "colorama",
+        ],
+        "npm" => &[
+            "lodash",
+            "react",
+            "react-dom",
+            "express",
+            "axios",
+            "chalk",
+            "commander",
+            "tslib",
+            "vue",
+            "webpack",
+            "typescript",
+            "jquery",
+            "next",
+            "eslint",
+            "prettier",
+            "uuid",
+            "dotenv",
+            "glob",
+            "semver",
+            "minimist",
+            "debug",
+            "async",
+            "rxjs",
+            "redux",
+            "moment",
+            "inquirer",
+            "yargs",
+            "ajv",
+            "classnames",
+            "prop-types",
+            "node-fetch",
+            "fs-extra",
+            "body-parser",
+            "cors",
+            "zod",
+        ],
+        _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn distance_basics() {
+        assert_eq!(damerau_levenshtein("", ""), 0);
+        assert_eq!(damerau_levenshtein("abc", "abc"), 0);
+        assert_eq!(damerau_levenshtein("", "abc"), 3);
+        assert_eq!(damerau_levenshtein("abc", ""), 3);
+        assert_eq!(damerau_levenshtein("kitten", "sitting"), 3);
+    }
+
+    #[test]
+    fn distance_counts_transposition_as_one_edit() {
+        // Plain Levenshtein would be 2 here; Damerau counts the swap as 1.
+        assert_eq!(damerau_levenshtein("reqeusts", "requests"), 1);
+        assert_eq!(damerau_levenshtein("ab", "ba"), 1);
+        assert_eq!(damerau_levenshtein("lodahs", "lodash"), 1);
+    }
+
+    #[test]
+    fn distance_single_edits() {
+        assert_eq!(damerau_levenshtein("request", "requests"), 1); // insertion
+        assert_eq!(damerau_levenshtein("requests", "request"), 1); // deletion
+        assert_eq!(damerau_levenshtein("reqvests", "requests"), 1); // substitution
+    }
+
+    #[test]
+    fn distance_handles_unicode() {
+        assert_eq!(damerau_levenshtein("café", "cafe"), 1);
+    }
+
+    #[test]
+    fn nearest_popular_finds_closest() {
+        let popular = strings(&["requests", "numpy", "pandas"]);
+        assert_eq!(
+            nearest_popular("reqeusts", &popular),
+            Some(("requests".to_string(), 1))
+        );
+        assert_eq!(
+            nearest_popular("nunpy", &popular),
+            Some(("numpy".to_string(), 1))
+        );
+        assert_eq!(nearest_popular("anything", &[]), None);
+    }
+
+    #[test]
+    fn typosquat_flags_within_distance() {
+        let popular = strings(&["requests", "numpy"]);
+        assert_eq!(
+            is_typosquat("reqeusts", &popular, 2),
+            Some("requests".to_string())
+        );
+        assert_eq!(
+            is_typosquat("Reqeusts", &popular, 2),
+            Some("requests".to_string()),
+            "matching is case-insensitive"
+        );
+    }
+
+    #[test]
+    fn typosquat_ignores_exact_and_distant_names() {
+        let popular = strings(&["requests", "numpy"]);
+        // Exact match: it IS the popular package.
+        assert_eq!(is_typosquat("requests", &popular, 2), None);
+        // Far away: unrelated name.
+        assert_eq!(is_typosquat("completely-different", &popular, 2), None);
+        // Distance 3 with max 2: not flagged.
+        assert_eq!(is_typosquat("reqzzsts", &popular, 1), None);
+    }
+
+    #[test]
+    fn typosquat_never_flags_a_listed_popular_package() {
+        // `request` is itself popular; distance 1 from `requests` must not flag.
+        let popular = strings(&["requests", "request"]);
+        assert_eq!(is_typosquat("request", &popular, 2), None);
+        assert_eq!(is_typosquat("requests", &popular, 2), None);
+    }
+
+    #[test]
+    fn seed_lists_present_for_supported_ecosystems() {
+        let pypi = default_popular_packages("pypi");
+        let npm = default_popular_packages("npm");
+        assert!(pypi.contains(&"requests"));
+        assert!(npm.contains(&"lodash"));
+        assert!(pypi.len() >= 20 && npm.len() >= 20);
+        assert!(default_popular_packages("docker").is_empty());
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -103,6 +103,7 @@ pub mod webhook_signing;
 pub mod age_gate_service;
 pub mod analytics_service;
 pub mod crash_reporting_service;
+pub mod curation;
 pub mod curation_service;
 pub mod curation_sync;
 pub mod health_monitor_service;


### PR DESCRIPTION
## Summary

Adds the self-contained evaluator + data-source layer for the `popularity` curation rule type (download-count threshold + typo-squat detection), from the curation rule-types epic. Motivated by a customer security evaluation: reduce manual approval overhead by letting curation policy catch unpopular and lexically-suspicious packages automatically.

Closes #2949
Depends on #2947 (curation foundation: `rule_type` discriminator + dispatch seam). This PR deliberately does **not** touch the `CurationRule` model, migrations, or `curation_service` dispatch — it provides the evaluator and data source the foundation wires in, so the two PRs compose with only a `mod` merge.

New module `backend/src/services/curation/`:

- **`popularity_source.rs`** — `#[async_trait] PopularitySource { async fn downloads(&self, format, name) -> PopularityResult }` with `PopularityResult::{Known(u64), Unknown}`. Real impl `HttpPopularitySource`: PyPI via `GET https://pypistats.org/api/packages/{name}/recent` (last-month total, PEP 503 name normalization) and npm via `GET https://api.npmjs.org/downloads/point/last-month/{name}` (scoped names path-encoded). Uses the repo-standard SSRF-guarded `base_client_builder()` with a 5s total / 3s connect timeout. Every failure (timeout, non-2xx incl. 429, malformed body) degrades to `Unknown` — a source never fabricates a count. `CachedPopularitySource<S>` TTL decorator (15 min positive / 60 s negative cache so an outage is not amplified but recovery is quick). `FakePopularitySource` test double with call counting.
- **`typosquat.rs`** — `damerau_levenshtein` (optimal-string-alignment: transposition = 1 edit, so `reqeusts`→`requests` is distance 1), `nearest_popular`, `is_typosquat(name, popular, max_distance) -> Option<target>` (self-exclusion: a name that is itself on the popular list is never flagged — `request` vs `requests`), plus built-in top-package seed lists for PyPI and npm (overridable per rule via config).
- **`popularity.rs`** — `pub async fn evaluate(config, format, name, version, source) -> Decision` with `Decision::{Allow, Flag(String), Block(String), NotApplicable}` (variants mirror the foundation's `CurationDecision`; the integration layer maps 1:1).

### Decision semantics (doc-commented + tested)

- **`NotApplicable`** for any format without a public download-count source (currently applicable: `pypi`/`poetry` and `npm`/`yarn`/`pnpm`) — popularity rules run as instance-wide policy, so a global rule silently passes generic/docker/maven/etc. through instead of flagging everything.
- Known count below `min_downloads` → configured `action` (`flag` default, `block` opt-in; flag-first because legit new packages are legitimately low-count), reason includes the count and threshold.
- Typo-squat match (within `max_distance`, clamped 1–2, of a popular name while not itself popular) → **Flag** naming the likely target; advisory-only, never a block on its own.
- `Unknown` downloads → `Flag("popularity unknown …")`, never Block, regardless of `action`: fail-open on the data source, fail-safe on the decision, so a stats-API outage cannot hard-block installs.
- Block > Flag when signals combine; reasons are joined.

Config shape: `{"min_downloads": N, "window": "month", "typosquat_check": true, "max_distance": 2, "action": "flag"|"block", "popular_packages": [...]}` — all keys optional.

No new crate dependencies (reuses `reqwest`, `async-trait`, `serde_json`). No migration.

### Reviewer note: external data sources

pypistats.org and api.npmjs.org are public, unauthenticated APIs with informal rate limits. The TTL cache plus short-TTL negative caching bounds request volume, and every degradation path is `Unknown` → flag-for-review, but operators with heavy ingest may want a curated `popular_packages` list and a higher cache TTL; a BigQuery-backed source can be added behind the same trait later.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated (33 new tests: threshold flag/block/allow, typo-squat incl. transposition + self-exclusion, Unknown→Flag-not-Block, NotApplicable formats with zero source calls, cache hit/TTL-expiry/negative-cache, distance properties, API-body parsers, PEP 503 normalization, path-segment encoding)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo nextest run --lib`: 14188 passed; fmt + clippy `-D warnings` clean; docker backend image builds)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (rule CRUD API lands with the foundation PR)
