### PR TITLE
feat(curation): typed curation rules — publisher_trust + popularity evaluators, global scope, decision dispatch

### DIFF
--- a/backend/migrations/180_curation_rule_types.sql
+++ b/backend/migrations/180_curation_rule_types.sql
@@ -1,0 +1,37 @@
+-- 180_curation_rule_types.sql
+-- #2947: shared foundation for typed curation rules. Existing rows are the
+-- glob/version/arch engine, now explicitly `rule_type = 'pattern'`; sibling
+-- rule types (`publisher_trust` #2948, `popularity` #2949) carry their
+-- type-specific parameters in `config`.
+--
+-- CONCURRENTLY N/A: ADD COLUMN with a constant default is a fast,
+-- catalog-only change on modern Postgres (no table rewrite, no long lock).
+ALTER TABLE curation_rules
+    ADD COLUMN IF NOT EXISTS rule_type TEXT NOT NULL DEFAULT 'pattern';
+ALTER TABLE curation_rules
+    ADD COLUMN IF NOT EXISTS config JSONB NOT NULL DEFAULT '{}';
+
+-- Scope dimension: 'repository' (attached to one staging repo, as today) vs
+-- 'global' (instance-wide baseline policy, no repo). `staging_repo_id` was
+-- created nullable in 071; DROP NOT NULL is a no-op belt-and-braces so the
+-- invariant (scope = 'global' <=> staging_repo_id IS NULL) is expressible on
+-- any upgrade path.
+ALTER TABLE curation_rules ALTER COLUMN staging_repo_id DROP NOT NULL;
+ALTER TABLE curation_rules
+    ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'repository';
+
+-- Backfill: every pre-existing rule is the pattern engine. The column default
+-- already stamps 'pattern' on old rows; this is an explicit belt-and-braces
+-- pass for any row that predates the default on unusual upgrade paths.
+UPDATE curation_rules SET rule_type = 'pattern' WHERE rule_type IS NULL OR rule_type = '';
+
+-- Backfill scope: rules without a staging repo were already evaluated
+-- instance-wide (the applicable-rules union has always included
+-- `staging_repo_id IS NULL`); name that behavior explicitly.
+UPDATE curation_rules SET scope = 'global' WHERE staging_repo_id IS NULL AND scope <> 'global';
+UPDATE curation_rules SET scope = 'repository' WHERE staging_repo_id IS NOT NULL AND scope <> 'repository';
+
+-- Global-baseline lookup: the enforcement seam reads all global rules ordered
+-- by priority for every evaluation, independent of repo.
+CREATE INDEX IF NOT EXISTS idx_curation_rules_scope_global
+    ON curation_rules (priority) WHERE scope = 'global';

--- a/backend/src/api/handlers/curation.rs
+++ b/backend/src/api/handlers/curation.rs
@@ -88,7 +88,12 @@ pub fn router() -> Router<SharedState> {
 #[derive(Debug, Deserialize, ToSchema)]
 #[schema(as = CurationCreateRuleRequest)]
 pub struct CreateRuleRequest {
+    /// Omit (with `scope: "global"` or no `scope`) to create an instance-wide
+    /// baseline rule; set to attach the rule to one staging repository.
     pub staging_repo_id: Option<Uuid>,
+    /// Only meaningful for `rule_type = "pattern"`; defaults to `*` so typed
+    /// rules (`publisher_trust`, `popularity`) can omit it.
+    #[serde(default = "default_wildcard")]
     pub package_pattern: String,
     #[serde(default = "default_wildcard")]
     pub version_constraint: String,
@@ -98,6 +103,18 @@ pub struct CreateRuleRequest {
     #[serde(default = "default_priority")]
     pub priority: i32,
     pub reason: String,
+    /// Evaluation engine: `pattern` (default), `publisher_trust`, `popularity`.
+    #[serde(default = "default_rule_type")]
+    pub rule_type: String,
+    /// Engine-specific parameters (JSON object). `{}` for `pattern` rules.
+    #[serde(default = "default_config")]
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+    /// `repository` (default when `staging_repo_id` is set) or `global`.
+    /// When present it must be consistent with `staging_repo_id`: `global`
+    /// forbids a repo id, `repository` requires one.
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 fn default_wildcard() -> String {
@@ -106,6 +123,14 @@ fn default_wildcard() -> String {
 
 fn default_priority() -> i32 {
     100
+}
+
+fn default_rule_type() -> String {
+    "pattern".to_string()
+}
+
+fn default_config() -> serde_json::Value {
+    serde_json::json!({})
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -122,6 +147,13 @@ pub struct UpdateRuleRequest {
     pub reason: String,
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Evaluation engine: `pattern` (default), `publisher_trust`, `popularity`.
+    #[serde(default = "default_rule_type")]
+    pub rule_type: String,
+    /// Engine-specific parameters (JSON object). `{}` for `pattern` rules.
+    #[serde(default = "default_config")]
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
 }
 
 fn default_true() -> bool {
@@ -139,9 +171,58 @@ pub struct RuleResponse {
     pub priority: i32,
     pub reason: String,
     pub enabled: bool,
+    pub rule_type: String,
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+    pub scope: String,
     pub created_by: Option<Uuid>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+/// Validate the #2947 typed-rule fields shared by create/update.
+///
+/// `declared_scope`/`staging_repo_id` are only checked on create (update never
+/// moves a rule between repos, so its scope is immutable).
+fn validate_typed_rule_fields(
+    rule_type: &str,
+    config: &serde_json::Value,
+    declared_scope: Option<&str>,
+    staging_repo_id: Option<Uuid>,
+) -> Result<(), AppError> {
+    if !crate::models::curation::CURATION_RULE_TYPES.contains(&rule_type) {
+        return Err(AppError::Validation(format!(
+            "Invalid rule_type '{rule_type}': expected one of {:?}",
+            crate::models::curation::CURATION_RULE_TYPES
+        )));
+    }
+    if !config.is_object() {
+        return Err(AppError::Validation(
+            "config must be a JSON object".to_string(),
+        ));
+    }
+    if let Some(scope) = declared_scope {
+        if !crate::models::curation::CURATION_RULE_SCOPES.contains(&scope) {
+            return Err(AppError::Validation(format!(
+                "Invalid scope '{scope}': expected one of {:?}",
+                crate::models::curation::CURATION_RULE_SCOPES
+            )));
+        }
+        match (scope, staging_repo_id) {
+            ("global", Some(_)) => {
+                return Err(AppError::Validation(
+                    "scope 'global' is incompatible with staging_repo_id".to_string(),
+                ))
+            }
+            ("repository", None) => {
+                return Err(AppError::Validation(
+                    "scope 'repository' requires staging_repo_id".to_string(),
+                ))
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -243,7 +324,10 @@ pub struct SyncTriggerResponse {
     get,
     path = "/api/v1/curation/rules",
     operation_id = "list_curation_rules",
-    params(("staging_repo_id" = Option<Uuid>, Query, description = "Filter by staging repo")),
+    params(
+        ("staging_repo_id" = Option<Uuid>, Query, description = "Filter by staging repo"),
+        ("scope" = Option<String>, Query, description = "Filter by rule scope: `global` lists only the instance-wide baseline rules (admin-only)"),
+    ),
     responses((status = 200, body = Vec<RuleResponse>)),
     tag = "Curation"
 )]
@@ -254,14 +338,43 @@ async fn list_rules(
 ) -> Result<Json<Vec<RuleResponse>>, AppError> {
     let svc = CurationService::new(state.db.clone());
     let repo_id = params.get("staging_repo_id").and_then(|s| s.parse().ok());
+    let scope = params.get("scope").map(|s| s.as_str());
     // Cross-repo authorization (#2443): curation rules expose the private
     // staging repo's package-gating policy. Filtered by staging repo → gate on
-    // that repo's visibility; unfiltered spans every repo → admin-only.
-    match repo_id {
-        Some(id) => require_repo_id_visible(&state.db, &auth, id, "Repository not found").await?,
-        None => auth.require_admin()?,
-    }
-    let rules = svc.list_rules(repo_id).await?;
+    // that repo's visibility; unfiltered or global-baseline listings span
+    // instance-wide policy → admin-only.
+    let rules = match (scope, repo_id) {
+        // Instance-wide baseline view (#2947): only the global rules.
+        (Some("global"), None) => {
+            auth.require_admin()?;
+            svc.list_global_rules().await?
+        }
+        (Some("global"), Some(_)) => {
+            return Err(AppError::Validation(
+                "scope=global is incompatible with staging_repo_id".to_string(),
+            ))
+        }
+        (Some("repository"), None) => {
+            return Err(AppError::Validation(
+                "scope=repository requires staging_repo_id".to_string(),
+            ))
+        }
+        (Some(other), _) if other != "repository" => {
+            return Err(AppError::Validation(format!(
+                "Invalid scope '{other}': expected one of {:?}",
+                crate::models::curation::CURATION_RULE_SCOPES
+            )))
+        }
+        // Repo-filtered view (global baseline included, as always).
+        (_, Some(id)) => {
+            require_repo_id_visible(&state.db, &auth, id, "Repository not found").await?;
+            svc.list_rules(Some(id)).await?
+        }
+        (_, None) => {
+            auth.require_admin()?;
+            svc.list_rules(None).await?
+        }
+    };
     Ok(Json(rules.into_iter().map(rule_to_response).collect()))
 }
 
@@ -279,6 +392,12 @@ async fn create_rule(
     Json(req): Json<CreateRuleRequest>,
 ) -> Result<(StatusCode, Json<RuleResponse>), AppError> {
     auth.require_admin()?;
+    validate_typed_rule_fields(
+        &req.rule_type,
+        &req.config,
+        req.scope.as_deref(),
+        req.staging_repo_id,
+    )?;
     let svc = CurationService::new(state.db.clone());
     let rule = svc
         .create_rule(
@@ -289,6 +408,8 @@ async fn create_rule(
             &req.action,
             req.priority,
             &req.reason,
+            &req.rule_type,
+            &req.config,
             auth.user_id,
         )
         .await?;
@@ -345,6 +466,7 @@ async fn update_rule(
     Json(req): Json<UpdateRuleRequest>,
 ) -> Result<Json<RuleResponse>, AppError> {
     auth.require_admin()?;
+    validate_typed_rule_fields(&req.rule_type, &req.config, None, None)?;
     let svc = CurationService::new(state.db.clone());
     let rule = svc
         .update_rule(
@@ -356,6 +478,8 @@ async fn update_rule(
             req.priority,
             &req.reason,
             req.enabled,
+            &req.rule_type,
+            &req.config,
         )
         .await?;
     Ok(Json(rule_to_response(rule)))
@@ -760,6 +884,9 @@ fn rule_to_response(rule: crate::models::curation::CurationRule) -> RuleResponse
         priority: rule.priority,
         reason: rule.reason,
         enabled: rule.enabled,
+        rule_type: rule.rule_type,
+        config: rule.config,
+        scope: rule.scope,
         created_by: rule.created_by,
         created_at: rule.created_at.to_rfc3339(),
         updated_at: rule.updated_at.to_rfc3339(),
@@ -882,18 +1009,24 @@ mod tests {
             .iter()
             .filter_map(|v| v.as_str())
             .collect::<Vec<_>>();
-        for field in ["package_pattern", "action", "reason"] {
+        for field in ["action", "reason"] {
             assert!(
                 required.contains(&field),
                 "expected {field} in required, got {required:?}"
             );
         }
-        // Defaulted/optional fields must not be required.
+        // Defaulted/optional fields must not be required. `package_pattern`
+        // joined this set with #2947: typed rules (publisher_trust,
+        // popularity) have no pattern, so it defaults to `*`.
         for field in [
             "staging_repo_id",
+            "package_pattern",
             "version_constraint",
             "architecture",
             "priority",
+            "rule_type",
+            "config",
+            "scope",
         ] {
             assert!(
                 !required.contains(&field),
@@ -949,6 +1082,203 @@ mod tests {
         assert_eq!(req.architecture, "*");
         assert_eq!(req.priority, 100);
         assert!(req.staging_repo_id.is_none());
+        // #2947 defaults: an untyped body is a pattern rule with empty config.
+        assert_eq!(req.rule_type, "pattern");
+        assert_eq!(req.config, serde_json::json!({}));
+        assert!(req.scope.is_none());
+    }
+
+    // -- #2947 typed rules: request shape + validation ------------------------
+
+    #[test]
+    fn test_create_rule_request_typed_global_deserializes() {
+        // A global publisher_trust rule needs no pattern and no repo.
+        let body = serde_json::json!({
+            "action": "block",
+            "reason": "untrusted publisher",
+            "rule_type": "publisher_trust",
+            "config": {"min_trust": 0.8},
+            "scope": "global"
+        });
+        let req: CreateRuleRequest =
+            serde_json::from_value(body).expect("deserialize typed global create body");
+        assert_eq!(req.rule_type, "publisher_trust");
+        assert_eq!(req.config, serde_json::json!({"min_trust": 0.8}));
+        assert_eq!(req.scope.as_deref(), Some("global"));
+        assert_eq!(req.package_pattern, "*", "pattern defaults for typed rules");
+        assert!(req.staging_repo_id.is_none());
+        assert!(validate_typed_rule_fields(
+            &req.rule_type,
+            &req.config,
+            req.scope.as_deref(),
+            req.staging_repo_id
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_typed_rule_fields_accepts_all_known_types() {
+        for rule_type in crate::models::curation::CURATION_RULE_TYPES {
+            assert!(
+                validate_typed_rule_fields(rule_type, &serde_json::json!({}), None, None).is_ok(),
+                "{rule_type} must validate"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_typed_rule_fields_rejects_unknown_type() {
+        let err =
+            validate_typed_rule_fields("mystery", &serde_json::json!({}), None, None).unwrap_err();
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("mystery")),
+            "unknown rule_type must be a Validation error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_rule_fields_rejects_non_object_config() {
+        for bad in [
+            serde_json::json!([1, 2]),
+            serde_json::json!("s"),
+            serde_json::json!(3),
+            serde_json::json!(null),
+        ] {
+            let err = validate_typed_rule_fields("popularity", &bad, None, None).unwrap_err();
+            assert!(
+                matches!(err, AppError::Validation(_)),
+                "non-object config {bad} must be rejected: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_typed_rule_fields_scope_consistency() {
+        let cfg = serde_json::json!({});
+        let repo = Some(Uuid::new_v4());
+        // Consistent combinations pass.
+        assert!(validate_typed_rule_fields("pattern", &cfg, Some("global"), None).is_ok());
+        assert!(validate_typed_rule_fields("pattern", &cfg, Some("repository"), repo).is_ok());
+        assert!(validate_typed_rule_fields("pattern", &cfg, None, repo).is_ok());
+        // Inconsistent or unknown scopes are rejected.
+        for (scope, repo_id) in [("global", repo), ("repository", None), ("everywhere", None)] {
+            let err =
+                validate_typed_rule_fields("pattern", &cfg, Some(scope), repo_id).unwrap_err();
+            assert!(
+                matches!(err, AppError::Validation(_)),
+                "scope={scope} repo={repo_id:?} must be rejected: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_openapi_curation_rule_response_has_typed_fields() {
+        let spec = curation_spec_json();
+        let props = &spec["components"]["schemas"]["RuleResponse"]["properties"];
+        for field in ["rule_type", "config", "scope"] {
+            assert!(
+                props.get(field).is_some(),
+                "RuleResponse must document {field}"
+            );
+        }
+    }
+
+    // #2947 DB round-trip through the HANDLERS: an admin creates a global
+    // publisher_trust rule (no repo), it persists with rule_type/config/scope,
+    // shows up in the scope=global listing, and deletes cleanly.
+    #[tokio::test]
+    async fn test_create_list_delete_global_typed_rule_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (admin, aname) = tdh::create_user(&pool).await;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+
+        let created = super::create_rule(
+            State(state.clone()),
+            Extension(tdh::admin_auth(admin, &aname)),
+            Json(CreateRuleRequest {
+                staging_repo_id: None,
+                package_pattern: "*".to_string(),
+                version_constraint: "*".to_string(),
+                architecture: "*".to_string(),
+                action: "block".to_string(),
+                priority: 42,
+                reason: "publisher below trust floor (#2947 test)".to_string(),
+                rule_type: "publisher_trust".to_string(),
+                config: serde_json::json!({"min_trust": 0.9}),
+                scope: Some("global".to_string()),
+            }),
+        )
+        .await
+        .expect("admin creates a global typed rule");
+        let rule = created.1 .0;
+        assert_eq!(rule.rule_type, "publisher_trust");
+        assert_eq!(rule.config, serde_json::json!({"min_trust": 0.9}));
+        assert_eq!(rule.scope, "global");
+        assert!(rule.staging_repo_id.is_none());
+
+        // scope=global listing (admin-only) contains it.
+        let mut params = std::collections::HashMap::new();
+        params.insert("scope".to_string(), "global".to_string());
+        let listed = super::list_rules(
+            State(state.clone()),
+            Extension(tdh::admin_auth(admin, &aname)),
+            Query(params.clone()),
+        )
+        .await
+        .expect("admin lists global rules");
+        assert!(
+            listed.0.iter().any(|r| r.id == rule.id),
+            "global listing must contain the created rule"
+        );
+
+        // Non-admin cannot read the instance-wide baseline.
+        let denied = super::list_rules(
+            State(state.clone()),
+            Extension(tdh::make_auth(admin, &aname)),
+            Query(params),
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(AppError::Authorization(_))),
+            "scope=global listing must be admin-only: {denied:?}"
+        );
+
+        // A bad rule_type is rejected before touching the DB.
+        let invalid = super::create_rule(
+            State(state.clone()),
+            Extension(tdh::admin_auth(admin, &aname)),
+            Json(CreateRuleRequest {
+                staging_repo_id: None,
+                package_pattern: "*".to_string(),
+                version_constraint: "*".to_string(),
+                architecture: "*".to_string(),
+                action: "block".to_string(),
+                priority: 42,
+                reason: "bad".to_string(),
+                rule_type: "mystery".to_string(),
+                config: serde_json::json!({}),
+                scope: None,
+            }),
+        )
+        .await;
+        assert!(
+            matches!(invalid, Err(AppError::Validation(_))),
+            "unknown rule_type must be rejected: {invalid:?}"
+        );
+
+        let deleted = super::delete_rule(
+            State(state),
+            Extension(tdh::admin_auth(admin, &aname)),
+            Path(rule.id),
+        )
+        .await
+        .expect("admin deletes the typed rule");
+        assert_eq!(deleted, StatusCode::NO_CONTENT);
+
+        tdh::cleanup_user(&pool, admin).await;
     }
 
     // ----------------------------------------------------------------------

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -198,6 +198,57 @@ pub async fn sso_provider_serial_lock() -> SsoProviderSerialGuard {
     SsoProviderSerialGuard { _conn: Some(conn) }
 }
 
+/// Advisory-lock key for [`curation_global_serial_lock`] (#2947).
+///
+/// Distinct from the other test lock keys and from the application advisory
+/// locks, so the global-curation-rule test cluster serializes only against
+/// itself.
+const CURATION_GLOBAL_TEST_LOCK_KEY: i64 = 0x4355_2947; // "CU" + issue #2947
+
+/// Cross-process serialization guard for tests that seed *global* curation
+/// rules (#2947).
+///
+/// A `scope = 'global'` rule (`staging_repo_id IS NULL`) is instance-wide
+/// policy: `fetch_applicable_rules` unions it into EVERY repository's rule
+/// set. Under `cargo nextest`'s process-per-test parallelism, one test's
+/// freshly-seeded global rule can decide (first-applicable-wins) a peer
+/// test's evaluation mid-assert. A Postgres *session* advisory lock —
+/// mirroring [`scan_dedup_serial_lock`] — makes every such test contend for
+/// one key, so only one runs its seed → evaluate → cleanup critical section
+/// at a time. The lock releases when the guard drops (connection closes),
+/// including on panic.
+pub struct CurationGlobalSerialGuard {
+    _conn: Option<sqlx::PgConnection>,
+}
+
+/// Acquire the process-wide global-curation-rule test lock, blocking until it
+/// is free.
+///
+/// Returns an inert guard (no lock held) when `DATABASE_URL` is unset or the
+/// database is unreachable, mirroring [`try_pool`] so DB-free environments
+/// still no-op cleanly. Call this as the first line of any DB-backed test
+/// that seeds global curation rules and asserts on rule evaluation, and bind
+/// the result for the whole test body.
+pub async fn curation_global_serial_lock() -> CurationGlobalSerialGuard {
+    use sqlx::Connection;
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        return CurationGlobalSerialGuard { _conn: None };
+    };
+    let mut conn = match sqlx::PgConnection::connect(&url).await {
+        Ok(c) => c,
+        Err(_) => return CurationGlobalSerialGuard { _conn: None },
+    };
+    if sqlx::query("SELECT pg_advisory_lock($1)")
+        .bind(CURATION_GLOBAL_TEST_LOCK_KEY)
+        .execute(&mut conn)
+        .await
+        .is_err()
+    {
+        return CurationGlobalSerialGuard { _conn: None };
+    }
+    CurationGlobalSerialGuard { _conn: Some(conn) }
+}
+
 /// Build a lazily-connecting pool that never actually opens a connection
 /// unless a query is issued. Useful for DB-free unit tests of code paths that
 /// short-circuit before touching the database.

--- a/backend/src/models/curation.rs
+++ b/backend/src/models/curation.rs
@@ -5,7 +5,32 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
-/// An explicit allow/block rule for package curation.
+/// Recognized `rule_type` values for [`CurationRule`] (#2947).
+///
+/// - `pattern`: the original glob/version/arch allow-block engine.
+/// - `publisher_trust`: publisher reputation evaluation (#2948).
+/// - `popularity`: download/adoption-signal evaluation (#2949).
+pub const CURATION_RULE_TYPES: [&str; 3] = ["pattern", "publisher_trust", "popularity"];
+
+/// Recognized `scope` values for [`CurationRule`] (#2947).
+///
+/// - `repository`: attached to one staging repository (`staging_repo_id` set).
+/// - `global`: instance-wide baseline policy (`staging_repo_id` is NULL);
+///   evaluated for every repository, union-ed with the repo's own rules.
+///
+/// Invariant: `scope == "global"` ⇔ `staging_repo_id IS NULL`. The service
+/// derives `scope` from the presence of `staging_repo_id` at write time so the
+/// two can never drift.
+pub const CURATION_RULE_SCOPES: [&str; 2] = ["repository", "global"];
+
+/// An explicit rule for package curation.
+///
+/// `rule_type` selects the evaluation engine (see [`CURATION_RULE_TYPES`]);
+/// `config` carries the engine-specific parameters as a JSON object. The
+/// legacy `pattern` engine keeps its parameters in the dedicated
+/// `package_pattern` / `version_constraint` / `architecture` columns.
+/// `scope` records whether the rule is repo-attached or an instance-wide
+/// baseline (see [`CURATION_RULE_SCOPES`]).
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct CurationRule {
     pub id: Uuid,
@@ -17,9 +42,33 @@ pub struct CurationRule {
     pub priority: i32,
     pub reason: String,
     pub enabled: bool,
+    pub rule_type: String,
+    pub config: serde_json::Value,
+    pub scope: String,
     pub created_by: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// The outcome a typed curation rule renders for one package (#2947).
+///
+/// The `String` payload carries the human-readable rationale surfaced to
+/// operators (evaluation reason / audit detail).
+///
+/// - `Allow`: the rule affirmatively passes the package.
+/// - `Flag`: the package should be routed to manual review.
+/// - `Block`: the package must not be served.
+/// - `NotApplicable`: the rule cannot meaningfully judge this package — e.g.
+///   a `publisher_trust`/`popularity` rule against a format with no such
+///   signal, or a `pattern` rule whose pattern does not match. The evaluator
+///   MUST have no effect: the enforcement seam skips it and continues, so a
+///   global policy silently passes through everything it cannot judge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CurationDecision {
+    Allow,
+    Flag(String),
+    Block(String),
+    NotApplicable,
 }
 
 /// A package tracked in the curation staging catalog.

--- a/backend/src/services/curation/mod.rs
+++ b/backend/src/services/curation/mod.rs
@@ -1,0 +1,9 @@
+//! Typed curation rule evaluators (#2947 foundation).
+//!
+//! Each submodule owns the evaluation logic for one `rule_type` of
+//! `curation_rules`. The dispatch seam in
+//! [`crate::services::curation_service::CurationService::evaluate_typed_rule`]
+//! routes a rule + package context to the matching evaluator.
+
+pub mod popularity;
+pub mod publisher_trust;

--- a/backend/src/services/curation/mod.rs
+++ b/backend/src/services/curation/mod.rs
@@ -1,9 +1,22 @@
-//! Typed curation rule evaluators (#2947 foundation).
+//! Typed curation rule evaluators (#2947 epic).
 //!
 //! Each submodule owns the evaluation logic for one `rule_type` of
-//! `curation_rules`. The dispatch seam in
+//! `curation_rules` and stays free of database dependencies so it can be
+//! unit-tested in isolation. The dispatch seam in
 //! [`crate::services::curation_service::CurationService::evaluate_typed_rule`]
-//! routes a rule + package context to the matching evaluator.
+//! routes a rule + package context to the matching evaluator; every evaluator
+//! renders a [`crate::models::curation::CurationDecision`].
+//!
+//! Currently implemented:
+//! - [`publisher_trust`] — trusted-publisher allowlisting (issue #2948),
+//!   backed by [`publisher_source`] (provenance-labeled publisher identity
+//!   extraction).
+//! - [`popularity`] — download-count threshold + typo-squat detection
+//!   (issue #2949), backed by [`popularity_source`] (pluggable download-count
+//!   providers) and [`typosquat`] (lexical-distance matching).
 
 pub mod popularity;
+pub mod popularity_source;
+pub mod publisher_source;
 pub mod publisher_trust;
+pub mod typosquat;

--- a/backend/src/services/curation/popularity.rs
+++ b/backend/src/services/curation/popularity.rs
@@ -13,14 +13,22 @@
 //!   applies the configured `action` (`"flag"` default, `"block"` opt-in).
 //!   Flag-first is deliberate: legitimately new packages have low counts.
 //! - **Typo-squat** — a name within `max_distance` (1–2) edits of a popular
-//!   package, while not itself popular, is *flagged* for review. The signal
-//!   is advisory (never a block from this check alone): lexical proximity has
-//!   false positives by construction.
+//!   package, while not itself popular, is *flagged* for review by default.
+//!   The default signal is advisory (lexical proximity has false positives by
+//!   construction), but an operator who accepts those false positives can set
+//!   `"block_typosquat": true` to escalate a typo-squat match to a hard
+//!   Block — otherwise a fresh malicious squat (which has no download
+//!   history and so can never trip the threshold check) only ever lands in
+//!   review.
 //! - **Unknown popularity** — a source outage/rate limit/unlisted package
-//!   yields `Flag("popularity unknown…")`, never Block, regardless of
-//!   `action`. Fail-open on the data source, fail-safe on the decision: the
-//!   package stays reviewable but an upstream stats outage can never
-//!   hard-block installs.
+//!   yields `Flag("popularity unknown…")` by default, never Block, regardless
+//!   of `action`. Fail-open on the data source, fail-safe on the decision:
+//!   the package stays reviewable but an upstream stats outage can never
+//!   hard-block installs. Operators running `action: "block"` who prefer to
+//!   fail *closed* on their own targets (a brand-new package has no history
+//!   and would otherwise evade the block) can opt in with
+//!   `"block_unknown": true`, which turns an `Unknown` count into a Block —
+//!   accepting that a stats outage then blocks new installs too.
 //!
 //! When both the threshold and the typo-squat signal fire, the strongest
 //! outcome wins (Block > Flag) and the reasons are combined.
@@ -55,6 +63,8 @@ const MAX_DISTANCE_CEILING: u64 = 2;
 ///   "typosquat_check": true,
 ///   "max_distance": 2,
 ///   "action": "flag",
+///   "block_unknown": false,
+///   "block_typosquat": false,
 ///   "popular_packages": ["requests", "..."]
 /// }
 /// ```
@@ -65,6 +75,18 @@ const MAX_DISTANCE_CEILING: u64 = 2;
 /// and `popular_packages` to the built-in per-ecosystem seed list. `window`
 /// is currently informational — both supported sources report last-month
 /// counts.
+///
+/// Two opt-in hardening flags (both default `false`, preserving the
+/// fail-open/advisory defaults):
+///
+/// * `block_unknown` — with `action: "block"`, a package whose download
+///   count is `Unknown` (brand-new, unlisted, or stats-source outage) is
+///   **blocked** instead of flagged, closing the fail-open gap where a fresh
+///   package evades the threshold block because it has no history yet.
+///   Without `action: "block"` the flag has no effect.
+/// * `block_typosquat` — a typo-squat match **blocks** instead of flagging,
+///   regardless of `action`. Off by default because lexical proximity has
+///   false positives by construction.
 ///
 /// `version` is accepted for signature-compatibility with the dispatch seam;
 /// popularity is a package-level signal, so it does not influence the
@@ -100,6 +122,15 @@ pub async fn evaluate(
         .and_then(serde_json::Value::as_str)
         .map(|a| a.eq_ignore_ascii_case("block"))
         .unwrap_or(false);
+    // Opt-in hardening flags; both default false (see doc comment).
+    let block_unknown = config
+        .get("block_unknown")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let block_typosquat = config
+        .get("block_typosquat")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
 
     let popular: Vec<String> = match config
         .get("popular_packages")
@@ -134,20 +165,38 @@ pub async fn evaluate(
         }
         PopularityResult::Known(_) => {}
         PopularityResult::Unknown => {
-            // Fail-open on the data source, fail-safe on the decision: a
-            // stats outage or unlisted package is reviewable, never a block.
-            flag_reasons.push(format!(
+            let reason = format!(
                 "popularity unknown for package '{name}' (download-count source unavailable or package not listed)"
-            ));
+            );
+            if block_action && block_unknown {
+                // Opt-in fail-closed: a brand-new package with no download
+                // history must not evade a block rule just because the count
+                // is Unknown.
+                block_reasons.push(reason);
+            } else {
+                // Default: fail-open on the data source, fail-safe on the
+                // decision — a stats outage or unlisted package is
+                // reviewable, never a block.
+                flag_reasons.push(reason);
+            }
         }
     }
 
     if typosquat_check {
         if let Some(target) = is_typosquat(name, &popular, max_distance) {
-            // Advisory signal only: lexical proximity alone never blocks.
-            flag_reasons.push(format!(
+            let reason = format!(
                 "name '{name}' is within edit distance {max_distance} of popular package '{target}' (possible typo-squat)"
-            ));
+            );
+            if block_typosquat {
+                // Opt-in enforcement: the operator accepts the false-positive
+                // rate of lexical matching in exchange for hard-blocking
+                // fresh squats that have no download history to trip on.
+                block_reasons.push(reason);
+            } else {
+                // Default: advisory only — lexical proximity alone never
+                // blocks.
+                flag_reasons.push(reason);
+            }
         }
     }
 
@@ -244,8 +293,9 @@ mod tests {
 
     #[tokio::test]
     async fn typosquat_is_advisory_even_with_block_action() {
-        // action=block applies to the threshold check only; a typo-squat
-        // match on an above-threshold package stays a Flag.
+        // action=block applies to the threshold check only; without the
+        // block_typosquat opt-in, a typo-squat match on an above-threshold
+        // package stays a Flag.
         let source = FakePopularitySource::new().with("pypi", "reqeusts", 9_999_999);
         let cfg = config(serde_json::json!({"min_downloads": 500, "action": "block"}));
         match evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await {
@@ -275,7 +325,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_popularity_flags_never_blocks() {
+    async fn unknown_popularity_flags_by_default_never_blocks() {
+        // Default (no block_unknown): fail-open on the source, Flag only.
         let source = FakePopularitySource::new(); // everything Unknown
         let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
         match evaluate(&cfg, "pypi", "brand-new-pkg", "0.1.0", &source).await {
@@ -283,6 +334,79 @@ mod tests {
                 assert!(reason.contains("popularity unknown"), "{reason}");
             }
             other => panic!("expected Flag (fail-open on source outage), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_popularity_blocks_when_block_unknown_opted_in() {
+        // block_unknown=true + action=block: a brand-new package with no
+        // download history no longer evades the block rule.
+        let source = FakePopularitySource::new(); // everything Unknown
+        let cfg = config(serde_json::json!({
+            "min_downloads": 1000,
+            "action": "block",
+            "block_unknown": true
+        }));
+        match evaluate(&cfg, "pypi", "brand-new-pkg", "0.1.0", &source).await {
+            CurationDecision::Block(reason) => {
+                assert!(reason.contains("popularity unknown"), "{reason}");
+            }
+            other => panic!("expected Block (opt-in fail-closed), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn block_unknown_without_block_action_still_flags() {
+        // block_unknown only has effect together with action=block; a
+        // flag-mode rule stays advisory.
+        let source = FakePopularitySource::new(); // everything Unknown
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "block_unknown": true}));
+        match evaluate(&cfg, "npm", "brand-new-pkg", "0.1.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("popularity unknown"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn typosquat_blocks_when_block_typosquat_opted_in() {
+        // block_typosquat=true escalates the lexical match to a hard Block,
+        // even for a package that clears the download threshold.
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 9_999_999);
+        let cfg = config(serde_json::json!({
+            "min_downloads": 500,
+            "action": "block",
+            "block_typosquat": true
+        }));
+        match evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await {
+            CurationDecision::Block(reason) => {
+                assert!(reason.contains("typo-squat"), "{reason}");
+                assert!(reason.contains("requests"), "{reason}");
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fresh_typosquat_with_both_optins_is_blocked_not_reviewed() {
+        // The finding scenario: a brand-new malicious typo-squat has no
+        // download history (Unknown) AND a near-popular name. With the
+        // default config it only ever lands in review; with both opt-ins a
+        // block rule now actually blocks it, combining both reasons.
+        let source = FakePopularitySource::new(); // everything Unknown
+        let cfg = config(serde_json::json!({
+            "min_downloads": 500,
+            "action": "block",
+            "block_unknown": true,
+            "block_typosquat": true
+        }));
+        match evaluate(&cfg, "pypi", "reqeusts", "0.0.1", &source).await {
+            CurationDecision::Block(reason) => {
+                assert!(reason.contains("popularity unknown"), "{reason}");
+                assert!(reason.contains("typo-squat"), "{reason}");
+            }
+            other => panic!("expected Block, got {other:?}"),
         }
     }
 

--- a/backend/src/services/curation/popularity.rs
+++ b/backend/src/services/curation/popularity.rs
@@ -1,0 +1,47 @@
+//! `popularity` curation rule evaluator (#2949).
+//!
+//! Stub wired up by the #2947 foundation so the dispatch seam, format
+//! applicability gate and API round-trip are in place; #2949 replaces the
+//! evaluation body with the real popularity/adoption-signal logic driven by
+//! `config`.
+
+use crate::models::curation::CurationDecision;
+
+/// Formats whose public registries expose a download/adoption signal this
+/// rule type can meaningfully judge. Anything else short-circuits to
+/// [`CurationDecision::NotApplicable`] (no effect), so a GLOBAL popularity
+/// policy silently passes through formats with no such signal.
+// TODO(#2949): revisit/extend alongside the real evaluator.
+pub const APPLICABLE_FORMATS: [&str; 7] = [
+    "npm", "pypi", "cargo", "nuget", "rubygems", "composer", "hex",
+];
+
+/// Whether this rule type applies to `format` at all.
+pub fn applies_to(format: &str) -> bool {
+    APPLICABLE_FORMATS.contains(&format)
+}
+
+/// Evaluate a `popularity` rule against one package.
+///
+/// Synchronous placeholder: the real #2949 implementation may consult cached
+/// popularity data and can change this seam to async behind the dispatch.
+/// `config` is the rule's JSONB `config` column (type-specific parameters);
+/// the remaining arguments are the package context. Returns
+/// [`CurationDecision::NotApplicable`] for formats without an adoption signal.
+pub fn evaluate_sync_placeholder(
+    config: &serde_json::Value,
+    format: &str,
+    name: &str,
+    version: &str,
+    metadata: &serde_json::Value,
+) -> CurationDecision {
+    match applies_to(format) {
+        false => CurationDecision::NotApplicable,
+        true => {
+            // TODO(#2949): real popularity evaluation (download counts,
+            // adoption thresholds) driven by `config`.
+            let _ = (metadata, version, name, config);
+            CurationDecision::Allow
+        }
+    }
+}

--- a/backend/src/services/curation/popularity.rs
+++ b/backend/src/services/curation/popularity.rs
@@ -1,47 +1,339 @@
-//! `popularity` curation rule evaluator (#2949).
+//! `popularity` curation rule evaluator (#2949): download-count threshold +
+//! typo-squat detection.
 //!
-//! Stub wired up by the #2947 foundation so the dispatch seam, format
-//! applicability gate and API round-trip are in place; #2949 replaces the
-//! evaluation body with the real popularity/adoption-signal logic driven by
-//! `config`.
+//! # Decision semantics
+//!
+//! - **Not applicable** — popularity rules run as instance-wide policy, but
+//!   only some ecosystems have a public download-count source (currently
+//!   PyPI via pypistats.org and npm via the npm downloads API, plus their
+//!   registry-compatible aliases). For any other format `evaluate` returns
+//!   [`CurationDecision::NotApplicable`] so a global rule silently passes raw/
+//!   generic/private-only formats through instead of flagging everything.
+//! - **Below threshold** — a known download count under `min_downloads`
+//!   applies the configured `action` (`"flag"` default, `"block"` opt-in).
+//!   Flag-first is deliberate: legitimately new packages have low counts.
+//! - **Typo-squat** — a name within `max_distance` (1–2) edits of a popular
+//!   package, while not itself popular, is *flagged* for review. The signal
+//!   is advisory (never a block from this check alone): lexical proximity has
+//!   false positives by construction.
+//! - **Unknown popularity** — a source outage/rate limit/unlisted package
+//!   yields `Flag("popularity unknown…")`, never Block, regardless of
+//!   `action`. Fail-open on the data source, fail-safe on the decision: the
+//!   package stays reviewable but an upstream stats outage can never
+//!   hard-block installs.
+//!
+//! When both the threshold and the typo-squat signal fire, the strongest
+//! outcome wins (Block > Flag) and the reasons are combined.
 
 use crate::models::curation::CurationDecision;
 
-/// Formats whose public registries expose a download/adoption signal this
-/// rule type can meaningfully judge. Anything else short-circuits to
-/// [`CurationDecision::NotApplicable`] (no effect), so a GLOBAL popularity
-/// policy silently passes through formats with no such signal.
-// TODO(#2949): revisit/extend alongside the real evaluator.
-pub const APPLICABLE_FORMATS: [&str; 7] = [
-    "npm", "pypi", "cargo", "nuget", "rubygems", "composer", "hex",
-];
+use super::popularity_source::{ecosystem_for_format, PopularityResult, PopularitySource};
+use super::typosquat::{default_popular_packages, is_typosquat};
 
-/// Whether this rule type applies to `format` at all.
+/// Whether this rule type applies to `format` at all — i.e. a public
+/// download-count ecosystem exists for it. The dispatch checks this BEFORE
+/// touching (or constructing) a [`PopularitySource`], so inapplicable formats
+/// never cost a lookup.
 pub fn applies_to(format: &str) -> bool {
-    APPLICABLE_FORMATS.contains(&format)
+    ecosystem_for_format(format).is_some()
 }
 
-/// Evaluate a `popularity` rule against one package.
+/// Default lexical distance for typo-squat matching.
+const DEFAULT_MAX_DISTANCE: u64 = 2;
+/// Ceiling for the configurable distance. Beyond 2 edits the false-positive
+/// rate on short names makes the signal noise.
+const MAX_DISTANCE_CEILING: u64 = 2;
+
+/// Evaluate the `popularity` rule for one package.
 ///
-/// Synchronous placeholder: the real #2949 implementation may consult cached
-/// popularity data and can change this seam to async behind the dispatch.
-/// `config` is the rule's JSONB `config` column (type-specific parameters);
-/// the remaining arguments are the package context. Returns
-/// [`CurationDecision::NotApplicable`] for formats without an adoption signal.
-pub fn evaluate_sync_placeholder(
+/// `config` is the rule's JSONB config:
+///
+/// ```json
+/// {
+///   "min_downloads": 500,
+///   "window": "month",
+///   "typosquat_check": true,
+///   "max_distance": 2,
+///   "action": "flag",
+///   "popular_packages": ["requests", "..."]
+/// }
+/// ```
+///
+/// All keys are optional: `min_downloads` defaults to 0 (threshold check
+/// disabled), `typosquat_check` to `true`, `max_distance` to 2 (clamped to
+/// 1–2), `action` to `"flag"` (anything other than `"block"` means flag),
+/// and `popular_packages` to the built-in per-ecosystem seed list. `window`
+/// is currently informational — both supported sources report last-month
+/// counts.
+///
+/// `version` is accepted for signature-compatibility with the dispatch seam;
+/// popularity is a package-level signal, so it does not influence the
+/// decision today.
+pub async fn evaluate(
     config: &serde_json::Value,
     format: &str,
     name: &str,
     version: &str,
-    metadata: &serde_json::Value,
+    source: &dyn PopularitySource,
 ) -> CurationDecision {
-    match applies_to(format) {
-        false => CurationDecision::NotApplicable,
-        true => {
-            // TODO(#2949): real popularity evaluation (download counts,
-            // adoption thresholds) driven by `config`.
-            let _ = (metadata, version, name, config);
-            CurationDecision::Allow
+    let _ = version; // package-level signal; see doc comment.
+
+    let Some(ecosystem) = ecosystem_for_format(format) else {
+        return CurationDecision::NotApplicable;
+    };
+
+    let min_downloads = config
+        .get("min_downloads")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let typosquat_check = config
+        .get("typosquat_check")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    let max_distance = config
+        .get("max_distance")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_MAX_DISTANCE)
+        .clamp(1, MAX_DISTANCE_CEILING) as usize;
+    let block_action = config
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .map(|a| a.eq_ignore_ascii_case("block"))
+        .unwrap_or(false);
+
+    let popular: Vec<String> = match config
+        .get("popular_packages")
+        .and_then(serde_json::Value::as_array)
+    {
+        Some(list) => list
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        None => default_popular_packages(ecosystem)
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    };
+
+    let downloads = source.downloads(format, name).await;
+
+    let mut block_reasons: Vec<String> = Vec::new();
+    let mut flag_reasons: Vec<String> = Vec::new();
+
+    match downloads {
+        PopularityResult::Known(d) if min_downloads > 0 && d < min_downloads => {
+            let reason = format!(
+                "package '{name}' has {d} recent downloads, below the configured minimum of {min_downloads}"
+            );
+            if block_action {
+                block_reasons.push(reason);
+            } else {
+                flag_reasons.push(reason);
+            }
         }
+        PopularityResult::Known(_) => {}
+        PopularityResult::Unknown => {
+            // Fail-open on the data source, fail-safe on the decision: a
+            // stats outage or unlisted package is reviewable, never a block.
+            flag_reasons.push(format!(
+                "popularity unknown for package '{name}' (download-count source unavailable or package not listed)"
+            ));
+        }
+    }
+
+    if typosquat_check {
+        if let Some(target) = is_typosquat(name, &popular, max_distance) {
+            // Advisory signal only: lexical proximity alone never blocks.
+            flag_reasons.push(format!(
+                "name '{name}' is within edit distance {max_distance} of popular package '{target}' (possible typo-squat)"
+            ));
+        }
+    }
+
+    if !block_reasons.is_empty() {
+        block_reasons.extend(flag_reasons);
+        CurationDecision::Block(block_reasons.join("; "))
+    } else if !flag_reasons.is_empty() {
+        CurationDecision::Flag(flag_reasons.join("; "))
+    } else {
+        CurationDecision::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::popularity_source::FakePopularitySource;
+    use super::*;
+
+    fn config(json: serde_json::Value) -> serde_json::Value {
+        json
+    }
+
+    #[tokio::test]
+    async fn below_threshold_flags_by_default() {
+        let source = FakePopularitySource::new().with("pypi", "obscure-pkg", 42);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        let decision = evaluate(&cfg, "pypi", "obscure-pkg", "1.0.0", &source).await;
+        match decision {
+            CurationDecision::Flag(reason) => {
+                assert!(
+                    reason.contains("42"),
+                    "reason should include the count: {reason}"
+                );
+                assert!(
+                    reason.contains("500"),
+                    "reason should include the threshold: {reason}"
+                );
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn below_threshold_blocks_when_opted_in() {
+        let source = FakePopularitySource::new().with("npm", "obscure-pkg", 3);
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
+        let decision = evaluate(&cfg, "npm", "obscure-pkg", "0.0.1", &source).await;
+        match decision {
+            CurationDecision::Block(reason) => {
+                assert!(reason.contains("below the configured minimum"))
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn above_threshold_allows() {
+        let source = FakePopularitySource::new().with("pypi", "healthy-pkg", 10_000);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "healthy-pkg", "2.1.0", &source).await,
+            CurationDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_threshold_disables_count_check() {
+        let source = FakePopularitySource::new().with("npm", "tiny-pkg", 1);
+        let cfg = config(serde_json::json!({"typosquat_check": false}));
+        assert_eq!(
+            evaluate(&cfg, "npm", "tiny-pkg", "1.0.0", &source).await,
+            CurationDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn typosquat_flags_and_names_the_target() {
+        // `reqeusts` is popular-ish by count but one transposition from
+        // `requests`: the advisory typo-squat flag fires on its own.
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 900);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "max_distance": 2}));
+        let decision = evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await;
+        match decision {
+            CurationDecision::Flag(reason) => {
+                assert!(
+                    reason.contains("requests"),
+                    "should name the target: {reason}"
+                );
+                assert!(reason.contains("typo-squat"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn typosquat_is_advisory_even_with_block_action() {
+        // action=block applies to the threshold check only; a typo-squat
+        // match on an above-threshold package stays a Flag.
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 9_999_999);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "action": "block"}));
+        match evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await {
+            CurationDecision::Flag(reason) => assert!(reason.contains("typo-squat")),
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn typosquat_respects_custom_popular_list_and_toggle() {
+        let source = FakePopularitySource::new().with("npm", "lodahs", 700);
+        // Custom list without lodash: no match.
+        let cfg = config(serde_json::json!({
+            "min_downloads": 500,
+            "popular_packages": ["express", "react"]
+        }));
+        assert_eq!(
+            evaluate(&cfg, "npm", "lodahs", "4.0.0", &source).await,
+            CurationDecision::Allow
+        );
+        // Toggle off: no match even against the default list.
+        let cfg = config(serde_json::json!({"min_downloads": 500, "typosquat_check": false}));
+        assert_eq!(
+            evaluate(&cfg, "npm", "lodahs", "4.0.0", &source).await,
+            CurationDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_popularity_flags_never_blocks() {
+        let source = FakePopularitySource::new(); // everything Unknown
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
+        match evaluate(&cfg, "pypi", "brand-new-pkg", "0.1.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("popularity unknown"), "{reason}");
+            }
+            other => panic!("expected Flag (fail-open on source outage), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn inapplicable_format_returns_not_applicable() {
+        // Global policy over a format with no download-count source must have
+        // no effect — even though the fake would return Unknown (which for an
+        // applicable format means Flag).
+        let source = FakePopularitySource::new();
+        let cfg = config(serde_json::json!({"min_downloads": 1000, "action": "block"}));
+        for format in ["generic", "docker", "maven", "rpm", "helm"] {
+            assert_eq!(
+                evaluate(&cfg, format, "anything", "1.0.0", &source).await,
+                CurationDecision::NotApplicable,
+                "format {format} should be NotApplicable"
+            );
+        }
+        // And the source was never consulted for inapplicable formats.
+        assert_eq!(source.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn block_and_typosquat_reasons_combine() {
+        let source = FakePopularitySource::new().with("pypi", "reqeusts", 5);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "action": "block"}));
+        match evaluate(&cfg, "pypi", "reqeusts", "1.0.0", &source).await {
+            CurationDecision::Block(reason) => {
+                assert!(reason.contains("below the configured minimum"), "{reason}");
+                assert!(reason.contains("typo-squat"), "{reason}");
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_config_allows_popular_known_package() {
+        let source = FakePopularitySource::new().with("npm", "some-lib", 123);
+        assert_eq!(
+            evaluate(&serde_json::json!({}), "npm", "some-lib", "1.0.0", &source).await,
+            CurationDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn max_distance_is_clamped_to_ceiling() {
+        // Distance 3 name; configured max_distance=5 clamps to 2 → no flag.
+        let source = FakePopularitySource::new().with("pypi", "reqzzzts", 10_000);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "max_distance": 5}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "reqzzzts", "1.0.0", &source).await,
+            CurationDecision::Allow
+        );
     }
 }

--- a/backend/src/services/curation/popularity_source.rs
+++ b/backend/src/services/curation/popularity_source.rs
@@ -1,0 +1,483 @@
+//! Pluggable download-count ("popularity") data sources for the `popularity`
+//! curation rule (#2949).
+//!
+//! The contract is deliberately narrow: given an ecosystem format and a
+//! package name, return either a **known** download count for the recent
+//! window or [`PopularityResult::Unknown`]. A source must NEVER fabricate a
+//! count — any transport error, non-2xx status, unparseable body, timeout, or
+//! unsupported ecosystem degrades to `Unknown`. The policy layer
+//! ([`super::popularity::evaluate`]) maps `Unknown` to a *flag-for-review*
+//! decision, never a hard block, so a data-source outage cannot break
+//! legitimate installs.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+/// Outcome of a download-count lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopularityResult {
+    /// The source returned an authoritative recent download count.
+    Known(u64),
+    /// The count could not be determined (source outage, rate limit,
+    /// unknown package, unsupported ecosystem). Callers must treat this as
+    /// "no data", not "zero downloads".
+    Unknown,
+}
+
+/// A provider of recent download counts for packages in an ecosystem.
+#[async_trait]
+pub trait PopularitySource: Send + Sync {
+    /// Return the recent (last-month) download count for `name` in the
+    /// ecosystem identified by `format` (e.g. `"pypi"`, `"npm"`), or
+    /// [`PopularityResult::Unknown`] when no authoritative answer exists.
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult;
+}
+
+/// Default total-request timeout for popularity lookups. These are small JSON
+/// responses from public APIs; a short hard deadline keeps a slow upstream
+/// from stalling curation evaluation.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default TTL for cached `Known` results.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// TTL for cached `Unknown` results. Deliberately shorter than the positive
+/// TTL: it shields an unavailable upstream from a request storm while still
+/// retrying soon after an outage or a freshly published package.
+const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Map a repository format (including registry-compatible aliases) to the
+/// upstream download-count ecosystem it belongs to.
+///
+/// Returns `None` for formats without a public download-count API; the
+/// evaluator treats those as not applicable rather than unpopular.
+pub fn ecosystem_for_format(format: &str) -> Option<&'static str> {
+    match format.to_ascii_lowercase().as_str() {
+        // Poetry/conda repos serve packages published on PyPI.
+        "pypi" | "poetry" => Some("pypi"),
+        // Yarn and pnpm resolve against the npm registry.
+        "npm" | "yarn" | "pnpm" => Some("npm"),
+        _ => None,
+    }
+}
+
+/// Real download-count source backed by public registry statistics APIs:
+///
+/// - **PyPI** → `GET https://pypistats.org/api/packages/{name}/recent`
+///   (last-month total from the `data.last_month` field)
+/// - **npm** → `GET https://api.npmjs.org/downloads/point/last-month/{name}`
+///   (the `downloads` field)
+///
+/// All failures — timeouts, non-2xx (including 429 rate limiting), malformed
+/// bodies — degrade to [`PopularityResult::Unknown`]. Wrap in
+/// [`CachedPopularitySource`] (see [`HttpPopularitySource::cached`]) for
+/// production use so repeated evaluations of the same package do not hammer
+/// the public APIs.
+pub struct HttpPopularitySource {
+    client: reqwest::Client,
+    pypistats_base: String,
+    npm_base: String,
+}
+
+impl HttpPopularitySource {
+    /// Build a source using the repo-standard SSRF-guarded HTTP client with a
+    /// short total-request timeout.
+    pub fn new() -> Self {
+        let client = crate::services::http_client::base_client_builder()
+            .timeout(DEFAULT_REQUEST_TIMEOUT)
+            .connect_timeout(Duration::from_secs(3))
+            .build()
+            .expect("failed to build popularity HTTP client");
+        Self {
+            client,
+            pypistats_base: "https://pypistats.org".to_string(),
+            npm_base: "https://api.npmjs.org".to_string(),
+        }
+    }
+
+    /// Override the upstream base URLs (tests / air-gapped mirrors).
+    pub fn with_base_urls(mut self, pypistats_base: &str, npm_base: &str) -> Self {
+        self.pypistats_base = pypistats_base.trim_end_matches('/').to_string();
+        self.npm_base = npm_base.trim_end_matches('/').to_string();
+        self
+    }
+
+    /// Wrap this source in an in-memory TTL cache with the default TTL.
+    pub fn cached(self) -> CachedPopularitySource<Self> {
+        CachedPopularitySource::new(self, DEFAULT_CACHE_TTL)
+    }
+
+    async fn fetch_json(&self, url: &str) -> Option<serde_json::Value> {
+        let resp = match self.client.get(url).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(url, error = %e, "popularity lookup failed");
+                return None;
+            }
+        };
+        if !resp.status().is_success() {
+            tracing::debug!(url, status = %resp.status(), "popularity lookup non-success");
+            return None;
+        }
+        match resp.json::<serde_json::Value>().await {
+            Ok(v) => Some(v),
+            Err(e) => {
+                tracing::debug!(url, error = %e, "popularity response not valid JSON");
+                None
+            }
+        }
+    }
+}
+
+impl Default for HttpPopularitySource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract the last-month total from a pypistats.org `/recent` response body:
+/// `{"data": {"last_day": .., "last_month": N, "last_week": ..}, ...}`.
+pub fn parse_pypistats_recent(body: &serde_json::Value) -> PopularityResult {
+    match body
+        .get("data")
+        .and_then(|d| d.get("last_month"))
+        .and_then(serde_json::Value::as_u64)
+    {
+        Some(n) => PopularityResult::Known(n),
+        None => PopularityResult::Unknown,
+    }
+}
+
+/// Extract the download count from an npm point-downloads response body:
+/// `{"downloads": N, "start": .., "end": .., "package": ..}`.
+pub fn parse_npm_point(body: &serde_json::Value) -> PopularityResult {
+    match body.get("downloads").and_then(serde_json::Value::as_u64) {
+        Some(n) => PopularityResult::Known(n),
+        None => PopularityResult::Unknown,
+    }
+}
+
+/// Percent-encode a package name for safe use as a single path segment.
+/// Keeps unreserved characters plus `@` untouched for readability of scoped
+/// npm names in logs; encodes `/` (scoped-package separator) and everything
+/// else that could alter the request path.
+fn encode_path_segment(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for b in name.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'@' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[async_trait]
+impl PopularitySource for HttpPopularitySource {
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult {
+        let Some(ecosystem) = ecosystem_for_format(format) else {
+            return PopularityResult::Unknown;
+        };
+        match ecosystem {
+            "pypi" => {
+                // PEP 503 normalization: lowercase, runs of -_. become -.
+                let normalized = normalize_pypi_name(name);
+                let url = format!(
+                    "{}/api/packages/{}/recent",
+                    self.pypistats_base,
+                    encode_path_segment(&normalized)
+                );
+                match self.fetch_json(&url).await {
+                    Some(body) => parse_pypistats_recent(&body),
+                    None => PopularityResult::Unknown,
+                }
+            }
+            "npm" => {
+                let url = format!(
+                    "{}/downloads/point/last-month/{}",
+                    self.npm_base,
+                    encode_path_segment(name)
+                );
+                match self.fetch_json(&url).await {
+                    Some(body) => parse_npm_point(&body),
+                    None => PopularityResult::Unknown,
+                }
+            }
+            _ => PopularityResult::Unknown,
+        }
+    }
+}
+
+/// Normalize a PyPI project name per PEP 503 (lowercase; runs of `-`, `_`,
+/// `.` collapse to a single `-`), which is what pypistats.org expects.
+pub fn normalize_pypi_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_sep = false;
+    for c in name.chars() {
+        if matches!(c, '-' | '_' | '.') {
+            if !prev_sep {
+                out.push('-');
+            }
+            prev_sep = true;
+        } else {
+            out.push(c.to_ascii_lowercase());
+            prev_sep = false;
+        }
+    }
+    out
+}
+
+/// In-memory TTL cache decorator over any [`PopularitySource`].
+///
+/// `Known` results are cached for the configured TTL; `Unknown` results are
+/// cached for the shorter [`NEGATIVE_CACHE_TTL`] so a source outage is not
+/// amplified into a request storm but recovery is picked up quickly.
+pub struct CachedPopularitySource<S: PopularitySource> {
+    inner: S,
+    ttl: Duration,
+    cache: Mutex<HashMap<(String, String), (Instant, PopularityResult)>>,
+}
+
+impl<S: PopularitySource> CachedPopularitySource<S> {
+    /// Wrap `inner` with a positive-result TTL of `ttl`.
+    pub fn new(inner: S, ttl: Duration) -> Self {
+        Self {
+            inner,
+            ttl,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl<S: PopularitySource> PopularitySource for CachedPopularitySource<S> {
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult {
+        let key = (format.to_string(), name.to_string());
+        if let Ok(cache) = self.cache.lock() {
+            if let Some((at, result)) = cache.get(&key) {
+                let ttl = match result {
+                    PopularityResult::Known(_) => self.ttl,
+                    PopularityResult::Unknown => NEGATIVE_CACHE_TTL.min(self.ttl),
+                };
+                if at.elapsed() < ttl {
+                    return *result;
+                }
+            }
+        }
+        let result = self.inner.downloads(format, name).await;
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.insert(key, (Instant::now(), result));
+        }
+        result
+    }
+}
+
+/// Deterministic in-memory test double. Returns `Known` for seeded
+/// `(format, name)` pairs and `Unknown` otherwise, and counts lookups so
+/// tests can assert caching behavior.
+#[derive(Default)]
+pub struct FakePopularitySource {
+    counts: HashMap<(String, String), u64>,
+    calls: AtomicUsize,
+}
+
+impl FakePopularitySource {
+    /// Empty fake: every lookup returns `Unknown`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed a known download count for `(format, name)`.
+    pub fn with(mut self, format: &str, name: &str, downloads: u64) -> Self {
+        self.counts
+            .insert((format.to_string(), name.to_string()), downloads);
+        self
+    }
+
+    /// Number of `downloads` calls made against this fake.
+    pub fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl PopularitySource for FakePopularitySource {
+    async fn downloads(&self, format: &str, name: &str) -> PopularityResult {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        match self.counts.get(&(format.to_string(), name.to_string())) {
+            Some(n) => PopularityResult::Known(*n),
+            None => PopularityResult::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pypistats_recent_body() {
+        let body = serde_json::json!({
+            "data": {"last_day": 100, "last_month": 12345, "last_week": 900},
+            "package": "requests",
+            "type": "recent_downloads"
+        });
+        assert_eq!(
+            parse_pypistats_recent(&body),
+            PopularityResult::Known(12345)
+        );
+    }
+
+    #[test]
+    fn parses_npm_point_body() {
+        let body = serde_json::json!({
+            "downloads": 987654,
+            "start": "2026-06-01",
+            "end": "2026-06-30",
+            "package": "lodash"
+        });
+        assert_eq!(parse_npm_point(&body), PopularityResult::Known(987654));
+    }
+
+    #[test]
+    fn malformed_bodies_degrade_to_unknown() {
+        assert_eq!(
+            parse_pypistats_recent(&serde_json::json!({"error": "not found"})),
+            PopularityResult::Unknown
+        );
+        assert_eq!(
+            parse_npm_point(&serde_json::json!({"error": "package not found"})),
+            PopularityResult::Unknown
+        );
+        // Negative / non-integer counts are not trusted.
+        assert_eq!(
+            parse_npm_point(&serde_json::json!({"downloads": -5})),
+            PopularityResult::Unknown
+        );
+    }
+
+    #[test]
+    fn ecosystem_mapping_covers_aliases_and_rejects_others() {
+        assert_eq!(ecosystem_for_format("pypi"), Some("pypi"));
+        assert_eq!(ecosystem_for_format("poetry"), Some("pypi"));
+        assert_eq!(ecosystem_for_format("npm"), Some("npm"));
+        assert_eq!(ecosystem_for_format("yarn"), Some("npm"));
+        assert_eq!(ecosystem_for_format("pnpm"), Some("npm"));
+        assert_eq!(ecosystem_for_format("NPM"), Some("npm"));
+        assert_eq!(ecosystem_for_format("generic"), None);
+        assert_eq!(ecosystem_for_format("docker"), None);
+        assert_eq!(ecosystem_for_format("maven"), None);
+    }
+
+    #[test]
+    fn pypi_name_normalization_is_pep503() {
+        assert_eq!(normalize_pypi_name("Django"), "django");
+        assert_eq!(
+            normalize_pypi_name("typing_extensions"),
+            "typing-extensions"
+        );
+        assert_eq!(normalize_pypi_name("zope.interface"), "zope-interface");
+        assert_eq!(normalize_pypi_name("a--b__c"), "a-b-c");
+    }
+
+    #[test]
+    fn path_segment_encoding_escapes_separators() {
+        assert_eq!(encode_path_segment("@scope/pkg"), "@scope%2Fpkg");
+        assert_eq!(encode_path_segment("simple-name"), "simple-name");
+        assert_eq!(encode_path_segment("a b"), "a%20b");
+    }
+
+    #[tokio::test]
+    async fn fake_source_returns_seeded_counts_and_unknown() {
+        let fake = FakePopularitySource::new().with("pypi", "requests", 1_000_000);
+        assert_eq!(
+            fake.downloads("pypi", "requests").await,
+            PopularityResult::Known(1_000_000)
+        );
+        assert_eq!(
+            fake.downloads("pypi", "not-seeded").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(fake.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn cache_serves_repeat_lookups_without_inner_calls() {
+        let fake = FakePopularitySource::new().with("npm", "lodash", 50_000_000);
+        let cached = CachedPopularitySource::new(fake, Duration::from_secs(60));
+        assert_eq!(
+            cached.downloads("npm", "lodash").await,
+            PopularityResult::Known(50_000_000)
+        );
+        assert_eq!(
+            cached.downloads("npm", "lodash").await,
+            PopularityResult::Known(50_000_000)
+        );
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_expires_after_ttl() {
+        let fake = FakePopularitySource::new().with("npm", "react", 40_000_000);
+        let cached = CachedPopularitySource::new(fake, Duration::from_millis(10));
+        assert_eq!(
+            cached.downloads("npm", "react").await,
+            PopularityResult::Known(40_000_000)
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(
+            cached.downloads("npm", "react").await,
+            PopularityResult::Known(40_000_000)
+        );
+        assert_eq!(cached.inner.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn unknown_results_are_negatively_cached_within_short_ttl() {
+        let fake = FakePopularitySource::new();
+        // Positive TTL shorter than NEGATIVE_CACHE_TTL: min() applies, so the
+        // Unknown entry is still fresh on the second lookup.
+        let cached = CachedPopularitySource::new(fake, Duration::from_secs(30));
+        assert_eq!(
+            cached.downloads("pypi", "ghost-pkg").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(
+            cached.downloads("pypi", "ghost-pkg").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn http_source_unsupported_format_is_unknown_without_network() {
+        // No network I/O happens for a format outside the ecosystem map.
+        let source =
+            HttpPopularitySource::new().with_base_urls("http://127.0.0.1:1", "http://127.0.0.1:1");
+        assert_eq!(
+            source.downloads("generic", "whatever").await,
+            PopularityResult::Unknown
+        );
+    }
+
+    #[tokio::test]
+    async fn http_source_degrades_to_unknown_on_connection_error() {
+        // Unroutable base URL: the request errors and the source degrades.
+        let source =
+            HttpPopularitySource::new().with_base_urls("http://127.0.0.1:1", "http://127.0.0.1:1");
+        assert_eq!(
+            source.downloads("pypi", "requests").await,
+            PopularityResult::Unknown
+        );
+        assert_eq!(
+            source.downloads("npm", "lodash").await,
+            PopularityResult::Unknown
+        );
+    }
+}

--- a/backend/src/services/curation/publisher_source.rs
+++ b/backend/src/services/curation/publisher_source.rs
@@ -1,0 +1,344 @@
+//! Publisher identity extraction for `publisher_trust` curation rules (#2948).
+//!
+//! Security model: a publisher identity is only as trustworthy as where it
+//! came from. This module makes that provenance explicit:
+//!
+//! * [`PublisherSource::Attestation`] — the identity comes from a registry
+//!   provenance/attestation record (PyPI Trusted Publishers / integrity API
+//!   attestation bundles, npm sigstore provenance). These are bound to an
+//!   OIDC identity at publish time and are the *strong* trust signal.
+//! * [`PublisherSource::Metadata`] — the identity is self-asserted package
+//!   metadata (`author`, `maintainer`, `_npmUser`, ...). Anyone can put
+//!   "Microsoft" in an `author` field, so this is a *weak*, spoofable signal
+//!   (a classic dependency-confusion vector). It is surfaced as a labeled
+//!   fallback and must never be treated as equivalent to an attestation.
+//!
+//! Parsing is deliberately defensive: any missing or malformed field yields
+//! `None` rather than a guess, so callers can fail safe.
+
+use serde_json::Value;
+
+/// Where a publisher identity was sourced from. Ordering of trust:
+/// `Attestation` (verified provenance) > `Metadata` (self-asserted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublisherSource {
+    /// Registry-verified provenance (PyPI Trusted Publisher attestation
+    /// bundle, npm sigstore attestation). Strong signal.
+    Attestation,
+    /// Self-asserted package metadata (`author` / `maintainer` / `_npmUser`).
+    /// Weak, spoofable signal — never sufficient on its own for trust
+    /// decisions under `match: "attestation"`.
+    Metadata,
+}
+
+/// A publisher identity extracted from package metadata, labeled with the
+/// signal it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublisherIdentity {
+    /// Publisher name as extracted (e.g. a GitHub org from an attestation
+    /// bundle, or an `author` string from self-asserted metadata).
+    pub name: String,
+    /// Which class of signal produced [`Self::name`].
+    pub source: PublisherSource,
+    /// `true` only when the identity comes from a registry-verified
+    /// provenance record. Always `false` for [`PublisherSource::Metadata`].
+    pub verified: bool,
+}
+
+/// Package formats for which a publisher/provenance concept exists and this
+/// module knows how to extract it. Formats outside this set have no
+/// meaningful publisher signal (e.g. `raw`/`generic`), so a global
+/// publisher-trust policy should treat them as not applicable rather than
+/// flagging everything.
+pub const APPLICABLE_FORMATS: &[&str] = &["pypi", "npm"];
+
+/// Returns `true` if `format` has a publisher concept this module can
+/// evaluate (see [`APPLICABLE_FORMATS`]).
+pub fn is_applicable_format(format: &str) -> bool {
+    APPLICABLE_FORMATS.contains(&format.to_ascii_lowercase().as_str())
+}
+
+/// Extracts the strongest available publisher identity from `metadata` for
+/// the given package `format`.
+///
+/// * `pypi` — expects the PyPI JSON API shape (`/pypi/{pkg}/json`): the
+///   self-asserted fields live under `info.author` / `info.maintainer` /
+///   `info.author_email` / `info.maintainer_email`. If a PyPI integrity-API
+///   provenance object has been merged into the blob (top-level
+///   `provenance.attestation_bundles[].publisher`, as returned by
+///   `/integrity/{pkg}/{version}/{file}/provenance`), the Trusted-Publisher
+///   identity (repository owner, e.g. the GitHub org) is preferred with
+///   `source = Attestation, verified = true`.
+/// * `npm` — expects the registry packument / version-document shape:
+///   self-asserted fields are `_npmUser.name` and `maintainers[].name`. If
+///   the version's `dist.attestations` carries a sigstore `provenance`
+///   record, the identity is labeled `Attestation`/`verified`.
+///
+/// Any other format, and any metadata where no non-empty publisher can be
+/// found, returns `None` — callers must not fabricate trust from absence.
+pub fn extract_publisher(format: &str, metadata: &Value) -> Option<PublisherIdentity> {
+    match format.to_ascii_lowercase().as_str() {
+        "pypi" => extract_pypi(metadata),
+        "npm" => extract_npm(metadata),
+        _ => None,
+    }
+}
+
+// -- PyPI --------------------------------------------------------------------
+
+fn extract_pypi(metadata: &Value) -> Option<PublisherIdentity> {
+    if let Some(name) = pypi_attestation_publisher(metadata) {
+        return Some(PublisherIdentity {
+            name,
+            source: PublisherSource::Attestation,
+            verified: true,
+        });
+    }
+
+    let info = metadata.get("info")?;
+    let name = non_empty_str(info.get("author"))
+        .or_else(|| non_empty_str(info.get("maintainer")))
+        .or_else(|| display_name_from_contact(info.get("author_email")))
+        .or_else(|| display_name_from_contact(info.get("maintainer_email")))?;
+
+    Some(PublisherIdentity {
+        name,
+        source: PublisherSource::Metadata,
+        verified: false,
+    })
+}
+
+/// Reads the Trusted-Publisher identity from a merged PyPI integrity-API
+/// provenance object: `provenance.attestation_bundles[].publisher` where the
+/// publisher is e.g. `{ "kind": "GitHub", "repository": "owner/repo", ... }`.
+/// The publisher *name* is the repository owner (the org), which is what an
+/// allowlist like `["Microsoft", "NumFOCUS"]` is meant to match.
+fn pypi_attestation_publisher(metadata: &Value) -> Option<String> {
+    let bundles = metadata.get("provenance")?.get("attestation_bundles")?;
+    let publisher = bundles
+        .as_array()?
+        .iter()
+        .find_map(|b| b.get("publisher"))?;
+    let repository = non_empty_str(publisher.get("repository"))?;
+    let owner = repository.split('/').next().unwrap_or(&repository).trim();
+    if owner.is_empty() {
+        return None;
+    }
+    Some(owner.to_string())
+}
+
+// -- npm ---------------------------------------------------------------------
+
+fn extract_npm(metadata: &Value) -> Option<PublisherIdentity> {
+    let name =
+        non_empty_str(metadata.get("_npmUser").and_then(|u| u.get("name"))).or_else(|| {
+            metadata
+                .get("maintainers")?
+                .as_array()?
+                .iter()
+                .find_map(|m| non_empty_str(m.get("name")))
+        })?;
+
+    if npm_has_provenance(metadata) {
+        return Some(PublisherIdentity {
+            name,
+            source: PublisherSource::Attestation,
+            verified: true,
+        });
+    }
+
+    Some(PublisherIdentity {
+        name,
+        source: PublisherSource::Metadata,
+        verified: false,
+    })
+}
+
+/// npm marks provenance on the version document as
+/// `dist.attestations: { "url": ..., "provenance": { "predicateType": ... } }`.
+/// Presence of the `provenance` record means the registry verified a sigstore
+/// attestation for this publish; the publishing identity is the npm user that
+/// performed the attested publish.
+fn npm_has_provenance(metadata: &Value) -> bool {
+    metadata
+        .get("dist")
+        .and_then(|d| d.get("attestations"))
+        .and_then(|a| a.get("provenance"))
+        .is_some_and(|p| !p.is_null())
+}
+
+// -- helpers -----------------------------------------------------------------
+
+fn non_empty_str(value: Option<&Value>) -> Option<String> {
+    let s = value?.as_str()?.trim();
+    if s.is_empty() {
+        return None;
+    }
+    Some(s.to_string())
+}
+
+/// Extracts a display name from an RFC 5322-style contact field such as
+/// `"NumFOCUS <admin@numfocus.org>"`. A bare email address carries no
+/// publisher *name* and yields `None` (an allowlist should never be matched
+/// against a raw email address).
+fn display_name_from_contact(value: Option<&Value>) -> Option<String> {
+    let contact = value?.as_str()?.trim();
+    let angle = contact.find('<')?;
+    let name = contact[..angle].trim().trim_matches('"').trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn pypi_metadata_only() -> Value {
+        json!({
+            "info": {
+                "author": "Microsoft Corporation",
+                "author_email": "opensource@microsoft.com",
+                "maintainer": null,
+                "maintainer_email": null,
+                "name": "azure-core",
+                "version": "1.30.0"
+            },
+            "urls": [{"filename": "azure_core-1.30.0-py3-none-any.whl"}]
+        })
+    }
+
+    fn pypi_with_attestation() -> Value {
+        json!({
+            "info": {
+                "author": "Totally Microsoft",
+                "name": "numpy",
+                "version": "2.0.0"
+            },
+            "provenance": {
+                "attestation_bundles": [{
+                    "publisher": {
+                        "kind": "GitHub",
+                        "repository": "NumFOCUS/numpy",
+                        "workflow": "release.yml",
+                        "environment": "pypi"
+                    },
+                    "attestations": [{"envelope": {}}]
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn pypi_prefers_attestation_over_self_asserted_author() {
+        let id = extract_publisher("pypi", &pypi_with_attestation()).unwrap();
+        // The attestation org wins over the spoofable `author` string.
+        assert_eq!(id.name, "NumFOCUS");
+        assert_eq!(id.source, PublisherSource::Attestation);
+        assert!(id.verified);
+    }
+
+    #[test]
+    fn pypi_falls_back_to_author_metadata_unverified() {
+        let id = extract_publisher("pypi", &pypi_metadata_only()).unwrap();
+        assert_eq!(id.name, "Microsoft Corporation");
+        assert_eq!(id.source, PublisherSource::Metadata);
+        assert!(!id.verified);
+    }
+
+    #[test]
+    fn pypi_null_author_uses_maintainer_then_contact_display_name() {
+        let md = json!({
+            "info": {
+                "author": null,
+                "maintainer": "  ",
+                "author_email": "NumFOCUS <admin@numfocus.org>"
+            }
+        });
+        let id = extract_publisher("pypi", &md).unwrap();
+        assert_eq!(id.name, "NumFOCUS");
+        assert_eq!(id.source, PublisherSource::Metadata);
+        assert!(!id.verified);
+    }
+
+    #[test]
+    fn pypi_bare_email_is_not_a_publisher_name() {
+        let md = json!({"info": {"author_email": "admin@numfocus.org"}});
+        assert_eq!(extract_publisher("pypi", &md), None);
+    }
+
+    #[test]
+    fn pypi_empty_or_malformed_yields_none() {
+        assert_eq!(extract_publisher("pypi", &json!({})), None);
+        assert_eq!(extract_publisher("pypi", &json!({"info": {}})), None);
+        assert_eq!(extract_publisher("pypi", &json!({"info": "oops"})), None);
+        // Malformed provenance must not panic and must not fabricate identity.
+        let md =
+            json!({"provenance": {"attestation_bundles": [{"publisher": {"repository": "/"}}]}});
+        assert_eq!(extract_publisher("pypi", &md), None);
+    }
+
+    fn npm_with_provenance() -> Value {
+        json!({
+            "name": "@azure/core-rest-pipeline",
+            "version": "1.16.0",
+            "_npmUser": {"name": "microsoft", "email": "npmjs@microsoft.com"},
+            "maintainers": [{"name": "azure-sdk", "email": "azuresdk@microsoft.com"}],
+            "dist": {
+                "tarball": "https://registry.npmjs.org/...",
+                "attestations": {
+                    "url": "https://registry.npmjs.org/-/npm/v1/attestations/@azure%2fcore-rest-pipeline@1.16.0",
+                    "provenance": {"predicateType": "https://slsa.dev/provenance/v1"}
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn npm_provenance_marks_attested_verified() {
+        let id = extract_publisher("npm", &npm_with_provenance()).unwrap();
+        assert_eq!(id.name, "microsoft");
+        assert_eq!(id.source, PublisherSource::Attestation);
+        assert!(id.verified);
+    }
+
+    #[test]
+    fn npm_without_provenance_is_metadata_only() {
+        let md = json!({
+            "maintainers": [{"name": "microsoft", "email": "npmjs@microsoft.com"}],
+            "dist": {"tarball": "https://registry.npmjs.org/..."}
+        });
+        let id = extract_publisher("npm", &md).unwrap();
+        assert_eq!(id.name, "microsoft");
+        assert_eq!(id.source, PublisherSource::Metadata);
+        assert!(!id.verified);
+    }
+
+    #[test]
+    fn npm_missing_fields_yield_none() {
+        assert_eq!(extract_publisher("npm", &json!({})), None);
+        assert_eq!(extract_publisher("npm", &json!({"maintainers": []})), None);
+        assert_eq!(
+            extract_publisher("npm", &json!({"maintainers": "oops", "_npmUser": 42})),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_format_yields_none() {
+        assert_eq!(extract_publisher("raw", &pypi_metadata_only()), None);
+        assert_eq!(extract_publisher("maven", &json!({})), None);
+    }
+
+    #[test]
+    fn applicable_format_set() {
+        assert!(is_applicable_format("pypi"));
+        assert!(is_applicable_format("npm"));
+        assert!(is_applicable_format("PyPI"));
+        assert!(!is_applicable_format("raw"));
+        assert!(!is_applicable_format("docker"));
+        assert!(!is_applicable_format("maven"));
+    }
+}

--- a/backend/src/services/curation/publisher_source.rs
+++ b/backend/src/services/curation/publisher_source.rs
@@ -5,8 +5,12 @@
 //!
 //! * [`PublisherSource::Attestation`] — the identity comes from a registry
 //!   provenance/attestation record (PyPI Trusted Publishers / integrity API
-//!   attestation bundles, npm sigstore provenance). These are bound to an
-//!   OIDC identity at publish time and are the *strong* trust signal.
+//!   attestation bundles, npm sigstore provenance). When cryptographically
+//!   verified, these are bound to an OIDC identity at publish time and are
+//!   the *strong* trust signal. Verification of the envelope
+//!   (sigstore/DSSE/PEP 740) is NOT implemented yet (#2955): structural
+//!   presence of a provenance record is not verification, so extraction
+//!   currently always reports `verified = false` for this source.
 //! * [`PublisherSource::Metadata`] — the identity is self-asserted package
 //!   metadata (`author`, `maintainer`, `_npmUser`, ...). Anyone can put
 //!   "Microsoft" in an `author` field, so this is a *weak*, spoofable signal
@@ -19,11 +23,14 @@
 use serde_json::Value;
 
 /// Where a publisher identity was sourced from. Ordering of trust:
-/// `Attestation` (verified provenance) > `Metadata` (self-asserted).
+/// `Attestation` (provenance record) > `Metadata` (self-asserted).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PublisherSource {
-    /// Registry-verified provenance (PyPI Trusted Publisher attestation
-    /// bundle, npm sigstore attestation). Strong signal.
+    /// A registry provenance record (PyPI Trusted Publisher attestation
+    /// bundle, npm sigstore attestation) was present and an identity was
+    /// extracted from it. Presence alone is NOT trust: until the envelope is
+    /// cryptographically verified (#2955), this identity is unverified and
+    /// [`PublisherIdentity::verified`] stays `false`.
     Attestation,
     /// Self-asserted package metadata (`author` / `maintainer` / `_npmUser`).
     /// Weak, spoofable signal — never sufficient on its own for trust
@@ -40,8 +47,12 @@ pub struct PublisherIdentity {
     pub name: String,
     /// Which class of signal produced [`Self::name`].
     pub source: PublisherSource,
-    /// `true` only when the identity comes from a registry-verified
-    /// provenance record. Always `false` for [`PublisherSource::Metadata`].
+    /// `true` only once the provenance envelope backing the identity has been
+    /// cryptographically verified. Always `false` for
+    /// [`PublisherSource::Metadata`], and — because attestation verification
+    /// (sigstore/DSSE/PEP 740) is not implemented yet (#2955) — currently
+    /// always `false` for [`PublisherSource::Attestation`] too. Structural
+    /// presence of an attestation must never set this to `true`.
     pub verified: bool,
 }
 
@@ -68,11 +79,13 @@ pub fn is_applicable_format(format: &str) -> bool {
 ///   `provenance.attestation_bundles[].publisher`, as returned by
 ///   `/integrity/{pkg}/{version}/{file}/provenance`), the Trusted-Publisher
 ///   identity (repository owner, e.g. the GitHub org) is preferred with
-///   `source = Attestation, verified = true`.
+///   `source = Attestation` — but `verified = false`, because the envelope
+///   is not cryptographically verified yet (#2955).
 /// * `npm` — expects the registry packument / version-document shape:
 ///   self-asserted fields are `_npmUser.name` and `maintainers[].name`. If
 ///   the version's `dist.attestations` carries a sigstore `provenance`
-///   record, the identity is labeled `Attestation`/`verified`.
+///   record, the identity is labeled `Attestation` (again with
+///   `verified = false` pending #2955).
 ///
 /// Any other format, and any metadata where no non-empty publisher can be
 /// found, returns `None` — callers must not fabricate trust from absence.
@@ -91,7 +104,11 @@ fn extract_pypi(metadata: &Value) -> Option<PublisherIdentity> {
         return Some(PublisherIdentity {
             name,
             source: PublisherSource::Attestation,
-            verified: true,
+            // Presence != trust: the attestation envelope is NOT
+            // cryptographically verified here. Until sigstore/PEP 740
+            // verification lands (#2955), a structurally present provenance
+            // blob — which anyone can forge — must stay unverified.
+            verified: false,
         });
     }
 
@@ -143,7 +160,10 @@ fn extract_npm(metadata: &Value) -> Option<PublisherIdentity> {
         return Some(PublisherIdentity {
             name,
             source: PublisherSource::Attestation,
-            verified: true,
+            // Presence != trust: the sigstore provenance record is NOT
+            // cryptographically verified here (#2955). A planted
+            // `dist.attestations.provenance` field must stay unverified.
+            verified: false,
         });
     }
 
@@ -156,9 +176,9 @@ fn extract_npm(metadata: &Value) -> Option<PublisherIdentity> {
 
 /// npm marks provenance on the version document as
 /// `dist.attestations: { "url": ..., "provenance": { "predicateType": ... } }`.
-/// Presence of the `provenance` record means the registry verified a sigstore
-/// attestation for this publish; the publishing identity is the npm user that
-/// performed the attested publish.
+/// Presence of the `provenance` record only *claims* a sigstore attestation
+/// exists for this publish — this module does not fetch or cryptographically
+/// verify it (#2955), so presence is a labeling signal, never trust.
 fn npm_has_provenance(metadata: &Value) -> bool {
     metadata
         .get("dist")
@@ -232,12 +252,15 @@ mod tests {
     }
 
     #[test]
-    fn pypi_prefers_attestation_over_self_asserted_author() {
+    fn pypi_prefers_attestation_over_self_asserted_author_but_stays_unverified() {
         let id = extract_publisher("pypi", &pypi_with_attestation()).unwrap();
-        // The attestation org wins over the spoofable `author` string.
+        // The attestation org wins over the spoofable `author` string...
         assert_eq!(id.name, "NumFOCUS");
         assert_eq!(id.source, PublisherSource::Attestation);
-        assert!(id.verified);
+        // ...but structural presence of a provenance blob is NOT
+        // cryptographic verification (#2955): a forged blob must never
+        // surface as verified.
+        assert!(!id.verified);
     }
 
     #[test]
@@ -297,11 +320,13 @@ mod tests {
     }
 
     #[test]
-    fn npm_provenance_marks_attested_verified() {
+    fn npm_provenance_marks_attested_but_not_verified() {
         let id = extract_publisher("npm", &npm_with_provenance()).unwrap();
         assert_eq!(id.name, "microsoft");
         assert_eq!(id.source, PublisherSource::Attestation);
-        assert!(id.verified);
+        // Presence of `dist.attestations.provenance` is unverified until
+        // #2955 lands actual sigstore envelope verification.
+        assert!(!id.verified);
     }
 
     #[test]

--- a/backend/src/services/curation/publisher_trust.rs
+++ b/backend/src/services/curation/publisher_trust.rs
@@ -1,0 +1,44 @@
+//! `publisher_trust` curation rule evaluator (#2948).
+//!
+//! Stub wired up by the #2947 foundation so the dispatch seam, format
+//! applicability gate and API round-trip are in place; #2948 replaces the
+//! evaluation body with the real publisher-reputation logic driven by
+//! `config`.
+
+use crate::models::curation::CurationDecision;
+
+/// Formats that carry a publisher/maintainer identity signal this rule type
+/// can meaningfully judge. Anything else short-circuits to
+/// [`CurationDecision::NotApplicable`] (no effect), so a GLOBAL
+/// publisher-trust policy silently passes through formats with no publisher
+/// concept (e.g. `generic`, `rpm`, `debian`).
+// TODO(#2948): revisit/extend alongside the real evaluator.
+pub const APPLICABLE_FORMATS: [&str; 8] = [
+    "npm", "pypi", "cargo", "nuget", "rubygems", "composer", "hex", "maven",
+];
+
+/// Whether this rule type applies to `format` at all.
+pub fn applies_to(format: &str) -> bool {
+    APPLICABLE_FORMATS.contains(&format)
+}
+
+/// Evaluate a `publisher_trust` rule against one package.
+///
+/// `config` is the rule's JSONB `config` column (type-specific parameters);
+/// the remaining arguments are the package context. Returns
+/// [`CurationDecision::NotApplicable`] for formats without a publisher signal.
+pub fn evaluate(
+    config: &serde_json::Value,
+    format: &str,
+    name: &str,
+    version: &str,
+    metadata: &serde_json::Value,
+) -> CurationDecision {
+    if !applies_to(format) {
+        return CurationDecision::NotApplicable;
+    }
+    // TODO(#2948): real publisher-trust evaluation (trusted-publisher lists,
+    // signature/provenance signals) driven by `config`.
+    let _ = (config, name, version, metadata);
+    CurationDecision::Allow
+}

--- a/backend/src/services/curation/publisher_trust.rs
+++ b/backend/src/services/curation/publisher_trust.rs
@@ -1,44 +1,495 @@
 //! `publisher_trust` curation rule evaluator (#2948).
 //!
-//! Stub wired up by the #2947 foundation so the dispatch seam, format
-//! applicability gate and API round-trip are in place; #2948 replaces the
-//! evaluation body with the real publisher-reputation logic driven by
-//! `config`.
+//! Matches a package's publisher against a configured trusted-publisher
+//! allowlist and maps the result to an allow / flag / block decision.
+//!
+//! # Config shape
+//!
+//! ```json
+//! {
+//!   "trusted_publishers": ["Microsoft", "NumFOCUS"],
+//!   "match": "attestation" | "metadata",
+//!   "action": "allow" | "flag" | "block"
+//! }
+//! ```
+//!
+//! * `trusted_publishers` — required, non-empty list of publisher names.
+//!   Names are compared **case-insensitively and exactly** (never substring:
+//!   `"Microsoft"` must not match `"Evil Microsoft Fans"`).
+//! * `match` — which signal quality is sufficient to consider a publisher
+//!   trusted. Defaults to `"attestation"` (the secure default):
+//!   * `"attestation"` — only a registry-verified provenance identity
+//!     ([`PublisherSource::Attestation`] with `verified = true`) can satisfy
+//!     the allowlist. Self-asserted `author`/`maintainer` metadata is
+//!     spoofable and is deliberately **not** sufficient in this mode.
+//!   * `"metadata"` — an operator opt-in that also accepts the weaker,
+//!     self-asserted metadata identity. Use only where the threat model
+//!     tolerates it.
+//! * `action` — what the rule does, defaulting to `"flag"` (fail-safe):
+//!   * `"block"` — enforcement mode: **block anything NOT from a trusted
+//!     publisher**; trusted packages are allowed.
+//!   * `"allow"` — allowlist mode: allow trusted packages; anything else is
+//!     flagged for review (an allow rule never silently admits an untrusted
+//!     package, and never hard-blocks — it defers to a human).
+//!   * `"flag"` — watch mode: **flag packages that DO come from a listed
+//!     publisher** (e.g. audit everything a given vendor ships); packages
+//!     from unlisted publishers pass through unaffected (`Allow`). This mode
+//!     is an observability tool, not a security gate — use `"block"` or
+//!     `"allow"` to gate.
+//!
+//! # Fail-safe behavior
+//!
+//! * Format with no publisher concept (anything outside
+//!   [`publisher_source::APPLICABLE_FORMATS`]) → [`CurationDecision::NotApplicable`],
+//!   so a global instance-wide rule silently passes e.g. `raw` artifacts
+//!   through instead of carpet-flagging them.
+//! * Applicable format but no extractable publisher → [`CurationDecision::Flag`]
+//!   ("publisher unknown"): absence of identity is never trusted, but it is
+//!   surfaced for review rather than hard-blocked.
+//! * Malformed config (missing/empty `trusted_publishers`, unknown `match`
+//!   or `action` value) → [`CurationDecision::Flag`] describing the misconfiguration.
+
+use serde_json::Value;
 
 use crate::models::curation::CurationDecision;
 
-/// Formats that carry a publisher/maintainer identity signal this rule type
-/// can meaningfully judge. Anything else short-circuits to
-/// [`CurationDecision::NotApplicable`] (no effect), so a GLOBAL
-/// publisher-trust policy silently passes through formats with no publisher
-/// concept (e.g. `generic`, `rpm`, `debian`).
-// TODO(#2948): revisit/extend alongside the real evaluator.
-pub const APPLICABLE_FORMATS: [&str; 8] = [
-    "npm", "pypi", "cargo", "nuget", "rubygems", "composer", "hex", "maven",
-];
+use super::publisher_source::{self, PublisherSource};
 
-/// Whether this rule type applies to `format` at all.
-pub fn applies_to(format: &str) -> bool {
-    APPLICABLE_FORMATS.contains(&format)
-}
-
-/// Evaluate a `publisher_trust` rule against one package.
+/// Evaluates a `publisher_trust` rule against one package.
 ///
-/// `config` is the rule's JSONB `config` column (type-specific parameters);
-/// the remaining arguments are the package context. Returns
-/// [`CurationDecision::NotApplicable`] for formats without a publisher signal.
+/// `config` is the rule's JSON config (see module docs), `format` the package
+/// format (`"pypi"`, `"npm"`, ...), `name`/`version` identify the package for
+/// reason strings, and `metadata` is the registry metadata blob the publisher
+/// is extracted from.
 pub fn evaluate(
-    config: &serde_json::Value,
+    config: &Value,
     format: &str,
     name: &str,
     version: &str,
-    metadata: &serde_json::Value,
+    metadata: &Value,
 ) -> CurationDecision {
-    if !applies_to(format) {
+    if !publisher_source::is_applicable_format(format) {
         return CurationDecision::NotApplicable;
     }
-    // TODO(#2948): real publisher-trust evaluation (trusted-publisher lists,
-    // signature/provenance signals) driven by `config`.
-    let _ = (config, name, version, metadata);
-    CurationDecision::Allow
+
+    let trusted: Vec<String> = match config.get("trusted_publishers").and_then(Value::as_array) {
+        Some(list) if !list.is_empty() => list
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    };
+    if trusted.is_empty() {
+        return CurationDecision::Flag(
+            "publisher_trust rule misconfigured: `trusted_publishers` is missing or empty"
+                .to_string(),
+        );
+    }
+
+    let match_mode = match config.get("match").and_then(Value::as_str) {
+        // Secure default: only verified provenance satisfies the allowlist.
+        None => "attestation",
+        Some(m @ ("attestation" | "metadata")) => m,
+        Some(other) => {
+            return CurationDecision::Flag(format!(
+                "publisher_trust rule misconfigured: unknown match mode `{other}`"
+            ));
+        }
+    };
+
+    let action = match config.get("action").and_then(Value::as_str) {
+        // Fail-safe default: surface for review rather than allow or block.
+        None => "flag",
+        Some(a @ ("allow" | "flag" | "block")) => a,
+        Some(other) => {
+            return CurationDecision::Flag(format!(
+                "publisher_trust rule misconfigured: unknown action `{other}`"
+            ));
+        }
+    };
+
+    let publisher = match publisher_source::extract_publisher(format, metadata) {
+        Some(p) => p,
+        None => {
+            // Applicable format but no identity: never trust silence.
+            return CurationDecision::Flag(format!(
+                "publisher unknown: no publisher identity could be extracted for {format} package {name}@{version}"
+            ));
+        }
+    };
+
+    let name_listed = trusted.contains(&publisher.name.to_lowercase());
+    let signal_sufficient = match match_mode {
+        "metadata" => true,
+        // `attestation` mode: self-asserted metadata must not be the sole
+        // trust signal (dependency-confusion / spoofing resistance).
+        _ => publisher.source == PublisherSource::Attestation && publisher.verified,
+    };
+    let is_trusted = name_listed && signal_sufficient;
+
+    let signal_label = match publisher.source {
+        PublisherSource::Attestation => "verified attestation",
+        PublisherSource::Metadata => "self-asserted metadata (unverified)",
+    };
+
+    match (action, is_trusted) {
+        // Trusted publishers pass under both gating modes.
+        ("allow" | "block", true) => CurationDecision::Allow,
+        // Enforcement: everything not provably trusted is rejected.
+        ("block", false) => CurationDecision::Block(untrusted_reason(
+            &publisher.name,
+            signal_label,
+            name_listed,
+            match_mode,
+            name,
+            version,
+        )),
+        // Allowlist mode fails safe: untrusted goes to review, not through.
+        ("allow", false) => CurationDecision::Flag(untrusted_reason(
+            &publisher.name,
+            signal_label,
+            name_listed,
+            match_mode,
+            name,
+            version,
+        )),
+        // Watch mode: flag the listed publisher's packages for review...
+        ("flag", true) => CurationDecision::Flag(format!(
+            "publisher `{}` matched trusted-publisher watch list via {signal_label} for {name}@{version}",
+            publisher.name
+        )),
+        // ...and pass everything else through unaffected.
+        _ => CurationDecision::Allow,
+    }
+}
+
+fn untrusted_reason(
+    publisher: &str,
+    signal_label: &str,
+    name_listed: bool,
+    match_mode: &str,
+    name: &str,
+    version: &str,
+) -> String {
+    if name_listed && match_mode == "attestation" {
+        format!(
+            "publisher `{publisher}` for {name}@{version} is on the trusted list but was asserted only via {signal_label}; `match: attestation` requires registry-verified provenance"
+        )
+    } else {
+        format!(
+            "publisher `{publisher}` ({signal_label}) for {name}@{version} is not in the trusted-publisher list"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn config(match_mode: &str, action: &str) -> Value {
+        json!({
+            "trusted_publishers": ["Microsoft", "NumFOCUS"],
+            "match": match_mode,
+            "action": action
+        })
+    }
+
+    /// Realistic PyPI JSON-API blob with a merged integrity-API provenance
+    /// object: attested Trusted-Publisher org `NumFOCUS`.
+    fn pypi_attested() -> Value {
+        json!({
+            "info": {"author": "NumPy Developers", "name": "numpy", "version": "2.0.0"},
+            "provenance": {
+                "attestation_bundles": [{
+                    "publisher": {"kind": "GitHub", "repository": "NumFOCUS/numpy", "workflow": "wheels.yml"},
+                    "attestations": [{"envelope": {}}]
+                }]
+            }
+        })
+    }
+
+    /// Self-asserted `author: "Microsoft"` with NO provenance — the
+    /// dependency-confusion shape a squatter would upload.
+    fn pypi_spoofed_author() -> Value {
+        json!({
+            "info": {
+                "author": "Microsoft",
+                "author_email": "attacker@example.com",
+                "name": "azure-coore",
+                "version": "99.0.0"
+            }
+        })
+    }
+
+    fn npm_attested() -> Value {
+        json!({
+            "name": "@azure/identity",
+            "version": "4.0.0",
+            "_npmUser": {"name": "Microsoft", "email": "npmjs@microsoft.com"},
+            "dist": {
+                "attestations": {
+                    "url": "https://registry.npmjs.org/-/npm/v1/attestations/@azure%2fidentity@4.0.0",
+                    "provenance": {"predicateType": "https://slsa.dev/provenance/v1"}
+                }
+            }
+        })
+    }
+
+    fn npm_metadata_only(user: &str) -> Value {
+        json!({
+            "maintainers": [{"name": user, "email": "x@example.com"}],
+            "dist": {"tarball": "https://registry.npmjs.org/..."}
+        })
+    }
+
+    // -- trust via attestation ------------------------------------------------
+
+    #[test]
+    fn trusted_publisher_via_attestation_is_allowed_under_block() {
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "numpy",
+            "2.0.0",
+            &pypi_attested(),
+        );
+        assert_eq!(d, CurationDecision::Allow);
+    }
+
+    #[test]
+    fn npm_trusted_publisher_via_provenance_is_allowed() {
+        let d = evaluate(
+            &config("attestation", "block"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        assert_eq!(d, CurationDecision::Allow);
+    }
+
+    // -- spoof resistance -----------------------------------------------------
+
+    #[test]
+    fn trusted_name_via_metadata_only_is_not_trusted_under_match_attestation() {
+        // `author: "Microsoft"` alone must NOT satisfy the allowlist: the
+        // field is self-asserted and spoofable.
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "azure-coore",
+            "99.0.0",
+            &pypi_spoofed_author(),
+        );
+        match d {
+            CurationDecision::Block(reason) => {
+                assert!(
+                    reason.contains("self-asserted metadata"),
+                    "reason: {reason}"
+                );
+                assert!(reason.contains("requires registry-verified provenance"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn metadata_match_mode_is_an_explicit_opt_in() {
+        // Under the weaker opt-in mode the same package IS trusted — the
+        // distinction is explicit config, never implicit.
+        let d = evaluate(
+            &config("metadata", "block"),
+            "pypi",
+            "azure-coore",
+            "99.0.0",
+            &pypi_spoofed_author(),
+        );
+        assert_eq!(d, CurationDecision::Allow);
+    }
+
+    #[test]
+    fn exact_match_only_no_substring_trust() {
+        let md = json!({"info": {"author": "Evil Microsoft Fans"}});
+        let d = evaluate(&config("metadata", "block"), "pypi", "pkg", "1.0", &md);
+        assert!(matches!(d, CurationDecision::Block(_)), "got {d:?}");
+        // Case-insensitive exact match still works.
+        let md = json!({"info": {"author": "microsoft"}});
+        let d = evaluate(&config("metadata", "block"), "pypi", "pkg", "1.0", &md);
+        assert_eq!(d, CurationDecision::Allow);
+    }
+
+    // -- action semantics -----------------------------------------------------
+
+    #[test]
+    fn untrusted_publisher_under_action_block_is_blocked() {
+        let d = evaluate(
+            &config("metadata", "block"),
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &npm_metadata_only("some-rando"),
+        );
+        match d {
+            CurationDecision::Block(reason) => {
+                assert!(
+                    reason.contains("not in the trusted-publisher list"),
+                    "reason: {reason}"
+                );
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn untrusted_publisher_under_action_allow_is_flagged_not_admitted() {
+        let d = evaluate(
+            &config("metadata", "allow"),
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &npm_metadata_only("some-rando"),
+        );
+        assert!(matches!(d, CurationDecision::Flag(_)), "got {d:?}");
+    }
+
+    #[test]
+    fn trusted_publisher_under_action_allow_is_allowed() {
+        let d = evaluate(
+            &config("attestation", "allow"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        assert_eq!(d, CurationDecision::Allow);
+    }
+
+    #[test]
+    fn action_flag_watches_listed_publishers_and_passes_others() {
+        // Listed publisher → flagged for review (watch mode).
+        let d = evaluate(
+            &config("attestation", "flag"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        match d {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("watch list"), "reason: {reason}")
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+        // Unlisted publisher → unaffected.
+        let d = evaluate(
+            &config("metadata", "flag"),
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &npm_metadata_only("some-rando"),
+        );
+        assert_eq!(d, CurationDecision::Allow);
+    }
+
+    // -- fail-safe paths ------------------------------------------------------
+
+    #[test]
+    fn missing_publisher_on_applicable_format_flags_publisher_unknown() {
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "mystery-pkg",
+            "0.1.0",
+            &json!({"info": {}}),
+        );
+        match d {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("publisher unknown"), "reason: {reason}");
+                assert!(reason.contains("mystery-pkg@0.1.0"));
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_applicable_format_is_not_applicable_not_flagged() {
+        // A global rule must pass raw/generic artifacts through untouched —
+        // they have no publisher concept.
+        for format in ["raw", "generic", "docker", "maven"] {
+            let d = evaluate(
+                &config("attestation", "block"),
+                format,
+                "some-artifact",
+                "1.0.0",
+                &json!({}),
+            );
+            assert_eq!(d, CurationDecision::NotApplicable, "format {format}");
+        }
+    }
+
+    #[test]
+    fn misconfigured_rule_flags_instead_of_deciding() {
+        // Missing allowlist.
+        let d = evaluate(
+            &json!({"action": "block"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(
+            matches!(d, CurationDecision::Flag(ref r) if r.contains("trusted_publishers")),
+            "got {d:?}"
+        );
+        // Empty allowlist.
+        let d = evaluate(
+            &json!({"trusted_publishers": [], "action": "block"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(matches!(d, CurationDecision::Flag(_)), "got {d:?}");
+        // Unknown match mode.
+        let d = evaluate(
+            &json!({"trusted_publishers": ["NumFOCUS"], "match": "vibes"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(
+            matches!(d, CurationDecision::Flag(ref r) if r.contains("vibes")),
+            "got {d:?}"
+        );
+        // Unknown action.
+        let d = evaluate(
+            &json!({"trusted_publishers": ["NumFOCUS"], "action": "yolo"}),
+            "pypi",
+            "p",
+            "1",
+            &pypi_attested(),
+        );
+        assert!(
+            matches!(d, CurationDecision::Flag(ref r) if r.contains("yolo")),
+            "got {d:?}"
+        );
+    }
+
+    #[test]
+    fn defaults_are_secure_attestation_match_and_fail_safe_flag_action() {
+        // No `match`, no `action`: attestation-only matching, flag action.
+        let cfg = json!({"trusted_publishers": ["NumFOCUS"]});
+        // Attested + listed → watch-mode flag (default action=flag).
+        let d = evaluate(&cfg, "pypi", "numpy", "2.0.0", &pypi_attested());
+        assert!(matches!(d, CurationDecision::Flag(_)), "got {d:?}");
+        // Metadata-only listed name under default match=attestation is NOT
+        // treated as the listed publisher → passes watch mode untouched.
+        let md = json!({"info": {"author": "NumFOCUS"}});
+        let d = evaluate(&cfg, "pypi", "pkg", "1.0", &md);
+        assert_eq!(d, CurationDecision::Allow);
+    }
 }

--- a/backend/src/services/curation/publisher_trust.rs
+++ b/backend/src/services/curation/publisher_trust.rs
@@ -18,10 +18,17 @@
 //!   `"Microsoft"` must not match `"Evil Microsoft Fans"`).
 //! * `match` — which signal quality is sufficient to consider a publisher
 //!   trusted. Defaults to `"attestation"` (the secure default):
-//!   * `"attestation"` — only a registry-verified provenance identity
-//!     ([`PublisherSource::Attestation`] with `verified = true`) can satisfy
-//!     the allowlist. Self-asserted `author`/`maintainer` metadata is
-//!     spoofable and is deliberately **not** sufficient in this mode.
+//!   * `"attestation"` — only a **cryptographically verified** provenance
+//!     identity ([`PublisherSource::Attestation`] with `verified = true`) can
+//!     satisfy the allowlist. Attestation-envelope verification
+//!     (sigstore/DSSE/PEP 740) is not implemented yet (#2955), so today no
+//!     attestation is verified: a listed publisher asserted via a
+//!     present-but-unverified attestation resolves to `Flag` (review) —
+//!     never `Allow` (presence is forgeable, so it must not confer trust)
+//!     and never a blanket `Block` (unverifiability alone must not reject
+//!     every legitimate package). Self-asserted `author`/`maintainer`
+//!     metadata is spoofable and remains deliberately **not** sufficient in
+//!     this mode (blocked under `action: "block"`, exactly as before).
 //!   * `"metadata"` — an operator opt-in that also accepts the weaker,
 //!     self-asserted metadata identity. Use only where the threat model
 //!     tolerates it.
@@ -46,6 +53,9 @@
 //! * Applicable format but no extractable publisher → [`CurationDecision::Flag`]
 //!   ("publisher unknown"): absence of identity is never trusted, but it is
 //!   surfaced for review rather than hard-blocked.
+//! * Listed publisher via a present-but-unverified attestation under
+//!   `match: "attestation"` → [`CurationDecision::Flag`] pending #2955:
+//!   review, not trust, not a blanket block.
 //! * Malformed config (missing/empty `trusted_publishers`, unknown `match`
 //!   or `action` value) → [`CurationDecision::Flag`] describing the misconfiguration.
 
@@ -121,21 +131,38 @@ pub fn evaluate(
     };
 
     let name_listed = trusted.contains(&publisher.name.to_lowercase());
+    let attestation_present = publisher.source == PublisherSource::Attestation;
     let signal_sufficient = match match_mode {
         "metadata" => true,
-        // `attestation` mode: self-asserted metadata must not be the sole
-        // trust signal (dependency-confusion / spoofing resistance).
-        _ => publisher.source == PublisherSource::Attestation && publisher.verified,
+        // `attestation` mode: only a cryptographically VERIFIED attestation
+        // is a trust signal. Presence != trust: a provenance blob is
+        // attacker-forgeable, and self-asserted metadata must not be the sole
+        // trust signal either (dependency-confusion / spoofing resistance).
+        _ => attestation_present && publisher.verified,
     };
     let is_trusted = name_listed && signal_sufficient;
 
+    // Fail-safe seam for unimplemented attestation verification (#2955):
+    // a listed publisher asserted via a present-but-UNVERIFIED attestation
+    // is neither trusted (Allow would let a forged provenance blob through)
+    // nor rejected wholesale (Block would reject every legitimate attested
+    // package until #2955 ships). It goes to review.
+    if match_mode == "attestation" && name_listed && attestation_present && !publisher.verified {
+        return CurationDecision::Flag(format!(
+            "publisher `{}` for {name}@{version} matches the trusted list via an attestation that is present but not cryptographically verified; held for review pending attestation verification (#2955)",
+            publisher.name
+        ));
+    }
+
     let signal_label = match publisher.source {
-        PublisherSource::Attestation => "verified attestation",
+        PublisherSource::Attestation => "attestation (present, not cryptographically verified)",
         PublisherSource::Metadata => "self-asserted metadata (unverified)",
     };
 
     match (action, is_trusted) {
-        // Trusted publishers pass under both gating modes.
+        // Trusted publishers pass under both gating modes. Under
+        // `match: attestation` this arm requires a genuinely verified
+        // attestation, i.e. it is unreachable until #2955 ships.
         ("allow" | "block", true) => CurationDecision::Allow,
         // Enforcement: everything not provably trusted is rejected.
         ("block", false) => CurationDecision::Block(untrusted_reason(
@@ -245,10 +272,14 @@ mod tests {
         })
     }
 
-    // -- trust via attestation ------------------------------------------------
+    // -- attestation presence is NOT trust (#2955 pending) --------------------
 
     #[test]
-    fn trusted_publisher_via_attestation_is_allowed_under_block() {
+    fn attested_listed_publisher_is_flagged_for_review_not_allowed() {
+        // Until #2955 lands cryptographic verification, an attestation is at
+        // most PRESENT — and presence is forgeable. A listed publisher via a
+        // present-but-unverified attestation must land in review, never be
+        // trusted, and never be blanket-blocked.
         let d = evaluate(
             &config("attestation", "block"),
             "pypi",
@@ -256,11 +287,51 @@ mod tests {
             "2.0.0",
             &pypi_attested(),
         );
-        assert_eq!(d, CurationDecision::Allow);
+        match d {
+            CurationDecision::Flag(reason) => {
+                assert!(
+                    reason.contains("not cryptographically verified"),
+                    "reason: {reason}"
+                );
+                assert!(reason.contains("#2955"), "reason: {reason}");
+            }
+            other => panic!("expected Flag (review), got {other:?}"),
+        }
     }
 
     #[test]
-    fn npm_trusted_publisher_via_provenance_is_allowed() {
+    fn forged_provenance_blob_cannot_buy_trust() {
+        // The attack: a squatter PLANTS a provenance object naming a trusted
+        // org in the metadata blob. Structural presence used to be treated as
+        // verified — the forgery was approved. It must now go to review.
+        let forged = json!({
+            "info": {"author": "attacker", "name": "numpyy", "version": "99.0.0"},
+            "provenance": {
+                "attestation_bundles": [{
+                    "publisher": {"kind": "GitHub", "repository": "NumFOCUS/numpy", "workflow": "wheels.yml"},
+                    "attestations": [{"envelope": {"payload": "Zm9yZ2Vk"}}]
+                }]
+            }
+        });
+        let d = evaluate(
+            &config("attestation", "block"),
+            "pypi",
+            "numpyy",
+            "99.0.0",
+            &forged,
+        );
+        assert!(
+            matches!(d, CurationDecision::Flag(ref r) if r.contains("not cryptographically verified")),
+            "forged provenance must resolve to review, not {d:?}"
+        );
+        assert!(
+            !matches!(d, CurationDecision::Allow),
+            "forged provenance must never be trusted"
+        );
+    }
+
+    #[test]
+    fn npm_attested_listed_publisher_is_flagged_for_review() {
         let d = evaluate(
             &config("attestation", "block"),
             "npm",
@@ -268,7 +339,34 @@ mod tests {
             "4.0.0",
             &npm_attested(),
         );
-        assert_eq!(d, CurationDecision::Allow);
+        assert!(
+            matches!(d, CurationDecision::Flag(ref r) if r.contains("#2955")),
+            "got {d:?}"
+        );
+    }
+
+    #[test]
+    fn attested_unlisted_publisher_keeps_normal_untrusted_handling() {
+        // The review carve-out is only for LISTED publishers pending #2955:
+        // an attested-but-unlisted publisher is plain untrusted (blocked
+        // under enforcement), same as before.
+        let md = json!({
+            "name": "some-lib",
+            "version": "1.0.0",
+            "_npmUser": {"name": "some-rando", "email": "x@example.com"},
+            "dist": {"attestations": {"provenance": {"predicateType": "https://slsa.dev/provenance/v1"}}}
+        });
+        let d = evaluate(
+            &config("attestation", "block"),
+            "npm",
+            "some-lib",
+            "1.0.0",
+            &md,
+        );
+        assert!(
+            matches!(d, CurationDecision::Block(ref r) if r.contains("not in the trusted-publisher list")),
+            "got {d:?}"
+        );
     }
 
     // -- spoof resistance -----------------------------------------------------
@@ -306,6 +404,16 @@ mod tests {
             "azure-coore",
             "99.0.0",
             &pypi_spoofed_author(),
+        );
+        assert_eq!(d, CurationDecision::Allow);
+        // The documented weaker mode is unchanged by the #2955 fail-safe: an
+        // attested package satisfies it too (identity name is what matters).
+        let d = evaluate(
+            &config("metadata", "block"),
+            "pypi",
+            "numpy",
+            "2.0.0",
+            &pypi_attested(),
         );
         assert_eq!(d, CurationDecision::Allow);
     }
@@ -356,9 +464,26 @@ mod tests {
     }
 
     #[test]
-    fn trusted_publisher_under_action_allow_is_allowed() {
+    fn attested_listed_publisher_under_action_allow_goes_to_review() {
+        // `action: allow` must not admit a package on an unverified
+        // attestation either — review, pending #2955.
         let d = evaluate(
             &config("attestation", "allow"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        assert!(
+            matches!(d, CurationDecision::Flag(ref r) if r.contains("not cryptographically verified")),
+            "got {d:?}"
+        );
+    }
+
+    #[test]
+    fn trusted_publisher_under_action_allow_is_allowed_metadata_mode() {
+        let d = evaluate(
+            &config("metadata", "allow"),
             "npm",
             "@azure/identity",
             "4.0.0",
@@ -369,9 +494,28 @@ mod tests {
 
     #[test]
     fn action_flag_watches_listed_publishers_and_passes_others() {
-        // Listed publisher → flagged for review (watch mode).
+        // Listed publisher, attestation present but unverified → flagged for
+        // review (the #2955 pending reason takes precedence over the plain
+        // watch-list phrasing under match: attestation).
         let d = evaluate(
             &config("attestation", "flag"),
+            "npm",
+            "@azure/identity",
+            "4.0.0",
+            &npm_attested(),
+        );
+        match d {
+            CurationDecision::Flag(reason) => {
+                assert!(
+                    reason.contains("not cryptographically verified"),
+                    "reason: {reason}"
+                )
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+        // Listed publisher under the metadata opt-in → classic watch flag.
+        let d = evaluate(
+            &config("metadata", "flag"),
             "npm",
             "@azure/identity",
             "4.0.0",
@@ -483,7 +627,7 @@ mod tests {
     fn defaults_are_secure_attestation_match_and_fail_safe_flag_action() {
         // No `match`, no `action`: attestation-only matching, flag action.
         let cfg = json!({"trusted_publishers": ["NumFOCUS"]});
-        // Attested + listed → watch-mode flag (default action=flag).
+        // Attested + listed → review flag (unverified attestation, #2955).
         let d = evaluate(&cfg, "pypi", "numpy", "2.0.0", &pypi_attested());
         assert!(matches!(d, CurationDecision::Flag(_)), "got {d:?}");
         // Metadata-only listed name under default match=attestation is NOT

--- a/backend/src/services/curation/typosquat.rs
+++ b/backend/src/services/curation/typosquat.rs
@@ -1,0 +1,265 @@
+//! Lexical typo-squat detection for the `popularity` curation rule (#2949).
+//!
+//! A classic supply-chain attack registers a package whose name is one or two
+//! keystrokes away from a heavily downloaded package (`reqeusts` vs
+//! `requests`). This module provides the string-distance primitive
+//! ([`damerau_levenshtein`], optimal-string-alignment variant, which counts
+//! adjacent transpositions as a single edit), a nearest-neighbor search over a
+//! popular-package list, and a small built-in seed list of top packages per
+//! ecosystem. The seed list is a default only — rules can supply their own
+//! list via config.
+
+/// Damerau-Levenshtein distance (optimal string alignment variant): the
+/// minimum number of single-character insertions, deletions, substitutions,
+/// and adjacent transpositions needed to turn `a` into `b`.
+///
+/// Operates on Unicode scalar values, not bytes.
+pub fn damerau_levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+
+    // Three rolling rows: two-back (for transpositions), previous, current.
+    let mut prev_prev: Vec<usize> = vec![0; n + 1];
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr: Vec<usize> = vec![0; n + 1];
+
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            let mut d = (prev[j] + 1) // deletion
+                .min(curr[j - 1] + 1) // insertion
+                .min(prev[j - 1] + cost); // substitution
+            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                d = d.min(prev_prev[j - 2] + 1); // adjacent transposition
+            }
+            curr[j] = d;
+        }
+        std::mem::swap(&mut prev_prev, &mut prev);
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
+/// Find the popular package name closest to `name` (case-insensitive) and its
+/// distance. Returns `None` for an empty popular list. Ties resolve to the
+/// first entry in list order.
+pub fn nearest_popular(name: &str, popular: &[String]) -> Option<(String, usize)> {
+    let name_lc = name.to_lowercase();
+    let mut best: Option<(String, usize)> = None;
+    for candidate in popular {
+        let d = damerau_levenshtein(&name_lc, &candidate.to_lowercase());
+        match &best {
+            Some((_, best_d)) if *best_d <= d => {}
+            _ => best = Some((candidate.clone(), d)),
+        }
+    }
+    best
+}
+
+/// Return `Some(target)` when `name` looks like a typo-squat of a popular
+/// package: within `max_distance` edits (but not identical) of an entry in
+/// `popular`, while `name` itself is NOT in the popular list.
+///
+/// The self-exclusion matters: `request` (a real, once-hugely-popular npm
+/// package) is distance 1 from `requests`, so a curated popular list that
+/// contains both must not flag either.
+pub fn is_typosquat(name: &str, popular: &[String], max_distance: usize) -> Option<String> {
+    let name_lc = name.to_lowercase();
+    // A package that IS popular by name is never a squat of another entry.
+    if popular.iter().any(|p| p.to_lowercase() == name_lc) {
+        return None;
+    }
+    let (target, distance) = nearest_popular(name, popular)?;
+    if distance >= 1 && distance <= max_distance {
+        Some(target)
+    } else {
+        None
+    }
+}
+
+/// Built-in seed list of heavily downloaded package names per ecosystem
+/// (`"pypi"` / `"npm"`). A pragmatic default so the rule is useful out of the
+/// box; rules can replace it with a curated list via the `popular_packages`
+/// config key. Unknown ecosystems get an empty list.
+pub fn default_popular_packages(ecosystem: &str) -> &'static [&'static str] {
+    match ecosystem {
+        "pypi" => &[
+            "requests",
+            "urllib3",
+            "boto3",
+            "botocore",
+            "numpy",
+            "pandas",
+            "setuptools",
+            "certifi",
+            "idna",
+            "charset-normalizer",
+            "typing-extensions",
+            "python-dateutil",
+            "six",
+            "pyyaml",
+            "cryptography",
+            "packaging",
+            "pip",
+            "wheel",
+            "s3transfer",
+            "attrs",
+            "click",
+            "jinja2",
+            "markupsafe",
+            "pydantic",
+            "sqlalchemy",
+            "aiohttp",
+            "flask",
+            "django",
+            "pytest",
+            "scipy",
+            "matplotlib",
+            "pillow",
+            "rich",
+            "httpx",
+            "colorama",
+        ],
+        "npm" => &[
+            "lodash",
+            "react",
+            "react-dom",
+            "express",
+            "axios",
+            "chalk",
+            "commander",
+            "tslib",
+            "vue",
+            "webpack",
+            "typescript",
+            "jquery",
+            "next",
+            "eslint",
+            "prettier",
+            "uuid",
+            "dotenv",
+            "glob",
+            "semver",
+            "minimist",
+            "debug",
+            "async",
+            "rxjs",
+            "redux",
+            "moment",
+            "inquirer",
+            "yargs",
+            "ajv",
+            "classnames",
+            "prop-types",
+            "node-fetch",
+            "fs-extra",
+            "body-parser",
+            "cors",
+            "zod",
+        ],
+        _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn distance_basics() {
+        assert_eq!(damerau_levenshtein("", ""), 0);
+        assert_eq!(damerau_levenshtein("abc", "abc"), 0);
+        assert_eq!(damerau_levenshtein("", "abc"), 3);
+        assert_eq!(damerau_levenshtein("abc", ""), 3);
+        assert_eq!(damerau_levenshtein("kitten", "sitting"), 3);
+    }
+
+    #[test]
+    fn distance_counts_transposition_as_one_edit() {
+        // Plain Levenshtein would be 2 here; Damerau counts the swap as 1.
+        assert_eq!(damerau_levenshtein("reqeusts", "requests"), 1);
+        assert_eq!(damerau_levenshtein("ab", "ba"), 1);
+        assert_eq!(damerau_levenshtein("lodahs", "lodash"), 1);
+    }
+
+    #[test]
+    fn distance_single_edits() {
+        assert_eq!(damerau_levenshtein("request", "requests"), 1); // insertion
+        assert_eq!(damerau_levenshtein("requests", "request"), 1); // deletion
+        assert_eq!(damerau_levenshtein("reqvests", "requests"), 1); // substitution
+    }
+
+    #[test]
+    fn distance_handles_unicode() {
+        assert_eq!(damerau_levenshtein("café", "cafe"), 1);
+    }
+
+    #[test]
+    fn nearest_popular_finds_closest() {
+        let popular = strings(&["requests", "numpy", "pandas"]);
+        assert_eq!(
+            nearest_popular("reqeusts", &popular),
+            Some(("requests".to_string(), 1))
+        );
+        assert_eq!(
+            nearest_popular("nunpy", &popular),
+            Some(("numpy".to_string(), 1))
+        );
+        assert_eq!(nearest_popular("anything", &[]), None);
+    }
+
+    #[test]
+    fn typosquat_flags_within_distance() {
+        let popular = strings(&["requests", "numpy"]);
+        assert_eq!(
+            is_typosquat("reqeusts", &popular, 2),
+            Some("requests".to_string())
+        );
+        assert_eq!(
+            is_typosquat("Reqeusts", &popular, 2),
+            Some("requests".to_string()),
+            "matching is case-insensitive"
+        );
+    }
+
+    #[test]
+    fn typosquat_ignores_exact_and_distant_names() {
+        let popular = strings(&["requests", "numpy"]);
+        // Exact match: it IS the popular package.
+        assert_eq!(is_typosquat("requests", &popular, 2), None);
+        // Far away: unrelated name.
+        assert_eq!(is_typosquat("completely-different", &popular, 2), None);
+        // Distance 3 with max 2: not flagged.
+        assert_eq!(is_typosquat("reqzzsts", &popular, 1), None);
+    }
+
+    #[test]
+    fn typosquat_never_flags_a_listed_popular_package() {
+        // `request` is itself popular; distance 1 from `requests` must not flag.
+        let popular = strings(&["requests", "request"]);
+        assert_eq!(is_typosquat("request", &popular, 2), None);
+        assert_eq!(is_typosquat("requests", &popular, 2), None);
+    }
+
+    #[test]
+    fn seed_lists_present_for_supported_ecosystems() {
+        let pypi = default_popular_packages("pypi");
+        let npm = default_popular_packages("npm");
+        assert!(pypi.contains(&"requests"));
+        assert!(npm.contains(&"lodash"));
+        assert!(pypi.len() >= 20 && npm.len() >= 20);
+        assert!(default_popular_packages("docker").is_empty());
+    }
+}

--- a/backend/src/services/curation/typosquat.rs
+++ b/backend/src/services/curation/typosquat.rs
@@ -78,6 +78,9 @@ pub fn is_typosquat(name: &str, popular: &[String], max_distance: usize) -> Opti
         return None;
     }
     let (target, distance) = nearest_popular(name, popular)?;
+    // TODO(#2956): pure edit distance misses homoglyph squats (Unicode
+    // confusables, e.g. Cyrillic lookalikes) and affix-style squats
+    // ("requests2", "python-requests"), which can sit beyond max_distance.
     if distance >= 1 && distance <= max_distance {
         Some(target)
     } else {

--- a/backend/src/services/curation_service.rs
+++ b/backend/src/services/curation_service.rs
@@ -1727,8 +1727,9 @@ mod tests {
     // #2948/#2949 evaluators, via the production `evaluate_package_typed`
     // entry point.
 
-    /// PyPI JSON-API blob with a merged integrity-API provenance object:
-    /// registry-verified Trusted-Publisher org `NumFOCUS`.
+    /// PyPI JSON-API blob with a merged integrity-API provenance object
+    /// naming the Trusted-Publisher org `NumFOCUS`. Presence-only: the
+    /// envelope is not cryptographically verified (#2955).
     fn pypi_attested_metadata() -> serde_json::Value {
         serde_json::json!({
             "info": {"author": "NumPy Developers", "name": "numpy", "version": "2.0.0"},
@@ -1799,7 +1800,9 @@ mod tests {
             "non-attested package must be blocked, got {decision:?}"
         );
 
-        // Attested package from the trusted publisher -> Allow.
+        // Attested package from the trusted publisher -> review (Flag): the
+        // attestation is present but not cryptographically verified (#2955),
+        // so presence must not buy trust — and must not hard-block either.
         let (decision, matched) = svc
             .evaluate_package_typed(
                 probe_repo,
@@ -1814,7 +1817,11 @@ mod tests {
             .await
             .expect("typed evaluation");
         assert_eq!(matched, Some(rule.id));
-        assert_eq!(decision, CurationDecision::Allow);
+        assert!(
+            matches!(decision, CurationDecision::Flag(ref r)
+                if r.contains("not cryptographically verified")),
+            "attested-but-unverified package must go to review, got {decision:?}"
+        );
 
         // A format with no publisher concept passes through untouched.
         let (decision, matched) = svc

--- a/backend/src/services/curation_service.rs
+++ b/backend/src/services/curation_service.rs
@@ -5,7 +5,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::models::curation::{CurationPackage, CurationRule};
+use crate::models::curation::{CurationDecision, CurationPackage, CurationRule};
 
 /// Result of evaluating a package against curation rules.
 #[derive(Debug, Clone, Serialize)]
@@ -166,6 +166,108 @@ impl CurationService {
     }
 
     // ---------------------------------------------------------------------------
+    // Typed rule dispatch (#2947)
+    // ---------------------------------------------------------------------------
+
+    /// Evaluate one typed rule against a package context, routing on
+    /// `rule.rule_type` (#2947).
+    ///
+    /// - `"pattern"`: the existing glob/version/arch evaluation, unchanged,
+    ///   wrapped to return a [`CurationDecision`]. The architecture is read
+    ///   from `metadata["architecture"]` when present. A pattern rule that does
+    ///   not match the package returns `NotApplicable` (no effect) — combining
+    ///   rules stays the caller's first-match concern, exactly as today.
+    /// - `"publisher_trust"`: dispatched to
+    ///   [`crate::services::curation::publisher_trust::evaluate`] (#2948 stub);
+    ///   `NotApplicable` for formats without a publisher signal.
+    /// - `"popularity"`: dispatched to
+    ///   [`crate::services::curation::popularity::evaluate_sync_placeholder`]
+    ///   (#2949 stub); `NotApplicable` for formats without an adoption signal.
+    /// - anything else: `Flag` — an unrecognized engine must never silently
+    ///   allow (the API rejects unknown types at write time; this is the
+    ///   defense-in-depth backstop).
+    pub fn evaluate_typed_rule(
+        rule: &CurationRule,
+        format: &str,
+        name: &str,
+        version: &str,
+        metadata: &serde_json::Value,
+    ) -> CurationDecision {
+        match rule.rule_type.as_str() {
+            "pattern" => {
+                let architecture = metadata.get("architecture").and_then(|v| v.as_str());
+                let eval = Self::evaluate_rules(
+                    std::slice::from_ref(rule),
+                    "allow",
+                    name,
+                    Some(version),
+                    architecture,
+                    false,
+                );
+                match eval.rule_id {
+                    None => CurationDecision::NotApplicable, // rule did not match
+                    Some(_) => match eval.action.as_str() {
+                        "allow" => CurationDecision::Allow,
+                        "block" => CurationDecision::Block(eval.reason),
+                        _ => CurationDecision::Flag(eval.reason),
+                    },
+                }
+            }
+            "publisher_trust" => crate::services::curation::publisher_trust::evaluate(
+                &rule.config,
+                format,
+                name,
+                version,
+                metadata,
+            ),
+            "popularity" => crate::services::curation::popularity::evaluate_sync_placeholder(
+                &rule.config,
+                format,
+                name,
+                version,
+                metadata,
+            ),
+            other => CurationDecision::Flag(format!(
+                "Unrecognized curation rule_type '{other}' (rule {}): routed to manual review",
+                rule.id
+            )),
+        }
+    }
+
+    /// First-applicable-wins typed evaluation over a pre-fetched rule set
+    /// (#2947 enforcement seam).
+    ///
+    /// `rules` is the priority-ordered UNION of the applicable global rules and
+    /// the repository's own rules — exactly what
+    /// [`Self::fetch_applicable_rules`] returns, since a global rule is stored
+    /// with `staging_repo_id IS NULL` (`scope = 'global'`) and that query has
+    /// always included the NULL-repo baseline.
+    ///
+    /// Each rule is dispatched through [`Self::evaluate_typed_rule`]; a
+    /// [`CurationDecision::NotApplicable`] result has NO effect (the rule is
+    /// skipped and evaluation continues), so a global `publisher_trust` /
+    /// `popularity` policy silently passes through formats it cannot judge.
+    /// The first `Allow` / `Flag` / `Block` decision wins, mirroring the
+    /// legacy first-match semantics. When no rule renders a decision the
+    /// caller's `default_decision` applies.
+    pub fn evaluate_typed_rules(
+        rules: &[CurationRule],
+        default_decision: CurationDecision,
+        format: &str,
+        name: &str,
+        version: &str,
+        metadata: &serde_json::Value,
+    ) -> (CurationDecision, Option<Uuid>) {
+        for rule in rules {
+            match Self::evaluate_typed_rule(rule, format, name, version, metadata) {
+                CurationDecision::NotApplicable => continue,
+                decision => return (decision, Some(rule.id)),
+            }
+        }
+        (default_decision, None)
+    }
+
+    // ---------------------------------------------------------------------------
     // Rule CRUD
     // ---------------------------------------------------------------------------
 
@@ -179,12 +281,23 @@ impl CurationService {
         action: &str,
         priority: i32,
         reason: &str,
+        rule_type: &str,
+        config: &serde_json::Value,
         created_by: Uuid,
     ) -> Result<CurationRule, sqlx::Error> {
+        // `scope` is DERIVED from the presence of a staging repo, never taken
+        // from the caller, so the invariant scope='global' <=> repo IS NULL
+        // cannot drift (the API validates the request's declared scope against
+        // this same derivation before calling in).
+        let scope = if staging_repo_id.is_some() {
+            "repository"
+        } else {
+            "global"
+        };
         sqlx::query_as(
             r#"INSERT INTO curation_rules
-               (staging_repo_id, package_pattern, version_constraint, architecture, action, priority, reason, created_by)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+               (staging_repo_id, package_pattern, version_constraint, architecture, action, priority, reason, rule_type, config, scope, created_by)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                RETURNING *"#,
         )
         .bind(staging_repo_id)
@@ -194,6 +307,9 @@ impl CurationService {
         .bind(action)
         .bind(priority)
         .bind(reason)
+        .bind(rule_type)
+        .bind(config)
+        .bind(scope)
         .bind(created_by)
         .fetch_one(&self.db)
         .await
@@ -222,6 +338,19 @@ impl CurationService {
         }
     }
 
+    /// List only the instance-wide (global) rules, priority-ordered — the
+    /// baseline policy view backing `GET /curation/rules?scope=global`.
+    /// Served by the `idx_curation_rules_scope_global` partial index.
+    pub async fn list_global_rules(&self) -> Result<Vec<CurationRule>, sqlx::Error> {
+        sqlx::query_as(
+            r#"SELECT * FROM curation_rules
+               WHERE scope = 'global'
+               ORDER BY priority ASC, created_at ASC"#,
+        )
+        .fetch_all(&self.db)
+        .await
+    }
+
     /// Fetch a single rule by id. Returns `NotFound` when the id is unknown.
     pub async fn get_rule(&self, rule_id: Uuid) -> Result<CurationRule, AppError> {
         let rule: Option<CurationRule> =
@@ -243,11 +372,14 @@ impl CurationService {
         priority: i32,
         reason: &str,
         enabled: bool,
+        rule_type: &str,
+        config: &serde_json::Value,
     ) -> Result<CurationRule, AppError> {
         let rule: Option<CurationRule> = sqlx::query_as(
             r#"UPDATE curation_rules SET
                package_pattern = $2, version_constraint = $3, architecture = $4,
-               action = $5, priority = $6, reason = $7, enabled = $8, updated_at = now()
+               action = $5, priority = $6, reason = $7, enabled = $8,
+               rule_type = $9, config = $10, updated_at = now()
                WHERE id = $1
                RETURNING *"#,
         )
@@ -259,6 +391,8 @@ impl CurationService {
         .bind(priority)
         .bind(reason)
         .bind(enabled)
+        .bind(rule_type)
+        .bind(config)
         .fetch_optional(&self.db)
         .await?;
         rule.ok_or_else(|| AppError::NotFound("Curation rule not found".to_string()))
@@ -811,6 +945,9 @@ mod tests {
             priority: 0,
             reason: format!("{action} by test rule"),
             enabled: true,
+            rule_type: "pattern".to_string(),
+            config: serde_json::json!({}),
+            scope: "global".to_string(),
             created_by: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -923,6 +1060,232 @@ mod tests {
         assert!(eval.reason.contains("review"));
     }
 
+    // -- typed rule dispatch (#2947) ------------------------------------------
+
+    fn typed_rule(rule_type: &str, config: serde_json::Value) -> CurationRule {
+        let mut rule = make_rule("*", "*", "*", "allow");
+        rule.rule_type = rule_type.to_string();
+        rule.config = config;
+        rule
+    }
+
+    #[test]
+    fn test_dispatch_pattern_block_matches_legacy_evaluation() {
+        // Regression: a matching pattern rule renders the same verdict + reason
+        // through the typed dispatch as through the legacy in-memory path.
+        let rule = make_rule("telnet*", "*", "*", "block");
+        let decision = CurationService::evaluate_typed_rule(
+            &rule,
+            "rpm",
+            "telnet-server",
+            "1.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Block(rule.reason.clone()));
+
+        let legacy = CurationService::evaluate_package_in_memory(
+            &[rule.clone()],
+            "allow",
+            "telnet-server",
+            "1.0",
+            None,
+        );
+        assert_eq!(legacy.action, "block");
+        assert_eq!(legacy.reason, rule.reason);
+    }
+
+    #[test]
+    fn test_dispatch_pattern_non_match_is_not_applicable() {
+        let rule = make_rule("telnet*", "*", "*", "block");
+        let decision = CurationService::evaluate_typed_rule(
+            &rule,
+            "rpm",
+            "curl",
+            "8.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::NotApplicable);
+    }
+
+    #[test]
+    fn test_dispatch_pattern_allow_rule_matches() {
+        let rule = make_rule("nginx", ">= 1.0", "*", "allow");
+        let decision = CurationService::evaluate_typed_rule(
+            &rule,
+            "rpm",
+            "nginx",
+            "1.5",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Allow);
+    }
+
+    #[test]
+    fn test_dispatch_pattern_reads_architecture_from_metadata() {
+        // The typed context carries architecture inside `metadata`; an
+        // arch-scoped pattern rule must honor it in both directions.
+        let rule = make_rule("*", "*", "aarch64", "block");
+        let mismatched = CurationService::evaluate_typed_rule(
+            &rule,
+            "rpm",
+            "nginx",
+            "1.0",
+            &serde_json::json!({"architecture": "x86_64"}),
+        );
+        assert_eq!(mismatched, CurationDecision::NotApplicable);
+
+        let matched = CurationService::evaluate_typed_rule(
+            &rule,
+            "rpm",
+            "nginx",
+            "1.0",
+            &serde_json::json!({"architecture": "aarch64"}),
+        );
+        assert_eq!(matched, CurationDecision::Block(rule.reason.clone()));
+    }
+
+    #[test]
+    fn test_dispatch_publisher_trust_reaches_stub() {
+        // TODO(#2948) stub: always Allow. This pins the dispatch wiring only.
+        let rule = typed_rule("publisher_trust", serde_json::json!({"min_trust": 0.8}));
+        let decision = CurationService::evaluate_typed_rule(
+            &rule,
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Allow);
+    }
+
+    #[test]
+    fn test_dispatch_popularity_reaches_stub() {
+        // TODO(#2949) stub: always Allow. This pins the dispatch wiring only.
+        let rule = typed_rule("popularity", serde_json::json!({"min_downloads": 1000}));
+        let decision = CurationService::evaluate_typed_rule(
+            &rule,
+            "pypi",
+            "requests",
+            "2.32.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Allow);
+    }
+
+    #[test]
+    fn test_dispatch_publisher_trust_not_applicable_format() {
+        // A format with no publisher concept must have NO effect — a global
+        // publisher-trust baseline cannot block/flag e.g. generic artifacts.
+        let rule = typed_rule("publisher_trust", serde_json::json!({"min_trust": 0.8}));
+        for format in ["generic", "rpm", "debian", "docker"] {
+            let decision = CurationService::evaluate_typed_rule(
+                &rule,
+                format,
+                "some-artifact",
+                "1.0",
+                &serde_json::json!({}),
+            );
+            assert_eq!(
+                decision,
+                CurationDecision::NotApplicable,
+                "publisher_trust must be NotApplicable for {format}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dispatch_popularity_not_applicable_format() {
+        let rule = typed_rule("popularity", serde_json::json!({"min_downloads": 1000}));
+        for format in ["generic", "rpm", "helm"] {
+            let decision = CurationService::evaluate_typed_rule(
+                &rule,
+                format,
+                "some-artifact",
+                "1.0",
+                &serde_json::json!({}),
+            );
+            assert_eq!(
+                decision,
+                CurationDecision::NotApplicable,
+                "popularity must be NotApplicable for {format}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_evaluate_typed_rules_skips_not_applicable() {
+        // A global popularity rule (NotApplicable for rpm) followed by a
+        // pattern block: the popularity rule must have no effect and the
+        // pattern rule must still decide.
+        let popularity = typed_rule("popularity", serde_json::json!({"min_downloads": 10}));
+        let block = make_rule("telnet*", "*", "*", "block");
+        let (decision, rule_id) = CurationService::evaluate_typed_rules(
+            &[popularity, block.clone()],
+            CurationDecision::Allow,
+            "rpm",
+            "telnet-server",
+            "1.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Block(block.reason.clone()));
+        assert_eq!(rule_id, Some(block.id));
+    }
+
+    #[test]
+    fn test_evaluate_typed_rules_default_when_nothing_applies() {
+        let popularity = typed_rule("popularity", serde_json::json!({}));
+        let miss = make_rule("telnet*", "*", "*", "block");
+        let (decision, rule_id) = CurationService::evaluate_typed_rules(
+            &[popularity, miss],
+            CurationDecision::Allow,
+            "rpm",
+            "curl",
+            "8.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Allow);
+        assert!(rule_id.is_none());
+    }
+
+    #[test]
+    fn test_evaluate_typed_rules_first_decision_wins() {
+        // Legacy parity: an earlier allow shadows a later block.
+        let allow = make_rule("nginx", "*", "*", "allow");
+        let block = make_rule("nginx", "*", "*", "block");
+        let (decision, rule_id) = CurationService::evaluate_typed_rules(
+            &[allow.clone(), block],
+            CurationDecision::Block("default".into()),
+            "rpm",
+            "nginx",
+            "1.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(decision, CurationDecision::Allow);
+        assert_eq!(rule_id, Some(allow.id));
+    }
+
+    #[test]
+    fn test_dispatch_unknown_rule_type_flags_for_review() {
+        // Defense-in-depth: an unrecognized engine must never silently allow.
+        let rule = typed_rule("mystery", serde_json::json!({}));
+        let decision = CurationService::evaluate_typed_rule(
+            &rule,
+            "rpm",
+            "nginx",
+            "1.0",
+            &serde_json::json!({}),
+        );
+        match decision {
+            CurationDecision::Flag(reason) => {
+                assert!(
+                    reason.contains("mystery"),
+                    "reason names the type: {reason}"
+                )
+            }
+            other => panic!("unknown rule_type must Flag, got {other:?}"),
+        }
+    }
+
     // -- by-id not-found mapping (#2020) --------------------------------------
     //
     // get_rule / update_rule / delete_rule must surface an unknown id as
@@ -933,6 +1296,116 @@ mod tests {
         let url = std::env::var("DATABASE_URL").ok()?;
         let pool = sqlx::PgPool::connect(&url).await.ok()?;
         Some(CurationService::new(pool))
+    }
+
+    // -- typed rule persistence (#2947, DB-backed) ----------------------------
+
+    // A global publisher_trust rule round-trips rule_type + config through
+    // create/list/get, derives scope='global' from the absent staging repo,
+    // and shows up in the global-baseline listing.
+    #[tokio::test]
+    async fn test_create_typed_global_rule_round_trip_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user, _uname) = tdh::create_user(&pool).await;
+        let svc = CurationService::new(pool.clone());
+
+        let config = serde_json::json!({"min_trust": 0.9, "trusted_publishers": ["acme"]});
+        let rule = svc
+            .create_rule(
+                None,
+                "*",
+                "*",
+                "*",
+                "block",
+                50,
+                "untrusted publisher (#2947 test)",
+                "publisher_trust",
+                &config,
+                user,
+            )
+            .await
+            .expect("create typed global rule");
+        assert_eq!(rule.rule_type, "publisher_trust");
+        assert_eq!(rule.config, config);
+        assert_eq!(rule.scope, "global", "NULL repo must derive scope=global");
+        assert!(rule.staging_repo_id.is_none());
+
+        let fetched = svc.get_rule(rule.id).await.expect("get typed rule");
+        assert_eq!(fetched.rule_type, "publisher_trust");
+        assert_eq!(fetched.config, config);
+        assert_eq!(fetched.scope, "global");
+
+        let global = svc.list_global_rules().await.expect("list global rules");
+        assert!(
+            global.iter().any(|r| r.id == rule.id),
+            "typed global rule must appear in the global-baseline listing"
+        );
+
+        // The persisted row reaches the (stub) dispatch: applicable format
+        // hits the TODO(#2948) stub (Allow), non-applicable is NotApplicable.
+        let dec = CurationService::evaluate_typed_rule(
+            &fetched,
+            "npm",
+            "left-pad",
+            "1.3.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(dec, CurationDecision::Allow);
+        let na = CurationService::evaluate_typed_rule(
+            &fetched,
+            "generic",
+            "blob",
+            "1.0",
+            &serde_json::json!({}),
+        );
+        assert_eq!(na, CurationDecision::NotApplicable);
+
+        svc.delete_rule(rule.id).await.expect("delete typed rule");
+        tdh::cleanup_user(&pool, user).await;
+    }
+
+    // Migration compatibility: a rule inserted the pre-#2947 way (no
+    // rule_type/config columns named) defaults to rule_type='pattern' with an
+    // empty config and still evaluates exactly as before.
+    #[tokio::test]
+    async fn test_legacy_insert_defaults_to_pattern_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user, _uname) = tdh::create_user(&pool).await;
+        let rule: CurationRule = sqlx::query_as(
+            r#"INSERT INTO curation_rules
+               (staging_repo_id, package_pattern, version_constraint, architecture, action, priority, reason, created_by)
+               VALUES (NULL, 'telnet*', '*', '*', 'block', 100, 'legacy insert (#2947 test)', $1)
+               RETURNING *"#,
+        )
+        .bind(user)
+        .fetch_one(&pool)
+        .await
+        .expect("legacy-shape insert");
+        assert_eq!(
+            rule.rule_type, "pattern",
+            "rule_type must default to pattern"
+        );
+        assert_eq!(rule.config, serde_json::json!({}));
+
+        let eval = CurationService::evaluate_package_in_memory(
+            &[rule.clone()],
+            "allow",
+            "telnet-server",
+            "1.0",
+            None,
+        );
+        assert_eq!(eval.action, "block");
+        assert_eq!(eval.rule_id, Some(rule.id));
+
+        let svc = CurationService::new(pool.clone());
+        svc.delete_rule(rule.id).await.expect("delete legacy rule");
+        tdh::cleanup_user(&pool, user).await;
     }
 
     #[tokio::test]
@@ -965,7 +1438,18 @@ mod tests {
             return;
         };
         let err = svc
-            .update_rule(Uuid::new_v4(), "pkg-*", "*", "*", "block", 100, "qa", true)
+            .update_rule(
+                Uuid::new_v4(),
+                "pkg-*",
+                "*",
+                "*",
+                "block",
+                100,
+                "qa",
+                true,
+                "pattern",
+                &serde_json::json!({}),
+            )
             .await
             .unwrap_err();
         assert!(

--- a/backend/src/services/curation_service.rs
+++ b/backend/src/services/curation_service.rs
@@ -178,20 +178,28 @@ impl CurationService {
     ///   not match the package returns `NotApplicable` (no effect) — combining
     ///   rules stays the caller's first-match concern, exactly as today.
     /// - `"publisher_trust"`: dispatched to
-    ///   [`crate::services::curation::publisher_trust::evaluate`] (#2948 stub);
+    ///   [`crate::services::curation::publisher_trust::evaluate`] (#2948);
     ///   `NotApplicable` for formats without a publisher signal.
     /// - `"popularity"`: dispatched to
-    ///   [`crate::services::curation::popularity::evaluate_sync_placeholder`]
-    ///   (#2949 stub); `NotApplicable` for formats without an adoption signal.
+    ///   [`crate::services::curation::popularity::evaluate`] (#2949);
+    ///   `NotApplicable` for formats without a download-count ecosystem — that
+    ///   gate runs FIRST, before `popularity_source` is consulted, so
+    ///   inapplicable formats never cost a lookup.
     /// - anything else: `Flag` — an unrecognized engine must never silently
     ///   allow (the API rejects unknown types at write time; this is the
     ///   defense-in-depth backstop).
-    pub fn evaluate_typed_rule(
+    ///
+    /// `popularity_source` is the download-count provider the `popularity`
+    /// arm consults (production: a cached
+    /// [`HttpPopularitySource`](crate::services::curation::popularity_source::HttpPopularitySource);
+    /// tests: [`FakePopularitySource`](crate::services::curation::popularity_source::FakePopularitySource)).
+    pub async fn evaluate_typed_rule(
         rule: &CurationRule,
         format: &str,
         name: &str,
         version: &str,
         metadata: &serde_json::Value,
+        popularity_source: &dyn crate::services::curation::popularity_source::PopularitySource,
     ) -> CurationDecision {
         match rule.rule_type.as_str() {
             "pattern" => {
@@ -220,13 +228,21 @@ impl CurationService {
                 version,
                 metadata,
             ),
-            "popularity" => crate::services::curation::popularity::evaluate_sync_placeholder(
-                &rule.config,
-                format,
-                name,
-                version,
-                metadata,
-            ),
+            "popularity" => {
+                // Format-gate FIRST: an inapplicable format must short-circuit
+                // without consulting the popularity source (no wasted fetch).
+                if !crate::services::curation::popularity::applies_to(format) {
+                    return CurationDecision::NotApplicable;
+                }
+                crate::services::curation::popularity::evaluate(
+                    &rule.config,
+                    format,
+                    name,
+                    version,
+                    popularity_source,
+                )
+                .await
+            }
             other => CurationDecision::Flag(format!(
                 "Unrecognized curation rule_type '{other}' (rule {}): routed to manual review",
                 rule.id
@@ -250,21 +266,136 @@ impl CurationService {
     /// The first `Allow` / `Flag` / `Block` decision wins, mirroring the
     /// legacy first-match semantics. When no rule renders a decision the
     /// caller's `default_decision` applies.
-    pub fn evaluate_typed_rules(
+    pub async fn evaluate_typed_rules(
         rules: &[CurationRule],
         default_decision: CurationDecision,
         format: &str,
         name: &str,
         version: &str,
         metadata: &serde_json::Value,
+        popularity_source: &dyn crate::services::curation::popularity_source::PopularitySource,
     ) -> (CurationDecision, Option<Uuid>) {
         for rule in rules {
-            match Self::evaluate_typed_rule(rule, format, name, version, metadata) {
+            match Self::evaluate_typed_rule(
+                rule,
+                format,
+                name,
+                version,
+                metadata,
+                popularity_source,
+            )
+            .await
+            {
                 CurationDecision::NotApplicable => continue,
                 decision => return (decision, Some(rule.id)),
             }
         }
         (default_decision, None)
+    }
+
+    /// DB-backed typed evaluation of one package for a staging repository —
+    /// the production enforcement entry point for the #2947 typed rules.
+    ///
+    /// Fetches the priority-ordered union of the repository's rules and the
+    /// global (`staging_repo_id IS NULL`) baseline, then runs
+    /// [`Self::evaluate_typed_rules`] over the package context. `architecture`
+    /// (when known) is threaded into the metadata context so arch-scoped
+    /// `pattern` rules keep their legacy semantics. The caller's
+    /// `default_action` (`"allow"` / `"block"` / `"review"`) supplies the
+    /// stance when no rule renders a decision.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn evaluate_package_typed(
+        &self,
+        staging_repo_id: Uuid,
+        default_action: &str,
+        format: &str,
+        package_name: &str,
+        version: &str,
+        architecture: Option<&str>,
+        metadata: &serde_json::Value,
+        popularity_source: &dyn crate::services::curation::popularity_source::PopularitySource,
+    ) -> Result<(CurationDecision, Option<Uuid>), sqlx::Error> {
+        let rules = self.fetch_applicable_rules(staging_repo_id).await?;
+        let context = Self::context_metadata(metadata, architecture);
+        Ok(Self::evaluate_typed_rules(
+            &rules,
+            Self::default_decision(default_action),
+            format,
+            package_name,
+            version,
+            &context,
+            popularity_source,
+        )
+        .await)
+    }
+
+    /// Map a repository's `curation_default_action` onto the decision that
+    /// applies when no rule matches.
+    fn default_decision(default_action: &str) -> CurationDecision {
+        match default_action {
+            "allow" => CurationDecision::Allow,
+            "block" => CurationDecision::Block(format!(
+                "No matching rule; default action: {default_action}"
+            )),
+            _ => CurationDecision::Flag(format!(
+                "No matching rule; default action: {default_action}"
+            )),
+        }
+    }
+
+    /// Build the metadata context handed to the typed dispatch: the package's
+    /// registry metadata blob, with the catalog's `architecture` column
+    /// injected under `"architecture"` (the key the `pattern` arm reads) when
+    /// the blob does not already carry one.
+    fn context_metadata(
+        metadata: &serde_json::Value,
+        architecture: Option<&str>,
+    ) -> serde_json::Value {
+        match architecture {
+            Some(arch) if metadata.get("architecture").is_none() => {
+                let mut context = metadata.clone();
+                match context.as_object_mut() {
+                    Some(map) => {
+                        map.insert(
+                            "architecture".to_string(),
+                            serde_json::Value::String(arch.to_string()),
+                        );
+                        context
+                    }
+                    // Non-object metadata: fall back to a fresh object so the
+                    // architecture still reaches arch-scoped pattern rules.
+                    None => serde_json::json!({"architecture": arch}),
+                }
+            }
+            _ => metadata.clone(),
+        }
+    }
+
+    /// Render a `(status, reason)` pair for the curation catalog from a typed
+    /// decision, mirroring the legacy action mapping
+    /// (`allow` → `approved`, `block` → `blocked`, anything else → `review`).
+    pub fn decision_to_status_reason(
+        decision: &CurationDecision,
+        rule_id: Option<Uuid>,
+    ) -> (&'static str, String) {
+        match decision {
+            CurationDecision::Allow => match rule_id {
+                Some(id) => ("approved", format!("Allowed by curation rule {id}")),
+                None => (
+                    "approved",
+                    "No matching rule; default action: allow".to_string(),
+                ),
+            },
+            CurationDecision::Block(reason) => ("blocked", reason.clone()),
+            CurationDecision::Flag(reason) => ("review", reason.clone()),
+            // Unreachable in practice: evaluate_typed_rules never returns
+            // NotApplicable and default decisions are Allow/Flag/Block. Fail
+            // safe to review if it ever surfaces.
+            CurationDecision::NotApplicable => (
+                "review",
+                "Rule evaluation rendered no decision; routed to manual review".to_string(),
+            ),
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -634,6 +765,13 @@ impl CurationService {
     /// `version` is `None` when the caller does not know the version, and
     /// `fold_names` folds both the rule pattern and the package name per PEP 503
     /// before matching (see [`Self::evaluate_pep503_package`]).
+    ///
+    /// Only `rule_type = "pattern"` rules participate: typed rules
+    /// (`publisher_trust`, `popularity`, #2947) default their
+    /// `package_pattern` to `*`, so interpreting them here would silently
+    /// turn e.g. a global publisher-trust `block` policy into a
+    /// block-everything glob on the legacy paths (the PEP 503 proxy gate).
+    /// Typed rules are evaluated exclusively by [`Self::evaluate_typed_rules`].
     fn evaluate_rules(
         rules: &[CurationRule],
         default_action: &str,
@@ -645,6 +783,9 @@ impl CurationService {
         let folded_name = fold_names.then(|| Self::fold_pep503(package_name));
 
         for rule in rules {
+            if rule.rule_type != "pattern" {
+                continue;
+            }
             let name_matches = match folded_name.as_deref() {
                 Some(name) => {
                     Self::pattern_matches(&Self::fold_pep503(&rule.package_pattern), name)
@@ -709,8 +850,12 @@ impl CurationService {
 
     /// Evaluate all pending packages against current rules and update their status.
     ///
-    /// Fetches rules once, evaluates each package in memory, then batches the
-    /// status updates to avoid N+1 query overhead.
+    /// Fetches rules once, evaluates each package through the typed dispatch
+    /// (#2947: `pattern`, `publisher_trust`, `popularity` rules all apply),
+    /// then batches the status updates to avoid N+1 query overhead. Popularity
+    /// lookups go through one TTL-cached HTTP source for the whole batch, so
+    /// re-evaluating a large catalog cannot hammer the public download-count
+    /// APIs.
     pub async fn re_evaluate_pending(
         &self,
         staging_repo_id: Uuid,
@@ -742,23 +887,28 @@ impl CurationService {
         let mut groups: std::collections::HashMap<(String, String, Option<Uuid>), Vec<Uuid>> =
             std::collections::HashMap::new();
 
+        // One cached source for the whole batch: repeated evaluations of the
+        // same package hit the in-memory TTL cache, not the public APIs.
+        let popularity_source =
+            crate::services::curation::popularity_source::HttpPopularitySource::new().cached();
+
         for pkg in &pending {
-            let eval = Self::evaluate_package_in_memory(
+            let context = Self::context_metadata(&pkg.metadata, pkg.architecture.as_deref());
+            let (decision, rule_id) = Self::evaluate_typed_rules(
                 &rules,
-                default_action,
+                Self::default_decision(default_action),
+                &pkg.format,
                 &pkg.package_name,
                 &pkg.version,
-                pkg.architecture.as_deref(),
-            );
+                &context,
+                &popularity_source,
+            )
+            .await;
 
-            let new_status = match eval.action.as_str() {
-                "allow" => "approved",
-                "block" => "blocked",
-                _ => "review",
-            };
+            let (new_status, reason) = Self::decision_to_status_reason(&decision, rule_id);
 
             groups
-                .entry((new_status.to_string(), eval.reason, eval.rule_id))
+                .entry((new_status.to_string(), reason, rule_id))
                 .or_default()
                 .push(pkg.id);
         }
@@ -1062,6 +1212,8 @@ mod tests {
 
     // -- typed rule dispatch (#2947) ------------------------------------------
 
+    use crate::services::curation::popularity_source::FakePopularitySource;
+
     fn typed_rule(rule_type: &str, config: serde_json::Value) -> CurationRule {
         let mut rule = make_rule("*", "*", "*", "allow");
         rule.rule_type = rule_type.to_string();
@@ -1069,8 +1221,14 @@ mod tests {
         rule
     }
 
-    #[test]
-    fn test_dispatch_pattern_block_matches_legacy_evaluation() {
+    /// Empty popularity source for tests that never exercise the popularity
+    /// arm (every lookup would return `Unknown`).
+    fn no_source() -> FakePopularitySource {
+        FakePopularitySource::new()
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_pattern_block_matches_legacy_evaluation() {
         // Regression: a matching pattern rule renders the same verdict + reason
         // through the typed dispatch as through the legacy in-memory path.
         let rule = make_rule("telnet*", "*", "*", "block");
@@ -1080,7 +1238,9 @@ mod tests {
             "telnet-server",
             "1.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(decision, CurationDecision::Block(rule.reason.clone()));
 
         let legacy = CurationService::evaluate_package_in_memory(
@@ -1094,8 +1254,8 @@ mod tests {
         assert_eq!(legacy.reason, rule.reason);
     }
 
-    #[test]
-    fn test_dispatch_pattern_non_match_is_not_applicable() {
+    #[tokio::test]
+    async fn test_dispatch_pattern_non_match_is_not_applicable() {
         let rule = make_rule("telnet*", "*", "*", "block");
         let decision = CurationService::evaluate_typed_rule(
             &rule,
@@ -1103,12 +1263,14 @@ mod tests {
             "curl",
             "8.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(decision, CurationDecision::NotApplicable);
     }
 
-    #[test]
-    fn test_dispatch_pattern_allow_rule_matches() {
+    #[tokio::test]
+    async fn test_dispatch_pattern_allow_rule_matches() {
         let rule = make_rule("nginx", ">= 1.0", "*", "allow");
         let decision = CurationService::evaluate_typed_rule(
             &rule,
@@ -1116,12 +1278,14 @@ mod tests {
             "nginx",
             "1.5",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(decision, CurationDecision::Allow);
     }
 
-    #[test]
-    fn test_dispatch_pattern_reads_architecture_from_metadata() {
+    #[tokio::test]
+    async fn test_dispatch_pattern_reads_architecture_from_metadata() {
         // The typed context carries architecture inside `metadata`; an
         // arch-scoped pattern rule must honor it in both directions.
         let rule = make_rule("*", "*", "aarch64", "block");
@@ -1131,7 +1295,9 @@ mod tests {
             "nginx",
             "1.0",
             &serde_json::json!({"architecture": "x86_64"}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(mismatched, CurationDecision::NotApplicable);
 
         let matched = CurationService::evaluate_typed_rule(
@@ -1140,43 +1306,83 @@ mod tests {
             "nginx",
             "1.0",
             &serde_json::json!({"architecture": "aarch64"}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(matched, CurationDecision::Block(rule.reason.clone()));
     }
 
-    #[test]
-    fn test_dispatch_publisher_trust_reaches_stub() {
-        // TODO(#2948) stub: always Allow. This pins the dispatch wiring only.
-        let rule = typed_rule("publisher_trust", serde_json::json!({"min_trust": 0.8}));
+    #[tokio::test]
+    async fn test_dispatch_publisher_trust_reaches_real_evaluator() {
+        // The #2948 evaluator (not the retired stub): a spoofed self-asserted
+        // `author` must NOT satisfy a `match: attestation` allowlist.
+        let rule = typed_rule(
+            "publisher_trust",
+            serde_json::json!({
+                "trusted_publishers": ["Microsoft"],
+                "match": "attestation",
+                "action": "block"
+            }),
+        );
+        let spoofed = serde_json::json!({
+            "info": {"author": "Microsoft", "author_email": "attacker@example.com"}
+        });
         let decision = CurationService::evaluate_typed_rule(
             &rule,
-            "npm",
-            "left-pad",
-            "1.3.0",
-            &serde_json::json!({}),
-        );
-        assert_eq!(decision, CurationDecision::Allow);
+            "pypi",
+            "azure-coore",
+            "99.0.0",
+            &spoofed,
+            &no_source(),
+        )
+        .await;
+        match decision {
+            CurationDecision::Block(reason) => {
+                assert!(
+                    reason.contains("requires registry-verified provenance"),
+                    "reason: {reason}"
+                );
+            }
+            other => panic!("expected Block from the real evaluator, got {other:?}"),
+        }
     }
 
-    #[test]
-    fn test_dispatch_popularity_reaches_stub() {
-        // TODO(#2949) stub: always Allow. This pins the dispatch wiring only.
+    #[tokio::test]
+    async fn test_dispatch_popularity_reaches_real_evaluator() {
+        // The #2949 evaluator (not the retired stub): a seeded below-threshold
+        // count must Flag, proving the source is threaded through the dispatch.
+        let source = FakePopularitySource::new().with("pypi", "obscure-pkg", 42);
         let rule = typed_rule("popularity", serde_json::json!({"min_downloads": 1000}));
         let decision = CurationService::evaluate_typed_rule(
             &rule,
             "pypi",
-            "requests",
-            "2.32.0",
+            "obscure-pkg",
+            "0.1.0",
             &serde_json::json!({}),
-        );
-        assert_eq!(decision, CurationDecision::Allow);
+            &source,
+        )
+        .await;
+        match decision {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("42"), "reason carries the count: {reason}");
+                assert!(
+                    reason.contains("1000"),
+                    "reason carries the threshold: {reason}"
+                );
+            }
+            other => panic!("expected Flag from the real evaluator, got {other:?}"),
+        }
+        assert_eq!(source.call_count(), 1);
     }
 
-    #[test]
-    fn test_dispatch_publisher_trust_not_applicable_format() {
+    #[tokio::test]
+    async fn test_dispatch_publisher_trust_not_applicable_format() {
         // A format with no publisher concept must have NO effect — a global
         // publisher-trust baseline cannot block/flag e.g. generic artifacts.
-        let rule = typed_rule("publisher_trust", serde_json::json!({"min_trust": 0.8}));
+        let rule = typed_rule(
+            "publisher_trust",
+            serde_json::json!({"trusted_publishers": ["acme"]}),
+        );
         for format in ["generic", "rpm", "debian", "docker"] {
             let decision = CurationService::evaluate_typed_rule(
                 &rule,
@@ -1184,7 +1390,9 @@ mod tests {
                 "some-artifact",
                 "1.0",
                 &serde_json::json!({}),
-            );
+                &no_source(),
+            )
+            .await;
             assert_eq!(
                 decision,
                 CurationDecision::NotApplicable,
@@ -1193,8 +1401,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_dispatch_popularity_not_applicable_format() {
+    #[tokio::test]
+    async fn test_dispatch_popularity_not_applicable_format_skips_source() {
+        // Format-gate FIRST: an inapplicable format is NotApplicable and the
+        // popularity source is never consulted (no wasted fetch).
+        let source = no_source();
         let rule = typed_rule("popularity", serde_json::json!({"min_downloads": 1000}));
         for format in ["generic", "rpm", "helm"] {
             let decision = CurationService::evaluate_typed_rule(
@@ -1203,17 +1414,24 @@ mod tests {
                 "some-artifact",
                 "1.0",
                 &serde_json::json!({}),
-            );
+                &source,
+            )
+            .await;
             assert_eq!(
                 decision,
                 CurationDecision::NotApplicable,
                 "popularity must be NotApplicable for {format}"
             );
         }
+        assert_eq!(
+            source.call_count(),
+            0,
+            "inapplicable formats must not consult the popularity source"
+        );
     }
 
-    #[test]
-    fn test_evaluate_typed_rules_skips_not_applicable() {
+    #[tokio::test]
+    async fn test_evaluate_typed_rules_skips_not_applicable() {
         // A global popularity rule (NotApplicable for rpm) followed by a
         // pattern block: the popularity rule must have no effect and the
         // pattern rule must still decide.
@@ -1226,13 +1444,15 @@ mod tests {
             "telnet-server",
             "1.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(decision, CurationDecision::Block(block.reason.clone()));
         assert_eq!(rule_id, Some(block.id));
     }
 
-    #[test]
-    fn test_evaluate_typed_rules_default_when_nothing_applies() {
+    #[tokio::test]
+    async fn test_evaluate_typed_rules_default_when_nothing_applies() {
         let popularity = typed_rule("popularity", serde_json::json!({}));
         let miss = make_rule("telnet*", "*", "*", "block");
         let (decision, rule_id) = CurationService::evaluate_typed_rules(
@@ -1242,13 +1462,15 @@ mod tests {
             "curl",
             "8.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(decision, CurationDecision::Allow);
         assert!(rule_id.is_none());
     }
 
-    #[test]
-    fn test_evaluate_typed_rules_first_decision_wins() {
+    #[tokio::test]
+    async fn test_evaluate_typed_rules_first_decision_wins() {
         // Legacy parity: an earlier allow shadows a later block.
         let allow = make_rule("nginx", "*", "*", "allow");
         let block = make_rule("nginx", "*", "*", "block");
@@ -1259,13 +1481,15 @@ mod tests {
             "nginx",
             "1.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(decision, CurationDecision::Allow);
         assert_eq!(rule_id, Some(allow.id));
     }
 
-    #[test]
-    fn test_dispatch_unknown_rule_type_flags_for_review() {
+    #[tokio::test]
+    async fn test_dispatch_unknown_rule_type_flags_for_review() {
         // Defense-in-depth: an unrecognized engine must never silently allow.
         let rule = typed_rule("mystery", serde_json::json!({}));
         let decision = CurationService::evaluate_typed_rule(
@@ -1274,7 +1498,9 @@ mod tests {
             "nginx",
             "1.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         match decision {
             CurationDecision::Flag(reason) => {
                 assert!(
@@ -1284,6 +1510,84 @@ mod tests {
             }
             other => panic!("unknown rule_type must Flag, got {other:?}"),
         }
+    }
+
+    // -- decision/status mapping (#2947 integration) --------------------------
+
+    #[test]
+    fn test_decision_to_status_reason_mapping() {
+        let id = Uuid::new_v4();
+        assert_eq!(
+            CurationService::decision_to_status_reason(&CurationDecision::Allow, Some(id)).0,
+            "approved"
+        );
+        let (status, reason) = CurationService::decision_to_status_reason(
+            &CurationDecision::Block("bad publisher".into()),
+            Some(id),
+        );
+        assert_eq!(status, "blocked");
+        assert_eq!(reason, "bad publisher");
+        let (status, reason) = CurationService::decision_to_status_reason(
+            &CurationDecision::Flag("needs review".into()),
+            Some(id),
+        );
+        assert_eq!(status, "review");
+        assert_eq!(reason, "needs review");
+        // Fail-safe: a stray NotApplicable routes to review, never approval.
+        assert_eq!(
+            CurationService::decision_to_status_reason(&CurationDecision::NotApplicable, None).0,
+            "review"
+        );
+    }
+
+    #[test]
+    fn test_default_decision_mapping() {
+        assert_eq!(
+            CurationService::default_decision("allow"),
+            CurationDecision::Allow
+        );
+        assert!(matches!(
+            CurationService::default_decision("block"),
+            CurationDecision::Block(_)
+        ));
+        assert!(matches!(
+            CurationService::default_decision("review"),
+            CurationDecision::Flag(_)
+        ));
+    }
+
+    #[test]
+    fn test_context_metadata_injects_architecture() {
+        // Column arch threads into the pattern-rule context...
+        let ctx = CurationService::context_metadata(&serde_json::json!({"a": 1}), Some("x86_64"));
+        assert_eq!(ctx["architecture"], "x86_64");
+        assert_eq!(ctx["a"], 1);
+        // ...but never overrides one the blob already carries.
+        let ctx = CurationService::context_metadata(
+            &serde_json::json!({"architecture": "aarch64"}),
+            Some("x86_64"),
+        );
+        assert_eq!(ctx["architecture"], "aarch64");
+        // No arch: context is the blob unchanged.
+        let ctx = CurationService::context_metadata(&serde_json::json!({"a": 1}), None);
+        assert_eq!(ctx, serde_json::json!({"a": 1}));
+    }
+
+    #[test]
+    fn test_legacy_pattern_engine_skips_typed_rules() {
+        // A typed rule's defaulted `*` pattern + block action must NOT be
+        // interpreted by the legacy pattern engine (the PEP 503 proxy gate and
+        // staging-sync fallback) as a block-everything glob: typed rules are
+        // evaluated only by the typed dispatch.
+        let mut typed = typed_rule(
+            "publisher_trust",
+            serde_json::json!({"trusted_publishers": ["acme"]}),
+        );
+        typed.action = "block".to_string();
+        let eval =
+            CurationService::evaluate_package_in_memory(&[typed], "allow", "anything", "1.0", None);
+        assert_eq!(eval.action, "allow", "typed rule must not decide here");
+        assert!(eval.rule_id.is_none());
     }
 
     // -- by-id not-found mapping (#2020) --------------------------------------
@@ -1344,23 +1648,31 @@ mod tests {
             "typed global rule must appear in the global-baseline listing"
         );
 
-        // The persisted row reaches the (stub) dispatch: applicable format
-        // hits the TODO(#2948) stub (Allow), non-applicable is NotApplicable.
+        // The persisted row reaches the real #2948 evaluator: an applicable
+        // format with no extractable publisher fails safe (Flag), a
+        // non-applicable format is NotApplicable.
         let dec = CurationService::evaluate_typed_rule(
             &fetched,
             "npm",
             "left-pad",
             "1.3.0",
             &serde_json::json!({}),
+            &no_source(),
+        )
+        .await;
+        assert!(
+            matches!(dec, CurationDecision::Flag(ref r) if r.contains("publisher unknown")),
+            "expected fail-safe Flag for missing publisher, got {dec:?}"
         );
-        assert_eq!(dec, CurationDecision::Allow);
         let na = CurationService::evaluate_typed_rule(
             &fetched,
             "generic",
             "blob",
             "1.0",
             &serde_json::json!({}),
-        );
+            &no_source(),
+        )
+        .await;
         assert_eq!(na, CurationDecision::NotApplicable);
 
         svc.delete_rule(rule.id).await.expect("delete typed rule");
@@ -1405,6 +1717,348 @@ mod tests {
 
         let svc = CurationService::new(pool.clone());
         svc.delete_rule(rule.id).await.expect("delete legacy rule");
+        tdh::cleanup_user(&pool, user).await;
+    }
+
+    // -- typed enforcement end-to-end (#2947 integration, DB-backed) ----------
+    //
+    // These exercise the WIRED feature: a persisted GLOBAL typed rule flows
+    // through fetch_applicable_rules -> evaluate_typed_rules -> the real
+    // #2948/#2949 evaluators, via the production `evaluate_package_typed`
+    // entry point.
+
+    /// PyPI JSON-API blob with a merged integrity-API provenance object:
+    /// registry-verified Trusted-Publisher org `NumFOCUS`.
+    fn pypi_attested_metadata() -> serde_json::Value {
+        serde_json::json!({
+            "info": {"author": "NumPy Developers", "name": "numpy", "version": "2.0.0"},
+            "provenance": {
+                "attestation_bundles": [{
+                    "publisher": {"kind": "GitHub", "repository": "NumFOCUS/numpy", "workflow": "wheels.yml"},
+                    "attestations": [{"envelope": {}}]
+                }]
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_integration_global_publisher_trust_rule_end_to_end_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let _guard = tdh::curation_global_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user, _uname) = tdh::create_user(&pool).await;
+        let svc = CurationService::new(pool.clone());
+
+        let config = serde_json::json!({
+            "trusted_publishers": ["NumFOCUS"],
+            "match": "attestation",
+            "action": "block"
+        });
+        let rule = svc
+            .create_rule(
+                None,
+                "*",
+                "*",
+                "*",
+                "block",
+                1,
+                "only attested trusted publishers (#2947 integ test)",
+                "publisher_trust",
+                &config,
+                user,
+            )
+            .await
+            .expect("create global publisher_trust rule");
+
+        // Any staging repo sees the global baseline (staging_repo_id IS NULL).
+        let probe_repo = Uuid::new_v4();
+
+        // Non-attested package (self-asserted author only) -> Block.
+        let spoofed = serde_json::json!({
+            "info": {"author": "NumFOCUS", "author_email": "attacker@example.com"}
+        });
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                probe_repo,
+                "allow",
+                "pypi",
+                "numpy-coore",
+                "99.0.0",
+                None,
+                &spoofed,
+                &no_source(),
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, Some(rule.id), "the global rule must decide");
+        assert!(
+            matches!(decision, CurationDecision::Block(ref r)
+                if r.contains("requires registry-verified provenance")),
+            "non-attested package must be blocked, got {decision:?}"
+        );
+
+        // Attested package from the trusted publisher -> Allow.
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                probe_repo,
+                "allow",
+                "pypi",
+                "numpy",
+                "2.0.0",
+                None,
+                &pypi_attested_metadata(),
+                &no_source(),
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, Some(rule.id));
+        assert_eq!(decision, CurationDecision::Allow);
+
+        // A format with no publisher concept passes through untouched.
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                probe_repo,
+                "allow",
+                "raw",
+                "some-blob",
+                "1.0",
+                None,
+                &serde_json::json!({}),
+                &no_source(),
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, None, "global rule must have no effect on raw");
+        assert_eq!(decision, CurationDecision::Allow);
+
+        svc.delete_rule(rule.id).await.expect("delete rule");
+        tdh::cleanup_user(&pool, user).await;
+    }
+
+    #[tokio::test]
+    async fn test_integration_global_popularity_rule_end_to_end_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let _guard = tdh::curation_global_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user, _uname) = tdh::create_user(&pool).await;
+        let svc = CurationService::new(pool.clone());
+
+        let config = serde_json::json!({"min_downloads": 500, "action": "block"});
+        let rule = svc
+            .create_rule(
+                None,
+                "*",
+                "*",
+                "*",
+                "block",
+                1,
+                "minimum adoption bar (#2947 integ test)",
+                "popularity",
+                &config,
+                user,
+            )
+            .await
+            .expect("create global popularity rule");
+
+        let probe_repo = Uuid::new_v4();
+        let source = FakePopularitySource::new()
+            .with("pypi", "obscure-lib", 10)
+            .with("pypi", "reqeusts", 900);
+
+        // Below threshold with action=block -> Block.
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                probe_repo,
+                "allow",
+                "pypi",
+                "obscure-lib",
+                "0.0.1",
+                None,
+                &serde_json::json!({}),
+                &source,
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, Some(rule.id));
+        assert!(
+            matches!(decision, CurationDecision::Block(ref r)
+                if r.contains("below the configured minimum")),
+            "below-threshold package must be blocked, got {decision:?}"
+        );
+
+        // Above threshold but one edit from `requests` -> advisory typo-squat
+        // Flag (never a block from the lexical signal alone).
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                probe_repo,
+                "allow",
+                "pypi",
+                "reqeusts",
+                "1.0.0",
+                None,
+                &serde_json::json!({}),
+                &source,
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, Some(rule.id));
+        assert!(
+            matches!(decision, CurationDecision::Flag(ref r)
+                if r.contains("requests") && r.contains("typo-squat")),
+            "typo-squat must flag and name the target, got {decision:?}"
+        );
+
+        // A format with no download-count ecosystem passes through untouched —
+        // and the source is never consulted for it.
+        let calls_before = source.call_count();
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                probe_repo,
+                "allow",
+                "raw",
+                "some-blob",
+                "1.0",
+                None,
+                &serde_json::json!({}),
+                &source,
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, None);
+        assert_eq!(decision, CurationDecision::Allow);
+        assert_eq!(
+            source.call_count(),
+            calls_before,
+            "inapplicable format must not consult the popularity source"
+        );
+
+        svc.delete_rule(rule.id).await.expect("delete rule");
+        tdh::cleanup_user(&pool, user).await;
+    }
+
+    #[tokio::test]
+    async fn test_integration_global_union_repo_rules_first_applicable_wins_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let _guard = tdh::curation_global_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user, _uname) = tdh::create_user(&pool).await;
+        let (repo_id, _key, _dir) = tdh::create_repo(&pool, "staging", "pypi").await;
+        let svc = CurationService::new(pool.clone());
+
+        // Repo-scoped pattern allow at higher priority (lower number)...
+        let repo_allow = svc
+            .create_rule(
+                Some(repo_id),
+                "legit-*",
+                "*",
+                "*",
+                "allow",
+                1,
+                "vetted internal packages (#2947 integ test)",
+                "pattern",
+                &serde_json::json!({}),
+                user,
+            )
+            .await
+            .expect("create repo pattern rule");
+        assert_eq!(repo_allow.scope, "repository");
+
+        // ...union-ed with a global publisher_trust block baseline.
+        let global_block = svc
+            .create_rule(
+                None,
+                "*",
+                "*",
+                "*",
+                "block",
+                2,
+                "untrusted publishers blocked (#2947 integ test)",
+                "publisher_trust",
+                &serde_json::json!({
+                    "trusted_publishers": ["NumFOCUS"],
+                    "match": "attestation",
+                    "action": "block"
+                }),
+                user,
+            )
+            .await
+            .expect("create global publisher_trust rule");
+
+        let untrusted_metadata = serde_json::json!({"info": {"author": "somebody"}});
+
+        // The repo allow matches first for its pattern: first-applicable wins
+        // over the later global block.
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                repo_id,
+                "review",
+                "pypi",
+                "legit-tool",
+                "1.0.0",
+                None,
+                &untrusted_metadata,
+                &no_source(),
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, Some(repo_allow.id));
+        assert_eq!(decision, CurationDecision::Allow);
+
+        // Outside the repo pattern, the global baseline decides.
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                repo_id,
+                "review",
+                "pypi",
+                "random-pkg",
+                "1.0.0",
+                None,
+                &untrusted_metadata,
+                &no_source(),
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(matched, Some(global_block.id));
+        assert!(
+            matches!(decision, CurationDecision::Block(_)),
+            "global baseline must block untrusted publishers, got {decision:?}"
+        );
+
+        // Another repository sees the global baseline but NOT this repo's rule.
+        let other_repo = Uuid::new_v4();
+        let (decision, matched) = svc
+            .evaluate_package_typed(
+                other_repo,
+                "review",
+                "pypi",
+                "legit-tool",
+                "1.0.0",
+                None,
+                &untrusted_metadata,
+                &no_source(),
+            )
+            .await
+            .expect("typed evaluation");
+        assert_eq!(
+            matched,
+            Some(global_block.id),
+            "repo-scoped allow must not leak to other repositories"
+        );
+        assert!(matches!(decision, CurationDecision::Block(_)));
+
+        svc.delete_rule(repo_allow.id).await.expect("delete rule");
+        svc.delete_rule(global_block.id).await.expect("delete rule");
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("delete repo");
         tdh::cleanup_user(&pool, user).await;
     }
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -103,6 +103,7 @@ pub mod webhook_signing;
 pub mod age_gate_service;
 pub mod analytics_service;
 pub mod crash_reporting_service;
+pub mod curation;
 pub mod curation_service;
 pub mod curation_sync;
 pub mod health_monitor_service;

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -1114,6 +1114,11 @@ pub(crate) async fn run_curation_sync_cycle(
     }
 
     let curation = CurationService::new(db.clone());
+    // One TTL-cached download-count source for the whole sweep, so `popularity`
+    // rules (#2949) evaluated across many packages / staging repos share
+    // lookups instead of hammering the public stats APIs.
+    let popularity_source =
+        crate::services::curation::popularity_source::HttpPopularitySource::new().cached();
     let client = crate::services::http_client::base_client_builder()
         .timeout(std::time::Duration::from_secs(60))
         .build()?;
@@ -1407,24 +1412,27 @@ pub(crate) async fn run_curation_sync_cycle(
                 .await
             {
                 Ok(pkg) if pkg.status == "pending" => {
+                    // Typed dispatch (#2947): pattern + publisher_trust +
+                    // popularity rules all apply, with the upstream metadata
+                    // blob as the evaluation context.
                     let eval = curation
-                        .evaluate_package(
+                        .evaluate_package_typed(
                             *staging_id,
                             default_action,
+                            &entry.format,
                             &entry.package_name,
                             &entry.version,
                             entry.architecture.as_deref(),
+                            &entry.metadata,
+                            &popularity_source,
                         )
                         .await;
 
-                    if let Ok(eval) = eval {
-                        let status = match eval.action.as_str() {
-                            "allow" => "approved",
-                            "block" => "blocked",
-                            _ => "review",
-                        };
+                    if let Ok((decision, rule_id)) = eval {
+                        let (status, reason) =
+                            CurationService::decision_to_status_reason(&decision, rule_id);
                         let _ = curation
-                            .set_package_status(pkg.id, status, &eval.reason, None, eval.rule_id)
+                            .set_package_status(pkg.id, status, &reason, None, rule_id)
                             .await;
                     }
                 }


### PR DESCRIPTION
## Summary

Complete typed curation rules feature (#2947 epic): the rule-type foundation plus both real evaluators, wired end-to-end into the curation enforcement path. This PR folds in the evaluator work from #2950 (`publisher_trust`, issue #2948) and #2951 (`popularity`, issue #2949) on top of the foundation, so one branch carries the whole feature.

Closes #2947

### Foundation (schema + API + dispatch)
- `curation_rules` gains `rule_type` (`pattern` | `publisher_trust` | `popularity`), `config` (JSONB engine parameters) and `scope` (`repository` | `global`), with `scope` derived from `staging_repo_id` at write time (migration `180_curation_rule_types.sql`).
- Global-rule CRUD on the curation API: a rule created without `staging_repo_id` is an instance-wide baseline, listed under `?scope=global` and union-ed into every repository's rule set.
- `CurationDecision { Allow, Flag(reason), Block(reason), NotApplicable }` as the shared decision type; `NotApplicable` has no effect, so global typed policies silently pass through formats they cannot judge.

### Evaluators (now real, not stubs)
- **`publisher_trust`** (#2948): trusted-publisher allowlisting with provenance-labeled identity extraction (`publisher_source`). `match: "attestation"` (secure default) only accepts registry-verified provenance (PyPI Trusted-Publisher attestation bundles, npm sigstore provenance); self-asserted `author`/`maintainer` metadata is an explicit opt-in (`match: "metadata"`). Actions: `block` / `allow` (fail-safe: untrusted goes to review) / `flag` (watch mode). Misconfiguration and missing-publisher cases fail safe to `Flag`.
- **`popularity`** (#2949): download-count threshold (pypistats.org / npm downloads API via a pluggable async `PopularitySource`) plus typo-squat detection (edit-distance ≤ 2 against per-ecosystem popular-package lists, advisory Flag only). Source outages fail open on data, fail safe on decision (`Flag`, never `Block`). Production uses a TTL-cached HTTP source (15 min positive / 60 s negative cache).

Both evaluators return `CurationDecision` directly (the branch-local `Decision` enums are gone).

### Integration (the wiring)
- `evaluate_typed_rule` / `evaluate_typed_rules` are now `async` and thread a `&dyn PopularitySource`; the `popularity` arm format-gates FIRST, so inapplicable formats never consult (or cost) a download-count lookup.
- New production entry point `CurationService::evaluate_package_typed` (fetch global ∪ repo rules → typed first-applicable-wins evaluation), used by:
  - the **curation-sync scheduler** (`run_curation_sync_cycle`) — newly ingested pending packages are decided by pattern + publisher_trust + popularity rules against the upstream metadata blob;
  - **`POST /api/v1/curation/packages/re-evaluate`** (`re_evaluate_pending`) — batch re-evaluation through the typed dispatch, one cached popularity source per batch.
- Hardening found during integration: the legacy pattern engine (`evaluate_rules`, used by the PEP 503 proxy gate) now skips non-`pattern` rules. Typed rules default `package_pattern` to `*`, so without the skip a global publisher-trust `block` policy would have been misread as a block-everything glob by the legacy path (and an `allow`-action typed rule could shadow real pattern blocks).

### Remaining wiring (follow-up)
The download/proxy pull gate (`enforce_pypi_curation` → `evaluate_pep503_package`) still evaluates **pattern rules only**; typed rules decide package status in the staging/curation catalog (sync + re-evaluate), not yet inline on proxy downloads. Wiring the typed decision into the pull path is left as a follow-up so its latency/caching profile can be designed deliberately (popularity lookups on the download path need a stricter budget).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated (evaluator modules: 40+ tests; dispatch: async conversion, format-gate-skips-source, legacy-engine-skips-typed-rules)
- [x] Integration tests added/updated (DB-backed end-to-end: global publisher_trust Block/Allow via attestation, global popularity Block/typo-squat Flag with a fake source, NotApplicable pass-through for `raw`, global ∪ repo first-applicable-wins + repo-rule isolation; serialized cross-process via a Postgres advisory lock)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (isolated deployment: global rule CRUD via API, `?scope=global` listing, re-evaluate enforcement path)
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
