### PR TITLE
fix(artifacts): expose per-artifact quarantine state on the repository listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - TBD
+
+### Fixed
+
+- **The repository artifacts listing reports per-artifact quarantine state** (#2940): `GET /api/v1/repositories/{key}/artifacts` rows now carry `quarantine_status`, `quarantine_until`, `quarantine_reason` and a derived `is_blocked`. Previously the listing said nothing about quarantine, so an artifact the download gate refuses with `409` was reported as ordinary and downloadable, and any client reading quarantine state from the listing got a clean bill of health. `is_blocked` is computed by the download gate's own predicate rather than restated, so the listing, the gate and `GET /api/v1/quarantine/{artifact_id}` cannot drift apart. State is loaded once per page rather than per row. The reason is visible only to a caller that can access the repository, because it carries policy names, per-artifact finding counts and admin incident notes, and listing routes are reachable anonymously on public repositories. All four fields are omitted rather than returned as null on surfaces that do not load quarantine state, so "not loaded" cannot be read as "not quarantined".
+
 ## [1.6.0] - TBD
 
 A security- and correctness-hardening release closing the 1.6.0 milestone: 24 security fixes, 9 features and enhancements, and 47 bug fixes, spanning multi-tenant isolation, supply-chain signing, ingestion/scan resource limits, native-client format fidelity across a dozen ecosystems, proxy/cache accounting, and SSO group mapping. It also folds in the cross-repository Maven flat-key attribution hardening and the npm replication-feed and webhook cluster-safety fixes carried over from the 1.5.x hotfix line. In-place upgrade from 1.5.x is automatic — a startup migration-ledger reconciliation resolves the history divergence with no operator action (#2686). The release date is stamped at cut.

--- a/backend/src/api/handlers/artifacts.rs
+++ b/backend/src/api/handlers/artifacts.rs
@@ -191,6 +191,14 @@ pub async fn get_artifact(
         // the by-id surface leaves it unset.
         revision: None,
         version_label: None,
+        // #2940 populated quarantine state on the repository artifacts
+        // listing. This by-id surface does not load it, so it omits the keys
+        // instead of reporting a `false` it never checked; callers that need
+        // the verdict use GET /api/v1/quarantine/{artifact_id}.
+        is_blocked: None,
+        quarantine_status: None,
+        quarantine_reason: None,
+        quarantine_until: None,
     }))
 }
 
@@ -336,6 +344,10 @@ mod tests {
         let resp = ArtifactResponse {
             revision: None,
             version_label: None,
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
             id,
             repository_key: "maven-releases".to_string(),
             path: "com/example/lib/1.0/lib-1.0.jar".to_string(),
@@ -373,6 +385,10 @@ mod tests {
         let resp = ArtifactResponse {
             revision: None,
             version_label: None,
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
             id: Uuid::new_v4(),
             repository_key: "generic-local".to_string(),
             path: "file.tar.gz".to_string(),
@@ -413,6 +429,10 @@ mod tests {
         let resp = ArtifactResponse {
             revision: None,
             version_label: None,
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
             id: Uuid::new_v4(),
             repository_key: "generic-local".to_string(),
             path: "empty".to_string(),
@@ -531,6 +551,10 @@ mod tests {
         let resp = ArtifactResponse {
             revision: None,
             version_label: None,
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
             id: Uuid::nil(),
             repository_key: "k".to_string(),
             path: "p".to_string(),

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -39,6 +39,7 @@ use crate::services::audit_service::{
 use crate::services::cache_classifier;
 use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
 use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
+use crate::services::quarantine_service::{self, QuarantineView};
 use crate::services::repository_service::{
     derive_format_key, CreateRepositoryRequest as ServiceCreateRepoReq, RepoVisibility,
     RepositoryService, UpdateRepositoryRequest as ServiceUpdateRepoReq,
@@ -4095,6 +4096,42 @@ pub struct ArtifactResponse {
     /// `revision`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version_label: Option<String>,
+    /// Whether the artifact's bytes are currently refused because it is under
+    /// quarantine (#2940). Named to match `QuarantineStatusResponse.is_blocked`
+    /// on `GET /api/v1/quarantine/{artifact_id}`, which models the same derived
+    /// verdict over the same three `quarantine_*` fields below.
+    ///
+    /// Computed by that endpoint's own predicate
+    /// ([`quarantine_service::check_download_allowed`]), so `true` here means a
+    /// download of this artifact is refused right now: 409 while a hold is
+    /// live, 403 once it has been rejected.
+    ///
+    /// Present on every row of the repository artifacts listing, including
+    /// unheld ones (`false`). **Absent** on surfaces that do not load
+    /// quarantine state, so a consumer can distinguish "the server looked and
+    /// it is fine" from "the server did not look", the ambiguity that let a
+    /// blocked artifact read as clean in the first place.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_blocked: Option<bool>,
+    /// Raw `artifacts.quarantine_status` (`quarantined`, `rejected`,
+    /// `released`, `clean`, `flagged`, `unscanned`). Same gating as
+    /// `is_blocked`. Note a `quarantined` status whose hold has already
+    /// lapsed is downloadable, so read `is_blocked` for the verdict rather
+    /// than comparing this string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_status: Option<String>,
+    /// Why the artifact is held, when a scan policy or an admin recorded a
+    /// reason. Disclosed only to callers that hold the repository: listing
+    /// routes are reachable anonymously on public repositories and the reason
+    /// carries internal policy names, per-artifact finding counts, and admin
+    /// incident notes (#2912).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_reason: Option<String>,
+    /// When a live hold lapses. Absent for an unconditional hold (admin
+    /// quarantine, scan-policy rejection) and for artifacts that are not held,
+    /// so it is not on its own a signal of quarantine state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_until: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -4401,6 +4438,25 @@ pub async fn list_artifacts(
         .get_download_stats_batch(&artifact_ids)
         .await?;
 
+    // #2940: the listing used to say nothing about quarantine, so an artifact
+    // the download gate refuses with 409 was reported as ordinary and every
+    // client that reads quarantine state from here concluded it was fine. One
+    // batched read per page (the same shape as the download-stats batch above)
+    // fills it in without degrading into a query per row, and the verdict is
+    // computed by the gate's own predicate rather than restated here.
+    let mut quarantine =
+        quarantine_service::views_for_artifacts(&state.db, &artifact_ids, chrono::Utc::now())
+            .await?;
+    // The reason carries internal policy names, per-artifact finding counts and
+    // free-text admin incident notes. This route is reachable anonymously on a
+    // public repository, so gate it exactly as the quarantine status endpoint
+    // does: only a caller that holds the repository sees it (#2912).
+    if !auth.as_ref().is_some_and(|a| a.can_access_repo(repo.id)) {
+        for view in quarantine.values_mut() {
+            view.redact_reason();
+        }
+    }
+
     // Legacy Maven/Gradle uploads used to group POM, sources, javadoc, and
     // other companion files under one artifact row in metadata.files (#1092).
     // New uploads store each Maven asset as its own `artifacts` row, but keep
@@ -4439,7 +4495,8 @@ pub async fn list_artifacts(
     for artifact in artifacts {
         let artifact_id = artifact.id;
         let download_count = *download_counts.get(&artifact_id).unwrap_or(&0);
-        let mut item = build_artifact_response(&artifact, &key, download_count);
+        let quarantine_view = quarantine.get(&artifact_id);
+        let mut item = build_artifact_response(&artifact, &key, download_count, quarantine_view);
         if rewrite_npm_tarball_paths {
             apply_npm_tarball_url_path(&mut item);
         }
@@ -4451,6 +4508,7 @@ pub async fn list_artifacts(
                 &key,
                 secondary,
                 &listed_maven_paths,
+                quarantine_view,
             ));
         }
     }
@@ -4694,6 +4752,16 @@ fn build_catalog_artifact_response(
         cache_expires_at: None,
         revision: None,
         version_label: None,
+        // A proxy-cached object has no `artifacts` row, so the quarantine
+        // columns this listing reads do not exist for it. Its hold lives in the
+        // cache sidecar (`proxy_service::check_quarantine_until`) and is not
+        // indexed in `proxy_cache_artifacts`, so it cannot be reported here
+        // without a storage read per row. Left absent rather than `false` so
+        // this does not claim the object is unheld (#2940).
+        is_blocked: None,
+        quarantine_status: None,
+        quarantine_reason: None,
+        quarantine_until: None,
     }
 }
 
@@ -4803,6 +4871,13 @@ fn build_cached_artifact_response(
         // Proxy-cache entries carry no versioned history (#2367).
         revision: None,
         version_label: None,
+        // No `artifacts` row, so no quarantine columns to read; the sidecar
+        // hold is not visible from a listing. Same rationale as
+        // `build_catalog_artifact_response` (#2940).
+        is_blocked: None,
+        quarantine_status: None,
+        quarantine_reason: None,
+        quarantine_until: None,
     }
 }
 
@@ -4962,6 +5037,7 @@ fn build_artifact_response(
     artifact: &crate::models::artifact::Artifact,
     repo_key: &str,
     download_count: i64,
+    quarantine: Option<&QuarantineView>,
 ) -> ArtifactResponse {
     ArtifactResponse {
         id: artifact.id,
@@ -4987,6 +5063,13 @@ fn build_artifact_response(
         // per-artifact metadata endpoint, not fanned out in listings (#2367).
         revision: None,
         version_label: None,
+        // #2940: quarantine state comes from the caller's batched read, not
+        // from a per-row query, and is left absent (rather than `false`) when
+        // the caller did not load it.
+        is_blocked: quarantine.map(|q| q.is_blocked),
+        quarantine_status: quarantine.and_then(|q| q.quarantine_status.clone()),
+        quarantine_reason: quarantine.and_then(|q| q.quarantine_reason.clone()),
+        quarantine_until: quarantine.and_then(|q| q.quarantine_until),
     }
 }
 
@@ -5002,6 +5085,7 @@ fn expand_maven_secondary_files(
     repo_key: &str,
     secondary: &[serde_json::Value],
     listed_paths: &std::collections::HashSet<String>,
+    quarantine: Option<&QuarantineView>,
 ) -> Vec<ArtifactResponse> {
     let mut out = Vec::new();
     for f in secondary {
@@ -5039,6 +5123,12 @@ fn expand_maven_secondary_files(
             cache_expires_at: None,
             revision: None,
             version_label: None,
+            // Downloads of a secondary file are gated by the primary row's
+            // quarantine state, so the listing must report it here too (#2940).
+            is_blocked: quarantine.map(|q| q.is_blocked),
+            quarantine_status: quarantine.and_then(|q| q.quarantine_status.clone()),
+            quarantine_reason: quarantine.and_then(|q| q.quarantine_reason.clone()),
+            quarantine_until: quarantine.and_then(|q| q.quarantine_until),
         });
     }
     out
@@ -6359,6 +6449,13 @@ pub async fn get_artifact_metadata(
             cache_expires_at: cache_meta.as_ref().map(|m| m.expires_at),
             revision,
             version_label,
+            // #2940 fixed the repository artifacts listing; this by-path
+            // metadata surface still does not load quarantine state, so it
+            // omits the keys rather than reporting a `false` it has not checked.
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
         })
         .into_response());
     }
@@ -6476,6 +6573,13 @@ fn artifact_version_to_response(
         cache_expires_at: None,
         revision: Some(stored.revision),
         version_label: stored.version_label,
+        // A historical revision is an `artifact_versions` row; quarantine is
+        // held on the `artifacts` HEAD row, so there is nothing to report for
+        // this id (#2940).
+        is_blocked: None,
+        quarantine_status: None,
+        quarantine_reason: None,
+        quarantine_until: None,
     }
 }
 
@@ -6838,6 +6942,13 @@ async fn persist_generic_staged_upload(
             cache_expires_at: None,
             revision,
             version_label,
+            // The upload-time hold (`apply_upload_hold`) is applied after this
+            // response is built, so reporting a verdict here would be stale.
+            // Omitted rather than guessed (#2940).
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
         }),
     )
         .into_response())
@@ -9738,7 +9849,7 @@ mod tests {
     #[test]
     fn test_build_artifact_response_copies_primary_fields() {
         let a = make_artifact_for_test("com/example/demo/1.0.0/demo-1.0.0.jar");
-        let resp = build_artifact_response(&a, "maven-hosted", 42);
+        let resp = build_artifact_response(&a, "maven-hosted", 42, None);
         assert_eq!(resp.id, a.id);
         assert_eq!(resp.repository_key, "maven-hosted");
         assert_eq!(resp.path, a.path);
@@ -9747,6 +9858,102 @@ mod tests {
         assert_eq!(resp.download_count, 42);
         // Hosted artifacts have a real DB id, so SBOM/scan resolve: analyzable.
         assert!(resp.analyzable);
+    }
+
+    // -----------------------------------------------------------------------
+    // Quarantine state on the artifacts listing (#2940)
+    //
+    // The listing used to carry no quarantine state at all, so an artifact that
+    // 409s on download was described as perfectly downloadable and every client
+    // that reads quarantine from the listing (the web UI's QuarantineBanner
+    // among them) never fired.
+    // -----------------------------------------------------------------------
+
+    fn held_view(reason: Option<&str>) -> quarantine_service::QuarantineView {
+        quarantine_service::QuarantineView::from_columns(
+            Some("quarantined".to_string()),
+            None,
+            reason.map(str::to_string),
+            chrono::Utc::now(),
+        )
+    }
+
+    #[test]
+    fn test_build_artifact_response_reports_quarantine() {
+        let a = make_artifact_for_test("pyyaml/5.3/PyYAML-5.3-py3-none-any.whl");
+        let view = held_view(Some("Policy 'demo-global-cve': 2 findings"));
+        let resp = build_artifact_response(&a, "team-packages", 0, Some(&view));
+        assert_eq!(resp.is_blocked, Some(true));
+        assert_eq!(resp.quarantine_status.as_deref(), Some("quarantined"));
+        assert_eq!(
+            resp.quarantine_reason.as_deref(),
+            Some("Policy 'demo-global-cve': 2 findings")
+        );
+        assert_eq!(resp.quarantine_until, None);
+    }
+
+    #[test]
+    fn test_build_artifact_response_reports_clean_artifact_explicitly() {
+        // A listed artifact that is not held must say so out loud: the key is
+        // present and false, so a consumer never has to guess whether the
+        // server looked.
+        let a = make_artifact_for_test("com/example/demo/1.0.0/demo-1.0.0.jar");
+        let view = quarantine_service::QuarantineView::default();
+        let resp = build_artifact_response(&a, "maven-hosted", 0, Some(&view));
+        assert_eq!(resp.is_blocked, Some(false));
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(
+            json.get("is_blocked"),
+            Some(&serde_json::Value::Bool(false)),
+            "a listed artifact must always carry is_blocked"
+        );
+    }
+
+    #[test]
+    fn test_build_artifact_response_omits_quarantine_when_not_loaded() {
+        // Surfaces that do not load quarantine state omit the keys entirely
+        // rather than emitting a null or a false, so "not loaded" can never be
+        // read as "not quarantined" (#2940).
+        let a = make_artifact_for_test("com/example/demo/1.0.0/demo-1.0.0.jar");
+        let resp = build_artifact_response(&a, "maven-hosted", 0, None);
+        assert_eq!(resp.is_blocked, None);
+        let json = serde_json::to_value(&resp).expect("serialize");
+        for key in [
+            "is_blocked",
+            "quarantine_status",
+            "quarantine_reason",
+            "quarantine_until",
+        ] {
+            assert!(
+                json.get(key).is_none(),
+                "{key} must be absent when quarantine state was not loaded"
+            );
+        }
+    }
+
+    #[test]
+    fn test_expand_maven_secondary_files_inherits_primary_quarantine() {
+        // Secondary Maven files are addressed under the primary's artifact row
+        // and are gated by that row's quarantine state, so the listing must
+        // report them held alongside the primary.
+        let primary = make_artifact_for_test("com/example/demo/1.0.0/demo-1.0.0.jar");
+        let secondary = vec![serde_json::json!({
+            "path": "com/example/demo/1.0.0/demo-1.0.0.pom",
+            "extension": "pom",
+            "sizeBytes": 120,
+            "sha256": "pom-sha",
+        })];
+        let view = held_view(None);
+        let rows = expand_maven_secondary_files(
+            &primary,
+            "maven-hosted",
+            &secondary,
+            &std::collections::HashSet::new(),
+            Some(&view),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].is_blocked, Some(true));
+        assert_eq!(rows[0].quarantine_status.as_deref(), Some("quarantined"));
     }
 
     // -----------------------------------------------------------------------
@@ -9759,7 +9966,7 @@ mod tests {
     #[test]
     fn test_apply_npm_tarball_url_path_rewrites_stored_tarball() {
         let a = make_artifact_for_test("rfs-pkg/1.0.5/rfs-pkg-1.0.5.tgz");
-        let mut resp = build_artifact_response(&a, "rfs-npm", 0);
+        let mut resp = build_artifact_response(&a, "rfs-npm", 0, None);
         apply_npm_tarball_url_path(&mut resp);
         assert_eq!(resp.path, "rfs-pkg/-/rfs-pkg-1.0.5.tgz");
     }
@@ -9767,7 +9974,7 @@ mod tests {
     #[test]
     fn test_apply_npm_tarball_url_path_rewrites_scoped_stored_tarball() {
         let a = make_artifact_for_test("@angular/core/17.0.0/core-17.0.0.tgz");
-        let mut resp = build_artifact_response(&a, "npm-hosted", 0);
+        let mut resp = build_artifact_response(&a, "npm-hosted", 0, None);
         apply_npm_tarball_url_path(&mut resp);
         assert_eq!(resp.path, "@angular/core/-/core-17.0.0.tgz");
     }
@@ -9776,7 +9983,7 @@ mod tests {
     fn test_apply_npm_tarball_url_path_noop_for_metadata_row() {
         // Non-tarball rows (a bare package metadata path) are left verbatim.
         let a = make_artifact_for_test("rfs-pkg/package.json");
-        let mut resp = build_artifact_response(&a, "rfs-npm", 0);
+        let mut resp = build_artifact_response(&a, "rfs-npm", 0, None);
         apply_npm_tarball_url_path(&mut resp);
         assert_eq!(resp.path, "rfs-pkg/package.json");
     }
@@ -9785,7 +9992,7 @@ mod tests {
     fn test_apply_npm_tarball_url_path_idempotent_on_url_shape() {
         // A path already in the `/-/` URL shape must not be rewritten again.
         let a = make_artifact_for_test("rfs-pkg/-/rfs-pkg-1.0.5.tgz");
-        let mut resp = build_artifact_response(&a, "rfs-npm", 0);
+        let mut resp = build_artifact_response(&a, "rfs-npm", 0, None);
         apply_npm_tarball_url_path(&mut resp);
         assert_eq!(resp.path, "rfs-pkg/-/rfs-pkg-1.0.5.tgz");
     }
@@ -9825,6 +10032,7 @@ mod tests {
             "maven-hosted",
             &secondary,
             &std::collections::HashSet::new(),
+            None,
         );
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].path, "com/example/demo/1.0.0/demo-1.0.0.pom");
@@ -9853,6 +10061,7 @@ mod tests {
             "maven-hosted",
             &secondary,
             &std::collections::HashSet::new(),
+            None,
         );
         assert!(rows.is_empty());
     }
@@ -9869,7 +10078,7 @@ mod tests {
         })];
         let listed_paths = std::collections::HashSet::from([real_path]);
         let rows =
-            expand_maven_secondary_files(&primary, "maven-hosted", &secondary, &listed_paths);
+            expand_maven_secondary_files(&primary, "maven-hosted", &secondary, &listed_paths, None);
         assert!(rows.is_empty());
     }
 
@@ -9887,6 +10096,7 @@ mod tests {
             "k",
             &secondary,
             &std::collections::HashSet::new(),
+            None,
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].path, "p/demo.pom");
@@ -9901,6 +10111,7 @@ mod tests {
             "k",
             &secondary,
             &std::collections::HashSet::new(),
+            None,
         );
         assert_eq!(rows[0].size_bytes, 0);
         assert_eq!(rows[0].checksum_sha256, "");
@@ -11295,6 +11506,10 @@ mod tests {
         let resp = ArtifactResponse {
             revision: None,
             version_label: None,
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
             id: Uuid::new_v4(),
             repository_key: "my-repo".to_string(),
             path: "org/example/1.0/example-1.0.jar".to_string(),
@@ -11378,6 +11593,10 @@ mod tests {
         let resp = ArtifactResponse {
             revision: None,
             version_label: None,
+            is_blocked: None,
+            quarantine_status: None,
+            quarantine_reason: None,
+            quarantine_until: None,
             id: Uuid::new_v4(),
             repository_key: "pypi-remote".to_string(),
             path: "requests/requests-2.31.0-py3-none-any.whl".to_string(),
@@ -16255,6 +16474,133 @@ mod tests {
         assert!(
             rows.is_empty(),
             "a metadata-only read is not a download and must record nothing"
+        );
+
+        fx.teardown().await;
+    }
+
+    // ---------------------------------------------------------------------
+    // list_artifacts: quarantine state must agree with the download gate
+    // (#2940).
+    //
+    // The bug: the listing carried no quarantine state, so an artifact that
+    // was actively blocked (409 on download, `is_blocked: true` from
+    // GET /api/v1/quarantine/{id}) listed as ordinary and downloadable. This
+    // pins both halves in one test so they cannot drift again: the same
+    // artifact is listed and downloaded in the same run.
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_artifacts_reports_quarantine_matching_download_gate() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let repo = fx.repo_info("local", None);
+        let held_id = tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &format!("q-test/{}.bin", Uuid::new_v4()),
+            "quarantined/blocked.bin",
+            "blocked",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(b"blocked-bytes"),
+            fx.user_id,
+        )
+        .await;
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &format!("q-test/{}.bin", Uuid::new_v4()),
+            "quarantined/ok.bin",
+            "ok",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(b"clean-bytes"),
+            fx.user_id,
+        )
+        .await;
+        quarantine_service::quarantine_now(
+            &fx.pool,
+            held_id,
+            Some("Policy 'demo-global-cve': 2 findings at or above high severity".to_string()),
+        )
+        .await
+        .expect("quarantine the artifact");
+
+        let req = tdh::get(format!("/{}/artifacts?per_page=100", fx.repo_key));
+        let (status, body) = tdh::send(fx.router_with_auth(router()), req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let v: serde_json::Value = serde_json::from_slice(&body).expect("listing JSON");
+        let items = v["items"].as_array().expect("items array");
+
+        let held = items
+            .iter()
+            .find(|i| i["path"] == "quarantined/blocked.bin")
+            .expect("held artifact must be listed");
+        assert_eq!(
+            held["is_blocked"],
+            serde_json::Value::Bool(true),
+            "a blocked artifact must list as quarantined"
+        );
+        assert_eq!(held["quarantine_status"], "quarantined");
+        assert_eq!(
+            held["quarantine_reason"],
+            "Policy 'demo-global-cve': 2 findings at or above high severity",
+            "a caller that holds the repository sees the reason"
+        );
+
+        let clean = items
+            .iter()
+            .find(|i| i["path"] == "quarantined/ok.bin")
+            .expect("clean artifact must be listed");
+        assert_eq!(
+            clean["is_blocked"],
+            serde_json::Value::Bool(false),
+            "an unheld artifact must say so rather than omit the key"
+        );
+
+        // The enforcement path must agree with what the listing just said.
+        let dl = tdh::get(format!("/{}/download/quarantined/blocked.bin", fx.repo_key));
+        let (dl_status, _) = tdh::send(fx.router_with_auth(download_router()), dl).await;
+        assert_eq!(
+            dl_status,
+            axum::http::StatusCode::CONFLICT,
+            "the artifact the listing reports as quarantined must 409 on download"
+        );
+        let dl_ok = tdh::get(format!("/{}/download/quarantined/ok.bin", fx.repo_key));
+        let (dl_ok_status, _) = tdh::send(fx.router_with_auth(download_router()), dl_ok).await;
+        assert_eq!(
+            dl_ok_status,
+            axum::http::StatusCode::OK,
+            "the artifact the listing reports as clean must download"
+        );
+
+        // #2912: the listing is reachable anonymously on a public repository,
+        // so the reason (policy names, finding counts, admin notes) must not
+        // ride along for a caller that has not proven it holds the repo. The
+        // verdict itself still must.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make repo public");
+        let anon_req = tdh::get(format!("/{}/artifacts?per_page=100", fx.repo_key));
+        let (anon_status, anon_body) = tdh::send(fx.router_anon(router()), anon_req).await;
+        assert_eq!(anon_status, axum::http::StatusCode::OK);
+        let anon: serde_json::Value = serde_json::from_slice(&anon_body).expect("listing JSON");
+        let anon_held = anon["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .find(|i| i["path"] == "quarantined/blocked.bin")
+            .expect("held artifact must be listed anonymously too");
+        assert_eq!(anon_held["is_blocked"], serde_json::Value::Bool(true));
+        assert!(
+            anon_held.get("quarantine_reason").is_none(),
+            "the quarantine reason must not be disclosed anonymously (#2912)"
         );
 
         fx.teardown().await;

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -601,6 +601,125 @@ pub fn validate_duration(minutes: i64) -> i64 {
 }
 
 // ---------------------------------------------------------------------------
+// Listing view (#2940)
+// ---------------------------------------------------------------------------
+
+/// The quarantine state of one artifact as reported by listing endpoints.
+///
+/// Exists so a listing never has to restate "is this blocked" for itself. The
+/// repository artifacts listing used to carry no quarantine state at all, which
+/// let it describe an artifact that 409s on download as perfectly fine (#2940).
+/// Every field here is derived from the same row and the same predicate the
+/// download gate uses, so the listing, the download gate, and
+/// `GET /api/v1/quarantine/{artifact_id}` cannot drift apart.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QuarantineView {
+    /// Whether the artifact's bytes are currently refused. Mirrors the
+    /// `is_blocked` field of the quarantine status endpoint exactly: `true`
+    /// covers both a live hold (409 Conflict) and a rejection (403 Forbidden).
+    pub is_blocked: bool,
+    /// Raw `artifacts.quarantine_status` (`quarantined`, `rejected`,
+    /// `released`, ...). `None` when the artifact has never been held.
+    pub quarantine_status: Option<String>,
+    /// When a live hold lapses. `None` for an unconditional hold and for
+    /// artifacts that are not held.
+    pub quarantine_until: Option<DateTime<Utc>>,
+    /// Why the artifact is held. Security-sensitive; see [`redact_reason`].
+    ///
+    /// [`redact_reason`]: Self::redact_reason
+    pub quarantine_reason: Option<String>,
+}
+
+impl QuarantineView {
+    /// Build the view from an artifact row's raw quarantine columns.
+    ///
+    /// `is_blocked` is computed by calling [`check_download_allowed`], not by
+    /// re-reading `quarantine_status` here, and carries the same name as
+    /// `QuarantineStatusResponse.is_blocked` because it is the same verdict. A
+    /// second, independently written notion of "blocked" is how a listing ends
+    /// up describing an artifact the download gate refuses (#2940), so there is
+    /// deliberately only one.
+    pub fn from_columns(
+        quarantine_status: Option<String>,
+        quarantine_until: Option<DateTime<Utc>>,
+        quarantine_reason: Option<String>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let is_blocked =
+            check_download_allowed(quarantine_status.as_deref(), quarantine_until, now).is_err();
+        Self {
+            is_blocked,
+            quarantine_status,
+            quarantine_until,
+            quarantine_reason,
+        }
+    }
+
+    /// Drop the reason.
+    ///
+    /// The reason carries internal policy names, per-artifact finding counts,
+    /// and free-text admin incident notes. Listing routes are reachable
+    /// anonymously on public repositories, so callers that have not proven they
+    /// hold the repository must not see it (#2912, same rule as
+    /// [`check_download_allowed`]).
+    pub fn redact_reason(&mut self) {
+        self.quarantine_reason = None;
+    }
+}
+
+/// Load the quarantine state for a page of artifacts in one query (#2940).
+///
+/// Batched on purpose: a listing page can hold up to 100 artifacts, and asking
+/// per row would put a quarantine SELECT behind every listed artifact. Keyed by
+/// `artifacts.id`, mirroring `ArtifactService::get_download_stats_batch`.
+///
+/// Ids with no live row are absent from the map rather than defaulting to "not
+/// quarantined", so a caller can tell "loaded, and clean" from "not loaded".
+/// Errors propagate: silently reporting an artifact as unheld because a query
+/// failed is the failure mode this whole change exists to remove.
+pub async fn views_for_artifacts(
+    db: &PgPool,
+    artifact_ids: &[Uuid],
+    now: DateTime<Utc>,
+) -> Result<HashMap<Uuid, QuarantineView>> {
+    if artifact_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        id: Uuid,
+        quarantine_status: Option<String>,
+        quarantine_until: Option<DateTime<Utc>>,
+        quarantine_reason: Option<String>,
+    }
+
+    let rows = sqlx::query_as::<_, Row>(
+        "SELECT id, quarantine_status, quarantine_until, quarantine_reason \
+         FROM artifacts WHERE id = ANY($1) AND is_deleted = false",
+    )
+    .bind(artifact_ids)
+    .fetch_all(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| {
+            (
+                r.id,
+                QuarantineView::from_columns(
+                    r.quarantine_status,
+                    r.quarantine_until,
+                    r.quarantine_reason,
+                    now,
+                ),
+            )
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
@@ -900,6 +1019,176 @@ mod tests {
         assert!(!admin_quarantine_allowed(Some("rejected")));
         // already quarantined is a no-op handled by the caller, not an error
         assert!(admin_quarantine_allowed(Some("quarantined")));
+    }
+
+    // -----------------------------------------------------------------------
+    // QuarantineView (#2940)
+    // -----------------------------------------------------------------------
+
+    /// Every (status, until) shape the download gate understands, so the
+    /// agreement test below covers the whole decision surface rather than the
+    /// one case someone happened to think of.
+    fn quarantine_column_cases(
+        now: DateTime<Utc>,
+    ) -> Vec<(Option<&'static str>, Option<DateTime<Utc>>)> {
+        vec![
+            (None, None),
+            (Some("quarantined"), None),
+            (Some("quarantined"), Some(now + Duration::minutes(30))),
+            (Some("quarantined"), Some(now - Duration::minutes(30))),
+            (Some("rejected"), None),
+            (Some("rejected"), Some(now + Duration::minutes(30))),
+            (Some("released"), None),
+            (Some("clean"), None),
+            (Some("flagged"), None),
+            (Some("unscanned"), None),
+        ]
+    }
+
+    /// The listing's `is_blocked` and the download gate must be the same
+    /// decision for every input. This is the regression guard for #2940: the
+    /// listing reported nothing while the download path returned 409 for the
+    /// same artifact, because each side had its own idea of "blocked".
+    #[test]
+    fn test_view_is_blocked_agrees_with_download_gate() {
+        let now = Utc::now();
+        for (status, until) in quarantine_column_cases(now) {
+            let view = QuarantineView::from_columns(status.map(str::to_string), until, None, now);
+            let blocked = check_download_allowed(status, until, now).is_err();
+            assert_eq!(
+                view.is_blocked, blocked,
+                "listing and download gate disagree for status={status:?} until={until:?}"
+            );
+        }
+    }
+
+    /// A live hold is reported as quarantined and echoes the raw columns back,
+    /// so a client can render the banner and the expiry without a second call.
+    #[test]
+    fn test_view_reports_live_hold() {
+        let now = Utc::now();
+        let until = now + Duration::minutes(45);
+        let view = QuarantineView::from_columns(
+            Some("quarantined".to_string()),
+            Some(until),
+            Some("Policy 'demo-global-cve': 2 findings at or above high severity".to_string()),
+            now,
+        );
+        assert!(view.is_blocked);
+        assert_eq!(view.quarantine_status.as_deref(), Some("quarantined"));
+        assert_eq!(view.quarantine_until, Some(until));
+        assert!(view.quarantine_reason.is_some());
+    }
+
+    /// An unconditional hold (`quarantine_until IS NULL`) is the shape an admin
+    /// quarantine and a scan-policy hold both take, and is exactly the case the
+    /// issue reproduced. It must not read as "no expiry, so not held".
+    #[test]
+    fn test_view_reports_unconditional_hold() {
+        let now = Utc::now();
+        let view = QuarantineView::from_columns(Some("quarantined".to_string()), None, None, now);
+        assert!(view.is_blocked);
+        assert_eq!(view.quarantine_until, None);
+    }
+
+    /// A rejected artifact is blocked too (403 rather than 409), so the listing
+    /// must not describe it as available.
+    #[test]
+    fn test_view_reports_rejected_as_blocked() {
+        let now = Utc::now();
+        let view = QuarantineView::from_columns(Some("rejected".to_string()), None, None, now);
+        assert!(view.is_blocked);
+        assert_eq!(view.quarantine_status.as_deref(), Some("rejected"));
+    }
+
+    /// An elapsed hold is downloadable again, so the listing reports it as not
+    /// quarantined while still echoing the raw status.
+    #[test]
+    fn test_view_reports_expired_hold_as_downloadable() {
+        let now = Utc::now();
+        let until = now - Duration::minutes(1);
+        let view =
+            QuarantineView::from_columns(Some("quarantined".to_string()), Some(until), None, now);
+        assert!(!view.is_blocked);
+        assert_eq!(view.quarantine_status.as_deref(), Some("quarantined"));
+    }
+
+    #[test]
+    fn test_view_clean_artifact() {
+        let view = QuarantineView::from_columns(None, None, None, Utc::now());
+        assert!(!view.is_blocked);
+        assert_eq!(view, QuarantineView::default());
+    }
+
+    #[test]
+    fn test_view_redact_reason_drops_only_the_reason() {
+        let now = Utc::now();
+        let until = now + Duration::minutes(10);
+        let mut view = QuarantineView::from_columns(
+            Some("quarantined".to_string()),
+            Some(until),
+            Some("internal policy detail".to_string()),
+            now,
+        );
+        view.redact_reason();
+        assert_eq!(view.quarantine_reason, None);
+        assert!(view.is_blocked, "redaction must not change the verdict");
+        assert_eq!(view.quarantine_status.as_deref(), Some("quarantined"));
+        assert_eq!(view.quarantine_until, Some(until));
+    }
+
+    #[tokio::test]
+    async fn test_views_for_artifacts_empty_input_makes_no_query() {
+        // No pool is touched, so this also documents that an empty page costs
+        // nothing.
+        let map = views_for_artifacts(
+            &PgPool::connect_lazy("postgres://invalid/invalid").expect("lazy pool"),
+            &[],
+            Utc::now(),
+        )
+        .await
+        .expect("empty input must not error");
+        assert!(map.is_empty());
+    }
+
+    // DATABASE_URL-gated: the batched read must report a held artifact as
+    // quarantined, must key the map by artifact id, and must omit ids that have
+    // no live row (so "absent" stays distinguishable from "clean").
+    #[tokio::test]
+    async fn test_views_for_artifacts_reports_held_artifact() {
+        use crate::api::handlers::test_db_helpers::Fixture;
+        let Some(fx) = Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let held = seed_row(&fx, "local", "quarantine/views/held.bin").await;
+        let clean = seed_row(&fx, "local", "quarantine/views/clean.bin").await;
+        let missing = Uuid::new_v4();
+        quarantine_now(&fx.pool, held, Some("policy hold".to_string()))
+            .await
+            .expect("quarantine the artifact");
+
+        let now = Utc::now();
+        let map = views_for_artifacts(&fx.pool, &[held, clean, missing], now)
+            .await
+            .expect("batched quarantine read");
+
+        let held_view = map.get(&held).expect("held artifact must be in the map");
+        assert!(held_view.is_blocked);
+        assert_eq!(held_view.quarantine_status.as_deref(), Some("quarantined"));
+        assert_eq!(held_view.quarantine_reason.as_deref(), Some("policy hold"));
+
+        let clean_view = map.get(&clean).expect("clean artifact must be in the map");
+        assert!(!clean_view.is_blocked);
+
+        assert!(
+            !map.contains_key(&missing),
+            "an id with no row must be absent, not reported clean"
+        );
+
+        // And the batched verdict matches the gate the download path runs.
+        assert!(check_artifact_download(&fx.pool, held).await.is_err());
+        assert!(check_artifact_download(&fx.pool, clean).await.is_ok());
+        fx.teardown().await;
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`GET /api/v1/repositories/{key}/artifacts` exposed no per-artifact quarantine state. The only quarantine fields on the repository API were repository-level policy config. Whether a given artifact was held was reachable only through `GET /api/v1/quarantine/{artifact_id}`, one artifact at a time, or by attempting a download and reading the 409.

So a listing described an artifact the download gate refuses as ordinary and downloadable, and a consumer building a "what is currently blocked" view against the listing got a clean bill of health.

The columns were already being fetched. `ArtifactService::list_page` and `list_for_repos_page` both SELECT `quarantine_status` and `quarantine_until`, and `build_artifact_response` dropped them because `ArtifactResponse` had nowhere to put them.

Listing rows now carry `quarantine_status`, `quarantine_until`, `quarantine_reason` and a derived `is_blocked`, reusing the vocabulary `QuarantineStatusResponse` already established rather than inventing a parallel one.

`is_blocked` is not a second implementation of the predicate: `QuarantineView::from_columns` calls `check_download_allowed`, the same function the download gate runs, and a test asserts the two agree across every (status, until) shape the gate understands.

State is loaded once per page by `quarantine_service::views_for_artifacts` (`id = ANY($1)`, mirroring the existing download-stats batch), so a hundred-row page costs one extra indexed lookup rather than a hundred.

The reason is gated as the quarantine status endpoint gates it: listing routes are reachable anonymously on public repositories and the reason carries policy names, per-artifact finding counts and admin incident notes, so only a caller that holds the repository sees it.

All four fields are omitted rather than emitted as false/null on surfaces that do not load quarantine state, so "not loaded" can never be read as "not quarantined". That ambiguity is what let a blocked artifact read as clean in the first place.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A, this is not a bug fix

`test_list_artifacts_reports_quarantine_matching_download_gate` and `test_view_is_blocked_agrees_with_download_gate` both fail on `main`, where the listing carries no quarantine state at all.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`cargo test --workspace --lib`: 14168 passed, 1 failed. The single failure is `services::http_client::tests::test_large_object_client_builder_does_not_apply_total_timeout`, which fails identically on pristine `origin/main` (verified at 05dc4042) and is unrelated; this branch does not touch `http_client.rs`. Quarantine-scoped run: 86 passed, 0 failed. This branch adds 14 tests.

Not manually tested against a running instance: no build carrying these fields exists yet.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid` (ran as part of the workspace run above)
- [x] Migration is reversible (if applicable): no migration required
- [ ] N/A, no API changes

Additive response fields only; no new endpoints and no removed or renamed fields.

## Merge order

Blocks artifact-keeper/artifact-keeper-web#650, which makes `QuarantineBanner` reachable by reading these fields. Merge this first, or that UI has nothing to read.

Closes #2940
