### PR TITLE
fix: strip userinfo credentials from redact_url_for_diagnostics

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -374,13 +374,28 @@ impl ReleaseEpochRead {
 
 /// Remove credential-bearing URL material before rendering an upstream target
 /// into logs or [`AppError`] messages.
+///
+/// Strips three sources of secrets so an upstream URL can be safely echoed to
+/// a client (e.g. a 502/error body) or a user-visible log:
+/// * `user:password@` userinfo — upstream repository credentials (#2926),
+/// * the query string — pre-signed URL signatures / tokens / keys, and
+/// * the fragment.
 fn redact_url_for_diagnostics(url: &str) -> String {
     if let Ok(mut parsed) = reqwest::Url::parse(url) {
+        // Drop userinfo first (password before username so the `@` is removed
+        // cleanly), then the query and fragment. `set_password`/`set_username`
+        // return `Err` for URLs that cannot carry userinfo (e.g. `mailto:`);
+        // there is nothing to strip in that case, so the error is ignored.
+        let _ = parsed.set_password(None);
+        let _ = parsed.set_username("");
         parsed.set_query(None);
         parsed.set_fragment(None);
         return parsed.to_string();
     }
 
+    // Fallback for inputs `reqwest::Url` cannot parse (e.g. relative paths).
+    // Trim the query/fragment, then strip any `userinfo@` still present in the
+    // leading authority so credentials never survive the redaction.
     let query_pos = url.find('?');
     let fragment_pos = url.find('#');
     let end = match (query_pos, fragment_pos) {
@@ -389,7 +404,32 @@ fn redact_url_for_diagnostics(url: &str) -> String {
         (None, Some(f)) => f,
         (None, None) => url.len(),
     };
-    url[..end].to_string()
+    strip_userinfo_fallback(&url[..end])
+}
+
+/// Best-effort userinfo removal for URL-ish strings that `reqwest::Url` could
+/// not parse. Removes a `userinfo@` segment from the authority (the part
+/// after an optional `scheme://` and before the first `/`), leaving the rest
+/// untouched.
+fn strip_userinfo_fallback(url: &str) -> String {
+    let (prefix, rest) = match url.find("://") {
+        Some(pos) => url.split_at(pos + 3),
+        None if url.starts_with("//") => url.split_at(2),
+        None => ("", url),
+    };
+    // The authority ends at the first path separator.
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    if let Some(at) = authority.rfind('@') {
+        format!(
+            "{}{}{}",
+            prefix,
+            &authority[at + 1..],
+            &rest[authority_end..]
+        )
+    } else {
+        url.to_string()
+    }
 }
 
 /// True when the SSRF DNS guard's "all resolved addresses blocked" marker
@@ -3931,7 +3971,14 @@ impl ProxyService {
         }
 
         let response = request.send().await.map_err(|e| {
-            AppError::Storage(format!("Failed to fetch from upstream: {} - {}", url, e))
+            // Redact the target URL (may carry `user:pass@` upstream creds) and
+            // drop the URL reqwest embeds in its own error (#2926) before this
+            // surfaces to a client.
+            AppError::Storage(format!(
+                "Failed to fetch from upstream: {} - {}",
+                redact_url_for_diagnostics(url),
+                e.without_url()
+            ))
         })?;
 
         let status = response.status();
@@ -9153,6 +9200,42 @@ mod tests {
 
         assert_eq!(
             redact_url_for_diagnostics("packages/pkg.zip?token=secret#frag"),
+            "packages/pkg.zip"
+        );
+    }
+
+    #[test]
+    fn test_redact_url_for_diagnostics_strips_userinfo_credentials() {
+        // #2926: upstream `user:password@` credentials and any credential-bearing
+        // query params must never survive into a client-facing diagnostic.
+        let redacted =
+            redact_url_for_diagnostics("https://user:pass@host.example.com/path?token=abc");
+        assert!(!redacted.contains("user"), "username leaked: {redacted}");
+        assert!(!redacted.contains("pass"), "password leaked: {redacted}");
+        assert!(!redacted.contains("abc"), "token leaked: {redacted}");
+        assert!(!redacted.contains('@'), "userinfo `@` retained: {redacted}");
+        assert_eq!(redacted, "https://host.example.com/path");
+    }
+
+    #[test]
+    fn test_redact_url_for_diagnostics_strips_userinfo_username_only() {
+        // A username-only userinfo (no password) must also be removed.
+        assert_eq!(
+            redact_url_for_diagnostics("https://token@registry.example.com/v2/"),
+            "https://registry.example.com/v2/"
+        );
+    }
+
+    #[test]
+    fn test_redact_url_for_diagnostics_strips_userinfo_unparseable_fallback() {
+        // The non-`reqwest::Url` fallback path must strip userinfo too.
+        assert_eq!(
+            redact_url_for_diagnostics("//user:pass@host/path?token=abc"),
+            "//host/path"
+        );
+        // No userinfo present: authority is left intact.
+        assert_eq!(
+            redact_url_for_diagnostics("packages/pkg.zip"),
             "packages/pkg.zip"
         );
     }


### PR DESCRIPTION
## Summary

`redact_url_for_diagnostics` is used to sanitize an upstream repository URL
before it is woven into user-visible diagnostics — 502/error response bodies
and user-facing log lines emitted by the proxy fetch paths. It stripped the
query string and fragment but left the `user:password@` userinfo intact, so a
remote repository configured with credentials embedded in (or applied to) its
upstream URL could leak those credentials to any client that triggered a proxy
fetch failure.

This change hardens the redaction so credentials never survive into a
diagnostic:

- **Userinfo is now removed.** The parsed path drops the password and username
  (`set_password(None)` + `set_username("")`) in addition to the existing
  query/fragment stripping. A best-effort fallback (`strip_userinfo_fallback`)
  removes a `userinfo@` segment from the authority for URL-ish strings that
  `reqwest::Url` cannot parse.
- **Credential-bearing query params stay stripped.** The whole query string is
  already dropped, which covers pre-signed-URL signatures / tokens / keys
  (e.g. `X-Amz-Signature`, `token=…`).
- **Closed one remaining raw-URL echo.** `fetch_from_upstream_conditional`
  built an `AppError::Storage` from the raw `url` plus the raw `reqwest` error
  (which itself embeds the URL). It now redacts the URL and calls
  `reqwest::Error::without_url()` so neither carries credentials to the client.

All other proxy call sites that surface an upstream URL to a client already
routed through `redact_url_for_diagnostics` (or `classify_send_error`, which
uses `without_url()` plus a redacted context string) and inherit the fix
automatically.

Closes #2926

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added unit tests on `redact_url_for_diagnostics`:
- `test_redact_url_for_diagnostics_strips_userinfo_credentials` —
  `https://user:pass@host.example.com/path?token=abc` redacts to
  `https://host.example.com/path`; asserts the output contains no `user`,
  `pass`, `abc`, or `@`. This fails on `main` (userinfo retained).
- `test_redact_url_for_diagnostics_strips_userinfo_username_only` —
  username-only userinfo is removed.
- `test_redact_url_for_diagnostics_strips_userinfo_unparseable_fallback` —
  the non-`reqwest::Url` fallback path also strips userinfo and leaves
  credential-free authorities untouched.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
