### PR TITLE
fix(ci): fail DB-backed tests loudly when the DB is unreachable instead of fiction-green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,12 @@ jobs:
           # Postgres service above instead of no-op'ing.
           SQLX_OFFLINE: true
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
+          # A database is provisioned for this job, so the DB-backed tests are
+          # REQUIRED to actually run. This makes `try_pool` treat a connect
+          # failure as a hard failure instead of a silent skip, so an
+          # unreachable/misconfigured Postgres can no longer "fiction-green" the
+          # suite (#2924).
+          AK_TESTS_REQUIRE_DB: "1"
           JWT_SECRET: ci-coverage-secret-at-least-32-bytes-long-for-tests
         # nextest runs each test in its own process and applies the repo's
         # .config/nextest.toml db-serial test groups, which serialize the
@@ -353,6 +359,11 @@ jobs:
         if: steps.detect.outputs.rust_changed == 'true'
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
+          # A database is provisioned for this job, so the DB-backed tests are
+          # REQUIRED to run. A connect failure now fails the suite loudly instead
+          # of silently skipping (which would also silently drop coverage). See
+          # issue #2924.
+          AK_TESTS_REQUIRE_DB: "1"
           SQLX_OFFLINE: true
           RUSTC_WRAPPER: ""
           # SSO credential encryption tests in auth_config_service rely on at

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3579,13 +3579,10 @@ mod tests {
         /// `let Some(pool) = try_pool().await else { return; };` so the suite
         /// is a no-op in environments without Postgres.
         pub async fn try_pool() -> Option<PgPool> {
-            let url = std::env::var("DATABASE_URL").ok()?;
-            sqlx::postgres::PgPoolOptions::new()
-                .max_connections(5)
-                .acquire_timeout(std::time::Duration::from_secs(30))
-                .connect(&url)
-                .await
-                .ok()
+            // Skip only when no DB is configured/reachable AND not required; a
+            // connect failure under AK_TESTS_REQUIRE_DB panics (no fiction-green,
+            // #2924).
+            crate::testing::try_pool_with(5).await
         }
 
         // ------------------------------------------------------------------

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -7617,13 +7617,10 @@ mod tests {
         use crate::config::Config;
 
         pub async fn try_pool() -> Option<PgPool> {
-            let url = std::env::var("DATABASE_URL").ok()?;
-            sqlx::postgres::PgPoolOptions::new()
-                .max_connections(3)
-                .acquire_timeout(std::time::Duration::from_secs(30))
-                .connect(&url)
-                .await
-                .ok()
+            // Skip only when no DB is configured/reachable AND not required; a
+            // connect failure under AK_TESTS_REQUIRE_DB panics (no fiction-green,
+            // #2924).
+            crate::testing::try_pool_with(3).await
         }
 
         fn test_config(storage_path: &str) -> Config {

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -32,19 +32,16 @@ use crate::api::{AppState, SharedState};
 use crate::config::Config;
 use crate::models::user::User;
 
-/// Connect to the test database. Returns `None` when `DATABASE_URL` is
-/// unset or unreachable so suites no-op gracefully.
+/// Connect to the test database.
+///
+/// Returns `None` only when no database is configured/reachable **and** the DB
+/// is not required, so DB-free local runs no-op gracefully. When the CI
+/// require-DB signal ([`crate::testing::REQUIRE_DB_ENV`]) is set, a missing
+/// `DATABASE_URL` or a connect failure PANICS instead of skipping, so an
+/// unreachable database can no longer silently "fiction-green" the suite
+/// (#2924).
 pub async fn try_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    sqlx::postgres::PgPoolOptions::new()
-        .max_connections(3)
-        // llvm-cov + nextest runs DB-backed lib tests in parallel processes.
-        // Keep each per-test pool small, but give Postgres pressure a chance
-        // to clear instead of turning transient contention into PoolTimedOut.
-        .acquire_timeout(std::time::Duration::from_secs(30))
-        .connect(&url)
-        .await
-        .ok()
+    crate::testing::try_pool_with(3).await
 }
 
 /// Advisory-lock key for [`scan_dedup_serial_lock`] (#2000).
@@ -82,12 +79,12 @@ pub struct ScanDedupSerialGuard {
 /// and bind the result for the whole test body.
 pub async fn scan_dedup_serial_lock() -> ScanDedupSerialGuard {
     use sqlx::Connection;
-    let Ok(url) = std::env::var("DATABASE_URL") else {
+    let Some(url) = crate::testing::require_db_url() else {
         return ScanDedupSerialGuard { _conn: None };
     };
-    let mut conn = match sqlx::PgConnection::connect(&url).await {
-        Ok(c) => c,
-        Err(_) => return ScanDedupSerialGuard { _conn: None },
+    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
+    else {
+        return ScanDedupSerialGuard { _conn: None };
     };
     if sqlx::query("SELECT pg_advisory_lock($1)")
         .bind(SCAN_DEDUP_TEST_LOCK_KEY)
@@ -131,12 +128,12 @@ pub struct BlobGcSerialGuard {
 /// test and bind the result for the whole test body.
 pub async fn blob_gc_serial_lock() -> BlobGcSerialGuard {
     use sqlx::Connection;
-    let Ok(url) = std::env::var("DATABASE_URL") else {
+    let Some(url) = crate::testing::require_db_url() else {
         return BlobGcSerialGuard { _conn: None };
     };
-    let mut conn = match sqlx::PgConnection::connect(&url).await {
-        Ok(c) => c,
-        Err(_) => return BlobGcSerialGuard { _conn: None },
+    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
+    else {
+        return BlobGcSerialGuard { _conn: None };
     };
     if sqlx::query("SELECT pg_advisory_lock($1)")
         .bind(BLOB_GC_TEST_LOCK_KEY)
@@ -180,12 +177,12 @@ pub struct SsoProviderSerialGuard {
 /// whole test body.
 pub async fn sso_provider_serial_lock() -> SsoProviderSerialGuard {
     use sqlx::Connection;
-    let Ok(url) = std::env::var("DATABASE_URL") else {
+    let Some(url) = crate::testing::require_db_url() else {
         return SsoProviderSerialGuard { _conn: None };
     };
-    let mut conn = match sqlx::PgConnection::connect(&url).await {
-        Ok(c) => c,
-        Err(_) => return SsoProviderSerialGuard { _conn: None },
+    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
+    else {
+        return SsoProviderSerialGuard { _conn: None };
     };
     if sqlx::query("SELECT pg_advisory_lock($1)")
         .bind(SSO_PROVIDER_TEST_LOCK_KEY)
@@ -231,12 +228,12 @@ pub struct CurationGlobalSerialGuard {
 /// the result for the whole test body.
 pub async fn curation_global_serial_lock() -> CurationGlobalSerialGuard {
     use sqlx::Connection;
-    let Ok(url) = std::env::var("DATABASE_URL") else {
+    let Some(url) = crate::testing::require_db_url() else {
         return CurationGlobalSerialGuard { _conn: None };
     };
-    let mut conn = match sqlx::PgConnection::connect(&url).await {
-        Ok(c) => c,
-        Err(_) => return CurationGlobalSerialGuard { _conn: None },
+    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
+    else {
+        return CurationGlobalSerialGuard { _conn: None };
     };
     if sqlx::query("SELECT pg_advisory_lock($1)")
         .bind(CURATION_GLOBAL_TEST_LOCK_KEY)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -18,6 +18,12 @@ pub mod models;
 pub mod services;
 pub mod storage;
 pub mod telemetry;
+// Test-harness plumbing (DB skip-vs-fail decision, #2924). Always compiled so
+// both the crate's `#[cfg(test)]` unit tests and the out-of-crate integration
+// tests under `backend/tests/` (which see the library without `cfg(test)`) can
+// share one place; `#[doc(hidden)]` because it carries no production behavior.
+#[doc(hidden)]
+pub mod testing;
 pub mod util;
 
 pub use config::Config;

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -4325,13 +4325,10 @@ mod tests {
     /// Connect to the test database when `DATABASE_URL` is set; otherwise
     /// return `None` so the test skips cleanly.
     async fn try_pool() -> Option<PgPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        sqlx::postgres::PgPoolOptions::new()
-            .max_connections(3)
-            .acquire_timeout(std::time::Duration::from_secs(30))
-            .connect(&url)
-            .await
-            .ok()
+        // Skip only when no DB is configured/reachable AND not required; a
+        // connect failure under AK_TESTS_REQUIRE_DB panics (no fiction-green,
+        // #2924).
+        crate::testing::try_pool_with(3).await
     }
 
     /// Seed a repository row with a unique key/storage path.

--- a/backend/src/testing.rs
+++ b/backend/src/testing.rs
@@ -1,0 +1,131 @@
+//! Shared test-harness plumbing for the DB-backed test suites.
+//!
+//! This module is deliberately part of the always-compiled (non-`cfg(test)`)
+//! surface: the DB connect helpers live both in the crate's own
+//! `#[cfg(test)]` unit tests **and** in the integration tests under
+//! `backend/tests/`, which compile against the library *without* `cfg(test)`
+//! and therefore cannot see `#[cfg(test)]`-gated items. Keeping the shared
+//! decision here lets every copy of `try_pool` route through one place.
+//!
+//! ## Why this exists (#2924)
+//!
+//! Historically each `try_pool` collapsed a database **connect failure** into
+//! `None`, and DB-backed tests treat `None` as "no DB configured -> skip and
+//! return green". That is correct for a developer running the suite locally
+//! with no Postgres, but in CI — where a database is provisioned and the
+//! DB-backed cases are the whole point — an unreachable or misconfigured
+//! database would make every such test silently skip while the suite still
+//! reported PASS ("fiction-green"), hiding real breakage from the release
+//! gate.
+//!
+//! The fix distinguishes the two situations with an explicit signal
+//! ([`REQUIRE_DB_ENV`]): when the database is *required* (CI sets it), a
+//! missing `DATABASE_URL` or a connect failure PANICS loudly instead of
+//! skipping; when it is not set (local dev), the historical skip behavior is
+//! preserved.
+#![allow(dead_code)]
+
+use sqlx::PgPool;
+
+/// Environment variable that marks the database as **required**. When set to a
+/// truthy value, a missing `DATABASE_URL` or a connect failure becomes a hard
+/// test failure instead of a silent skip. The CI DB-backed jobs set it so the
+/// suite can no longer "fiction-green" against an unreachable database.
+pub const REQUIRE_DB_ENV: &str = "AK_TESTS_REQUIRE_DB";
+
+/// True when the harness must have a working database, i.e. [`REQUIRE_DB_ENV`]
+/// is set to a truthy value (`1`/`true`/`yes`).
+pub fn tests_require_db() -> bool {
+    matches!(
+        std::env::var(REQUIRE_DB_ENV)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Pure skip-vs-fail decision, factored out so it can be unit-tested without
+/// touching process-global env or panicking.
+///
+/// Returns `true` when the harness must FAIL LOUDLY (the database is required
+/// but unavailable); `false` when it is fine to proceed or to skip cleanly.
+pub fn must_fail_loud(db_available: bool, db_required: bool) -> bool {
+    db_required && !db_available
+}
+
+/// Panic with a fiction-green diagnostic when the database is required but
+/// unavailable; otherwise do nothing. `why` describes what was unavailable.
+fn enforce_db_available(db_available: bool, why: &str) {
+    if must_fail_loud(db_available, tests_require_db()) {
+        panic!(
+            "{REQUIRE_DB_ENV} is set (database REQUIRED) but {why}. Refusing to \
+             silently skip DB-backed tests, which would report a false PASS \
+             ('fiction-green'). Provide a reachable DATABASE_URL or unset \
+             {REQUIRE_DB_ENV} for a DB-free local run. See issue #2924."
+        );
+    }
+}
+
+/// Resolve the test `DATABASE_URL`, honoring the require-DB signal.
+///
+/// * `Some(url)` when `DATABASE_URL` is set.
+/// * `None` when it is unset **and** the DB is not required (legitimate local
+///   skip).
+/// * PANICS when it is unset **and** the DB *is* required ([`REQUIRE_DB_ENV`]).
+pub fn require_db_url() -> Option<String> {
+    let url = std::env::var("DATABASE_URL").ok();
+    enforce_db_available(url.is_some(), "DATABASE_URL is unset");
+    url
+}
+
+/// Turn a connect `Result` into the harness's skip-or-fail decision.
+///
+/// * `Some(value)` on success.
+/// * `None` on failure when the DB is not required (legitimate local skip).
+/// * PANICS on failure when the DB *is* required ([`REQUIRE_DB_ENV`]), surfacing
+///   the underlying connect error instead of a false PASS.
+pub fn on_connect_result<T>(result: Result<T, sqlx::Error>) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(err) => {
+            enforce_db_available(false, &format!("the database is unreachable: {err}"));
+            None
+        }
+    }
+}
+
+/// Connect a small `PgPool` for a DB-backed test, honoring the require-DB
+/// signal. This is the shared body every module-local `try_pool` delegates to.
+///
+/// Returns `None` (skip) only when no database is configured/reachable *and*
+/// the DB is not required; a connect failure under [`REQUIRE_DB_ENV`] panics.
+pub async fn try_pool_with(max_connections: u32) -> Option<PgPool> {
+    let url = require_db_url()?;
+    on_connect_result(
+        sqlx::postgres::PgPoolOptions::new()
+            .max_connections(max_connections)
+            // llvm-cov + nextest run DB-backed lib tests in parallel processes.
+            // Keep each per-test pool small, but give Postgres pressure a chance
+            // to clear instead of turning transient contention into PoolTimedOut.
+            .acquire_timeout(std::time::Duration::from_secs(30))
+            .connect(&url)
+            .await,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fiction_green_only_blocked_when_required_and_unavailable() {
+        // Database present -> never fail loud, regardless of the flag.
+        assert!(!must_fail_loud(true, true));
+        assert!(!must_fail_loud(true, false));
+        // Database absent but NOT required -> legitimate local skip.
+        assert!(!must_fail_loud(false, false));
+        // Database absent AND required -> the fiction-green case we must block.
+        assert!(must_fail_loud(false, true));
+    }
+}

--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -43,13 +43,9 @@ pub fn ensure_sso_encryption_key() {
 /// Connect to the throwaway Postgres named by `DATABASE_URL`, or return `None`
 /// so the caller can skip cleanly (matching the repo `--ignored` convention).
 pub async fn try_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    sqlx::postgres::PgPoolOptions::new()
-        .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(30))
-        .connect(&url)
-        .await
-        .ok()
+    // Skip only when no DB is configured/reachable AND not required; a connect
+    // failure under AK_TESTS_REQUIRE_DB panics (no fiction-green, #2924).
+    artifact_keeper_backend::testing::try_pool_with(3).await
 }
 
 /// Minimal `Config` for building `AppState` in the SSO e2e tests.

--- a/backend/tests/gitlfs_locks_tests.rs
+++ b/backend/tests/gitlfs_locks_tests.rs
@@ -46,13 +46,9 @@ const LFS_CT: &str = "application/vnd.git-lfs+json";
 /// Connect to the test database. Returns `None` when `DATABASE_URL` is unset or
 /// unreachable so the suite no-ops gracefully instead of flaking.
 async fn try_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    sqlx::postgres::PgPoolOptions::new()
-        .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(30))
-        .connect(&url)
-        .await
-        .ok()
+    // Skip only when no DB is configured/reachable AND not required; a connect
+    // failure under AK_TESTS_REQUIRE_DB panics (no fiction-green, #2924).
+    artifact_keeper_backend::testing::try_pool_with(3).await
 }
 
 fn test_config(storage_path: &str) -> Config {

--- a/backend/tests/oci_upload_range_test.rs
+++ b/backend/tests/oci_upload_range_test.rs
@@ -44,13 +44,9 @@ use artifact_keeper_backend::config::Config;
 /// Connect to the test database. Returns `None` when `DATABASE_URL` is unset or
 /// unreachable so the suite no-ops gracefully instead of flaking.
 async fn try_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    sqlx::postgres::PgPoolOptions::new()
-        .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(30))
-        .connect(&url)
-        .await
-        .ok()
+    // Skip only when no DB is configured/reachable AND not required; a connect
+    // failure under AK_TESTS_REQUIRE_DB panics (no fiction-green, #2924).
+    artifact_keeper_backend::testing::try_pool_with(3).await
 }
 
 fn test_config(storage_path: &str) -> Config {


### PR DESCRIPTION
## Summary

DB-backed lib tests could report **PASS even when the database was unreachable**.
The shared test helper `try_pool` (and the four DB advisory-lock guards next to
it) collapsed a *connect failure* into `None`, and every DB-backed test treats
`None` as "no DB configured — skip and return green". In CI, where a Postgres is
provisioned specifically so those tests run, an unreachable or misconfigured
database therefore made the whole DB-backed suite silently skip while still
reporting green ("fiction-green"), hiding real breakage from the test/coverage
gate. This is the same integrity failure class as the earlier conda
fiction-green issue and directly undermines the release-assurance bar.

This change distinguishes the two situations:

- **No database configured/available *by design*** (a developer running
  `cargo test --lib` locally with no Postgres) — still skips cleanly, unchanged.
- **A connect failure when a database is *expected*** — now FAILS LOUDLY
  (panics) instead of silently skipping.

The "database is expected" signal is the new env var `AK_TESTS_REQUIRE_DB`.
When it is set to a truthy value, a missing `DATABASE_URL` or a connect failure
panics with a diagnostic that points at this issue. When it is unset (local
dev), the historical skip-when-absent behavior is preserved exactly.

The skip-vs-fail decision is centralized in a new always-compiled
`artifact_keeper_backend::testing` module so both the in-crate `#[cfg(test)]`
unit tests and the out-of-crate integration tests under `backend/tests/` (which
compile against the library *without* `cfg(test)`) share one implementation.
Every copy of `try_pool` — the central one in `test_db_helpers`, the
module-local copies in `conan`, `proxy_helpers`, `sbom_service`, and the
integration-test copies in `gitlfs_locks_tests` / `oci_upload_range_test` /
`sso_support` — now delegates to it, along with the four
`*_serial_lock` guards. This also removes six near-identical inline `try_pool`
bodies (net reduction in duplication).

The two DB-backed CI jobs that provision Postgres (`Backend Unit Tests` and
`Code Coverage`) now export `AK_TESTS_REQUIRE_DB=1`, so an unreachable Postgres
in CI can no longer fiction-green the suite.

### Behavior proof (before/after)

Same DB-backed test under each condition:

| Condition | Old behavior | New behavior |
|---|---|---|
| DB reachable, `AK_TESTS_REQUIRE_DB=1` | runs & passes | runs & passes (unchanged) |
| DB **unreachable**, `AK_TESTS_REQUIRE_DB=1` | silent skip → **green** | **panics → suite FAILS** |
| `DATABASE_URL` unset, no require | skip → green | skip → green (unchanged) |
| DB unreachable, no require (local) | skip → green | skip → green (unchanged) |

Full `--lib` suite (14247 tests) passes green against a reachable DB with
`AK_TESTS_REQUIRE_DB=1`; a deliberately unreachable `DATABASE_URL` under the
same flag turns the suite red with the fiction-green diagnostic.

Closes #2924

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

A pure unit test (`testing::tests::fiction_green_only_blocked_when_required_and_unavailable`)
pins the skip-vs-fail decision: it must fail loud only when the database is
required *and* unavailable, and must skip cleanly in every other combination.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
