### PR TITLE
fix(curation): enforce curation block rules across proxy formats (npm/docker/maven/cargo/nuget)

### DIFF
--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -827,6 +827,20 @@ async fn download(
     let repo = resolve_cargo_repo(&state.db, &repo_key, &state.repo_cache).await?;
     let name_lower = name.to_lowercase();
 
+    // Curation enforcement (#2930): block a curated crate before it is resolved
+    // locally or proxied from upstream. The cargo handler's private `RepoInfo`
+    // does not carry the curation columns, so use the by-id lookup variant
+    // (no-op / no query for hosted repos and when curation is off).
+    proxy_helpers::enforce_curation_lookup(
+        &state.db,
+        repo.id,
+        &repo_key,
+        &repo.repo_type,
+        &name_lower,
+        Some(&version),
+    )
+    .await?;
+
     let artifact = sqlx::query!(
         r#"
         SELECT id, storage_key, size_bytes, checksum_sha256

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -898,6 +898,19 @@ async fn download(
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
 
+    // Curation enforcement (#2930): block a curated artifact pull on a
+    // remote/virtual repo. The package identity is `groupId:artifactId`
+    // (`maven_proxy_package_name`, the same shape the proxy-sync catalog uses),
+    // so a rule authored for the curation catalog matches here. Metadata and
+    // checksum/signature sidecars derive no package identity (the helper returns
+    // `None`) and pass through untouched; hosted repos / curation-off are no-ops.
+    if let Some(pkg) = crate::services::proxy_service::maven_proxy_package_name(&path) {
+        let version = crate::formats::maven::MavenHandler::parse_coordinates(&path)
+            .ok()
+            .map(|c| c.version);
+        proxy_helpers::enforce_curation(&state.db, &repo, &pkg, version.as_deref()).await?;
+    }
+
     // 1. Check if this is a checksum request for metadata.
     //    Always compute the checksum from the actual metadata XML bytes
     //    so the result is guaranteed to match what this same URL returns

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2728,6 +2728,14 @@ async fn serve_tarball(
 ) -> Result<Response, Response> {
     let repo = resolve_npm_repo(&state.db, repo_key).await?;
 
+    // Curation enforcement (#2930): a `block` rule on this remote/virtual repo
+    // must block the tarball pull, the same way the pypi seam gates simple-index
+    // + download. No-op for hosted repos and when curation is disabled. Version
+    // is not passed: an npm tarball filename (`pkg-1.2.3.tgz`, prerelease
+    // suffixes and hyphenated names included) cannot be split into name/version
+    // unambiguously, so name-pattern rules (the block-a-package case) apply.
+    proxy_helpers::enforce_curation(&state.db, &repo, package_name, None).await?;
+
     // Tarball URLs keep the scope separator as a literal `/`
     // (`@scope/pkg/-/file.tgz`); only metadata uses `%2F`. Encoding it here
     // collapsed the scope and package into one path segment that no upstream

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -893,6 +893,11 @@ async fn flatcontainer_download(
     let repo = resolve_nuget_repo(&state.db, &repo_key).await?;
     let package_id_lower = package_id.to_lowercase();
 
+    // Curation enforcement (#2930): block a curated package before it is
+    // resolved locally or proxied from an upstream V3 feed. No-op for hosted
+    // repos / curation off.
+    proxy_helpers::enforce_curation(&state.db, &repo, &package_id_lower, Some(&version)).await?;
+
     // Find the artifact matching this package/version.
     let artifact = sqlx::query!(
         r#"
@@ -1453,6 +1458,11 @@ async fn v2_download(
     version: &str,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
+    // Curation enforcement (#2930): gate the V2 .nupkg download seam too, so a
+    // block rule holds regardless of whether the client uses the V3 flat
+    // container or the legacy V2 package route. No-op for hosted / curation off.
+    proxy_helpers::enforce_curation(&state.db, repo, &id.to_lowercase(), Some(version)).await?;
+
     if repo.repo_type == RepositoryType::Remote {
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -6600,6 +6600,22 @@ async fn handle_head_manifest(
         }
     }
 
+    // Curation enforcement (#2930): mirror the GET-manifest gate so a HEAD probe
+    // (which many clients issue before the GET) is blocked identically. No-op
+    // for hosted repos / curation off.
+    if let Err(resp) = proxy_helpers::enforce_curation_lookup(
+        &state.db,
+        repo.id,
+        &repo.key,
+        &repo.repo_type,
+        &repo.image,
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+
     // Reference can be a tag or a digest. Resolve locally first: a surviving
     // tag row, or — for a digest this hosted repo proves it owns via committed
     // metadata — the content-addressable object itself, so a manifest stays
@@ -6881,6 +6897,26 @@ async fn handle_get_manifest(
         if let Err(resp) = enforce_token_repo_scope(claims, repo.id) {
             return resp;
         }
+    }
+
+    // Curation enforcement (#2930): a `block` rule on this remote/virtual repo
+    // must block the image pull. The manifest GET is the single seam every
+    // `docker pull` passes through (blobs are content-addressed by digest and
+    // carry no image identity), so gating it here blocks the pull without a
+    // per-blob check. The image name is the curation identity; the reference
+    // (tag or digest) is not passed as a version. No-op for hosted repos /
+    // curation off.
+    if let Err(resp) = proxy_helpers::enforce_curation_lookup(
+        &state.db,
+        repo.id,
+        &repo.key,
+        &repo.repo_type,
+        &repo.image,
+        None,
+    )
+    .await
+    {
+        return resp;
     }
 
     // Resolve locally first: a surviving tag row, or — for a digest this hosted

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4790,6 +4790,147 @@ pub fn curation_blocked_response(package: &str, reason: &str) -> Response {
         .into_response()
 }
 
+/// The repository fields curation enforcement needs, decoupled from any one
+/// handler's repo struct so every proxy format can reach the shared seam.
+///
+/// Most format handlers carry a [`RepoInfo`] (which converts for free via
+/// `From`); the OCI/Docker handler carries its own `OciRepoInfo`, so it builds
+/// this borrow-only view by hand.
+pub struct CurationTarget<'a> {
+    pub id: Uuid,
+    pub key: &'a str,
+    pub repo_type: &'a str,
+    pub curation_enabled: bool,
+    pub default_action: &'a str,
+}
+
+impl<'a> From<&'a RepoInfo> for CurationTarget<'a> {
+    fn from(repo: &'a RepoInfo) -> Self {
+        CurationTarget {
+            id: repo.id,
+            key: &repo.key,
+            repo_type: &repo.repo_type,
+            curation_enabled: repo.curation_enabled,
+            default_action: &repo.curation_default_action,
+        }
+    }
+}
+
+/// Enforce a repository's curation rules on a proxy pull/download for ANY
+/// format (#2930).
+///
+/// This is the format-agnostic generalization of the pypi-specific
+/// `enforce_pypi_curation` seam. PyPI historically enforced curation on its
+/// simple-index and download paths, but every other proxy format left
+/// `curation_enabled` settable yet inert — a `block` rule was silently ignored
+/// on npm / docker / maven / cargo / nuget / … pulls. Each format handler now
+/// calls this at its download seam with the package identity it already parses
+/// (npm package name, OCI image, `groupId:artifactId`, crate name, nuget id).
+///
+/// No-op unless the repository has curation enabled AND is a `remote` /
+/// `virtual` proxy repo: curation rules describe what may be pulled from
+/// upstream, so applying them to a hosted (`local` / `staging`) repo would 403
+/// that repository's own published packages. On a rule-evaluation error it
+/// fails OPEN (logged with repo + package so the unenforced request is
+/// greppable) rather than taking the proxy down — identical to the pypi seam.
+///
+/// Only `pattern` rules are consulted here (via
+/// [`CurationService::evaluate_pep503_package`]), matching the pypi seam
+/// exactly; typed `publisher_trust` / `popularity` rules run on the
+/// staging/sync path, not on the hot download path.
+#[allow(clippy::result_large_err)]
+pub async fn enforce_curation<'a>(
+    db: &PgPool,
+    target: impl Into<CurationTarget<'a>>,
+    package: &str,
+    version: Option<&str>,
+) -> Result<(), Response> {
+    let target = target.into();
+    if !target.curation_enabled || !matches!(target.repo_type, "remote" | "virtual") {
+        return Ok(());
+    }
+    let svc = crate::services::curation_service::CurationService::new(db.clone());
+    let eval = svc
+        .evaluate_pep503_package(target.id, target.default_action, package, version)
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                repo_id = %target.id,
+                repo_key = %target.key,
+                package = %package,
+                error = %e,
+                "curation evaluation failed; failing open"
+            );
+        })
+        .ok();
+    if let Some(eval) = eval {
+        if eval.action == "block" {
+            return Err(curation_blocked_response(package, &eval.reason));
+        }
+    }
+    Ok(())
+}
+
+/// Curation enforcement (#2930) for handlers whose repo struct does NOT carry
+/// the curation columns (the cargo handler's private `RepoInfo`, the OCI
+/// handler's `OciRepoInfo`). Looks the two columns up by id, then defers to
+/// [`enforce_curation`].
+///
+/// The lookup is skipped entirely for hosted repos: `repo_type` is already in
+/// hand, so a `local` / `staging` pull costs no extra query. On the
+/// remote/virtual path it is one small primary-key SELECT, comparable to the
+/// per-request repo resolution these handlers already perform. A lookup error
+/// fails OPEN (logged), matching the evaluation-error stance of the seam.
+#[allow(clippy::result_large_err)]
+pub async fn enforce_curation_lookup(
+    db: &PgPool,
+    repo_id: Uuid,
+    repo_key: &str,
+    repo_type: &str,
+    package: &str,
+    version: Option<&str>,
+) -> Result<(), Response> {
+    if !matches!(repo_type, "remote" | "virtual") {
+        return Ok(());
+    }
+    use sqlx::Row;
+    let row = sqlx::query(
+        "SELECT curation_enabled, curation_default_action FROM repositories WHERE id = $1",
+    )
+    .bind(repo_id)
+    .fetch_optional(db)
+    .await;
+    let (curation_enabled, default_action) = match row {
+        Ok(Some(r)) => (
+            r.try_get::<bool, _>("curation_enabled").unwrap_or(false),
+            r.try_get::<String, _>("curation_default_action")
+                .unwrap_or_else(|_| "allow".to_string()),
+        ),
+        // Row missing or query failed: fail open (the pull proceeds unenforced),
+        // logged so the gap is greppable — never take the proxy down on a
+        // curation-config read error.
+        Ok(None) => return Ok(()),
+        Err(e) => {
+            tracing::warn!(
+                repo_id = %repo_id,
+                repo_key = %repo_key,
+                package = %package,
+                error = %e,
+                "curation config lookup failed; failing open"
+            );
+            return Ok(());
+        }
+    };
+    let target = CurationTarget {
+        id: repo_id,
+        key: repo_key,
+        repo_type,
+        curation_enabled,
+        default_action: &default_action,
+    };
+    enforce_curation(db, target, package, version).await
+}
+
 /// Build a minimal `Repository` model for proxy operations.
 ///
 /// Visible to other handler modules so they can construct a stand-in
@@ -11024,5 +11165,164 @@ mod tests {
 
         assert!(out.is_none(), "feature disabled must stream, not 302");
         assert_eq!(presign_calls, 0, "no presign when the feature is off");
+    }
+
+    // ── Cross-format curation enforcement (#2930) ────────────────────────
+    //
+    // The shared `enforce_curation` seam must block a proxy pull whose package
+    // matches a `block` rule on a curation-enabled remote/virtual repo, and be
+    // an inert no-op otherwise — hosted repos, curation disabled, or a
+    // non-matching package. These pin the behaviour every format handler now
+    // depends on. DB-backed; skip silently when `DATABASE_URL` is unset so
+    // offline `cargo test --lib` stays usable.
+
+    /// Create a repo of `repo_type`, set `curation_enabled`, and (optionally)
+    /// insert a `block` rule for `blocked_pkg`. Returns (user_id, repo_id, key).
+    async fn seed_curated_repo(
+        pool: &sqlx::PgPool,
+        repo_type: &str,
+        curation_enabled: bool,
+        blocked_pkg: Option<&str>,
+    ) -> (uuid::Uuid, uuid::Uuid, String) {
+        let user_id = db_helpers::create_user(pool).await;
+        let (repo_id, key, _) = db_helpers::create_repo(pool, repo_type, "npm").await;
+        sqlx::query(
+            "UPDATE repositories SET curation_enabled = $2, curation_default_action = 'allow' \
+             WHERE id = $1",
+        )
+        .bind(repo_id)
+        .bind(curation_enabled)
+        .execute(pool)
+        .await
+        .expect("enable curation");
+        if let Some(pkg) = blocked_pkg {
+            sqlx::query(
+                "INSERT INTO curation_rules (staging_repo_id, package_pattern, version_constraint, \
+                 architecture, action, priority, reason, created_by) \
+                 VALUES ($1, $2, '*', '*', 'block', 100, '#2930 test block', $3)",
+            )
+            .bind(repo_id)
+            .bind(pkg)
+            .bind(user_id)
+            .execute(pool)
+            .await
+            .expect("insert block rule");
+        }
+        (user_id, repo_id, key)
+    }
+
+    async fn curation_cleanup(pool: &sqlx::PgPool, repo_id: uuid::Uuid, user_id: uuid::Uuid) {
+        let _ = sqlx::query("DELETE FROM curation_rules WHERE staging_repo_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        db_helpers::cleanup(pool, repo_id, user_id).await;
+    }
+
+    fn repo_info_for(
+        id: uuid::Uuid,
+        key: &str,
+        repo_type: &str,
+        curation_enabled: bool,
+    ) -> RepoInfo {
+        RepoInfo {
+            id,
+            key: key.to_string(),
+            storage_path: "/tmp/ph-curation".to_string(),
+            storage_backend: "filesystem".to_string(),
+            repo_type: repo_type.to_string(),
+            format: "npm".to_string(),
+            upstream_url: Some("https://upstream.example.test".to_string()),
+            promotion_only: false,
+            age_gate_enabled: false,
+            age_gate_min_age_days: 0,
+            curation_enabled,
+            curation_default_action: "allow".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_enforce_curation_blocks_matching_and_passes_others_remote() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let (user_id, repo_id, key) =
+            seed_curated_repo(&pool, "remote", true, Some("blocked-pkg")).await;
+        let repo = repo_info_for(repo_id, &key, "remote", true);
+
+        // Matching package -> blocked (403).
+        let blocked = enforce_curation(&pool, &repo, "blocked-pkg", None).await;
+        let resp = blocked.expect_err("blocked package must 403");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // A different package on the same repo is unaffected.
+        let allowed = enforce_curation(&pool, &repo, "some-other-pkg", None).await;
+        assert!(allowed.is_ok(), "non-matching package must pass through");
+
+        curation_cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_enforce_curation_noop_when_disabled() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        // Rule present but curation_enabled = false: the block must NOT fire.
+        let (user_id, repo_id, key) =
+            seed_curated_repo(&pool, "remote", false, Some("blocked-pkg")).await;
+        let repo = repo_info_for(repo_id, &key, "remote", false);
+        let out = enforce_curation(&pool, &repo, "blocked-pkg", None).await;
+        assert!(
+            out.is_ok(),
+            "curation disabled must be a no-op even with a block rule"
+        );
+        curation_cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_enforce_curation_noop_on_hosted_repo() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        // Hosted (local) repo: curation describes upstream pulls, so a hosted
+        // repo's own published package must never be 403'd.
+        let (user_id, repo_id, key) =
+            seed_curated_repo(&pool, "local", true, Some("blocked-pkg")).await;
+        let repo = repo_info_for(repo_id, &key, "local", true);
+        let out = enforce_curation(&pool, &repo, "blocked-pkg", None).await;
+        assert!(
+            out.is_ok(),
+            "hosted repo pulls must never be curation-blocked"
+        );
+        curation_cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_enforce_curation_lookup_blocks_and_skips_hosted() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        // The by-id lookup path (cargo/oci handlers) resolves the curation
+        // columns itself and blocks a matching pull on a remote repo.
+        let (user_id, repo_id, key) =
+            seed_curated_repo(&pool, "remote", true, Some("blocked-pkg")).await;
+        let blocked =
+            enforce_curation_lookup(&pool, repo_id, &key, "remote", "blocked-pkg", None).await;
+        assert_eq!(
+            blocked
+                .expect_err("lookup path must 403 a blocked pull")
+                .status(),
+            StatusCode::FORBIDDEN
+        );
+
+        // A hosted repo_type short-circuits before any lookup.
+        let hosted =
+            enforce_curation_lookup(&pool, repo_id, &key, "local", "blocked-pkg", None).await;
+        assert!(
+            hosted.is_ok(),
+            "hosted repo must skip curation lookup entirely"
+        );
+
+        curation_cleanup(&pool, repo_id, user_id).await;
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -256,32 +256,10 @@ async fn enforce_pypi_curation(
     project: &str,
     version: Option<&str>,
 ) -> Result<(), Response> {
-    if !repo.curation_enabled || !matches!(repo.repo_type.as_str(), "remote" | "virtual") {
-        return Ok(());
-    }
-    let svc = crate::services::curation_service::CurationService::new(state.db.clone());
-    let eval = svc
-        .evaluate_pep503_package(repo.id, &repo.curation_default_action, project, version)
-        .await
-        .map_err(|e| {
-            tracing::warn!(
-                repo_id = %repo.id,
-                repo_key = %repo.key,
-                package = %project,
-                error = %e,
-                "curation evaluation failed; failing open"
-            );
-        })
-        .ok();
-    if let Some(eval) = eval {
-        if eval.action == "block" {
-            return Err(proxy_helpers::curation_blocked_response(
-                project,
-                &eval.reason,
-            ));
-        }
-    }
-    Ok(())
+    // Delegate to the shared, format-agnostic curation seam (#2930). PyPI was
+    // the original (and once only) enforced format; the seam now lives in
+    // `proxy_helpers` so every proxy format shares one implementation.
+    proxy_helpers::enforce_curation(&state.db, repo, project, version).await
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`curation_enabled` is settable on every repository, but only the PyPI proxy
pull path actually enforced a curation `block` rule. On the other proxy formats
(npm, docker/OCI, maven, cargo, nuget, …) a block rule was silently inert — the
blocked package streamed straight through the download path.

This wires the same enforcement seam PyPI already used into the download/pull
paths of the highest-value proxy formats, via one shared helper instead of N
copy-pastes:

- **New shared seam** `proxy_helpers::enforce_curation` (and an
  `enforce_curation_lookup` variant for handlers whose repo struct does not
  carry the curation columns). It is the format-agnostic generalization of the
  old `enforce_pypi_curation`: no-op unless the repo has curation enabled and is
  a `remote`/`virtual` proxy repo, evaluates the repo's `pattern` rules through
  `CurationService::evaluate_pep503_package`, and returns a 403
  `curation_blocked` response on a `block` decision. It fails **open** (logged)
  on an evaluation error, exactly like the PyPI seam, so a rule-eval hiccup never
  takes the proxy down.
- **PyPI** now delegates to the shared helper (removing the duplicated body).
- **Wired formats** — each calls the seam at its download/pull point with the
  package identity it already parses:
  - **npm** — tarball serve path (`serve_tarball`), package name.
  - **docker/OCI** — GET **and** HEAD manifest (the single seam every
    `docker pull` passes through; blobs are content-addressed and carry no image
    identity), image name.
  - **maven** — artifact GET, `groupId:artifactId` (via the existing
    `maven_proxy_package_name`, the same shape the proxy-sync catalog uses).
    Metadata/checksum sidecars derive no package identity and pass through.
  - **cargo** — crate download, crate name + version.
  - **nuget** — V3 flat-container and V2 package download, package id + version.

Hosted (`local`/`staging`) and filesystem paths are unaffected: the seam
short-circuits for non-proxy repo types, so a repository's own published
packages are never 403'd. Only remote/virtual proxy pulls gate.

Formats deferred: identifier-poor pull paths where there is no stable package
identity to curate on (e.g. Go module `@v` paths, bare generic downloads) are
not wired here; they can adopt the same one-line seam later. This PR covers the
formats named in the issue plus nuget V2.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added DB-backed unit tests in `proxy_helpers` covering the seam directly: a
`block` rule 403s a matching pull on a remote repo; a non-matching package
passes; curation-disabled and hosted repos are no-ops; and the by-id lookup
variant blocks on remote yet skips hosted. A cross-format end-to-end deployment
test (curation block 403s an npm tarball pull and a docker manifest pull; a
non-blocked package is unaffected) fails on a pre-fix image and passes here.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2930
