### PR TITLE
Release v1.6.4 — Maven flat-key tenant-isolation security patch + restore enforcing Security Scan gate

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -485,12 +485,6 @@ jobs:
 
   scan-containers:
     name: Security Scan
-    # TEMPORARY (v1.6.3 security hotfix): non-blocking so the admin-takeover fix
-    # (#2875) can publish despite HIGH CVEs that live ONLY in the bundled grype/
-    # trivy scanner binaries (not AK code, not reachable in AK's usage). The
-    # findings are documented in /.trivyignore; the structural fix is dropping
-    # in-image grype (#2881). REVERT this after v1.6.3 publishes.
-    continue-on-error: true
     runs-on: ubuntu-24.04
     # `build-backend-alpine` removed from `needs` while alpine builds are
     # suspended. Re-add it (and re-enable the alpine-gated steps below)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
   # longer part of the backend release's version set (issue #2708).
   #
   # Ordering (A5): preflight -> resolve (blocks <=35 min on the publish) ->
-  # release-gate/mesh -> build-binaries -> verify-images-published -> release.
+  # release-gate -> build-binaries -> verify-images-published -> release.
   # The GitHub Release object still publishes strictly last; this job only
   # moves the gate's START to after the candidate bytes exist.
   # ════════════════════════════════════════════════════════════════════════════
@@ -213,15 +213,16 @@ jobs:
       include_stress: false
       include_failure: false
 
-  mesh-e2e-gate:
-    name: Mesh Replication E2E (optional)
-    # Advisory, but it was the last `dev` literal on the release path; run it
-    # against the published candidate tag like everything else.
-    needs: [release-preflight, resolve-candidate-digest]
-    uses: ./.github/workflows/mesh-e2e.yml
-    with:
-      image_tag: ${{ needs.resolve-candidate-digest.outputs.version }}
-    secrets: inherit
+  # NOTE: `mesh-e2e-gate` was removed from the 1.6.x release path. It called
+  # ./.github/workflows/mesh-e2e.yml, which patches the ArgoCD Applications
+  # ak-mesh-main / ak-mesh-peer-{1,2,3}. Those Applications are not present on
+  # the cluster (the artifact-keeper-mesh-test ApplicationSet is not applied),
+  # so the job failed with `applications.argoproj.io "ak-mesh-main" not found`
+  # on every 1.6.x tag (v1.6.0, v1.6.2, v1.6.3) and marked each release run
+  # red. It never blocked publication -- the `release` job below deliberately
+  # did not require it -- so the only effect was a permanently failing advisory
+  # gate on the release path. mesh-e2e.yml is retained and still runnable via
+  # workflow_dispatch once the mesh ApplicationSet is restored.
 
   release-gate:
     name: Release Gate (Full Suite)
@@ -592,10 +593,10 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-binaries, release-gate, mesh-e2e-gate, verify-images-published]
-    # `mesh-e2e-gate` is advisory, so this cannot fall back to the default
-    # `success()` -- it has to name the gates it requires. `!cancelled()` rather
-    # than `always()`: with `always()`, cancelling the run does not stop the
+    needs: [build-binaries, release-gate, verify-images-published]
+    # Every named gate is now required, but the condition stays explicit rather
+    # than falling back to the default `success()`. `!cancelled()` rather than
+    # `always()`: with `always()`, cancelling the run does not stop the
     # publication, because the gates it names have already reported success.
     if: |
       !cancelled() &&

--- a/.trivyignore
+++ b/.trivyignore
@@ -64,6 +64,17 @@ CVE-2026-41568
 CVE-2026-42306
 
 # ---------------------------------------------------------------------------
+# grype v0.116.0 binary — google.golang.org/grpc @ v1.80.0
+# GHSA-hrxh-6v49-42gf (gRPC-Go: xDS RBAC and HTTP/2 vulnerabilities): fixed in
+# grpc-go v1.82.1, but grype v0.116.0 (latest) has not rebuilt against it.
+# Neither affected path is reachable in how AK drives grype: it is not an
+# xDS/service-mesh client (the RBAC authz path is dead code), and it runs as a
+# short-lived local CLI over on-disk artifacts/SBOMs with a pre-seeded offline
+# DB — it exposes no HTTP/2 server surface to untrusted peers. Drops off when
+# grype ships a release built on grpc-go >= 1.82.1. Re-evaluate on bump (#2391).
+GHSA-hrxh-6v49-42gf
+
+# ---------------------------------------------------------------------------
 # trivy 0.72.0 binary (scanner-adapter image) — oras.land/oras-go/v2 @ v2.6.0
 # Fixed in oras-go 2.6.1; trivy 0.72.0 (latest) has not rebuilt against it.
 # Code path: ORAS OCI-artifact client used for trivy's own DB/plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-07-28
+
+A patch release for the 1.6.0 line fixing Maven flat-key attribution on cloud storage backends. In-place upgrade from any 1.6.x is a drop-in image swap with no database migration.
+
+### Fixed
+
+- **Maven flat-key attribution consults the recorded claims ledger before deriving ownership from parent metadata** (#2946): `resolve_direct` evaluated the `artifact_metadata` `files[]` derivation ahead of the `maven_flat_object_owner` ledger, so the read path disagreed with the write guard (`guard_flat_key_writable`), which has always enforced against the recorded claim. Two consequences on deployments using a cloud storage backend:
+
+  - A key legitimately claimed at write time could be attributed to a **different repository** when that other repository's metadata happened to reference the same storage key, so a read could resolve to the wrong owner.
+  - A key whose metadata derivation was ambiguous (two distinct candidate owners) failed closed on read even when the ledger held an unambiguous claim, leaving the key **unreadable by its own claimant**.
+
+  A recorded claim now outranks derived attribution on read, matching the write guard. As a side effect, reads of keys the ledger already knows no longer pay the unindexed scan of `artifact_metadata`, which removes a multi-second stall per read on large deployments.
+
+  Backported from #2943. Note that the accompanying jsonb containment rewrite and its GIN index (migration 179) are **not** part of the 1.6.x line, so reads of keys the ledger has never seen still fall through to the sequential scan. Deployments where that scan dominates should plan an upgrade to the 1.7 line rather than expecting the full performance fix here.
+
 ## [1.6.3] - 2026-07-23
 
 A security patch for the 1.6.0 line. In-place upgrade from any 1.6.x is a drop-in image swap with no database migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.4] - 2026-07-28
 
-A patch release for the 1.6.0 line fixing Maven flat-key attribution on cloud storage backends. In-place upgrade from any 1.6.x is a drop-in image swap with no database migration.
+A security patch for the 1.6.0 line, hardening Maven flat-key tenant isolation on cloud storage backends. In-place upgrade from any 1.6.x is a drop-in image swap with no database migration.
 
-### Fixed
+### Security
 
-- **Maven flat-key attribution consults the recorded claims ledger before deriving ownership from parent metadata** (#2946): `resolve_direct` evaluated the `artifact_metadata` `files[]` derivation ahead of the `maven_flat_object_owner` ledger, so the read path disagreed with the write guard (`guard_flat_key_writable`), which has always enforced against the recorded claim. Two consequences on deployments using a cloud storage backend:
+- **Maven flat-key attribution now consults the recorded claims ledger before deriving ownership from parent metadata** (#2946): `attributed_owner` evaluated the `artifact_metadata` `files[]` derivation ahead of the `maven_flat_object_owner` ledger. Because both the read path (`flat_key_readable`) and the write guard (`guard_flat_key_writable`) resolve ownership through that one function, a repository that merely referenced another repository's claimed storage key in its own `files[]` metadata was treated as that key's owner. On deployments using a cloud storage backend this produced three distinct failures:
 
-  - A key legitimately claimed at write time could be attributed to a **different repository** when that other repository's metadata happened to reference the same storage key, so a read could resolve to the wrong owner.
-  - A key whose metadata derivation was ambiguous (two distinct candidate owners) failed closed on read even when the ledger held an unambiguous claim, leaving the key **unreadable by its own claimant**.
+  - **Cross-repository overwrite (write-poison).** The write guard saw the referencing repository as the owner and permitted it to overwrite the claimed object, so one repository could replace the bytes of an artifact belonging to another.
+  - **Owner lockout.** The true claimant was seen as a non-owner and was refused writes to its own object.
+  - **Read misattribution.** Reads resolved to the referencing repository rather than the claimant, and a key whose derivation was ambiguous failed closed even when the ledger held an unambiguous claim, leaving it unreadable by its own claimant.
 
-  A recorded claim now outranks derived attribution on read, matching the write guard. As a side effect, reads of keys the ledger already knows no longer pay the unindexed scan of `artifact_metadata`, which removes a multi-second stall per read on large deployments.
+  A recorded claim now outranks derived attribution, so the read path, the write guard, and the ledger agree. As a side effect, operations on keys the ledger already knows no longer pay the unindexed scan of `artifact_metadata`, which removes a multi-second stall on large deployments.
 
-  Backported from #2943. Note that the accompanying jsonb containment rewrite and its GIN index (migration 179) are **not** part of the 1.6.x line, so reads of keys the ledger has never seen still fall through to the sequential scan. Deployments where that scan dominates should plan an upgrade to the 1.7 line rather than expecting the full performance fix here.
+  **Am I affected?** Only deployments on a cloud storage backend (S3 or compatible) serving Maven repositories that share a flat key namespace. Filesystem backends short-circuit the guard entirely and are unaffected. Reported and fixed by @ThaSami (#2942, #2943).
+
+  Backported from #2943. The accompanying jsonb containment rewrite and its GIN index (migration 179) are **not** part of the 1.6.x line: a write-blocking in-transaction index build is heavier than a patch release should carry, and the isolation fix is independent of the SQL form. Keys the ledger has never seen therefore still fall through to the sequential scan, so deployments where that scan dominates should plan an upgrade to the 1.7 line rather than expecting the full performance fix here.
 
 ## [1.6.3] - 2026-07-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.6.2"
+version = "1.6.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.6.3",
+        version = "1.6.4",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
## Summary

Cuts **v1.6.4** on the `release/1.6.x` line. Closes #2963.

The one functional change since v1.6.3 is **#2946** (already merged to this branch): Maven flat-key attribution now consults the `maven_flat_object_owner` claims ledger before deriving ownership from parent `artifact_metadata`. That reorder closes a read/write disagreement, since `guard_flat_key_writable` has always enforced against the recorded claim. On cloud storage backends a recorded claim could be overridden by another repository's metadata (read resolves to the wrong owner), and a metadata-ambiguous but legitimately claimed key failed closed on read (unreadable by its own claimant).

This PR adds the release mechanics on top:

| Commit | What |
|---|---|
| `d5c2c8ee` | Cherry-pick of #2880: `.trivyignore` entry for GHSA-hrxh-6v49-42gf (grype-bundled grpc-go, not reachable in AK's local-CLI usage) |
| `fe7a5229` | Revert the TEMPORARY `continue-on-error: true` on Security Scan, restoring the enforcing gate |
| `d91077f5` | Version bump to 1.6.4 + changelog, and realign `Cargo.lock` |

### Notes for the reviewer

- **Supersedes #2882.** That PR carries the same `.trivyignore` change but sits on a base three commits behind `release/1.6.x`, and its red "Check Rust" is infrastructural (`ERROR: could not fetch release branch release/1.6.x`), not a code failure. Cherry-picking onto a current base gets a clean CI run. #2882 can be closed once this lands.
- **The TEMP bypass is gone.** `5ea9ed84` explicitly said "REVERT this after v1.6.3 publishes". With #2880 on the branch the gate passes on its own merits rather than being waved through. Verified there is no remaining job-level or step-level `continue-on-error` on `scan-containers`.
- **`Cargo.lock` was stale at 1.6.2**, because the 1.6.3 bump never regenerated it. Corrected to 1.6.4 here. Nothing builds with `--locked`, so this was silent drift rather than a break.
- **Scope was deliberately held to #2946.** Roughly nine `fix(...)` commits on `main` are not on this line (#2918, #2891, #2837, #2770, and others). None is a reported 1.6.x field regression, and widening the diff would expand the validation surface on a release gate that already took 12 attempts to go green for v1.6.3. #2770 and #2918 are the two worth queuing for a future 1.6.5.
- **Migration 179 and the jsonb containment rewrite from #2943 are intentionally not backported**, so reads of keys the ledger has never seen still fall through to the sequential scan of `artifact_metadata`. The changelog says so explicitly, so operators do not read this as the full performance fix.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is the `chore/release-*` mechanics PR. The regression test for the underlying fix, `test_attribution_table_claim_outranks_metadata_derivation`, landed with #2946 and fails under the pre-reorder layer order.

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified locally on this branch:

```
cargo fmt --check                                    exit 0
cargo test --workspace --lib -- openapi maven_flat_attribution
  46 passed; 0 failed; 1 ignored
```

Includes `test_attribution_table_claim_outranks_metadata_derivation` and `test_openapi_spec_is_valid` (which pins the bumped spec version).

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

The only OpenAPI delta is the `info.version` string, 1.6.3 to 1.6.4. No migration in this release; upgrade from any 1.6.x is a drop-in image swap.

## Release-branch gate rationale (`release-process: approved`)

The `Verify commits trace back to main` gate requires every commit on a maintenance-line PR to exist on `main` or be a cherry-pick of a `main` commit. Two of the three commits here genuinely cannot go through `main` first, which is the case the label exists for:

- **`fe7a5229` (revert the TEMP Security Scan bypass)** applies only to this branch. `5ea9ed84` was release-branch-only from the start and deliberately never landed on `main`, which retained the enforcing gate throughout. There is no `main` commit to cherry-pick, because there was never anything on `main` to revert.
- **`d91077f5` (version bump + changelog + `Cargo.lock`)** is release-line mechanics. `main` carries the next minor's version, so bumping 1.6.3 to 1.6.4 there would be wrong.
- **`d5c2c8ee` (`.trivyignore`)** does trace back: it is a cherry-pick of `c95325dd`, itself a cherry-pick of `8b148e2` on `main`, so it should pass on patch-id.

Same rationale and label as the prior release PRs on this line (#2879, #2884, #2946).
