### PR TITLE
fix(security): validate+normalize repo scan-config severity_threshold

### DIFF
--- a/backend/src/models/security.rs
+++ b/backend/src/models/security.rs
@@ -77,6 +77,20 @@ impl Severity {
         }
     }
 
+    /// Canonical lowercase form, matching the `scan_configs_severity_threshold_check`
+    /// database CHECK constraint (`critical|high|medium|low|info`). Use this when
+    /// persisting a severity so a normalized value (e.g. "High" -> "high",
+    /// "moderate" -> "medium") is what reaches Postgres.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Severity::Critical => "critical",
+            Severity::High => "high",
+            Severity::Medium => "medium",
+            Severity::Low => "low",
+            Severity::Info => "info",
+        }
+    }
+
     /// Returns true if this severity is at or above the given threshold.
     pub fn meets_threshold(self, threshold: Severity) -> bool {
         self <= threshold
@@ -384,6 +398,30 @@ mod tests {
         assert_eq!(Severity::from_str_loose("unknown"), None);
         assert_eq!(Severity::from_str_loose(""), None);
         assert_eq!(Severity::from_str_loose("very-high"), None);
+    }
+
+    #[test]
+    fn test_severity_as_str_canonical_lowercase() {
+        // as_str() must match the scan_configs_severity_threshold_check set so a
+        // normalized value can be persisted safely (#2953).
+        assert_eq!(Severity::Critical.as_str(), "critical");
+        assert_eq!(Severity::High.as_str(), "high");
+        assert_eq!(Severity::Medium.as_str(), "medium");
+        assert_eq!(Severity::Low.as_str(), "low");
+        assert_eq!(Severity::Info.as_str(), "info");
+    }
+
+    #[test]
+    fn test_severity_as_str_roundtrips_through_from_str_loose() {
+        for s in [
+            Severity::Critical,
+            Severity::High,
+            Severity::Medium,
+            Severity::Low,
+            Severity::Info,
+        ] {
+            assert_eq!(Severity::from_str_loose(s.as_str()), Some(s));
+        }
     }
 
     #[test]

--- a/backend/src/services/scan_config_service.rs
+++ b/backend/src/services/scan_config_service.rs
@@ -3,8 +3,8 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::error::Result;
-use crate::models::security::ScanConfig;
+use crate::error::{AppError, Result};
+use crate::models::security::{ScanConfig, Severity};
 
 /// Request to create or update a scan configuration.
 ///
@@ -31,6 +31,25 @@ pub struct UpsertScanConfigRequest {
     pub block_on_policy_violation: Option<bool>,
     #[serde(default)]
     pub severity_threshold: Option<String>,
+}
+
+/// Validate + normalize a caller-supplied `severity_threshold` to the canonical
+/// lowercase form enforced by the `scan_configs_severity_threshold_check` CHECK
+/// constraint (`critical|high|medium|low|info`).
+///
+/// Accepts input case-insensitively and resolves aliases ("moderate" -> "medium",
+/// "informational"/"none" -> "info"). A genuinely-invalid value yields a
+/// `Validation` error (HTTP 400) instead of being passed to Postgres where it
+/// would trip the constraint and surface as a raw DB error / HTTP 500 (#2953).
+fn normalize_severity_threshold(raw: &str) -> Result<String> {
+    Severity::from_str_loose(raw)
+        .map(|s| s.as_str().to_string())
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "invalid severity_threshold '{raw}'; allowed values are \
+                 critical, high, medium, low, info"
+            ))
+        })
 }
 
 pub struct ScanConfigService {
@@ -93,12 +112,22 @@ impl ScanConfigService {
                 .map(|c| c.block_on_policy_violation)
                 .unwrap_or(false)
         });
-        let severity_threshold = req.severity_threshold.clone().unwrap_or_else(|| {
-            existing
+        // Validate + normalize the caller-supplied severity_threshold BEFORE the
+        // DB write. The column carries a `scan_configs_severity_threshold_check`
+        // CHECK constraint over the canonical lowercase set
+        // (critical|high|medium|low|info); passing a raw casing like "High" or a
+        // bogus value like "yolo" straight through surfaced the constraint
+        // violation as a raw DB error -> HTTP 500 (#2953). Accept case-insensitive
+        // input and aliases ("moderate" -> "medium"), normalize to the canonical
+        // form, and reject a genuinely-invalid value with a 400. An omitted field
+        // keeps the existing (already-valid) row value, or the documented default.
+        let severity_threshold = match req.severity_threshold.as_deref() {
+            Some(raw) => normalize_severity_threshold(raw)?,
+            None => existing
                 .as_ref()
                 .map(|c| c.severity_threshold.clone())
-                .unwrap_or_else(|| "high".to_string())
-        });
+                .unwrap_or_else(|| "high".to_string()),
+        };
 
         let config = sqlx::query_as!(
             ScanConfig,
@@ -434,5 +463,68 @@ mod tests {
             opt.unwrap_or(false)
         }
         assert!(!is_scan_enabled(Some(false)));
+    }
+
+    // -----------------------------------------------------------------------
+    // severity_threshold validation / normalization (#2953)
+    //
+    // The handler used to pass the raw string straight to Postgres, so a
+    // non-lowercase casing ("High") or a bogus value ("yolo") tripped the
+    // `scan_configs_severity_threshold_check` CHECK constraint and leaked as an
+    // HTTP 500. normalize_severity_threshold now canonicalizes valid input and
+    // rejects invalid input with a Validation error (HTTP 400) before the DB
+    // write. These tests are pure and need no DATABASE_URL.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_normalize_severity_accepts_canonical_lowercase() {
+        for v in ["critical", "high", "medium", "low", "info"] {
+            assert_eq!(normalize_severity_threshold(v).unwrap(), v);
+        }
+    }
+
+    #[test]
+    fn test_normalize_severity_normalizes_casing() {
+        // The exact #2953 repro: "High" must be accepted and normalized, not 500.
+        assert_eq!(normalize_severity_threshold("High").unwrap(), "high");
+        assert_eq!(
+            normalize_severity_threshold("CRITICAL").unwrap(),
+            "critical"
+        );
+        assert_eq!(normalize_severity_threshold("Medium").unwrap(), "medium");
+    }
+
+    #[test]
+    fn test_normalize_severity_resolves_aliases() {
+        assert_eq!(normalize_severity_threshold("moderate").unwrap(), "medium");
+        assert_eq!(normalize_severity_threshold("Moderate").unwrap(), "medium");
+        assert_eq!(
+            normalize_severity_threshold("informational").unwrap(),
+            "info"
+        );
+        assert_eq!(normalize_severity_threshold("none").unwrap(), "info");
+    }
+
+    #[test]
+    fn test_normalize_severity_rejects_invalid_with_validation_error() {
+        // "yolo" must be a 400 (Validation), never reach Postgres as a 500.
+        let err = normalize_severity_threshold("yolo").unwrap_err();
+        assert!(
+            matches!(err, AppError::Validation(_)),
+            "invalid severity must map to Validation (400), got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("severity_threshold") && msg.contains("critical"),
+            "message must name the field and list allowed values: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_normalize_severity_rejects_empty() {
+        assert!(matches!(
+            normalize_severity_threshold("").unwrap_err(),
+            AppError::Validation(_)
+        ));
     }
 }


### PR DESCRIPTION
## Summary
`PUT /api/v1/repositories/{key}/security` passed the caller-supplied
`severity_threshold` straight to Postgres. Any value outside the canonical
lowercase set enforced by the `scan_configs_severity_threshold_check` CHECK
constraint — including a mere casing difference like `"High"`, or a genuinely
invalid value like `"yolo"` — tripped the constraint and surfaced as a raw
database error, i.e. **HTTP 500**, instead of a clean input-validation **400**.

This change validates and normalizes `severity_threshold` in the scan-config
upsert path before the write:

- Input is accepted case-insensitively and common aliases are resolved
  (`"High"` → `high`, `"moderate"` → `medium`, `"informational"`/`"none"` →
  `info`) via the existing `Severity::from_str_loose`, then stored in the
  canonical lowercase form (new `Severity::as_str`) so the value always
  satisfies the CHECK constraint.
- A genuinely invalid value now returns **400** `VALIDATION_ERROR` with a
  message listing the allowed values, and never reaches the database.
- Omitted `severity_threshold` keeps its existing (already-valid) row value or
  the documented default, so the partial-upsert behavior is unchanged.

The other mutable fields on this endpoint (`scan_enabled`, `scan_on_upload`,
`scan_on_proxy`, `block_on_policy_violation`) are typed `bool`, so a bad value
is already rejected at deserialization — `severity_threshold` was the only
free-form enum-ish field with the raw-passthrough issue.

Closes #2953

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests (all pure, no DB required):
- `normalize_severity_threshold` accepts canonical lowercase, normalizes casing
  (`"High"` → `high`), resolves aliases (`"moderate"` → `medium`), and rejects
  `"yolo"`/empty with a `Validation` (400) error naming the field and allowed
  values.
- `Severity::as_str` returns the canonical lowercase form and round-trips
  through `from_str_loose`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification against a locally built image:
- `severity_threshold: "High"` → **200**, persisted as `high` (was 500).
- `severity_threshold: "yolo"` → **400** `VALIDATION_ERROR` (was 500).
- `severity_threshold: "moderate"` → **200**, persisted as `medium`.
- `severity_threshold: "high"` → **200** (legitimate path intact).

## API Changes
- [x] N/A - no API changes

(No route, request/response shape, or migration changes; behavior change only —
invalid input now maps to 400 instead of 500.)
