### PR TITLE
feat(artifacts): surface per-artifact quarantine state in artifact listing

### DIFF
--- a/backend/src/api/handlers/artifacts.rs
+++ b/backend/src/api/handlers/artifacts.rs
@@ -101,6 +101,8 @@ struct ArtifactByIdRow {
     checksum_sha256: String,
     content_type: String,
     created_at: chrono::DateTime<chrono::Utc>,
+    quarantine_status: Option<String>,
+    quarantine_until: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -140,7 +142,8 @@ pub async fn get_artifact(
 ) -> Result<Json<ArtifactResponse>> {
     let artifact: ArtifactByIdRow = sqlx::query_as(
         "SELECT a.id, r.key AS repository_key, a.path, a.name, a.version, \
-                a.size_bytes, a.checksum_sha256, a.content_type, a.created_at \
+                a.size_bytes, a.checksum_sha256, a.content_type, a.created_at, \
+                a.quarantine_status, a.quarantine_until \
          FROM artifacts a \
          JOIN repositories r ON r.id = a.repository_id \
          WHERE a.id = $1 AND a.is_deleted = false",
@@ -191,6 +194,12 @@ pub async fn get_artifact(
         // the by-id surface leaves it unset.
         revision: None,
         version_label: None,
+        // Surface the resolved row's quarantine state, matching the listing
+        // (#2940). Same joined query — no extra round-trip.
+        quarantine_status: crate::api::handlers::repositories::quarantine_status_label(
+            artifact.quarantine_status.as_deref(),
+        ),
+        quarantine_until: artifact.quarantine_until,
     }))
 }
 
@@ -350,6 +359,8 @@ mod tests {
             analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
+            quarantine_status: "not_quarantined".to_string(),
+            quarantine_until: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], id.to_string());
@@ -387,6 +398,8 @@ mod tests {
             analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
+            quarantine_status: "not_quarantined".to_string(),
+            quarantine_until: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         let obj = json.as_object().unwrap();
@@ -428,6 +441,8 @@ mod tests {
             analyzable: false,
             cache_cached_at: None,
             cache_expires_at: None,
+            quarantine_status: "not_quarantined".to_string(),
+            quarantine_until: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["size_bytes"], 0);
@@ -545,6 +560,8 @@ mod tests {
             analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
+            quarantine_status: "not_quarantined".to_string(),
+            quarantine_until: None,
         };
         let debug_str = format!("{:?}", resp);
         assert!(debug_str.contains("ArtifactResponse"));

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4095,6 +4095,28 @@ pub struct ArtifactResponse {
     /// `revision`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version_label: Option<String>,
+    /// Per-artifact quarantine state so a client/operator can tell which
+    /// listed artifacts are held for security review (#2940). Always
+    /// serialized so the listing never hides the control:
+    /// - `"quarantined"` — held pending review; downloads return 409 (until
+    ///   any `quarantine_until` lapses),
+    /// - `"rejected"` — terminally blocked by an admin,
+    /// - a scan-lifecycle state (`"clean"`, `"flagged"`, `"unscanned"`,
+    ///   `"released"`),
+    /// - `"not_quarantined"` — the explicit default when the row carries no
+    ///   quarantine state, so clients never have to treat a missing value as
+    ///   a state.
+    ///
+    /// The human-readable *reason* is intentionally NOT surfaced here: it is
+    /// per-artifact security detail disclosed only by the authenticated,
+    /// repository-visibility-checked `GET /api/v1/quarantine/{id}` (#2912),
+    /// whereas this listing is reachable anonymously on public repositories.
+    pub quarantine_status: String,
+    /// When a timed quarantine hold lapses and the artifact becomes
+    /// downloadable again. `None` for a permanent (admin) quarantine and for
+    /// artifacts that are not quarantined. (#2940)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_until: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -4694,6 +4716,10 @@ fn build_catalog_artifact_response(
         cache_expires_at: None,
         revision: None,
         version_label: None,
+        // Proxy-cached objects have no `artifacts` row and no quarantine
+        // state; the upload-hold workflow only applies to hosted artifacts.
+        quarantine_status: NOT_QUARANTINED.to_string(),
+        quarantine_until: None,
     }
 }
 
@@ -4803,6 +4829,10 @@ fn build_cached_artifact_response(
         // Proxy-cache entries carry no versioned history (#2367).
         revision: None,
         version_label: None,
+        // Proxy-cached objects have no `artifacts` row and no quarantine
+        // state; the upload-hold workflow only applies to hosted artifacts.
+        quarantine_status: NOT_QUARANTINED.to_string(),
+        quarantine_until: None,
     }
 }
 
@@ -4958,6 +4988,22 @@ fn apply_npm_tarball_url_path(item: &mut ArtifactResponse) {
     }
 }
 
+/// The [`ArtifactResponse::quarantine_status`] label for an artifact that
+/// carries no quarantine row state.
+pub(crate) const NOT_QUARANTINED: &str = "not_quarantined";
+
+/// Map the nullable `artifacts.quarantine_status` column to the always-present
+/// listing label (#2940). A missing or empty column value is reported as the
+/// explicit [`NOT_QUARANTINED`] state so clients never have to treat `null`
+/// as a state; any recorded status (`quarantined`, `rejected`, `clean`, …) is
+/// surfaced verbatim.
+pub(crate) fn quarantine_status_label(raw: Option<&str>) -> String {
+    match raw {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => NOT_QUARANTINED.to_string(),
+    }
+}
+
 fn build_artifact_response(
     artifact: &crate::models::artifact::Artifact,
     repo_key: &str,
@@ -4987,6 +5033,11 @@ fn build_artifact_response(
         // per-artifact metadata endpoint, not fanned out in listings (#2367).
         revision: None,
         version_label: None,
+        // Quarantine state is carried on the same `artifacts` row already
+        // selected by `list_page`/`list_for_repos_page`, so surfacing it here
+        // adds no extra query (no join, no N+1) (#2940).
+        quarantine_status: quarantine_status_label(artifact.quarantine_status.as_deref()),
+        quarantine_until: artifact.quarantine_until,
     }
 }
 
@@ -5039,6 +5090,10 @@ fn expand_maven_secondary_files(
             cache_expires_at: None,
             revision: None,
             version_label: None,
+            // Companion files share the primary's `artifacts` row, so they
+            // inherit its quarantine state (#2940).
+            quarantine_status: quarantine_status_label(artifact.quarantine_status.as_deref()),
+            quarantine_until: artifact.quarantine_until,
         });
     }
     out
@@ -6359,6 +6414,10 @@ pub async fn get_artifact_metadata(
             cache_expires_at: cache_meta.as_ref().map(|m| m.expires_at),
             revision,
             version_label,
+            // Surface the resolved row's quarantine state, matching the
+            // listing (#2940).
+            quarantine_status: quarantine_status_label(artifact.quarantine_status.as_deref()),
+            quarantine_until: artifact.quarantine_until,
         })
         .into_response());
     }
@@ -6476,6 +6535,11 @@ fn artifact_version_to_response(
         cache_expires_at: None,
         revision: Some(stored.revision),
         version_label: stored.version_label,
+        // A historical revision row (`artifact_versions`) carries no live
+        // quarantine state; quarantine is tracked on the HEAD `artifacts`
+        // row (#2940).
+        quarantine_status: NOT_QUARANTINED.to_string(),
+        quarantine_until: None,
     }
 }
 
@@ -6838,6 +6902,13 @@ async fn persist_generic_staged_upload(
             cache_expires_at: None,
             revision,
             version_label,
+            // The upload-time quarantine hold (`apply_upload_hold`) runs as a
+            // post-commit UPDATE after the INSERT's `RETURNING` built this
+            // struct, so the value here predates any hold. The authoritative
+            // per-artifact state is the listing / `GET /api/v1/quarantine/{id}`
+            // (#2940).
+            quarantine_status: quarantine_status_label(artifact.quarantine_status.as_deref()),
+            quarantine_until: artifact.quarantine_until,
         }),
     )
         .into_response())
@@ -9747,6 +9818,49 @@ mod tests {
         assert_eq!(resp.download_count, 42);
         // Hosted artifacts have a real DB id, so SBOM/scan resolve: analyzable.
         assert!(resp.analyzable);
+        // A normal (un-held) artifact reports the explicit not-quarantined
+        // state, never a bare null (#2940).
+        assert_eq!(resp.quarantine_status, "not_quarantined");
+        assert!(resp.quarantine_until.is_none());
+    }
+
+    #[test]
+    fn test_quarantine_status_label_maps_missing_to_not_quarantined() {
+        // A null/empty column is the common (unquarantined) case and must
+        // report the explicit label so clients never treat null as a state.
+        assert_eq!(quarantine_status_label(None), "not_quarantined");
+        assert_eq!(quarantine_status_label(Some("")), "not_quarantined");
+        // Any recorded status is surfaced verbatim.
+        assert_eq!(quarantine_status_label(Some("quarantined")), "quarantined");
+        assert_eq!(quarantine_status_label(Some("rejected")), "rejected");
+        assert_eq!(quarantine_status_label(Some("clean")), "clean");
+    }
+
+    #[test]
+    fn test_build_artifact_response_surfaces_quarantined_state() {
+        // The listing must make a held artifact visible: a quarantined row
+        // surfaces `quarantine_status = "quarantined"` and its hold expiry,
+        // while an unquarantined row surfaces the not-quarantined default.
+        let until = chrono::Utc::now() + chrono::Duration::minutes(30);
+
+        let mut held = make_artifact_for_test("held/pkg-1.0.0.jar");
+        held.quarantine_status = Some("quarantined".to_string());
+        held.quarantine_until = Some(until);
+        let held_resp = build_artifact_response(&held, "generic-hosted", 0);
+        assert_eq!(held_resp.quarantine_status, "quarantined");
+        assert_eq!(held_resp.quarantine_until, Some(until));
+
+        let clean = make_artifact_for_test("clean/pkg-1.0.0.jar");
+        let clean_resp = build_artifact_response(&clean, "generic-hosted", 0);
+        assert_eq!(clean_resp.quarantine_status, "not_quarantined");
+        assert!(clean_resp.quarantine_until.is_none());
+
+        // The held item serializes the state (and the reason is NOT present
+        // here — it is only disclosed by the authenticated quarantine
+        // endpoint, #2912).
+        let json = serde_json::to_value(&held_resp).unwrap();
+        assert_eq!(json["quarantine_status"], "quarantined");
+        assert!(json.get("quarantine_reason").is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -11309,9 +11423,16 @@ mod tests {
             analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
+            quarantine_status: "not_quarantined".to_string(),
+            quarantine_until: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"download_count\":42"));
+        // Unquarantined artifacts report the explicit default state (#2940).
+        assert!(json.contains("\"quarantine_status\":\"not_quarantined\""));
+        // `quarantine_until` is omitted when None so the wire shape stays
+        // minimal for the common (unquarantined) case.
+        assert!(!json.contains("quarantine_until"));
         assert!(json.contains("\"size_bytes\":1024"));
         // `analyzable` is always serialized (no serde skip) so clients can
         // gate the SBOM/Scan actions on it (#2227).
@@ -11392,6 +11513,8 @@ mod tests {
             analyzable: false,
             cache_cached_at: Some(cached),
             cache_expires_at: Some(expires),
+            quarantine_status: "not_quarantined".to_string(),
+            quarantine_until: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"cache_cached_at\":\"2026-06-01T10:00:00Z\""));

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -2465,6 +2465,58 @@ mod tests {
         .expect("seed artifact");
     }
 
+    /// #2940: `list_page` must keep selecting the quarantine columns so the
+    /// listing handler can surface per-artifact quarantine state. Guards
+    /// against a future refactor dropping them from the SELECT (which would
+    /// silently report every artifact as unquarantined again).
+    #[tokio::test]
+    async fn test_list_page_carries_quarantine_state() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _, storage_dir) = tdh::create_repo(&pool, "local", "generic").await;
+
+        let held_key = format!("generic/{}", Uuid::new_v4());
+        let clean_key = format!("generic/{}", Uuid::new_v4());
+        seed_artifact(&pool, repo_id, "held/pkg-1.0.0.bin", &held_key).await;
+        seed_artifact(&pool, repo_id, "clean/pkg-1.0.0.bin", &clean_key).await;
+
+        let until = chrono::Utc::now() + chrono::Duration::minutes(30);
+        sqlx::query(
+            "UPDATE artifacts SET quarantine_status = 'quarantined', quarantine_until = $2 \
+             WHERE repository_id = $1 AND path = 'held/pkg-1.0.0.bin'",
+        )
+        .bind(repo_id)
+        .bind(until)
+        .execute(&pool)
+        .await
+        .expect("apply quarantine");
+
+        let storage: Arc<dyn StorageBackend> = Arc::new(
+            crate::storage::filesystem::FilesystemStorage::new(storage_dir),
+        );
+        let service = ArtifactService::new(pool.clone(), storage);
+        let page = service
+            .list_page(repo_id, None, None, None, 0, 50)
+            .await
+            .expect("list page");
+
+        let held = page
+            .iter()
+            .find(|a| a.path == "held/pkg-1.0.0.bin")
+            .expect("held artifact listed");
+        assert_eq!(held.quarantine_status.as_deref(), Some("quarantined"));
+        assert!(held.quarantine_until.is_some());
+
+        let clean = page
+            .iter()
+            .find(|a| a.path == "clean/pkg-1.0.0.bin")
+            .expect("clean artifact listed");
+        assert!(clean.quarantine_status.is_none());
+        assert!(clean.quarantine_until.is_none());
+    }
+
     #[tokio::test]
     async fn test_guard_rejects_foreign_repo_owning_key() {
         use crate::api::handlers::test_db_helpers as tdh;


### PR DESCRIPTION
## Summary

The repository artifacts listing (`GET /api/v1/repositories/{key}/artifacts`)
returned every artifact without its per-artifact quarantine state, so a
client/UI/operator could not tell which listed artifacts are held for security
review. Quarantine is a core download control (a held artifact's download is
blocked), but it was invisible in the listing — operators could not see what
was being held.

This surfaces the state on the listing item (`ArtifactResponse`):

- **`quarantine_status`** — always present. `"quarantined"` (held pending
  review), the terminal `"rejected"`, a scan-lifecycle state (`"clean"`,
  `"flagged"`, `"unscanned"`, `"released"`), or the explicit default
  `"not_quarantined"` when the row carries no quarantine state, so clients
  never have to treat a missing value as a state.
- **`quarantine_until`** — the expiry of a timed hold (omitted when `None`,
  i.e. a permanent/admin quarantine or an unquarantined artifact).

The values come from the `quarantine_status` / `quarantine_until` columns on
the **same `artifacts` row the listing query already selects**
(`list_page` / `list_for_repos_page`) — no extra join and no per-row (N+1)
lookup. The by-id (`GET /api/v1/artifacts/{id}`) and by-path artifact
responses carry the same fields (the by-id `SELECT` gained the two columns on
its existing join).

The human-readable **reason is intentionally not** placed on the listing: it
stays behind the authenticated, repository-visibility-checked
`GET /api/v1/quarantine/{id}`, because the listing is reachable anonymously on
public repositories and the reason is per-artifact security detail (matching
the disclosure boundary established for blocked-download errors).

## Regression test (required for `fix/*` PRs)
- [x] This PR adds tests that would have caught the bug
- [ ] N/A — this is not a bug fix

Added:
- `test_build_artifact_response_surfaces_quarantined_state` — a quarantined
  artifact maps to `quarantine_status="quarantined"` (+ its hold expiry); an
  un-held one maps to `"not_quarantined"`; the serialized item carries no
  `quarantine_reason`.
- `test_quarantine_status_label_maps_missing_to_not_quarantined` — the
  null/empty column maps to the explicit not-quarantined label; recorded
  statuses pass through verbatim.
- `test_list_page_carries_quarantine_state` (DB-backed) — guards that the
  listing query keeps selecting the quarantine columns so the handler can read
  them (a future refactor dropping them from the `SELECT` would silently report
  every artifact as unquarantined again).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations (N/A — existing endpoints; response schema extended)
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no schema change
- [ ] N/A - no API changes

Closes #2940
