### PR TITLE
feat(age-gate): reopen and re-decide terminal reviews

### DIFF
--- a/.sqlx/query-15eb75e866dcdc2e6d206c9bb93aed80a6f532f2744b4aea232ee13cadf7c885.json
+++ b/.sqlx/query-15eb75e866dcdc2e6d206c9bb93aed80a6f532f2744b4aea232ee13cadf7c885.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE age_gate_reviews\n            SET status = 'pending', reviewed_by = $2, reviewed_at = NOW(),\n                review_reason = $3\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "15eb75e866dcdc2e6d206c9bb93aed80a6f532f2744b4aea232ee13cadf7c885"
+}

--- a/backend/.sqlx/query-15eb75e866dcdc2e6d206c9bb93aed80a6f532f2744b4aea232ee13cadf7c885.json
+++ b/backend/.sqlx/query-15eb75e866dcdc2e6d206c9bb93aed80a6f532f2744b4aea232ee13cadf7c885.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE age_gate_reviews\n            SET status = 'pending', reviewed_by = $2, reviewed_at = NOW(),\n                review_reason = $3\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "15eb75e866dcdc2e6d206c9bb93aed80a6f532f2744b4aea232ee13cadf7c885"
+}

--- a/backend/src/api/handlers/age_gate.rs
+++ b/backend/src/api/handlers/age_gate.rs
@@ -53,6 +53,7 @@ pub fn admin_router() -> Router<SharedState> {
         .route("/reviews/:id", get(get_review))
         .route("/reviews/:id/approve", post(approve_review))
         .route("/reviews/:id/reject", post(reject_review))
+        .route("/reviews/:id/reopen", post(reopen_review))
 }
 
 pub fn repo_config_routes() -> Router<SharedState> {
@@ -137,14 +138,49 @@ fn age_gate_service(
 }
 
 /// Build the audit-log details for an approve/reject action.
-fn build_review_audit_details(
-    review: &AgeGateReviewResponse,
+fn build_review_audit_details(review: &AgeGateReview, reason: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "review_id": review.id,
+        "package": review.package_name,
+        "version": review.package_version,
+        "reason": reason,
+    })
+}
+
+/// Emit the audit entry for a review state change and return the JSON response.
+/// Shared by approve/reject/reopen so the audit-logging tail lives in one place.
+async fn log_review_action(
+    state: &SharedState,
+    actor: Uuid,
+    action: AuditAction,
+    review: AgeGateReview,
+    details: serde_json::Value,
+) -> Json<AgeGateReviewResponse> {
+    let repository_id = review.repository_id;
+    let resp = review_to_response(review);
+    let audit = AuditService::new(state.db.clone());
+    let _ = audit
+        .log(
+            AuditEntry::new(action, ResourceType::Repository)
+                .user(actor)
+                .resource(repository_id)
+                .details(details),
+        )
+        .await;
+    Json(resp)
+}
+
+/// Build the audit-log details for a reopen action, capturing the prior state.
+fn build_reopen_audit_details(
+    review: &AgeGateReview,
+    previous_status: &str,
     reason: Option<&str>,
 ) -> serde_json::Value {
     serde_json::json!({
         "review_id": review.id,
         "package": review.package_name,
         "version": review.package_version,
+        "previous_status": previous_status,
         "reason": reason,
     })
 }
@@ -250,19 +286,15 @@ pub async fn approve_review(
         .approve(id, auth.user_id, body.reason.as_deref())
         .await?;
 
-    let repository_id = review.repository_id;
-    let resp = review_to_response(review);
-    let audit = AuditService::new(state.db.clone());
-    let _ = audit
-        .log(
-            AuditEntry::new(AuditAction::AgeGateApproved, ResourceType::Repository)
-                .user(auth.user_id)
-                .resource(repository_id)
-                .details(build_review_audit_details(&resp, body.reason.as_deref())),
-        )
-        .await;
-
-    Ok(Json(resp))
+    let details = build_review_audit_details(&review, body.reason.as_deref());
+    Ok(log_review_action(
+        &state,
+        auth.user_id,
+        AuditAction::AgeGateApproved,
+        review,
+        details,
+    )
+    .await)
 }
 
 #[utoipa::path(
@@ -284,19 +316,45 @@ pub async fn reject_review(
     let svc = age_gate_service(&state)?;
     let review = svc.reject(id, auth.user_id, body.reason.as_deref()).await?;
 
-    let repository_id = review.repository_id;
-    let resp = review_to_response(review);
-    let audit = AuditService::new(state.db.clone());
-    let _ = audit
-        .log(
-            AuditEntry::new(AuditAction::AgeGateRejected, ResourceType::Repository)
-                .user(auth.user_id)
-                .resource(repository_id)
-                .details(build_review_audit_details(&resp, body.reason.as_deref())),
-        )
-        .await;
+    let details = build_review_audit_details(&review, body.reason.as_deref());
+    Ok(log_review_action(
+        &state,
+        auth.user_id,
+        AuditAction::AgeGateRejected,
+        review,
+        details,
+    )
+    .await)
+}
 
-    Ok(Json(resp))
+#[utoipa::path(
+    post,
+    path = "/age-gate/reviews/{id}/reopen",
+    context_path = "/api/v1/admin",
+    tag = "age-gate",
+    security(("bearer_auth" = [])),
+    request_body = ReviewActionRequest,
+    responses((status = 200, body = AgeGateReviewResponse))
+)]
+pub async fn reopen_review(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<ReviewActionRequest>,
+) -> Result<Json<AgeGateReviewResponse>> {
+    auth.require_admin()?;
+    let svc = age_gate_service(&state)?;
+    let (previous_status, review) = svc.reopen(id, auth.user_id, body.reason.as_deref()).await?;
+
+    let details = build_reopen_audit_details(&review, &previous_status, body.reason.as_deref());
+    Ok(log_review_action(
+        &state,
+        auth.user_id,
+        AuditAction::AgeGateReopened,
+        review,
+        details,
+    )
+    .await)
 }
 
 #[utoipa::path(
@@ -384,7 +442,7 @@ pub async fn update_repo_age_gate(
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(list_reviews, get_review, approve_review, reject_review, get_repo_age_gate, update_repo_age_gate),
+    paths(list_reviews, get_review, approve_review, reject_review, reopen_review, get_repo_age_gate, update_repo_age_gate),
     components(schemas(
         AgeGateReviewResponse,
         AgeGateReviewListResponse,
@@ -476,39 +534,16 @@ mod tests {
         assert!(require_remote_repo_for_age_gate(&RepositoryType::Remote).is_ok());
     }
 
-    #[test]
-    fn build_review_audit_details_includes_fields() {
+    /// Build an `AgeGateReview` fixture for the pure detail/mapping tests.
+    fn sample_review(name: &str, version: &str, status: &str) -> AgeGateReview {
         let now = Utc::now();
-        let resp = AgeGateReviewResponse {
-            id: Uuid::new_v4(),
-            repository_key: "npm-remote".to_string(),
-            package_name: "react".to_string(),
-            package_version: "18.0.0".to_string(),
-            upstream_published_at: None,
-            status: "pending".to_string(),
-            requested_at: now,
-            reviewed_by: None,
-            reviewed_at: None,
-            review_reason: None,
-            request_count: 1,
-            last_requested_at: now,
-        };
-        let details = build_review_audit_details(&resp, Some("looks safe"));
-        assert_eq!(details["package"], "react");
-        assert_eq!(details["version"], "18.0.0");
-        assert_eq!(details["reason"], "looks safe");
-    }
-
-    #[test]
-    fn review_to_response_maps_fields_and_default_key() {
-        let now = Utc::now();
-        let review = crate::services::age_gate_service::AgeGateReview {
+        AgeGateReview {
             id: Uuid::new_v4(),
             repository_id: Uuid::new_v4(),
-            package_name: "lodash".to_string(),
-            package_version: "4.0.0".to_string(),
+            package_name: name.to_string(),
+            package_version: version.to_string(),
             upstream_published_at: None,
-            status: "pending".to_string(),
+            status: status.to_string(),
             requested_at: now,
             reviewed_by: None,
             reviewed_at: None,
@@ -516,8 +551,31 @@ mod tests {
             request_count: 1,
             last_requested_at: now,
             repository_key: None,
-        };
-        let resp = review_to_response(review);
+        }
+    }
+
+    #[test]
+    fn build_review_audit_details_includes_fields() {
+        let review = sample_review("react", "18.0.0", "pending");
+        let details = build_review_audit_details(&review, Some("looks safe"));
+        assert_eq!(details["package"], "react");
+        assert_eq!(details["version"], "18.0.0");
+        assert_eq!(details["reason"], "looks safe");
+    }
+
+    #[test]
+    fn build_reopen_audit_details_includes_previous_status() {
+        let review = sample_review("left-pad", "1.3.0", "pending");
+        let details = build_reopen_audit_details(&review, "approved", Some("turned out bad"));
+        assert_eq!(details["package"], "left-pad");
+        assert_eq!(details["version"], "1.3.0");
+        assert_eq!(details["previous_status"], "approved");
+        assert_eq!(details["reason"], "turned out bad");
+    }
+
+    #[test]
+    fn review_to_response_maps_fields_and_default_key() {
+        let resp = review_to_response(sample_review("lodash", "4.0.0", "pending"));
         assert_eq!(resp.repository_key, "");
         assert_eq!(resp.package_name, "lodash");
         assert_eq!(resp.status, "pending");

--- a/backend/src/services/age_gate_service.rs
+++ b/backend/src/services/age_gate_service.rs
@@ -180,12 +180,18 @@ pub fn validate_min_age_days(min_age_days: i32) -> Result<()> {
     Ok(())
 }
 
-/// Reject approve/reject on a review that is no longer pending.
-pub(crate) fn require_pending_review(status: &str) -> Result<()> {
-    if status != AgeGateReviewStatus::Pending.as_str() {
+/// Guard a review state transition. Errors when the review is already in the
+/// requested target state (a no-op transition), otherwise allows the change.
+///
+/// Reviews are no longer terminal: an admin can approve, reject, or reopen a
+/// review from ANY current state (e.g. re-block a previously-approved package
+/// by rejecting it, or re-approve a previously-rejected one). The only refused
+/// transition is one that would not change anything.
+pub(crate) fn require_distinct_status(current: &str, target: AgeGateReviewStatus) -> Result<()> {
+    if current == target.as_str() {
         return Err(AppError::Validation(format!(
             "Review is already {}",
-            status
+            target.as_str()
         )));
     }
     Ok(())
@@ -577,7 +583,7 @@ impl AgeGateService {
         reason: Option<&str>,
     ) -> Result<AgeGateReview> {
         let review = self.get_review_by_id(id).await?;
-        require_pending_review(&review.status)?;
+        require_distinct_status(&review.status, AgeGateReviewStatus::Approved)?;
 
         sqlx::query!(
             r#"
@@ -611,7 +617,7 @@ impl AgeGateService {
         reason: Option<&str>,
     ) -> Result<AgeGateReview> {
         let review = self.get_review_by_id(id).await?;
-        require_pending_review(&review.status)?;
+        require_distinct_status(&review.status, AgeGateReviewStatus::Rejected)?;
 
         sqlx::query!(
             r#"
@@ -636,6 +642,50 @@ impl AgeGateService {
         );
 
         self.get_review_by_id(id).await
+    }
+
+    /// Reopen a decided review, moving it back to `pending` so the age gate can
+    /// be revisited. Allowed from any non-`pending` state; a review that is
+    /// already pending is refused as a no-op. The download path re-reads the
+    /// review status on every request, so reopening a young package's review
+    /// re-blocks subsequent pulls until it is decided again (or ages out).
+    ///
+    /// Returns `(previous_status, updated_review)` so callers can record the
+    /// prior state in the audit trail.
+    pub async fn reopen(
+        &self,
+        id: Uuid,
+        reviewer_id: Uuid,
+        reason: Option<&str>,
+    ) -> Result<(String, AgeGateReview)> {
+        let review = self.get_review_by_id(id).await?;
+        require_distinct_status(&review.status, AgeGateReviewStatus::Pending)?;
+        let previous_status = review.status.clone();
+
+        sqlx::query!(
+            r#"
+            UPDATE age_gate_reviews
+            SET status = 'pending', reviewed_by = $2, reviewed_at = NOW(),
+                review_reason = $3
+            WHERE id = $1
+            "#,
+            id,
+            reviewer_id,
+            reason
+        )
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        self.event_bus.emit_for_repo(
+            "age_gate.reopened",
+            id,
+            review.repository_id,
+            Some(reviewer_id.to_string()),
+        );
+
+        let updated = self.get_review_by_id(id).await?;
+        Ok((previous_status, updated))
     }
 
     pub async fn update_repo_config(
@@ -1639,6 +1689,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn db_reopen_and_redecide_flips_enforcement() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let bus = Arc::new(EventBus::new(64));
+        let svc = AgeGateService::new(pool.clone(), bus);
+        let (repo_id, repo_key) = create_age_gate_repo(&pool, RepositoryFormat::Npm, 7).await;
+        let params = npm_params(repo_id, repo_key, 7);
+        let reviewer = create_reviewer(&pool).await;
+
+        // A young version is blocked and creates a pending review.
+        let young = Utc::now() - Duration::days(1);
+        let review_id = match svc.check(&params, "reopen-pkg", "1.0.0", Some(young)).await {
+            Ok(AgeGateDecision::Block { review_id, .. }) => review_id,
+            other => panic!("young version should block, got {other:?}"),
+        };
+
+        // Admin approves -> pulls are now allowed.
+        let approved = svc
+            .approve(review_id, reviewer, Some("looked fine"))
+            .await
+            .expect("approve pending");
+        assert_eq!(approved.status, "approved");
+        assert!(matches!(
+            svc.check(&params, "reopen-pkg", "1.0.0", Some(young)).await,
+            Ok(AgeGateDecision::Allow)
+        ));
+
+        // Re-approving an already-approved review is a refused no-op.
+        assert!(svc.approve(review_id, reviewer, None).await.is_err());
+
+        // Reopen the terminal review -> back to pending, and the young version is
+        // re-blocked on the very next pull.
+        let (prev, reopened) = svc
+            .reopen(review_id, reviewer, Some("turned out bad"))
+            .await
+            .expect("reopen approved review");
+        assert_eq!(prev, "approved");
+        assert_eq!(reopened.status, "pending");
+        assert!(matches!(
+            svc.check(&params, "reopen-pkg", "1.0.0", Some(young)).await,
+            Ok(AgeGateDecision::Block { .. })
+        ));
+
+        // Reject the reopened review -> hard block regardless of age.
+        let rejected = svc
+            .reject(review_id, reviewer, Some("confirmed bad"))
+            .await
+            .expect("reject reopened review");
+        assert_eq!(rejected.status, "rejected");
+        assert!(matches!(
+            svc.check(
+                &params,
+                "reopen-pkg",
+                "1.0.0",
+                Some(Utc::now() - Duration::days(90))
+            )
+            .await,
+            Ok(AgeGateDecision::Block { .. })
+        ));
+
+        // Directly re-approve the rejected review (no reopen step) -> unblocked.
+        let reapproved = svc
+            .approve(review_id, reviewer, Some("now fine"))
+            .await
+            .expect("re-approve rejected review");
+        assert_eq!(reapproved.status, "approved");
+        assert!(matches!(
+            svc.check(&params, "reopen-pkg", "1.0.0", Some(young)).await,
+            Ok(AgeGateDecision::Allow)
+        ));
+
+        // Direct re-decide the other way: reject an approved review -> re-blocked.
+        let reblocked = svc
+            .reject(review_id, reviewer, Some("re-block"))
+            .await
+            .expect("reject approved review");
+        assert_eq!(reblocked.status, "rejected");
+        assert!(matches!(
+            svc.check(&params, "reopen-pkg", "1.0.0", Some(young)).await,
+            Ok(AgeGateDecision::Block { .. })
+        ));
+
+        // Reopening an already-pending review is a refused no-op.
+        let pending_id = insert_review_row(
+            &pool,
+            repo_id,
+            "reopen-pkg",
+            "2.0.0",
+            "pending",
+            Some(young),
+        )
+        .await;
+        assert!(svc.reopen(pending_id, reviewer, None).await.is_err());
+    }
+
+    #[tokio::test]
     async fn db_metadata_filters_batch_reviews_and_sweep() {
         let Some(pool) = try_db_pool().await else {
             return;
@@ -1861,10 +2008,18 @@ mod tests {
     }
 
     #[test]
-    fn require_pending_review_rejects_non_pending() {
-        assert!(require_pending_review("pending").is_ok());
-        assert!(require_pending_review("approved").is_err());
-        assert!(require_pending_review("rejected").is_err());
+    fn require_distinct_status_refuses_only_noop_transitions() {
+        // Approve is allowed from pending and rejected, refused from approved.
+        assert!(require_distinct_status("pending", AgeGateReviewStatus::Approved).is_ok());
+        assert!(require_distinct_status("rejected", AgeGateReviewStatus::Approved).is_ok());
+        assert!(require_distinct_status("approved", AgeGateReviewStatus::Approved).is_err());
+        // Reject is allowed from pending and approved, refused from rejected.
+        assert!(require_distinct_status("approved", AgeGateReviewStatus::Rejected).is_ok());
+        assert!(require_distinct_status("rejected", AgeGateReviewStatus::Rejected).is_err());
+        // Reopen is allowed from any terminal state, refused when already pending.
+        assert!(require_distinct_status("approved", AgeGateReviewStatus::Pending).is_ok());
+        assert!(require_distinct_status("rejected", AgeGateReviewStatus::Pending).is_ok());
+        assert!(require_distinct_status("pending", AgeGateReviewStatus::Pending).is_err());
     }
 
     #[test]

--- a/backend/src/services/audit_export.rs
+++ b/backend/src/services/audit_export.rs
@@ -121,6 +121,7 @@ impl AuditAction {
             | AuditAction::SessionsInvalidated
             | AuditAction::AgeGateQueued
             | AuditAction::AgeGateApproved
+            | AuditAction::AgeGateReopened
             | AuditAction::CurationSyncTriggered => Outcome::Success,
         }
     }
@@ -847,6 +848,7 @@ mod tests {
             AuditAction::ScanReaped,
             AuditAction::BackupCompleted,
             AuditAction::AgeGateApproved,
+            AuditAction::AgeGateReopened,
         ] {
             assert_eq!(a.outcome(), Outcome::Success, "{}", a.as_str());
         }

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -87,6 +87,7 @@ pub enum AuditAction {
     AgeGateQueued,
     AgeGateApproved,
     AgeGateRejected,
+    AgeGateReopened,
 
     // Authorization decisions (#2366 functional audit log). Recorded when an
     // authenticated principal is refused a privileged operation (e.g. a
@@ -153,6 +154,7 @@ impl AuditAction {
             AuditAction::AgeGateQueued => "AGE_GATE_QUEUED",
             AuditAction::AgeGateApproved => "AGE_GATE_APPROVED",
             AuditAction::AgeGateRejected => "AGE_GATE_REJECTED",
+            AuditAction::AgeGateReopened => "AGE_GATE_REOPENED",
             AuditAction::PermissionDenied => "PERMISSION_DENIED",
             AuditAction::CurationSyncTriggered => "CURATION_SYNC_TRIGGERED",
         }


### PR DESCRIPTION
## Summary

Closes #2939.

Age-gate reviews were terminal: once an admin approved or rejected a held
package version there was no way to revisit that decision. Operators could not
re-block a package that was approved but later turned out bad, nor unblock a
package that was rejected but is now fine.

This makes reviews revisitable:

- **New endpoint** `POST /api/v1/admin/age-gate/reviews/{id}/reopen` transitions
  a decided (approved/rejected) review back to `pending`. Refused as a no-op if
  the review is already pending.
- **Approve/reject are now re-decidable.** The old `require_pending_review`
  guard is replaced by `require_distinct_status`, so an admin can approve a
  rejected review (unblock) or reject an approved one (re-block). The only
  refused transition is one that would not change the status.
- **Enforcement follows automatically.** The proxy metadata/download path
  (`AgeGateService::check` / `decide_age_gate_check`) re-reads the review status
  on every request, so flipping a review's decision flips what the proxy serves
  on the very next pull — reopening a young package's review re-blocks it,
  re-approving a rejected one unblocks it.
- **Audit trail.** Reopen emits an `AGE_GATE_REOPENED` audit entry (and
  `age_gate.reopened` event) capturing actor, timestamp and the previous status.
- **Admin-gated**, consistent with the existing approve/reject routes (both the
  `/admin` middleware and an in-handler `require_admin()`).

No schema change is needed: the `age_gate_reviews.status` CHECK already permits
`pending`/`approved`/`rejected`, and enforcement is entirely status-driven.

The approve/reject/reopen handlers now share a single audit-and-respond helper,
removing pre-existing duplication between them.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added `db_reopen_and_redecide_flips_enforcement` (DB-backed): approve → reopen →
`check` blocks again; reject → `check` blocks; re-approve a rejected review →
`check` allows; reject an approved review → `check` blocks. Plus a pure
state-machine test `require_distinct_status_refuses_only_noop_transitions` and a
handler test for the reopen audit-detail builder.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified end-to-end against a live npm remote proxy (age gate at max threshold):
approving a held version serves it, reopening re-blocks it on the next pull,
rejecting keeps it blocked, and re-approving the rejected review serves it again
— the packument the proxy returns flips in lock-step with each decision.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no migration
- [ ] N/A - no API changes
