### PR TITLE
test(formats): drive advertised download URLs through the real router (batch 2)

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -3172,6 +3172,65 @@ mod db_cov_tests {
         fx.teardown().await;
     }
 
+    // -----------------------------------------------------------------------
+    // Advertised-location conformance (#2657 class)
+    //
+    // apk-tools does not read a download URL out of the APKINDEX: it downloads
+    // `{P}-{V}.apk` from the SAME arch directory the index was fetched from.
+    // The `build_alpine_artifact_path` unit tests prove that path is a string;
+    // only reconstructing the filename from the `P:`/`V:` the REAL index
+    // advertises and fetching it against the download route proves an `apk add`
+    // of an indexed package resolves. A `P:`/`V:` pair whose `{P}-{V}.apk` the
+    // download route 404s passes every builder test yet breaks `apk add`.
+    // -----------------------------------------------------------------------
+
+    /// Read the first value of a single-letter APKINDEX field (`P:`, `V:`).
+    fn apkindex_field(text: &str, key: char) -> String {
+        let prefix = format!("{key}:");
+        text.lines()
+            .find_map(|l| l.strip_prefix(&prefix))
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn test_indexed_package_apk_resolves_against_download_route() {
+        let Some(fx) = tdh::Fixture::setup("local", "alpine").await else {
+            return;
+        };
+        let text = publish_marker_and_fetch_index(&fx).await;
+
+        // Reconstruct the download filename exactly as apk-tools does from the
+        // `P:`/`V:` the index advertises: `{name}-{version}.apk`, fetched from
+        // the same `{branch}/{repository}/{arch}` directory as APKINDEX.tar.gz.
+        let name = apkindex_field(&text, 'P');
+        let version = apkindex_field(&text, 'V');
+        assert_eq!(name, "dtf-marker", "index must advertise P:");
+        assert!(!version.is_empty(), "index must advertise V:");
+        let advertised_filename = format!("{name}-{version}.apk");
+
+        let k = fx.repo_key.clone();
+        let app = fx.router_with_auth(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{k}/v3.21/main/aarch64/{advertised_filename}")),
+        )
+        .await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "the package the index advertises ({advertised_filename}) must resolve, not 404"
+        );
+        assert_eq!(
+            &body[..],
+            super::MARKER_APK,
+            "the advertised .apk must serve the published package bytes"
+        );
+    }
+
     /// A package stored before the apk checksum was recorded is backfilled from
     /// the stored bytes on the next index request, instead of dropping out of it.
     #[tokio::test]

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -7380,6 +7380,86 @@ mod agent2_recipe_reads {
         let _ = std::fs::remove_dir_all(&storage_dir);
     }
 
+    // -----------------------------------------------------------------------
+    // Advertised-location conformance (#2657 class)
+    //
+    // The `build_files_listing_json` unit tests prove the listing echoes the
+    // filenames it is handed; only downloading a file whose name the REAL
+    // `/files` listing advertised — appended to the same `.../files/` base a
+    // Conan client uses — proves that advertised name resolves against the
+    // download route. A listing that names a file the download route 404s
+    // passes every builder test yet breaks `conan install`.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn recipe_files_list_advertises_downloadable_file() {
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let (user_id, username, _pw) = create_user(&pool).await;
+        let (repo_id, repo_key, storage_dir) = create_conan_repo(&pool, "local").await;
+        let state = build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = make_auth(user_id, &username);
+
+        let contents = b"from conan import ConanFile\nclass T(ConanFile): pass\n";
+        let put_status = upload_recipe_file(
+            &state,
+            &auth,
+            &repo_key,
+            "advurl",
+            "1.0",
+            "_",
+            "_",
+            "rev_adv",
+            "conanfile.py",
+            contents,
+        )
+        .await;
+        assert!(put_status.is_success(), "upload failed: {}", put_status);
+
+        // Read the file the `/files` listing advertises for this revision.
+        let files_base = format!(
+            "/{}/v2/conans/advurl/1.0/_/_/revisions/rev_adv/files",
+            repo_key
+        );
+        let app = router_with_auth(state.clone(), auth.clone());
+        let (list_status, list_body) = send(app, get(files_base.clone())).await;
+        assert_eq!(list_status, StatusCode::OK, "files listing");
+        let listing: serde_json::Value = serde_json::from_slice(&list_body).expect("json");
+        let advertised = listing["files"]
+            .as_object()
+            .and_then(|m| m.keys().next())
+            .cloned()
+            .unwrap_or_default();
+
+        // A Conan client downloads by appending the advertised name to the same
+        // `.../files/` base the listing was served from.
+        let app = router_with_auth(state.clone(), auth.clone());
+        let (dl_status, dl_body) = if advertised.is_empty() {
+            (StatusCode::NOT_FOUND, bytes::Bytes::new())
+        } else {
+            send(app, get(format!("{files_base}/{advertised}"))).await
+        };
+
+        cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        assert_eq!(
+            advertised, "conanfile.py",
+            "listing must advertise the file"
+        );
+        assert_eq!(
+            dl_status,
+            StatusCode::OK,
+            "the advertised file ({advertised}) must resolve, not 404"
+        );
+        assert_eq!(
+            dl_body.as_ref(),
+            contents,
+            "the advertised file must serve the uploaded bytes"
+        );
+    }
+
     #[tokio::test]
     async fn recipe_file_download_404_when_missing_in_hosted_repo() {
         let Some(pool) = try_pool().await else {

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -3113,6 +3113,122 @@ mod tests {
         f.teardown().await;
     }
 
+    // -----------------------------------------------------------------------
+    // Advertised-location conformance (#2657 class)
+    //
+    // The `build_hex_tarball_url` unit tests prove the builder emits a string;
+    // only routing the URL the `/packages/{name}` document actually advertises
+    // against the REAL router (mounted where `api::routes` nests it) proves a
+    // hex client can fetch the published tarball. A wrongly-shaped or
+    // wrongly-prefixed release `url` passes every builder test yet 404s on
+    // `mix deps.get`.
+    // -----------------------------------------------------------------------
+
+    /// The hex routes mounted exactly where `api::routes` nests them. The
+    /// advertised release `url` is root-absolute and carries the `/hex` prefix.
+    fn mounted_router() -> Router<SharedState> {
+        Router::new().nest("/hex", super::router())
+    }
+
+    /// Resolve an advertised URL against the document that carried it and return
+    /// the path+query to request (dropping any fragment).
+    fn resolve_advertised(document_url: &str, advertised: &str) -> String {
+        let base = reqwest::Url::parse(document_url).expect("document url");
+        let joined = base.join(advertised).expect("advertised url must resolve");
+        joined[url::Position::BeforePath..url::Position::AfterQuery].to_string()
+    }
+
+    /// The tarball `url` the `/packages/{name}` document advertises (the JSON
+    /// release resource a Virtual hex repo serves) must resolve against the real
+    /// download route and serve the published tarball bytes. The advertised url
+    /// carries the VIRTUAL repo key, so a client following it lands back on the
+    /// same virtual repo, which serves the local member's bytes.
+    #[tokio::test]
+    async fn test_advertised_release_url_resolves_against_real_router() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, _username) = tdh::create_user(&pool).await;
+        let (local_repo_id, _local_key, local_storage_dir) =
+            tdh::create_repo(&pool, "local", "hex").await;
+        let (virtual_repo_id, virtual_key, _virtual_storage_dir) =
+            tdh::create_repo(&pool, "virtual", "hex").await;
+        let state = tdh::build_state(pool.clone(), local_storage_dir.to_str().unwrap());
+
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(virtual_repo_id)
+        .bind(local_repo_id)
+        .execute(&pool)
+        .await
+        .expect("link virtual member");
+
+        let name = "jason";
+        let version = "1.4.1";
+        let tarball: &[u8] = b"hex-tarball-bytes-for-advertised-url";
+        let local_repo =
+            tdh::make_repo_info(local_repo_id, "local-hex", &local_storage_dir, "hex", None);
+        tdh::seed_artifact(
+            &state,
+            &pool,
+            &local_repo,
+            &format!("hex/{name}/{version}/{name}-{version}.tar"),
+            &format!("{name}/{version}/{name}-{version}.tar"),
+            name,
+            version,
+            "application/octet-stream",
+            bytes::Bytes::from_static(tarball),
+            user_id,
+        )
+        .await;
+
+        // Read the release `url` the package-info document advertises.
+        let meta_path = format!("/hex/{virtual_key}/packages/{name}");
+        let meta_doc_url = format!("http://ak.test{meta_path}");
+        let (meta_status, meta_body) = tdh::send(
+            tdh::router_anon(mounted_router(), state.clone()),
+            tdh::get(meta_path),
+        )
+        .await;
+        let meta: serde_json::Value = serde_json::from_slice(&meta_body).unwrap_or_default();
+        let advertised = meta["releases"][0]["url"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+
+        let (dl_status, dl_body) = if advertised.is_empty() {
+            (StatusCode::NOT_FOUND, Bytes::new())
+        } else {
+            let path = resolve_advertised(&meta_doc_url, &advertised);
+            tdh::send(
+                tdh::router_anon(mounted_router(), state.clone()),
+                tdh::get(path),
+            )
+            .await
+        };
+
+        tdh::cleanup(&pool, virtual_repo_id, user_id).await;
+        tdh::cleanup(&pool, local_repo_id, user_id).await;
+
+        assert_eq!(meta_status, StatusCode::OK, "package-info document");
+        assert!(
+            !advertised.is_empty(),
+            "package-info must advertise a release url"
+        );
+        assert_eq!(
+            dl_status,
+            StatusCode::OK,
+            "the advertised release url ({advertised}) must resolve, not 404"
+        );
+        assert_eq!(
+            &dl_body[..],
+            tarball,
+            "the advertised release url must serve the published tarball bytes"
+        );
+    }
+
     #[tokio::test]
     async fn test_hex_package_info_404_when_missing() {
         let Some(f) = tdh::Fixture::setup("local", "hex").await else {

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -5328,6 +5328,101 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Advertised-location conformance (#2657 class)
+    //
+    // The rewrite/build tests prove `dist.tarball` is emitted as a string;
+    // only routing that URL against the REAL router (mounted where `api::routes`
+    // nests it) proves an npm client can fetch the published tarball. A tarball
+    // URL whose path the download route 404s passes every rewrite test yet
+    // breaks `npm install` (the #2587 class).
+    // -----------------------------------------------------------------------
+
+    /// The npm routes mounted exactly where `api::routes` nests them. The
+    /// advertised `dist.tarball` is absolute and carries the `/npm` prefix.
+    fn npm_mounted_router() -> Router<crate::api::SharedState> {
+        Router::new().nest("/npm", super::router())
+    }
+
+    /// Resolve an advertised URL against the document that carried it and return
+    /// the path+query to request.
+    fn resolve_advertised(document_url: &str, advertised: &str) -> String {
+        let base = reqwest::Url::parse(document_url).expect("document url");
+        let joined = base.join(advertised).expect("advertised url must resolve");
+        joined[url::Position::BeforePath..url::Position::AfterQuery].to_string()
+    }
+
+    #[tokio::test]
+    async fn test_advertised_dist_tarball_resolves_against_real_router() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "npm").await else {
+            return;
+        };
+
+        let package = "widget";
+        let version = "1.0.0";
+        let tgz: &[u8] = b"npm-tgz-bytes-for-advertised-url";
+        let repo = fx.repo_info("local", None);
+        let path = format!("{package}/{version}/{package}-{version}.tgz");
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &format!("npm/{path}"),
+            &path,
+            package,
+            version,
+            "application/gzip",
+            Bytes::from_static(tgz),
+            fx.user_id,
+        )
+        .await;
+
+        // Read the `dist.tarball` the packument advertises.
+        let meta_path = format!("/npm/{}/{package}", fx.repo_key);
+        let meta_doc_url = format!("http://ak.test{meta_path}");
+        let (meta_status, meta_body) = tdh::send(
+            tdh::router_anon(npm_mounted_router(), fx.state.clone()),
+            tdh::get(meta_path),
+        )
+        .await;
+        let meta: serde_json::Value = serde_json::from_slice(&meta_body).unwrap_or_default();
+        let tarball = meta["versions"][version]["dist"]["tarball"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+
+        let (dl_status, dl_body) = if tarball.is_empty() {
+            (StatusCode::NOT_FOUND, Bytes::new())
+        } else {
+            let dl_path = resolve_advertised(&meta_doc_url, &tarball);
+            tdh::send(
+                tdh::router_anon(npm_mounted_router(), fx.state.clone()),
+                tdh::get(dl_path),
+            )
+            .await
+        };
+
+        fx.teardown().await;
+
+        assert_eq!(meta_status, StatusCode::OK, "packument");
+        assert!(
+            !tarball.is_empty(),
+            "packument must advertise a dist.tarball"
+        );
+        assert_eq!(
+            dl_status,
+            StatusCode::OK,
+            "the advertised dist.tarball ({tarball}) must resolve, not 404"
+        );
+        assert_eq!(
+            &dl_body[..],
+            tgz,
+            "the advertised dist.tarball must serve the published tarball bytes"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // RepoInfo struct
     // -----------------------------------------------------------------------
 

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -3363,6 +3363,106 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Advertised-location conformance (#2657 class)
+    //
+    // The `generate_primary_xml` unit tests prove `<location href>` is emitted
+    // as a string; only resolving that href the way dnf/yum does — against the
+    // repository base URL (the directory that holds `repodata/`), NOT against
+    // the primary.xml document itself — and routing it against the REAL router
+    // proves a package the index advertises is actually downloadable. A href
+    // that 404s at the download route passes every generator test yet breaks
+    // `dnf install`.
+    // -----------------------------------------------------------------------
+
+    /// The rpm routes mounted exactly where `api::routes` nests them, so the
+    /// repo-base-relative `<location href>` resolves with the `/rpm` prefix.
+    fn rpm_mounted_router() -> Router<SharedState> {
+        Router::new().nest("/rpm", super::router())
+    }
+
+    /// Resolve an advertised URL against the document that carried it and return
+    /// the path to request.
+    fn resolve_advertised(document_url: &str, advertised: &str) -> String {
+        let base = reqwest::Url::parse(document_url).expect("document url");
+        let joined = base.join(advertised).expect("advertised url must resolve");
+        joined[url::Position::BeforePath..url::Position::AfterQuery].to_string()
+    }
+
+    #[tokio::test]
+    async fn test_advertised_primary_location_resolves_against_real_router() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+
+        // Publish a package's bytes under the exact `packages/<file>` path the
+        // native RPM PUT stores, so both the index location and the download
+        // route agree on it.
+        let filename = "realpkg-1.0-1.x86_64.rpm";
+        let rpm_bytes: &[u8] = b"fake-rpm-package-bytes-for-advertised-url";
+        let repo = f.repo_info("local", None);
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            &format!("packages/{filename}"),
+            &format!("packages/{filename}"),
+            "realpkg",
+            "1.0-1",
+            "application/x-rpm",
+            bytes::Bytes::from_static(rpm_bytes),
+            f.user_id,
+        )
+        .await;
+
+        // Read the `<location href>` primary.xml advertises for the package.
+        let (status, body) = tdh::send(
+            f.router_anon(rpm_mounted_router()),
+            tdh::get(format!("/rpm/{}/repodata/primary.xml.gz", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "primary.xml.gz");
+        let mut primary = String::new();
+        GzDecoder::new(&body[..])
+            .read_to_string(&mut primary)
+            .expect("decompress primary.xml.gz");
+        let href = primary
+            .split_once("<location href=\"")
+            .and_then(|(_, rest)| rest.split_once('"'))
+            .map(|(h, _)| h.to_string())
+            .unwrap_or_default();
+
+        // dnf resolves `<location href>` against the repository base URL — the
+        // directory that CONTAINS `repodata/`, not the primary.xml document.
+        let repo_base = format!("http://ak.test/rpm/{}/", f.repo_key);
+        let (dl_status, dl_body) = if href.is_empty() {
+            (StatusCode::NOT_FOUND, bytes::Bytes::new())
+        } else {
+            let path = resolve_advertised(&repo_base, &href);
+            tdh::send(f.router_anon(rpm_mounted_router()), tdh::get(path)).await
+        };
+
+        f.teardown().await;
+
+        assert!(
+            !href.is_empty(),
+            "primary.xml must advertise a <location href>, got: {primary}"
+        );
+        assert_eq!(
+            dl_status,
+            StatusCode::OK,
+            "the advertised <location href> ({href}) must resolve, not 404"
+        );
+        assert_eq!(
+            &dl_body[..],
+            rpm_bytes,
+            "the advertised location must serve the published .rpm bytes"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // repomd.xml.asc / repomd.xml.key — the OpenPGP contract (#2636)
     //
     // These replace the former `pgp_armor_signature` tests, which asserted the


### PR DESCRIPTION
## Summary

Second batch of the router-driven advertised-URL test conversion started in
#2908. Handler test modules define `build_*` / `format_*` helpers *inside*
`#[cfg(test)] mod tests` that duplicate production `format!` logic and then
assert a test-local builder matches a literal — so they cannot catch a
production advertised-URL bug (an advertised path the served route 404s, the
#2587 / #2361 class).

This PR adds router-driven conformance tests for five more format handlers.
Each publishes/seeds a package, reads the URL the protocol actually advertises
out of the document the server emits, and follows that URL against the **real
router mounted where `api::routes` nests it** — asserting the advertised URL
resolves (200) and serves the published bytes, not that a builder matches its
own literal:

- **rpm** — the `<location href>` in `primary.xml.gz`, resolved the way dnf/yum
  does (against the repository base URL that holds `repodata/`, **not** against
  the primary.xml document), routed through `/rpm`.
- **hex** — the release `url` a Virtual hex repo advertises in
  `/packages/{name}`, followed back through `/hex` to the local member's tarball.
- **conan** — a filename the real `/files` listing advertises, downloaded by
  appending it to the same `.../files/` base a Conan client uses.
- **alpine/apk** — the `{P}-{V}.apk` apk-tools reconstructs from the `P:`/`V:`
  the served `APKINDEX.tar.gz` advertises, fetched from the same arch directory.
- **npm** — the `dist.tarball` URL the packument advertises, routed through
  `/npm` to the published `.tgz`.

No production advertised-URL bug was found in this batch: all five advertised
URLs resolve to the published bytes, so these tests land as regression guards
for the shape each protocol depends on.

Remaining handlers still on the test-local builder pattern (follow-up under
#2657): goproxy already drives list→info→zip→mod through the real router, so it
is effectively covered; cocoapods, conda, protobuf, vscode, plus the
lower-priority approval/promotion/repositories modules remain.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Refs #2657
