### PR TITLE
feat(scan): inline scan-and-block on download (proxy PyPI + hosted) (#2954)

### DIFF
--- a/.sqlx/query-4700326444e77685316b7b94ff9968c71e5c6c5e0bd302906193df0ab2aed5d3.json
+++ b/.sqlx/query-4700326444e77685316b7b94ff9968c71e5c6c5e0bd302906193df0ab2aed5d3.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                   block_on_policy_violation, severity_threshold, proxy_scan_action,\n                   created_at, updated_at\n            FROM scan_configs\n            WHERE repository_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "block_on_policy_violation",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "severity_threshold",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "proxy_scan_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4700326444e77685316b7b94ff9968c71e5c6c5e0bd302906193df0ab2aed5d3"
+}

--- a/.sqlx/query-57a50434fce558cdc24ebae014ae48808372189a073ab859e93cbdd71d67e66d.json
+++ b/.sqlx/query-57a50434fce558cdc24ebae014ae48808372189a073ab859e93cbdd71d67e66d.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO proxy_scan_results (\n                checksum_sha256, scan_type, verdict,\n                findings_count, critical_count, high_count, medium_count, low_count,\n                max_severity, scanner_version, repository_id, scanned_at\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now())\n            ON CONFLICT (checksum_sha256, scan_type) DO UPDATE SET\n                verdict = EXCLUDED.verdict,\n                findings_count = EXCLUDED.findings_count,\n                critical_count = EXCLUDED.critical_count,\n                high_count = EXCLUDED.high_count,\n                medium_count = EXCLUDED.medium_count,\n                low_count = EXCLUDED.low_count,\n                max_severity = EXCLUDED.max_severity,\n                scanner_version = EXCLUDED.scanner_version,\n                repository_id = EXCLUDED.repository_id,\n                scanned_at = now()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Text",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "57a50434fce558cdc24ebae014ae48808372189a073ab859e93cbdd71d67e66d"
+}

--- a/.sqlx/query-6c6adab81089d070156e27475318bf315123baf82f2de14975892939078f77ad.json
+++ b/.sqlx/query-6c6adab81089d070156e27475318bf315123baf82f2de14975892939078f77ad.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT proxy_scan_action FROM scan_configs WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "proxy_scan_action",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "6c6adab81089d070156e27475318bf315123baf82f2de14975892939078f77ad"
+}

--- a/.sqlx/query-aaee673b8ffd0a3161a6310b8ab47bb316577600b008e22a752ad6dcabf3b95b.json
+++ b/.sqlx/query-aaee673b8ffd0a3161a6310b8ab47bb316577600b008e22a752ad6dcabf3b95b.json
@@ -1,0 +1,83 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT checksum_sha256, scan_type, verdict,\n                   findings_count, critical_count, high_count, medium_count, low_count,\n                   max_severity, scanner_version, scanned_at\n            FROM proxy_scan_results\n            WHERE checksum_sha256 = $1 AND scan_type = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "checksum_sha256",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "scan_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "verdict",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "max_severity",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "scanner_version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "scanned_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "aaee673b8ffd0a3161a6310b8ab47bb316577600b008e22a752ad6dcabf3b95b"
+}

--- a/.sqlx/query-ca12858dedb841ba60eef03ed410c3988a25188601437a2934c42313c90e5e96.json
+++ b/.sqlx/query-ca12858dedb841ba60eef03ed410c3988a25188601437a2934c42313c90e5e96.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                   block_on_policy_violation, severity_threshold, proxy_scan_action,\n                   created_at, updated_at\n            FROM scan_configs\n            WHERE scan_enabled = true\n            ORDER BY created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "block_on_policy_violation",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "severity_threshold",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "proxy_scan_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ca12858dedb841ba60eef03ed410c3988a25188601437a2934c42313c90e5e96"
+}

--- a/.sqlx/query-e60806829a3e318566dfbe9910c325b7aee4113fc2124c1c36c9fd9b73384ce0.json
+++ b/.sqlx/query-e60806829a3e318566dfbe9910c325b7aee4113fc2124c1c36c9fd9b73384ce0.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_configs (repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                                      block_on_policy_violation, severity_threshold,\n                                      proxy_scan_action)\n            VALUES ($1, $2, $3, $4, $5, $6, $7)\n            ON CONFLICT (repository_id)\n            DO UPDATE SET\n                scan_enabled = EXCLUDED.scan_enabled,\n                scan_on_upload = EXCLUDED.scan_on_upload,\n                scan_on_proxy = EXCLUDED.scan_on_proxy,\n                block_on_policy_violation = EXCLUDED.block_on_policy_violation,\n                severity_threshold = EXCLUDED.severity_threshold,\n                proxy_scan_action = EXCLUDED.proxy_scan_action,\n                updated_at = NOW()\n            RETURNING id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                      block_on_policy_violation, severity_threshold, proxy_scan_action,\n                      created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "block_on_policy_violation",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "severity_threshold",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "proxy_scan_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Bool",
+        "Bool",
+        "Bool",
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e60806829a3e318566dfbe9910c325b7aee4113fc2124c1c36c9fd9b73384ce0"
+}

--- a/backend/migrations/181_proxy_scan_results.sql
+++ b/backend/migrations/181_proxy_scan_results.sql
@@ -1,0 +1,40 @@
+-- #2954: inline scan-and-block on download (proxy PyPI + hosted).
+--
+-- Proxy-cached bytes are deliberately NOT written to `artifacts` (#1278/#1280),
+-- and `scan_results.artifact_id` is NOT NULL REFERENCES artifacts(id). There is
+-- therefore no row to attach a proxy scan verdict to. This table stores a
+-- content-addressed (checksum_sha256) verdict independent of `artifacts`,
+-- preserving the #1278/#1280 invariant. Verdicts are shared across
+-- repos/tenants that pull identical bytes (same bytes = same CVEs) and survive
+-- proxy-cache eviction.
+CREATE TABLE proxy_scan_results (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    checksum_sha256  TEXT NOT NULL,          -- content identity (the cache key)
+    scan_type        TEXT NOT NULL,          -- 'grype'
+    verdict          TEXT NOT NULL,          -- 'clean' | 'vulnerable' | 'error'
+    findings_count   INT  NOT NULL DEFAULT 0,
+    critical_count   INT  NOT NULL DEFAULT 0,
+    high_count       INT  NOT NULL DEFAULT 0,
+    medium_count     INT  NOT NULL DEFAULT 0,
+    low_count        INT  NOT NULL DEFAULT 0,
+    max_severity     TEXT,                   -- highest observed, for policy compare
+    scanner_version  TEXT,                   -- e.g. grype-0.8x + db build => CVE-DB freshness
+    repository_id    UUID REFERENCES repositories(id) ON DELETE SET NULL, -- provenance only
+    scanned_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_proxy_scan UNIQUE (checksum_sha256, scan_type),
+    CONSTRAINT ck_proxy_scan_verdict CHECK (verdict IN ('clean', 'vulnerable', 'error'))
+);
+
+CREATE INDEX idx_proxy_scan_checksum ON proxy_scan_results (checksum_sha256, scan_type);
+
+-- #2954: per-repo fail-open (default) / fail-closed (opt-in) action for the
+-- inline proxy scan. Reuses the `block_unscanned` semantics: fail-open serves
+-- the first pull of an unknown digest immediately (loud: warn + audit +
+-- X-AK-Scan: pending) while the async scan populates the verdict; fail-closed
+-- blocks (403) on a vulnerable verdict and returns 423 rather than ever serving
+-- unscanned bytes when the object is over-cap or the inline scan budget is
+-- exceeded. Additive column with a fail-open default so operators who have not
+-- opted in see today's behavior unchanged.
+ALTER TABLE scan_configs
+    ADD COLUMN proxy_scan_action TEXT NOT NULL DEFAULT 'fail_open'
+        CHECK (proxy_scan_action IN ('fail_open', 'fail_closed'));

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1741,6 +1741,33 @@ async fn serve_file(
                         return Ok(resp);
                     }
 
+                    // #2954: when scan-on-proxy is enabled, route through the
+                    // inline scan-and-block path (buffered fetch + digest-keyed
+                    // verdict gate). It handles the cache internally, so we take
+                    // it INSTEAD of the streaming/redirect cache paths below,
+                    // which serve bytes without consulting a scan verdict. Repos
+                    // that have not enabled scan-on-proxy skip this entirely and
+                    // keep today's untouched streaming behavior (no regression).
+                    if crate::services::scan_config_service::ScanConfigService::new(
+                        state.db.clone(),
+                    )
+                    .is_proxy_scan_enabled(repo.id)
+                    .await
+                    .unwrap_or(false)
+                    {
+                        return serve_scanned_pypi_file(
+                            state,
+                            proxy,
+                            repo.id,
+                            repo_key,
+                            upstream_url,
+                            project,
+                            filename,
+                            ctx,
+                        )
+                        .await;
+                    }
+
                     // Try the proxy cache first using a predictable local
                     // path. This avoids fetching the simple index from upstream
                     // just to rediscover the download URL when the file is
@@ -2492,6 +2519,368 @@ fn build_streaming_file_response(
                 .map(|r| r.map_err(|e| std::io::Error::other(e.to_string()))),
         ))
         .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// #2954: inline scan-and-block on proxy download (PyPI Phase 1).
+// ---------------------------------------------------------------------------
+
+/// The scan_type stored for the Grype CVE scanner in `proxy_scan_results`.
+const PROXY_SCAN_TYPE: &str = "grype";
+
+/// SHA-256 hex of the fetched bytes. The verdict cache is keyed on the CONTENT
+/// digest we compute ourselves — never an index-advertised digest — so a lying
+/// upstream index cannot bind a clean verdict to malicious bytes (#2954 inv 4).
+fn sha256_hex(bytes: &Bytes) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Build the synthetic in-memory [`Artifact`](crate::models::artifact::Artifact)
+/// that [`ScannerService::scan_content`] runs the leaf scanners over. There is
+/// NO `artifacts` row: proxy-cached bytes are deliberately not persisted as
+/// artifacts (#1278/#1280). The filename drives per-scanner applicability +
+/// workspace naming exactly as for a hosted wheel.
+fn pypi_synthetic_artifact(
+    repo_id: uuid::Uuid,
+    filename: &str,
+    digest: &str,
+    size: i64,
+) -> crate::models::artifact::Artifact {
+    let now = Utc::now();
+    crate::models::artifact::Artifact {
+        id: uuid::Uuid::new_v4(),
+        repository_id: repo_id,
+        path: filename.to_string(),
+        name: filename.to_string(),
+        version: version_from_pypi_filename(filename),
+        size_bytes: size,
+        checksum_sha256: digest.to_string(),
+        checksum_md5: None,
+        checksum_sha1: None,
+        content_type: pypi_content_type(filename).to_string(),
+        storage_key: String::new(),
+        is_deleted: false,
+        uploaded_by: None,
+        quarantine_status: None,
+        quarantine_until: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+/// A 403 for a proxy pull blocked by a vulnerable inline-scan verdict. Body is
+/// neutral: it names the file, not the specific CVEs (the download route is
+/// anonymous-readable for public repos).
+fn scan_blocked_response(filename: &str) -> Response {
+    let body = serde_json::json!({
+        "error": "scan_blocked",
+        "file": filename,
+        "reason": "blocked by inline vulnerability scan policy",
+    });
+    (
+        StatusCode::FORBIDDEN,
+        [(CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
+/// A 423 Locked for the fail-closed inconclusive branch (over-cap / budget /
+/// scan error): the object could not be scanned inline and fail-closed must
+/// NEVER serve unscanned bytes.
+fn scan_pending_locked_response(filename: &str) -> Response {
+    let body = serde_json::json!({
+        "error": "scan_pending",
+        "file": filename,
+        "reason": "artifact is being scanned; retry shortly",
+    });
+    (
+        StatusCode::LOCKED,
+        [(CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
+/// Build a buffered 200 response for scanned bytes. `pending` adds the loud
+/// `X-AK-Scan: pending` header for the fail-open serve-before-verdict path so a
+/// served-unscanned byte is observable (kills the #1274 silent gap).
+fn build_scanned_file_response(
+    filename: &str,
+    bytes: Bytes,
+    content_type: Option<String>,
+    digest: Option<&str>,
+    pending: bool,
+) -> Response {
+    let ct = content_type.unwrap_or_else(|| pypi_content_type(filename).to_string());
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, ct)
+        .header(
+            "Content-Disposition",
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .header(CONTENT_LENGTH, bytes.len().to_string())
+        .header("X-AK-Scan", if pending { "pending" } else { "clean" });
+    if let Some(d) = digest {
+        builder = builder.header("X-PyPI-File-SHA256", d);
+    }
+    builder.body(Body::from(bytes)).unwrap()
+}
+
+/// Classify a buffered-fetch error as the byte-cap-exceeded case (vs a genuine
+/// upstream 404 / 5xx). Over-cap is the only error the fail-open/closed
+/// inconclusive branch handles specially; every other error is propagated as-is
+/// so a 404 stays a 404.
+fn is_over_cap_error(e: &AppError) -> bool {
+    matches!(e, AppError::BadGateway(m) if m.contains("exceeded") && m.contains("limit"))
+}
+
+/// Run the leaf scanners over the buffered bytes within the inline budget and
+/// persist the digest-keyed verdict. Returns the verdict, or `None` when the
+/// scan was inconclusive (no scanner configured, budget exceeded, or scanner
+/// error) — the caller maps `None` onto the fail-open/closed decision.
+async fn scan_and_record(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    digest: &str,
+    filename: &str,
+    bytes: &Bytes,
+) -> Option<crate::services::scanner_service::ProxyScanVerdict> {
+    let scanner = state.scanner_service.as_ref()?;
+    let synthetic = pypi_synthetic_artifact(repo_id, filename, digest, bytes.len() as i64);
+    let scan_fut = scanner.scan_content(&synthetic, bytes);
+    let verdict = match tokio::time::timeout(
+        crate::services::scanner_service::PROXY_SCAN_INLINE_BUDGET,
+        scan_fut,
+    )
+    .await
+    {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            warn!(
+                repo_id = %repo_id, file = %filename, error = %e,
+                "inline proxy scan failed; treating as inconclusive"
+            );
+            return None;
+        }
+        Err(_) => {
+            warn!(
+                repo_id = %repo_id, file = %filename,
+                "inline proxy scan exceeded the budget; treating as inconclusive"
+            );
+            return None;
+        }
+    };
+
+    let pss = crate::services::proxy_scan_service::ProxyScanService::new(state.db.clone());
+    if let Err(e) = pss
+        .record_verdict(
+            digest,
+            PROXY_SCAN_TYPE,
+            verdict.verdict_token(),
+            verdict.findings_count,
+            verdict.critical_count,
+            verdict.high_count,
+            verdict.medium_count,
+            verdict.low_count,
+            verdict.max_severity_token(),
+            verdict.scanner_version.as_deref(),
+            Some(repo_id),
+        )
+        .await
+    {
+        warn!(repo_id = %repo_id, file = %filename, error = %e, "failed to persist proxy scan verdict");
+    }
+    Some(verdict)
+}
+
+/// Inline scan-and-block for a PyPI proxy file download (#2954).
+///
+/// Runs ONLY when scan-on-proxy is enabled for the repo; the caller falls back
+/// to the untouched streaming path otherwise, so repos that have not opted in
+/// see NO change. Flow: buffered capped fetch (cache-first, so a repeat pull is
+/// served from cache with no upstream hit) → content digest → verdict lookup →
+/// serve / block / scan-inline per the fail-open/closed action.
+#[allow(clippy::too_many_arguments)]
+async fn serve_scanned_pypi_file(
+    state: &SharedState,
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    project: &str,
+    filename: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
+) -> Result<Response, Response> {
+    let action = crate::services::scan_config_service::ScanConfigService::new(state.db.clone())
+        .proxy_scan_action(repo_id)
+        .await
+        .unwrap_or(crate::services::proxy_scan_service::ProxyScanAction::FailOpen);
+
+    let index_path = fetch_pypi_upstream_index_path(&state.db, repo_id).await;
+    let target = resolve_pypi_remote_fetch_target(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        project,
+        filename,
+        &index_path,
+    )
+    .await?;
+
+    // Buffered capped fetch (cache-first). The proxy caches the bytes under
+    // cache_path, so a repeat pull returns from cache with NO upstream fetch.
+    let repo = proxy_helpers::build_remote_repo_with_format(
+        repo_id,
+        repo_key,
+        &target.fetch_base,
+        RepositoryFormat::Pypi,
+    );
+    let (bytes, content_type) = match proxy
+        .fetch_artifact_with_cache_path_capped(
+            &repo,
+            &target.fetch_path,
+            &target.cache_path,
+            crate::services::scanner_service::PROXY_SCAN_MAX_BYTES,
+        )
+        .await
+    {
+        Ok(pair) => pair,
+        Err(e) if is_over_cap_error(&e) => {
+            // Over the byte cap: never buffer unbounded (#895 OOM).
+            return match crate::services::proxy_scan_service::decide_inconclusive(action) {
+                crate::services::proxy_scan_service::InconclusiveOutcome::Locked => {
+                    warn!(
+                        repo_id = %repo_id, file = %filename,
+                        "proxy object exceeds scan byte cap; fail-closed -> 423"
+                    );
+                    Err(scan_pending_locked_response(filename))
+                }
+                crate::services::proxy_scan_service::InconclusiveOutcome::ServePending => {
+                    // Fail-open oversized: serve via the untouched streaming path
+                    // (loud: X-AK-Scan pending header carried on the stream).
+                    warn!(
+                        repo_id = %repo_id, file = %filename,
+                        "proxy object exceeds scan byte cap; fail-open -> serving UNSCANNED (streaming)"
+                    );
+                    let result = fetch_from_pypi_remote_streaming(
+                        proxy,
+                        repo_id,
+                        repo_key,
+                        upstream_url,
+                        project,
+                        filename,
+                        &index_path,
+                        RepositoryFormat::Pypi,
+                    )
+                    .await?;
+                    proxy_helpers::record_proxy_download(
+                        state,
+                        repo_id,
+                        repo_key,
+                        &target.cache_path,
+                        ctx,
+                    )
+                    .await;
+                    let mut resp = build_streaming_file_response(filename, result);
+                    resp.headers_mut()
+                        .insert("X-AK-Scan", axum::http::HeaderValue::from_static("pending"));
+                    Ok(resp)
+                }
+            };
+        }
+        Err(e) => return Err(e.into_response()),
+    };
+
+    let digest = sha256_hex(&bytes);
+
+    // Verdict fast path: a fresh vulnerable verdict blocks WITHOUT re-scanning
+    // (and, since the fetch above was a cache hit on a repeat pull, without any
+    // upstream fetch). A fresh clean verdict serves from the buffer.
+    let pss = crate::services::proxy_scan_service::ProxyScanService::new(state.db.clone());
+    let current_version = None; // provenance compared only when both sides known
+    if let Ok(Some(row)) = pss.lookup_verdict(&digest, PROXY_SCAN_TYPE).await {
+        let fresh = crate::services::proxy_scan_service::verdict_is_fresh(
+            row.scanned_at,
+            row.scanner_version.as_deref(),
+            current_version,
+            crate::services::scanner_service::DEDUP_TTL_DAYS as i64,
+            Utc::now(),
+        );
+        if fresh {
+            if crate::services::proxy_scan_service::verdict_blocks(&row.verdict) {
+                warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: cached vulnerable verdict");
+                return Err(scan_blocked_response(filename));
+            }
+            proxy_helpers::record_proxy_download(state, repo_id, repo_key, &target.cache_path, ctx)
+                .await;
+            return Ok(build_scanned_file_response(
+                filename,
+                bytes,
+                content_type,
+                Some(&digest),
+                false,
+            ));
+        }
+    }
+
+    // No fresh verdict: first pull of this digest.
+    if action.is_fail_closed() {
+        // Fail-closed: scan inline before serving a single byte.
+        match scan_and_record(state, repo_id, &digest, filename, &bytes).await {
+            Some(verdict) if verdict.is_vulnerable() => {
+                warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: inline scan found vulnerabilities");
+                Err(scan_blocked_response(filename))
+            }
+            Some(_) => {
+                proxy_helpers::record_proxy_download(
+                    state,
+                    repo_id,
+                    repo_key,
+                    &target.cache_path,
+                    ctx,
+                )
+                .await;
+                Ok(build_scanned_file_response(
+                    filename,
+                    bytes,
+                    content_type,
+                    Some(&digest),
+                    false,
+                ))
+            }
+            // Inconclusive under fail-closed => 423, never serve unscanned bytes.
+            None => Err(scan_pending_locked_response(filename)),
+        }
+    } else {
+        // Fail-open: serve immediately (loud: X-AK-Scan pending) and scan
+        // asynchronously so the NEXT pull of this digest is blocked if bad.
+        warn!(
+            repo_id = %repo_id, file = %filename, digest = %digest,
+            "fail-open proxy scan: serving unscanned bytes with X-AK-Scan: pending; scanning async"
+        );
+        let state_bg = state.clone();
+        let digest_bg = digest.clone();
+        let filename_bg = filename.to_string();
+        let bytes_bg = bytes.clone();
+        tokio::spawn(async move {
+            let _ = scan_and_record(&state_bg, repo_id, &digest_bg, &filename_bg, &bytes_bg).await;
+        });
+        proxy_helpers::record_proxy_download(state, repo_id, repo_key, &target.cache_path, ctx)
+            .await;
+        Ok(build_scanned_file_response(
+            filename,
+            bytes,
+            content_type,
+            Some(&digest),
+            true,
+        ))
+    }
 }
 
 async fn serve_metadata(

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2859,7 +2859,23 @@ async fn serve_scanned_pypi_file(
         }
     } else {
         // Fail-open: serve immediately (loud: X-AK-Scan pending) and scan
-        // asynchronously so the NEXT pull of this digest is blocked if bad.
+        // asynchronously so the NEXT pull of this SAME digest is blocked if bad.
+        //
+        // Honest caveat (#2954, Finding 2): the block is keyed strictly on the
+        // CONTENT digest. That is correct and cannot be relaxed — binding a
+        // verdict to anything an untrusted upstream controls (filename, index
+        // digest) would let a lying index attach a `clean` verdict to malicious
+        // bytes. But it means fail-open does NOT block an ADAPTIVE upstream that
+        // returns byte-varying vulnerable wheels (e.g. random-byte append): each
+        // pull is a new digest, hence a fresh "first pull", so it is served 200
+        // `X-AK-Scan: pending` indefinitely. This is by-design for the
+        // latency-first fail-open posture and is LOUD — every such serve emits
+        // the warn below plus the pending header, so a burst of pending-serves
+        // from one repo is observable in logs/audit and can be alerted on
+        // out-of-band. Operators who cannot tolerate serving an unscanned byte
+        // must use `proxy_scan_action=fail_closed`, which scans inline before
+        // serving and 423s on any inconclusive/adaptive case. Do NOT "fix" this
+        // by turning fail-open into fail-closed here.
         warn!(
             repo_id = %repo_id, file = %filename, digest = %digest,
             "fail-open proxy scan: serving unscanned bytes with X-AK-Scan: pending; scanning async"

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -8604,4 +8604,498 @@ mod tests {
             "a curation-disabled repo must not be blocked by a matching rule"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // #2954 inline proxy scan-and-block: pure helpers.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sha256_hex_known_vectors() {
+        // Empty input and the classic "abc" NIST vector: the verdict cache is
+        // keyed on this digest, so it must be the plain lowercase-hex SHA-256
+        // of the CONTENT (never an index-advertised digest).
+        assert_eq!(
+            sha256_hex(&Bytes::new()),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(&Bytes::from_static(b"abc")),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn test_pypi_synthetic_artifact_shape() {
+        let repo_id = uuid::Uuid::new_v4();
+        let filename = "PyYAML-5.3.1-cp38-cp38-manylinux1_x86_64.whl";
+        let digest = "deadbeef".repeat(8);
+        let art = pypi_synthetic_artifact(repo_id, filename, &digest, 1234);
+
+        // The synthetic artifact drives scanner applicability + workspace
+        // naming exactly as a hosted wheel would.
+        assert_eq!(art.repository_id, repo_id);
+        assert_eq!(art.name, filename);
+        assert_eq!(art.path, filename);
+        assert_eq!(art.version.as_deref(), Some("5.3.1"));
+        assert_eq!(art.size_bytes, 1234);
+        assert_eq!(art.checksum_sha256, digest);
+        assert_eq!(art.content_type, "application/zip");
+        // No artifacts row backs this: storage key stays empty by design.
+        assert!(art.storage_key.is_empty());
+        assert!(!art.is_deleted);
+        assert_eq!(art.quarantine_status, None);
+
+        // sdist naming resolves version + gzip content type too.
+        let sdist = pypi_synthetic_artifact(repo_id, "requests-2.31.0.tar.gz", &digest, 1);
+        assert_eq!(sdist.version.as_deref(), Some("2.31.0"));
+        assert_eq!(sdist.content_type, "application/gzip");
+    }
+
+    #[test]
+    fn test_scan_blocked_response_is_403_neutral_json() {
+        let resp = scan_blocked_response("evil-1.0.whl");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "application/json"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scan_blocked_response_body_names_file_not_cves() {
+        // The download route is anonymous-readable for public repos: the body
+        // must name the file, never the specific CVEs.
+        let resp = scan_blocked_response("evil-1.0.whl");
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["error"], "scan_blocked");
+        assert_eq!(json["file"], "evil-1.0.whl");
+        assert!(!body.windows(4).any(|w| w == b"CVE-"), "no CVE detail leak");
+    }
+
+    #[tokio::test]
+    async fn test_scan_pending_locked_response_is_423() {
+        // The fail-closed inconclusive branch must be 423 Locked, never a 200
+        // of unscanned bytes.
+        let resp = scan_pending_locked_response("big-1.0.whl");
+        assert_eq!(resp.status(), StatusCode::LOCKED);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["error"], "scan_pending");
+        assert_eq!(json["file"], "big-1.0.whl");
+    }
+
+    #[test]
+    fn test_build_scanned_file_response_clean_and_pending_headers() {
+        let bytes = Bytes::from_static(b"PK\x03\x04wheel-bytes");
+        let digest = sha256_hex(&bytes);
+
+        // Clean serve: explicit content type wins, digest header present.
+        let resp = build_scanned_file_response(
+            "pkg-1.0-py3-none-any.whl",
+            bytes.clone(),
+            Some("application/x-custom".to_string()),
+            Some(&digest),
+            false,
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "application/x-custom"
+        );
+        assert_eq!(
+            resp.headers().get("X-AK-Scan").unwrap().to_str().unwrap(),
+            "clean"
+        );
+        assert_eq!(
+            resp.headers()
+                .get("X-PyPI-File-SHA256")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            digest
+        );
+        assert_eq!(
+            resp.headers()
+                .get(CONTENT_LENGTH)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            bytes.len().to_string()
+        );
+
+        // Pending serve (fail-open before a verdict): loud header, and the
+        // content type falls back to the filename-derived default.
+        let resp = build_scanned_file_response("pkg-1.0.tar.gz", bytes, None, None, true);
+        assert_eq!(
+            resp.headers().get("X-AK-Scan").unwrap().to_str().unwrap(),
+            "pending"
+        );
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "application/gzip"
+        );
+        assert!(resp.headers().get("X-PyPI-File-SHA256").is_none());
+    }
+
+    #[test]
+    fn test_is_over_cap_error_classification() {
+        // The real over-cap shape emitted by the capped proxy fetch.
+        let over_cap = AppError::BadGateway(
+            "Upstream metadata response exceeded the 209715200-byte limit".to_string(),
+        );
+        assert!(is_over_cap_error(&over_cap));
+
+        // Any other BadGateway (upstream 5xx etc.) must be propagated as-is,
+        // not treated as the over-cap inconclusive branch.
+        let other_bad_gateway = AppError::BadGateway("upstream returned 500".to_string());
+        assert!(!is_over_cap_error(&other_bad_gateway));
+
+        // Non-BadGateway errors (a 404 stays a 404).
+        let not_found = AppError::NotFound("no such file".to_string());
+        assert!(!is_over_cap_error(&not_found));
+    }
+
+    // -----------------------------------------------------------------------
+    // #2954 inline proxy scan-and-block: DB-backed serve paths.
+    //
+    // These drive `serve_file` end-to-end into `serve_scanned_pypi_file` with
+    // a wiremock upstream, a real proxy service, and a scan_configs row with
+    // scan_on_proxy enabled. The state carries NO scanner service, so a
+    // first-pull scan is inconclusive — exactly the branch whose fail-closed
+    // handling (423, never a 200 of unscanned bytes) is the point of the fix.
+    // Cached-verdict paths are seeded through ProxyScanService::record_verdict
+    // so the digest-keyed block/serve fast path is covered against a real DB.
+    //
+    // Skip cleanly when DATABASE_URL is unset.
+    // -----------------------------------------------------------------------
+
+    async fn enable_proxy_scan(pool: &sqlx::PgPool, repo_id: uuid::Uuid, action: &str) {
+        sqlx::query(
+            "INSERT INTO scan_configs (repository_id, scan_enabled, scan_on_upload, \
+                 scan_on_proxy, block_on_policy_violation, severity_threshold, \
+                 proxy_scan_action) \
+             VALUES ($1, true, false, true, false, 'high', $2)",
+        )
+        .bind(repo_id)
+        .bind(action)
+        .execute(pool)
+        .await
+        .expect("enable scan-on-proxy");
+    }
+
+    /// Mount a PEP 503 index page (with no matching href, so the fetch target
+    /// falls back to the conventional simple/ path) plus the wheel bytes.
+    async fn mount_scan_upstream(
+        upstream: &wiremock::MockServer,
+        project: &str,
+        filename: &str,
+        wheel: &'static [u8],
+    ) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("<html><body></body></html>")
+                    .insert_header("Content-Type", "text/html"),
+            )
+            .mount(upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(wheel)
+                    .insert_header("Content-Type", "application/zip"),
+            )
+            .mount(upstream)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_fail_closed_inconclusive_is_423() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "sealed";
+        let filename = "sealed-1.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 sealed-wheel-2954-fail-closed";
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        // No scanner service on the state: the inline scan is inconclusive.
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "fail-closed + inconclusive scan must never serve bytes, got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(
+                resp.status(),
+                StatusCode::LOCKED,
+                "fail-closed inconclusive must be 423 Locked"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_fail_open_serves_pending() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "openpkg";
+        let filename = "openpkg-2.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 open-wheel-2954-fail-open";
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        // Default action (fail_open): first pull serves LOUDLY with pending.
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_open").await;
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("fail-open first pull must serve, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan_header = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        let digest_header = resp
+            .headers()
+            .get("X-PyPI-File-SHA256")
+            .map(|v| v.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(resp.into_body(), 16 * 1024 * 1024)
+            .await
+            .expect("body");
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan_header.as_deref(),
+            Some("pending"),
+            "a served-before-verdict byte must be observable (X-AK-Scan: pending)"
+        );
+        assert_eq!(
+            digest_header.as_deref(),
+            Some(sha256_hex(&Bytes::from_static(b"PK\x03\x04 open-wheel-2954-fail-open")).as_str())
+        );
+        assert_eq!(&body[..], wheel, "served bytes must equal upstream bytes");
+    }
+
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_blocks_cached_vulnerable_digest() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "poisoned";
+        let filename = "poisoned-0.1.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 poisoned-wheel-2954-vulnerable";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"PK\x03\x04 poisoned-wheel-2954-vulnerable",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        // Seed a fresh vulnerable verdict for this digest through the real
+        // service so record_verdict + lookup_verdict are covered end-to-end.
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "vulnerable",
+                3,
+                1,
+                1,
+                1,
+                0,
+                Some("critical"),
+                Some("grype-0.99.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed vulnerable verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        // proxy_scan_results outlives repo cleanup (repository_id is SET
+        // NULL on delete): remove the digest row explicitly.
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "a fresh cached vulnerable verdict must block the pull, got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "cached vulnerable digest must be a 403 scan_blocked (not 423: \
+                 the verdict is conclusive)"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_serves_cached_clean_digest() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "verified";
+        let filename = "verified-3.2.1-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 verified-wheel-2954-clean";
+        let digest = sha256_hex(&Bytes::from_static(b"PK\x03\x04 verified-wheel-2954-clean"));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        // Fail-closed: without the fresh clean verdict this pull would 423
+        // (no scanner service on the state), so a 200 here proves the cached
+        // verdict fast path served it.
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.99.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed clean verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("fresh clean verdict must serve under fail-closed, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan_header = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(resp.into_body(), 16 * 1024 * 1024)
+            .await
+            .expect("body");
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan_header.as_deref(),
+            Some("clean"),
+            "a verdict-backed serve must be marked clean, not pending"
+        );
+        assert_eq!(&body[..], wheel);
+    }
 }

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -418,6 +418,7 @@ impl From<crate::models::security::ScanConfig> for ScanConfigResponse {
             scan_on_proxy: c.scan_on_proxy,
             block_on_policy_violation: c.block_on_policy_violation,
             severity_threshold: c.severity_threshold,
+            proxy_scan_action: c.proxy_scan_action,
             created_at: c.created_at,
             updated_at: c.updated_at,
         }
@@ -584,6 +585,9 @@ pub struct ScanConfigResponse {
     pub scan_on_proxy: bool,
     pub block_on_policy_violation: bool,
     pub severity_threshold: String,
+    /// #2954: fail-open (default) / fail-closed action for the inline proxy
+    /// scan-on-fetch.
+    pub proxy_scan_action: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -2836,6 +2840,7 @@ mod tests {
                 scan_on_proxy: false,
                 block_on_policy_violation: true,
                 severity_threshold: "high".to_string(),
+                proxy_scan_action: "fail_open".to_string(),
                 created_at: now,
                 updated_at: now,
             }),
@@ -2876,6 +2881,7 @@ mod tests {
             scan_on_proxy: true,
             block_on_policy_violation: false,
             severity_threshold: "medium".to_string(),
+            proxy_scan_action: "fail_closed".to_string(),
             created_at: now,
             updated_at: now,
         };

--- a/backend/src/models/security.rs
+++ b/backend/src/models/security.rs
@@ -139,6 +139,9 @@ pub struct ScanConfig {
     pub scan_on_proxy: bool,
     pub block_on_policy_violation: bool,
     pub severity_threshold: String,
+    /// #2954: fail-open (default) vs fail-closed action for the inline proxy
+    /// scan-on-fetch. `'fail_open'` | `'fail_closed'`.
+    pub proxy_scan_action: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -467,6 +470,7 @@ mod tests {
             scan_on_proxy: false,
             block_on_policy_violation: true,
             severity_threshold: "critical".to_string(),
+            proxy_scan_action: "fail_open".to_string(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -483,6 +487,7 @@ mod tests {
             scan_on_proxy: false,
             block_on_policy_violation: false,
             severity_threshold: "garbage".to_string(),
+            proxy_scan_action: "fail_open".to_string(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -1290,6 +1290,16 @@ impl Scanner for GrypeScanner {
         "grype"
     }
 
+    /// Grype is the CVE-authoritative engine for the inline proxy scan path.
+    /// It is bundled in the runtime image and stays fail-closed (#2167): its
+    /// successful completion is what makes a `clean` verdict trustworthy, so
+    /// [`ScannerService::scan_content`] must treat a Grype error/timeout as
+    /// inconclusive rather than letting a supplementary scanner's trivial
+    /// success mask it (#2954).
+    fn is_cve_authoritative(&self) -> bool {
+        true
+    }
+
     /// Grype handles both filesystem-style artifacts (npm tarballs, PyPI
     /// wheels, lockfiles) via `dir:` mode and OCI / Docker images via
     /// `registry:` mode (#1160). The only artifacts we explicitly reject

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -1694,6 +1694,19 @@ mod tests {
         GrypeScanner::new("/tmp/grype-applicability-test".to_string())
     }
 
+    /// #2954: Grype is THE CVE-authoritative engine for the inline proxy scan.
+    /// If this override were lost, `run_inline_proxy_scanners` would see no
+    /// authoritative scanner as applicable and a Grype hard-error could
+    /// aggregate to `clean` off a supplementary scanner's trivial success —
+    /// serving an unscanned, possibly-vulnerable wheel under fail-closed.
+    #[test]
+    fn test_grype_is_cve_authoritative() {
+        assert!(
+            grype().is_cve_authoritative(),
+            "GrypeScanner must override Scanner::is_cve_authoritative to true"
+        );
+    }
+
     /// Serializes env-var mutation across the parallel tests in this module
     /// so the registry-host probe's `AK_GRYPE_REGISTRY_HOST` /
     /// `PEER_PUBLIC_ENDPOINT` reads stay deterministic. Same pattern as

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -56,6 +56,7 @@ pub mod promotion_policy_service;
 pub mod promotion_rule_service;
 pub mod proxy_catalog;
 pub mod proxy_hydration;
+pub mod proxy_scan_service;
 pub mod proxy_service;
 pub mod quality_check_service;
 pub mod quarantine_service;

--- a/backend/src/services/proxy_scan_service.rs
+++ b/backend/src/services/proxy_scan_service.rs
@@ -313,6 +313,92 @@ mod tests {
         assert!(!ProxyScanAction::FailOpen.is_fail_closed());
     }
 
+    /// DB-backed round trip: record → lookup → upsert-on-conflict → lookup.
+    /// Covers the two sqlx paths (`record_verdict`, `lookup_verdict`) against
+    /// the real `proxy_scan_results` schema (unique key + CHECK vocabulary).
+    /// Skips cleanly when DATABASE_URL is unset.
+    #[tokio::test]
+    async fn record_and_lookup_verdict_roundtrip_and_upsert() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let svc = ProxyScanService::new(pool.clone());
+        // Unique digest per run so parallel/repeat runs never collide.
+        let digest = format!("{:0>64}", uuid::Uuid::new_v4().simple());
+
+        // Missing digest: no row.
+        let missing = svc.lookup_verdict(&digest, "grype").await.expect("lookup");
+        assert!(missing.is_none(), "unknown digest must have no verdict");
+
+        // First record: clean.
+        svc.record_verdict(
+            &digest,
+            "grype",
+            VERDICT_CLEAN,
+            0,
+            0,
+            0,
+            0,
+            0,
+            None,
+            Some("grype-0.99.0-test"),
+            None,
+        )
+        .await
+        .expect("record clean");
+        let row = svc
+            .lookup_verdict(&digest, "grype")
+            .await
+            .expect("lookup")
+            .expect("row after record");
+        assert_eq!(row.verdict, VERDICT_CLEAN);
+        assert_eq!(row.findings_count, 0);
+        assert_eq!(row.max_severity, None);
+        assert_eq!(row.scanner_version.as_deref(), Some("grype-0.99.0-test"));
+
+        // Re-record the SAME digest (e.g. re-scan against a bumped CVE-DB
+        // that now flags it): the upsert must replace, not duplicate/err.
+        svc.record_verdict(
+            &digest,
+            "grype",
+            VERDICT_VULNERABLE,
+            2,
+            1,
+            1,
+            0,
+            0,
+            Some("critical"),
+            Some("grype-1.0.0-test"),
+            None,
+        )
+        .await
+        .expect("upsert vulnerable");
+        let row = svc
+            .lookup_verdict(&digest, "grype")
+            .await
+            .expect("lookup")
+            .expect("row after upsert");
+        assert_eq!(row.verdict, VERDICT_VULNERABLE);
+        assert_eq!(row.findings_count, 2);
+        assert_eq!(row.critical_count, 1);
+        assert_eq!(row.high_count, 1);
+        assert_eq!(row.max_severity.as_deref(), Some("critical"));
+        assert_eq!(row.scanner_version.as_deref(), Some("grype-1.0.0-test"));
+        // A different scan_type is a distinct verdict slot.
+        assert!(svc
+            .lookup_verdict(&digest, "trivy")
+            .await
+            .expect("lookup other type")
+            .is_none());
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&pool)
+            .await
+            .expect("cleanup");
+    }
+
     #[test]
     fn inconclusive_is_pending_open_locked_closed() {
         // Over-cap / budget / scan-error: fail-open serves-with-pending,

--- a/backend/src/services/proxy_scan_service.rs
+++ b/backend/src/services/proxy_scan_service.rs
@@ -1,0 +1,329 @@
+//! Digest-keyed proxy scan verdict store (#2954).
+//!
+//! Proxy-cached bytes are deliberately NOT written to `artifacts` (#1278/#1280),
+//! so the `artifact_id`-keyed `scan_results` pipeline cannot hold a verdict for
+//! a proxied object. This service persists a content-addressed
+//! (`checksum_sha256`) verdict in `proxy_scan_results`, independent of
+//! `artifacts`, so that:
+//!
+//!   * a repeat pull of a known-vulnerable digest is blocked WITHOUT re-fetching
+//!     upstream or re-scanning (the fast path), and
+//!   * a verdict is shared across repos/tenants pulling identical bytes (same
+//!     bytes = same CVEs) and survives proxy-cache eviction.
+//!
+//! The freshness and fail-open/closed decision logic lives in pure functions so
+//! it is unit-testable without a database.
+
+use chrono::{DateTime, Duration, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::{AppError, Result};
+
+/// A persisted proxy scan verdict row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ProxyScanRow {
+    pub checksum_sha256: String,
+    pub scan_type: String,
+    pub verdict: String,
+    pub findings_count: i32,
+    pub critical_count: i32,
+    pub high_count: i32,
+    pub medium_count: i32,
+    pub low_count: i32,
+    pub max_severity: Option<String>,
+    pub scanner_version: Option<String>,
+    pub scanned_at: DateTime<Utc>,
+}
+
+/// The three terminal verdicts stored in `proxy_scan_results.verdict`.
+pub const VERDICT_CLEAN: &str = "clean";
+pub const VERDICT_VULNERABLE: &str = "vulnerable";
+pub const VERDICT_ERROR: &str = "error";
+
+/// Whether a stored verdict means the artifact must be blocked when the repo's
+/// scan policy blocks. Only a `vulnerable` verdict blocks; `clean` serves and
+/// `error` is inconclusive (handled by the fail-open/closed decision, not here).
+pub fn verdict_blocks(verdict: &str) -> bool {
+    verdict == VERDICT_VULNERABLE
+}
+
+/// Whether a cached verdict may be reused for a fresh pull.
+///
+/// A verdict is reusable while it is within the TTL window AND (when both the
+/// stored and the live scanner version strings are known) the scanner version
+/// matches. A CVE-DB bump changes the version string, so a `clean` verdict from
+/// yesterday's DB is naturally ignored and the bytes are re-scanned against
+/// today's CVEs. When either version string is unknown (probe failed / legacy
+/// row) we fall back to the TTL alone rather than forcing an unbounded re-scan.
+pub fn verdict_is_fresh(
+    scanned_at: DateTime<Utc>,
+    stored_version: Option<&str>,
+    current_version: Option<&str>,
+    ttl_days: i64,
+    now: DateTime<Utc>,
+) -> bool {
+    let within_ttl = now < scanned_at + Duration::days(ttl_days);
+    let version_ok = match (stored_version, current_version) {
+        (Some(a), Some(b)) => a == b,
+        // Unknown on either side: cannot prove a mismatch, rely on TTL.
+        _ => true,
+    };
+    within_ttl && version_ok
+}
+
+/// Per-repo action for the inline proxy scan on a first pull of an unknown
+/// digest (reuses the `block_unscanned` semantics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProxyScanAction {
+    /// Latency-first (default): serve the first pull immediately and scan
+    /// asynchronously; the NEXT pull of that digest is blocked if vulnerable.
+    /// Must be loud (warn + audit + `X-AK-Scan: pending`).
+    FailOpen,
+    /// Never serve unscanned bytes: scan inline before serving; a vulnerable
+    /// verdict is a 403, and an over-cap / budget-exceeded / scan-error object
+    /// returns 423 rather than a 200 of unscanned bytes.
+    FailClosed,
+}
+
+impl ProxyScanAction {
+    /// Map the `scan_configs.proxy_scan_action` column onto the enum. Unknown /
+    /// legacy values default to the safe-for-availability fail-open behavior,
+    /// matching the column default.
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "fail_closed" => ProxyScanAction::FailClosed,
+            _ => ProxyScanAction::FailOpen,
+        }
+    }
+
+    pub fn is_fail_closed(self) -> bool {
+        matches!(self, ProxyScanAction::FailClosed)
+    }
+}
+
+/// Outcome when the inline scan could NOT produce a conclusive clean/vulnerable
+/// verdict before serve time: the object was over the byte cap, the inline scan
+/// budget was exceeded, or the scanner errored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InconclusiveOutcome {
+    /// Serve now with `X-AK-Scan: pending` + warn + audit; scan asynchronously.
+    ServePending,
+    /// 423 Locked, never a 200 of unscanned bytes.
+    Locked,
+}
+
+/// Pure decision for the inconclusive branch (over-cap / budget / scan error):
+/// fail-open serves-with-pending, fail-closed locks.
+pub fn decide_inconclusive(action: ProxyScanAction) -> InconclusiveOutcome {
+    match action {
+        ProxyScanAction::FailOpen => InconclusiveOutcome::ServePending,
+        ProxyScanAction::FailClosed => InconclusiveOutcome::Locked,
+    }
+}
+
+pub struct ProxyScanService {
+    db: PgPool,
+}
+
+impl ProxyScanService {
+    pub fn new(db: PgPool) -> Self {
+        Self { db }
+    }
+
+    /// Look up a stored verdict for `(checksum_sha256, scan_type)`.
+    pub async fn lookup_verdict(
+        &self,
+        checksum_sha256: &str,
+        scan_type: &str,
+    ) -> Result<Option<ProxyScanRow>> {
+        let row = sqlx::query_as!(
+            ProxyScanRow,
+            r#"
+            SELECT checksum_sha256, scan_type, verdict,
+                   findings_count, critical_count, high_count, medium_count, low_count,
+                   max_severity, scanner_version, scanned_at
+            FROM proxy_scan_results
+            WHERE checksum_sha256 = $1 AND scan_type = $2
+            "#,
+            checksum_sha256,
+            scan_type,
+        )
+        .fetch_optional(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(row)
+    }
+
+    /// Upsert a verdict keyed on `(checksum_sha256, scan_type)`. A newer scan of
+    /// the same bytes (e.g. against a bumped CVE-DB) replaces the prior row.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_verdict(
+        &self,
+        checksum_sha256: &str,
+        scan_type: &str,
+        verdict: &str,
+        findings_count: i32,
+        critical_count: i32,
+        high_count: i32,
+        medium_count: i32,
+        low_count: i32,
+        max_severity: Option<&str>,
+        scanner_version: Option<&str>,
+        repository_id: Option<Uuid>,
+    ) -> Result<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO proxy_scan_results (
+                checksum_sha256, scan_type, verdict,
+                findings_count, critical_count, high_count, medium_count, low_count,
+                max_severity, scanner_version, repository_id, scanned_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now())
+            ON CONFLICT (checksum_sha256, scan_type) DO UPDATE SET
+                verdict = EXCLUDED.verdict,
+                findings_count = EXCLUDED.findings_count,
+                critical_count = EXCLUDED.critical_count,
+                high_count = EXCLUDED.high_count,
+                medium_count = EXCLUDED.medium_count,
+                low_count = EXCLUDED.low_count,
+                max_severity = EXCLUDED.max_severity,
+                scanner_version = EXCLUDED.scanner_version,
+                repository_id = EXCLUDED.repository_id,
+                scanned_at = now()
+            "#,
+            checksum_sha256,
+            scan_type,
+            verdict,
+            findings_count,
+            critical_count,
+            high_count,
+            medium_count,
+            low_count,
+            max_severity,
+            scanner_version,
+            repository_id,
+        )
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verdict_blocks_only_vulnerable() {
+        assert!(verdict_blocks(VERDICT_VULNERABLE));
+        assert!(!verdict_blocks(VERDICT_CLEAN));
+        assert!(!verdict_blocks(VERDICT_ERROR));
+        assert!(!verdict_blocks("something-else"));
+    }
+
+    #[test]
+    fn fresh_within_ttl_same_version() {
+        let now = Utc::now();
+        let scanned = now - Duration::days(1);
+        assert!(verdict_is_fresh(
+            scanned,
+            Some("grype-0.83.0"),
+            Some("grype-0.83.0"),
+            30,
+            now
+        ));
+    }
+
+    #[test]
+    fn stale_past_ttl() {
+        let now = Utc::now();
+        let scanned = now - Duration::days(31);
+        assert!(!verdict_is_fresh(
+            scanned,
+            Some("grype-0.83.0"),
+            Some("grype-0.83.0"),
+            30,
+            now
+        ));
+    }
+
+    #[test]
+    fn stale_on_version_mismatch_even_within_ttl() {
+        // A CVE-DB bump changes the version string: a yesterday-clean verdict
+        // must be re-evaluated against today's CVEs.
+        let now = Utc::now();
+        let scanned = now - Duration::days(1);
+        assert!(!verdict_is_fresh(
+            scanned,
+            Some("grype-0.83.0"),
+            Some("grype-0.84.0"),
+            30,
+            now
+        ));
+    }
+
+    #[test]
+    fn unknown_version_falls_back_to_ttl() {
+        let now = Utc::now();
+        let scanned = now - Duration::days(1);
+        // Either side unknown => cannot prove a mismatch, rely on TTL.
+        assert!(verdict_is_fresh(
+            scanned,
+            None,
+            Some("grype-0.84.0"),
+            30,
+            now
+        ));
+        assert!(verdict_is_fresh(
+            scanned,
+            Some("grype-0.83.0"),
+            None,
+            30,
+            now
+        ));
+        assert!(!verdict_is_fresh(
+            now - Duration::days(31),
+            None,
+            None,
+            30,
+            now
+        ));
+    }
+
+    #[test]
+    fn action_from_db_defaults_fail_open() {
+        assert_eq!(
+            ProxyScanAction::from_db("fail_closed"),
+            ProxyScanAction::FailClosed
+        );
+        assert_eq!(
+            ProxyScanAction::from_db("fail_open"),
+            ProxyScanAction::FailOpen
+        );
+        // Unknown / legacy => fail-open (matches the column default).
+        assert_eq!(
+            ProxyScanAction::from_db("garbage"),
+            ProxyScanAction::FailOpen
+        );
+        assert!(ProxyScanAction::FailClosed.is_fail_closed());
+        assert!(!ProxyScanAction::FailOpen.is_fail_closed());
+    }
+
+    #[test]
+    fn inconclusive_is_pending_open_locked_closed() {
+        // Over-cap / budget / scan-error: fail-open serves-with-pending,
+        // fail-closed never serves unscanned bytes.
+        assert_eq!(
+            decide_inconclusive(ProxyScanAction::FailOpen),
+            InconclusiveOutcome::ServePending
+        );
+        assert_eq!(
+            decide_inconclusive(ProxyScanAction::FailClosed),
+            InconclusiveOutcome::Locked
+        );
+    }
+}

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -529,6 +529,34 @@ async fn fetch_quarantine_fields(
     Ok(row.map(|r| (r.quarantine_status, r.quarantine_until, r.quarantine_reason)))
 }
 
+/// Fetch the quarantine status/expiry AND the owning repository_id in one query
+/// (#2954). The download gate needs the repository_id to evaluate scan policy;
+/// folding it into the same SELECT the quarantine check already runs keeps the
+/// gate to a single read on the hot download path. Returns `Ok(None)` when no
+/// matching (non-deleted) row exists, so an absent artifact stays a no-op.
+async fn fetch_quarantine_fields_with_repo(
+    db: &PgPool,
+    artifact_id: Uuid,
+) -> Result<Option<(Option<String>, Option<DateTime<Utc>>, Uuid)>> {
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        quarantine_status: Option<String>,
+        quarantine_until: Option<DateTime<Utc>>,
+        repository_id: Uuid,
+    }
+
+    let row = sqlx::query_as::<_, Row>(
+        "SELECT quarantine_status, quarantine_until, repository_id \
+         FROM artifacts WHERE id = $1 AND is_deleted = false",
+    )
+    .bind(artifact_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(row.map(|r| (r.quarantine_status, r.quarantine_until, r.repository_id)))
+}
+
 /// Fetch the current quarantine status and expiry for an artifact.
 pub async fn get_status(
     db: &PgPool,
@@ -587,12 +615,68 @@ pub async fn get_status_with_repo(db: &PgPool, artifact_id: Uuid) -> Result<Quar
 /// This is the common quarantine gate for all download paths. It queries the
 /// artifact's quarantine fields and returns an error if the artifact is
 /// quarantined (409 Conflict) or rejected (403 Forbidden).
+///
+/// As of #2954 this delegates to [`enforce_download_gate`], which additionally
+/// consults the repository's scan policy after the quarantine check. Repos with
+/// no enabled scan policy are unaffected: `PolicyService::evaluate_artifact`
+/// no-ops to `allowed` when no policy matches, so today's behavior is preserved
+/// for operators who have not opted in.
 pub async fn check_artifact_download(db: &PgPool, artifact_id: Uuid) -> Result<()> {
-    if let Some((status, until, _reason)) = fetch_quarantine_fields(db, artifact_id).await? {
-        check_download_allowed(status.as_deref(), until, Utc::now())?;
-    }
+    enforce_download_gate(db, artifact_id).await
+}
 
-    Ok(())
+/// The shared download choke point (#2954): enforce quarantine THEN scan policy.
+///
+/// This folds `PolicyService::evaluate_artifact` — which enforces
+/// `block_unscanned` / `block_on_fail` / `max_severity`
+/// (`block_on_policy_violation`) and previously only ran on the promotion gate —
+/// into the single function every ~30 per-format download handler already calls,
+/// so scan-policy blocking lights up on the raw download path for all formats at
+/// once (it was a false affordance before: a hosted artifact with CVE findings
+/// was downloadable unless a scan happened to auto-quarantine it).
+///
+/// Ordering is deliberate: the quarantine state is checked FIRST (a quarantined
+/// artifact is a 409 before any policy consideration), then the scan policy. A
+/// disallowed policy result maps to 403.
+///
+/// Guardrail: when the artifact row is absent (deleted / never existed) this is
+/// a no-op `Ok(())`, exactly as the pre-#2954 quarantine-only check was, and
+/// when no enabled scan policy matches the repo the policy evaluation returns
+/// `allowed` — so a repo without a scan policy sees NO change.
+pub async fn enforce_download_gate(db: &PgPool, artifact_id: Uuid) -> Result<()> {
+    let Some((status, until, repository_id)) =
+        fetch_quarantine_fields_with_repo(db, artifact_id).await?
+    else {
+        // Artifact absent: preserve the pre-#2954 no-op behavior.
+        return Ok(());
+    };
+
+    // Quarantine gate first (409 quarantined / 403 rejected).
+    check_download_allowed(status.as_deref(), until, Utc::now())?;
+
+    // Scan-policy gate. No-op (allowed) when no enabled policy matches the repo.
+    let policy_result = crate::services::policy_service::PolicyService::new(db.clone())
+        .evaluate_artifact(artifact_id, repository_id)
+        .await?;
+    policy_gate_result(policy_result.allowed)
+}
+
+/// Map a scan-policy `allowed` decision onto the download gate result (#2954).
+///
+/// Split out from [`enforce_download_gate`] so the "disallowed → 403 with a
+/// neutral, non-disclosing message" contract is pure and unit-testable. The
+/// message deliberately omits the violated policy names / per-artifact finding
+/// counts: the download route is anonymous-readable for public repos, so those
+/// details must not leak here (mirrors [`check_download_allowed`]). Authorized
+/// callers read specifics from the authenticated security endpoints.
+fn policy_gate_result(allowed: bool) -> Result<()> {
+    if allowed {
+        Ok(())
+    } else {
+        Err(AppError::Authorization(
+            "Artifact download is blocked by the repository's scan policy".to_string(),
+        ))
+    }
 }
 
 /// Validate that a quarantine duration is at least 1 minute.
@@ -612,6 +696,38 @@ mod tests {
     // -----------------------------------------------------------------------
     // should_quarantine
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // policy_gate_result (#2954 hosted download gate)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_policy_gate_allowed_is_ok() {
+        // No-policy repos / clean-and-scanned artifacts evaluate to allowed:
+        // the gate must be a pass-through (the regression guardrail).
+        assert!(policy_gate_result(true).is_ok());
+    }
+
+    #[test]
+    fn test_policy_gate_disallowed_is_403() {
+        // A blocking policy maps to 403 Forbidden (AppError::Authorization) with
+        // a non-disclosing message.
+        let err = policy_gate_result(false).unwrap_err();
+        assert!(
+            matches!(err, AppError::Authorization(_)),
+            "disallowed policy must be a 403 Authorization error"
+        );
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("scan policy"),
+            "message should name the scan policy generically: {msg}"
+        );
+        // Must NOT leak specific policy names or finding counts.
+        assert!(
+            !msg.contains("critical"),
+            "must not disclose finding detail"
+        );
+    }
 
     #[test]
     fn test_should_quarantine_enabled() {

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -1188,4 +1188,109 @@ mod tests {
         assert_eq!(until, None);
         fx.teardown().await;
     }
+
+    // -----------------------------------------------------------------------
+    // enforce_download_gate (#2954): quarantine THEN scan policy at the shared
+    // download choke point. DB-backed; no-op without DATABASE_URL.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_enforce_download_gate_absent_artifact_is_noop() {
+        use crate::api::handlers::test_db_helpers::Fixture;
+        let Some(fx) = Fixture::setup("local", "maven").await else {
+            return;
+        };
+        // A deleted / never-existing artifact preserves the pre-#2954 no-op.
+        let result = enforce_download_gate(&fx.pool, Uuid::new_v4()).await;
+        fx.teardown().await;
+        assert!(result.is_ok(), "absent artifact must stay a no-op Ok");
+    }
+
+    #[tokio::test]
+    async fn test_enforce_download_gate_no_policy_allows_then_quarantine_blocks() {
+        use crate::api::handlers::test_db_helpers::Fixture;
+        let Some(fx) = Fixture::setup("local", "maven").await else {
+            return;
+        };
+        let aid = seed_row(&fx, "local", "com/example/g/1.0/g-1.0.jar").await;
+
+        // Regression guardrail: no quarantine + no enabled scan policy => the
+        // gate is a pass-through (repos that never opted in see NO change).
+        let clean = enforce_download_gate(&fx.pool, aid).await;
+
+        // Quarantined (unexpired hold): 409 Conflict BEFORE any policy logic.
+        sqlx::query(
+            "UPDATE artifacts SET quarantine_status = 'quarantined', \
+                 quarantine_until = NOW() + INTERVAL '1 hour' WHERE id = $1",
+        )
+        .bind(aid)
+        .execute(&fx.pool)
+        .await
+        .expect("set quarantined");
+        let quarantined = enforce_download_gate(&fx.pool, aid).await;
+
+        // Rejected: 403.
+        sqlx::query("UPDATE artifacts SET quarantine_status = 'rejected' WHERE id = $1")
+            .bind(aid)
+            .execute(&fx.pool)
+            .await
+            .expect("set rejected");
+        let rejected = enforce_download_gate(&fx.pool, aid).await;
+
+        fx.teardown().await;
+
+        assert!(clean.is_ok(), "no hold + no policy must allow: {clean:?}");
+        assert!(
+            matches!(quarantined, Err(AppError::Conflict(_))),
+            "active quarantine must be a 409 Conflict, got {quarantined:?}"
+        );
+        assert!(
+            matches!(rejected, Err(AppError::Authorization(_))),
+            "rejected artifact must be a 403, got {rejected:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enforce_download_gate_blocks_unscanned_via_scan_policy() {
+        use crate::api::handlers::test_db_helpers::Fixture;
+        let Some(fx) = Fixture::setup("local", "maven").await else {
+            return;
+        };
+        let aid = seed_row(&fx, "local", "com/example/h/1.0/h-1.0.jar").await;
+
+        // A repo-scoped enabled policy with block_unscanned: the seeded
+        // artifact has no completed scan, so the policy evaluation disallows
+        // and the download gate must 403 — the exact false affordance #2954
+        // closes (scan policy previously only ran on the promotion gate).
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'high', true, true, true)",
+        )
+        .bind(format!("gate-2954-{}", fx.repo_id))
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let result = enforce_download_gate(&fx.pool, aid).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+
+        match result {
+            Err(AppError::Authorization(msg)) => {
+                assert!(
+                    msg.contains("scan policy"),
+                    "gate message names the scan policy generically: {msg}"
+                );
+                // Anonymous-readable route: no policy names / finding counts.
+                assert!(!msg.contains("gate-2954"), "must not leak policy names");
+            }
+            other => panic!("unscanned artifact under block_unscanned must 403, got {other:?}"),
+        }
+    }
 }

--- a/backend/src/services/scan_config_service.rs
+++ b/backend/src/services/scan_config_service.rs
@@ -5,6 +5,24 @@ use uuid::Uuid;
 
 use crate::error::Result;
 use crate::models::security::ScanConfig;
+use crate::services::proxy_scan_service::ProxyScanAction;
+
+/// Canonicalize a client-supplied `proxy_scan_action` (#2954), preserving the
+/// existing row's value when the patch omits it and defaulting to `fail_open`.
+///
+/// Unknown values are coerced to `fail_open` rather than passed through to the
+/// DB CHECK constraint (which would surface as an opaque 500). Pure /
+/// unit-testable.
+fn normalize_proxy_scan_action(patch: Option<&str>, existing: Option<&str>) -> String {
+    let raw = patch
+        .or(existing)
+        .map(|s| s.trim().to_ascii_lowercase())
+        .unwrap_or_else(|| "fail_open".to_string());
+    match raw.as_str() {
+        "fail_closed" => "fail_closed".to_string(),
+        _ => "fail_open".to_string(),
+    }
+}
 
 /// Request to create or update a scan configuration.
 ///
@@ -31,6 +49,10 @@ pub struct UpsertScanConfigRequest {
     pub block_on_policy_violation: Option<bool>,
     #[serde(default)]
     pub severity_threshold: Option<String>,
+    /// #2954: `'fail_open'` (default) | `'fail_closed'` for the inline proxy
+    /// scan-on-fetch action.
+    #[serde(default)]
+    pub proxy_scan_action: Option<String>,
 }
 
 pub struct ScanConfigService {
@@ -48,7 +70,8 @@ impl ScanConfigService {
             ScanConfig,
             r#"
             SELECT id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,
-                   block_on_policy_violation, severity_threshold, created_at, updated_at
+                   block_on_policy_violation, severity_threshold, proxy_scan_action,
+                   created_at, updated_at
             FROM scan_configs
             WHERE repository_id = $1
             "#,
@@ -99,13 +122,21 @@ impl ScanConfigService {
                 .map(|c| c.severity_threshold.clone())
                 .unwrap_or_else(|| "high".to_string())
         });
+        // #2954: default fail-open (matches the column default) so operators who
+        // have not opted into fail-closed see today's behavior. A bad value is
+        // normalized to fail-open rather than tripping the DB CHECK constraint.
+        let proxy_scan_action = normalize_proxy_scan_action(
+            req.proxy_scan_action.as_deref(),
+            existing.as_ref().map(|c| c.proxy_scan_action.as_str()),
+        );
 
         let config = sqlx::query_as!(
             ScanConfig,
             r#"
             INSERT INTO scan_configs (repository_id, scan_enabled, scan_on_upload, scan_on_proxy,
-                                      block_on_policy_violation, severity_threshold)
-            VALUES ($1, $2, $3, $4, $5, $6)
+                                      block_on_policy_violation, severity_threshold,
+                                      proxy_scan_action)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
             ON CONFLICT (repository_id)
             DO UPDATE SET
                 scan_enabled = EXCLUDED.scan_enabled,
@@ -113,9 +144,11 @@ impl ScanConfigService {
                 scan_on_proxy = EXCLUDED.scan_on_proxy,
                 block_on_policy_violation = EXCLUDED.block_on_policy_violation,
                 severity_threshold = EXCLUDED.severity_threshold,
+                proxy_scan_action = EXCLUDED.proxy_scan_action,
                 updated_at = NOW()
             RETURNING id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,
-                      block_on_policy_violation, severity_threshold, created_at, updated_at
+                      block_on_policy_violation, severity_threshold, proxy_scan_action,
+                      created_at, updated_at
             "#,
             repository_id,
             scan_enabled,
@@ -123,6 +156,7 @@ impl ScanConfigService {
             scan_on_proxy,
             block_on_policy_violation,
             severity_threshold,
+            proxy_scan_action,
         )
         .fetch_one(&self.db)
         .await
@@ -137,7 +171,8 @@ impl ScanConfigService {
             ScanConfig,
             r#"
             SELECT id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,
-                   block_on_policy_violation, severity_threshold, created_at, updated_at
+                   block_on_policy_violation, severity_threshold, proxy_scan_action,
+                   created_at, updated_at
             FROM scan_configs
             WHERE scan_enabled = true
             ORDER BY created_at DESC
@@ -175,6 +210,23 @@ impl ScanConfigService {
 
         Ok(result.unwrap_or(false))
     }
+
+    /// The inline proxy scan action (fail-open / fail-closed) for this repo
+    /// (#2954). Defaults to fail-open when no config row exists, matching the
+    /// column default and preserving today's availability-first behavior.
+    pub async fn proxy_scan_action(&self, repository_id: Uuid) -> Result<ProxyScanAction> {
+        let result = sqlx::query_scalar!(
+            r#"SELECT proxy_scan_action FROM scan_configs WHERE repository_id = $1"#,
+            repository_id
+        )
+        .fetch_optional(&self.db)
+        .await
+        .map_err(|e| crate::error::AppError::Database(e.to_string()))?;
+
+        Ok(result
+            .map(|v| ProxyScanAction::from_db(&v))
+            .unwrap_or(ProxyScanAction::FailOpen))
+    }
 }
 
 #[cfg(test)]
@@ -200,6 +252,32 @@ mod tests {
         assert_eq!(req.scan_on_proxy, Some(false));
         assert_eq!(req.block_on_policy_violation, Some(true));
         assert_eq!(req.severity_threshold.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn test_normalize_proxy_scan_action() {
+        // Patch wins over existing.
+        assert_eq!(
+            normalize_proxy_scan_action(Some("fail_closed"), Some("fail_open")),
+            "fail_closed"
+        );
+        // Omitted patch preserves existing.
+        assert_eq!(
+            normalize_proxy_scan_action(None, Some("fail_closed")),
+            "fail_closed"
+        );
+        // Neither => fail-open default.
+        assert_eq!(normalize_proxy_scan_action(None, None), "fail_open");
+        // Case-insensitive + trimmed.
+        assert_eq!(
+            normalize_proxy_scan_action(Some("  FAIL_CLOSED "), None),
+            "fail_closed"
+        );
+        // Unknown value coerced to fail-open (never trips the DB CHECK).
+        assert_eq!(
+            normalize_proxy_scan_action(Some("garbage"), None),
+            "fail_open"
+        );
     }
 
     #[test]
@@ -294,6 +372,7 @@ mod tests {
             scan_on_proxy: false,
             block_on_policy_violation: true,
             severity_threshold: "medium".to_string(),
+            proxy_scan_action: "fail_open".to_string(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }
@@ -360,6 +439,7 @@ mod tests {
             scan_on_proxy: Some(true),
             block_on_policy_violation: Some(true),
             severity_threshold: Some("medium".to_string()),
+            proxy_scan_action: Some("fail_closed".to_string()),
         };
         let cloned = req.clone();
         assert_eq!(cloned.scan_enabled, req.scan_enabled);
@@ -380,6 +460,7 @@ mod tests {
             scan_on_proxy: Some(false),
             block_on_policy_violation: Some(false),
             severity_threshold: Some("low".to_string()),
+            proxy_scan_action: None,
         };
         let debug_str = format!("{:?}", req);
         assert!(debug_str.contains("UpsertScanConfigRequest"));
@@ -402,6 +483,7 @@ mod tests {
             scan_on_proxy: false,
             block_on_policy_violation: true,
             severity_threshold: "medium".to_string(),
+            proxy_scan_action: "fail_open".to_string(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/backend/src/services/scan_config_service.rs
+++ b/backend/src/services/scan_config_service.rs
@@ -609,4 +609,71 @@ mod tests {
             AppError::Validation(_)
         ));
     }
+
+    /// DB-backed round trip for the #2954 `proxy_scan_action` column: default
+    /// when no config row exists, persist via `upsert_config`, read back via
+    /// `proxy_scan_action` / `is_proxy_scan_enabled`, and preserve the stored
+    /// value when a later patch omits the field (#1374 B11 semantics).
+    /// Skips cleanly when DATABASE_URL is unset.
+    #[tokio::test]
+    async fn test_proxy_scan_action_db_default_upsert_and_patch_preserve() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let svc = ScanConfigService::new(fx.pool.clone());
+
+        // No config row: action defaults to fail-open (today's behavior) and
+        // scan-on-proxy reads disabled.
+        assert_eq!(
+            svc.proxy_scan_action(fx.repo_id).await.expect("action"),
+            ProxyScanAction::FailOpen
+        );
+        assert!(!svc
+            .is_proxy_scan_enabled(fx.repo_id)
+            .await
+            .expect("enabled"));
+
+        // Upsert with fail_closed persists and round-trips.
+        let req = UpsertScanConfigRequest {
+            scan_enabled: Some(true),
+            scan_on_upload: None,
+            scan_on_proxy: Some(true),
+            block_on_policy_violation: None,
+            severity_threshold: None,
+            proxy_scan_action: Some("fail_closed".to_string()),
+        };
+        let cfg = svc.upsert_config(fx.repo_id, &req).await.expect("upsert");
+        assert_eq!(cfg.proxy_scan_action, "fail_closed");
+        assert!(cfg.scan_on_proxy);
+        assert_eq!(
+            svc.proxy_scan_action(fx.repo_id).await.expect("action"),
+            ProxyScanAction::FailClosed
+        );
+        assert!(svc
+            .is_proxy_scan_enabled(fx.repo_id)
+            .await
+            .expect("enabled"));
+
+        // A later patch that omits proxy_scan_action must PRESERVE the stored
+        // fail_closed, not silently reset the security posture to fail-open.
+        let patch = UpsertScanConfigRequest {
+            scan_enabled: None,
+            scan_on_upload: Some(true),
+            scan_on_proxy: None,
+            block_on_policy_violation: None,
+            severity_threshold: None,
+            proxy_scan_action: None,
+        };
+        let cfg = svc.upsert_config(fx.repo_id, &patch).await.expect("patch");
+        assert_eq!(
+            cfg.proxy_scan_action, "fail_closed",
+            "an omitted proxy_scan_action must keep the existing value"
+        );
+        // get_config reads the column back too.
+        let read = svc.get_config(fx.repo_id).await.expect("get").expect("row");
+        assert_eq!(read.proxy_scan_action, "fail_closed");
+
+        fx.teardown().await;
+    }
 }

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -13574,6 +13574,63 @@ mod tests {
         );
     }
 
+    /// The `Scanner::is_cve_authoritative` trait DEFAULT is false: a scanner
+    /// that does not opt in is a supplementary signal whose success must not
+    /// satisfy the "the CVE scanner ran" condition (only `GrypeScanner`
+    /// overrides to true — pinned in grype_scanner's own tests).
+    #[test]
+    fn test_scanner_trait_default_is_not_cve_authoritative() {
+        use inline_proxy_scan_fixtures::*;
+        // TrivialDependencyScanner inherits the trait default.
+        assert!(!TrivialDependencyScanner.is_cve_authoritative());
+        // The mock CVE scanner overrides it, mirroring GrypeScanner.
+        assert!(CveAuthoritativeScanner {
+            outcome: CveOutcome::Clean,
+        }
+        .is_cve_authoritative());
+    }
+
+    /// `ScannerService::scan_content` (#2954): the fair-share-permitted wrapper
+    /// over `run_inline_proxy_scanners`. DB-backed only for the fixture state;
+    /// the scanners are in-memory mocks. Covers the verdict path and the
+    /// no-scanner inconclusive path through the public seam the PyPI handler
+    /// calls. Skips cleanly when DATABASE_URL is unset.
+    #[tokio::test]
+    async fn test_scan_content_verdict_and_inconclusive_through_service() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let Some(fx) =
+            crate::api::handlers::test_db_helpers::Fixture::setup("remote", "pypi").await
+        else {
+            return;
+        };
+        let mut svc = scanner_for_fixture(&fx);
+        svc.scanners = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Critical,
+            }),
+        ];
+        let artifact = inline_scan_artifact();
+        let verdict = svc.scan_content(&artifact, &Bytes::new()).await;
+
+        // Same service with NO scanners: inconclusive error, never clean.
+        svc.scanners = vec![];
+        let inconclusive = svc.scan_content(&artifact, &Bytes::new()).await;
+
+        fx.teardown().await;
+
+        let verdict = verdict.expect("critical Grype-mock run must yield a verdict");
+        assert!(verdict.is_vulnerable());
+        assert_eq!(verdict.critical_count, 1);
+        assert_eq!(verdict.verdict_token(), "vulnerable");
+        assert!(
+            inconclusive.is_err(),
+            "scan_content with no scanner must surface the inconclusive error"
+        );
+    }
+
     /// Concrete regression for #994: the lodash fixture (generic tarball
     /// uploaded as `scan_type=image`) must trigger
     /// `ImageScanner::is_applicable=false`, so the orchestrator can skip

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -81,6 +81,23 @@ pub(crate) const ZERO_FINDINGS_DEDUP_TTL_DAYS: i32 = 1;
 /// still capping a hostile or runaway upload.
 pub(crate) const MAX_SCAN_INPUT_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 
+/// Hard byte ceiling for the inline proxy scan-on-fetch buffer (#2954).
+///
+/// The proxy download miss path deliberately STREAMS the upstream body so a
+/// multi-hundred-MiB wheel never sits in memory (#895 OOM). Buffering to scan
+/// reintroduces that risk, so the buffer is capped: an object larger than this
+/// is never buffered. Over-cap objects fall back to the streaming serve under
+/// the fail-open path, or return 423 under fail-closed — never an unbounded
+/// buffer. 200 MiB covers essentially every real wheel/sdist while bounding
+/// worst-case per-request memory.
+pub const PROXY_SCAN_MAX_BYTES: usize = 200 * 1024 * 1024;
+
+/// Wall-clock budget for a single inline proxy scan (#2954). A cold Grype scan
+/// of a fresh wheel is seconds; this bounds the added `pip install` latency so a
+/// slow or contended scan cannot stall the pull indefinitely. Budget exceeded
+/// is treated as inconclusive (fail-open serves-with-pending, fail-closed 423).
+pub const PROXY_SCAN_INLINE_BUDGET: Duration = Duration::from_secs(30);
+
 /// Below this size we keep the scan input in heap (`Bytes`) and skip the
 /// tempfile + mmap machinery entirely. The mmap path exists to keep
 /// multi-GiB artifacts off anon heap so the cgroup OOM killer leaves the
@@ -1959,6 +1976,80 @@ pub struct ScanTarget<'a> {
     pub manifest_body: Option<&'a [u8]>,
 }
 
+/// Aggregated verdict from an inline proxy scan over raw bytes (#2954).
+///
+/// Produced by [`ScannerService::scan_content`], which runs the leaf scanners
+/// over a synthetic in-memory [`Artifact`] + `Bytes` with NO `artifacts` row
+/// (proxy-cached bytes are intentionally not persisted as artifacts —
+/// #1278/#1280). The counts feed the digest-keyed `proxy_scan_results` store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyScanVerdict {
+    pub findings_count: i32,
+    pub critical_count: i32,
+    pub high_count: i32,
+    pub medium_count: i32,
+    pub low_count: i32,
+    /// Highest severity observed across all findings, for policy comparison.
+    pub max_severity: Option<Severity>,
+    /// Scanner binary/DB version string (e.g. `grype-0.83.0`), for CVE-DB
+    /// freshness gating of a reused verdict.
+    pub scanner_version: Option<String>,
+}
+
+impl ProxyScanVerdict {
+    /// A vulnerable verdict is any non-zero finding count. Whether that BLOCKS a
+    /// pull is a policy decision made by the caller against the repo's action.
+    pub fn is_vulnerable(&self) -> bool {
+        self.findings_count > 0
+    }
+
+    /// The stored `proxy_scan_results.verdict` token for this result.
+    pub fn verdict_token(&self) -> &'static str {
+        if self.is_vulnerable() {
+            crate::services::proxy_scan_service::VERDICT_VULNERABLE
+        } else {
+            crate::services::proxy_scan_service::VERDICT_CLEAN
+        }
+    }
+
+    /// Lowercase token for the highest observed severity (schema-compatible).
+    pub fn max_severity_token(&self) -> Option<&'static str> {
+        self.max_severity.map(severity_token)
+    }
+}
+
+/// Stable lowercase token for a [`Severity`], matching the DB CHECK vocabulary.
+pub fn severity_token(sev: Severity) -> &'static str {
+    match sev {
+        Severity::Critical => "critical",
+        Severity::High => "high",
+        Severity::Medium => "medium",
+        Severity::Low => "low",
+        Severity::Info => "info",
+    }
+}
+
+/// Fold a flat list of [`RawFinding`]s (from one or more scanners run over the
+/// same bytes) into a [`ProxyScanVerdict`]. Pure: no DB, no I/O — the security-
+/// relevant verdict logic is unit-testable over a synthetic finding list.
+pub fn aggregate_proxy_verdict(
+    findings: &[RawFinding],
+    scanner_version: Option<String>,
+) -> ProxyScanVerdict {
+    let count = |sev: Severity| findings.iter().filter(|f| f.severity == sev).count() as i32;
+    // Severity is ordered Critical=0 .. Info=4, so `min` is the highest.
+    let max_severity = findings.iter().map(|f| f.severity).min();
+    ProxyScanVerdict {
+        findings_count: findings.len() as i32,
+        critical_count: count(Severity::Critical),
+        high_count: count(Severity::High),
+        medium_count: count(Severity::Medium),
+        low_count: count(Severity::Low),
+        max_severity,
+        scanner_version,
+    }
+}
+
 /// A pluggable vulnerability scanner.
 #[async_trait]
 pub trait Scanner: Send + Sync {
@@ -3477,6 +3568,77 @@ impl ScannerService {
     ) -> Result<()> {
         self.scan_artifact_inner(artifact_id, force, bypass_dedup, Some(prepared))
             .await
+    }
+
+    /// Run the leaf scanners over raw in-memory bytes with NO `artifacts` row
+    /// and NO `scan_results` persistence (#2954 inline proxy scan-on-fetch).
+    ///
+    /// This is the seam that makes proxy scan-on-fetch feasible: the scanner
+    /// CORE (`Scanner::scan` — e.g. `GrypeScanner` running `grype dir:<ws>` over
+    /// the bytes) never needs a DB row. `synthetic` is an [`Artifact`] the
+    /// caller fabricates from the proxied object's filename/digest so the
+    /// per-scanner applicability + workspace naming behave exactly as for a
+    /// hosted artifact; the returned [`ProxyScanVerdict`] is stored digest-keyed
+    /// in `proxy_scan_results` by the caller, never in `scan_results`.
+    ///
+    /// The scanner's per-tenant fair-share extraction permit is acquired for the
+    /// duration so a burst of inline pulls cannot starve upload scans (#2555).
+    /// Any scanner error is surfaced to the caller so the fail-open/closed
+    /// decision can treat it as inconclusive rather than silently "clean".
+    pub async fn scan_content(
+        &self,
+        synthetic: &Artifact,
+        content: &Bytes,
+    ) -> Result<ProxyScanVerdict> {
+        // Fair-share + global cap: inline scans queue behind the same semaphore
+        // as upload scans instead of contending for unbounded extraction slots.
+        let _extraction_permit = acquire_scan_extraction_permit(synthetic.repository_id).await;
+
+        let mut findings: Vec<RawFinding> = Vec::new();
+        let mut scanner_version: Option<String> = None;
+        // Track whether at least one applicable scanner actually ran. A single
+        // scanner failing (e.g. an optional Trivy adapter that is down) must NOT
+        // abort the whole scan — the orchestrator `scan_artifact_inner` skips a
+        // failed scanner and keeps going, and Grype (the always-bundled CVE
+        // engine) is what produces the CVE verdict. If NO scanner ran we return
+        // an error so the caller treats it as inconclusive rather than a false
+        // "clean" (fail-closed then 423s instead of serving unscanned bytes).
+        let mut any_ran = false;
+
+        for scanner in &self.scanners {
+            // Applicability gates on the synthetic artifact's path/content-type,
+            // exactly as the orchestrator gates a hosted artifact.
+            if !scanner.is_applicable(synthetic) {
+                continue;
+            }
+            match scanner.scan(synthetic, None, content).await {
+                Ok(output) => {
+                    any_ran = true;
+                    // Capture the first available scanner version as provenance
+                    // for CVE-DB freshness (Grype reports one).
+                    if scanner_version.is_none() {
+                        scanner_version = scanner.version().await;
+                    }
+                    findings.extend(output.findings);
+                }
+                Err(e) => {
+                    warn!(
+                        "Inline proxy scan: scanner {} failed on {} ({}); skipping this scanner",
+                        scanner.name(),
+                        synthetic.name,
+                        e
+                    );
+                }
+            }
+        }
+
+        if !any_ran {
+            return Err(AppError::Internal(
+                "no applicable scanner completed for inline proxy scan".to_string(),
+            ));
+        }
+
+        Ok(aggregate_proxy_verdict(&findings, scanner_version))
     }
 
     /// Scan a single artifact: run all applicable scanners, persist results,
@@ -8950,6 +9112,63 @@ mod tests {
             source: None,
             source_url: None,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // aggregate_proxy_verdict / ProxyScanVerdict (#2954 inline proxy scan)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_proxy_verdict_clean_when_no_findings() {
+        let verdict = aggregate_proxy_verdict(&[], Some("grype-0.83.0".to_string()));
+        assert_eq!(verdict.findings_count, 0);
+        assert!(!verdict.is_vulnerable());
+        assert_eq!(verdict.verdict_token(), "clean");
+        assert_eq!(verdict.max_severity, None);
+        assert_eq!(verdict.max_severity_token(), None);
+        assert_eq!(verdict.scanner_version.as_deref(), Some("grype-0.83.0"));
+    }
+
+    #[test]
+    fn test_proxy_verdict_vulnerable_with_critical() {
+        // A single critical finding (the CVE-wheel case) => vulnerable verdict.
+        let findings = vec![make_finding(Severity::Critical)];
+        let verdict = aggregate_proxy_verdict(&findings, None);
+        assert_eq!(verdict.findings_count, 1);
+        assert!(verdict.is_vulnerable());
+        assert_eq!(verdict.verdict_token(), "vulnerable");
+        assert_eq!(verdict.critical_count, 1);
+        assert_eq!(verdict.max_severity, Some(Severity::Critical));
+        assert_eq!(verdict.max_severity_token(), Some("critical"));
+    }
+
+    #[test]
+    fn test_proxy_verdict_max_severity_is_highest() {
+        // Mixed findings: max_severity must be the HIGHEST (Critical < .. < Info
+        // in ordinal terms), and per-severity counts must tally.
+        let findings = vec![
+            make_finding(Severity::Low),
+            make_finding(Severity::High),
+            make_finding(Severity::Medium),
+            make_finding(Severity::High),
+        ];
+        let verdict = aggregate_proxy_verdict(&findings, None);
+        assert_eq!(verdict.findings_count, 4);
+        assert_eq!(verdict.high_count, 2);
+        assert_eq!(verdict.medium_count, 1);
+        assert_eq!(verdict.low_count, 1);
+        assert_eq!(verdict.critical_count, 0);
+        assert_eq!(verdict.max_severity, Some(Severity::High));
+        assert_eq!(verdict.max_severity_token(), Some("high"));
+    }
+
+    #[test]
+    fn test_severity_token_vocabulary() {
+        assert_eq!(severity_token(Severity::Critical), "critical");
+        assert_eq!(severity_token(Severity::High), "high");
+        assert_eq!(severity_token(Severity::Medium), "medium");
+        assert_eq!(severity_token(Severity::Low), "low");
+        assert_eq!(severity_token(Severity::Info), "info");
     }
 
     #[test]

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -2050,6 +2050,97 @@ pub fn aggregate_proxy_verdict(
     }
 }
 
+/// Run the applicable leaf scanners over raw proxy bytes and fold their output
+/// into a [`ProxyScanVerdict`], or return an error when the result is
+/// INCONCLUSIVE. Extracted from [`ScannerService::scan_content`] (minus the
+/// fair-share permit) so the #2954 fail-closed correctness contract is
+/// unit-testable over mock scanners, with no `ScannerService`/DB/storage.
+///
+/// Fail-closed correctness (#2954): a non-error (`clean`/`vulnerable`) verdict
+/// is only trustworthy when the CVE-AUTHORITATIVE scanner (Grype —
+/// [`Scanner::is_cve_authoritative`]) actually completed `Ok`. The always-on
+/// `DependencyScanner` returns `Ok(ScanOutput::default())` on a binary wheel
+/// (non-UTF-8 content -> zero parsed deps), so "some scanner ran" is trivially
+/// true even when Grype hard-errored / timed out / OOM-died or the pre-seeded
+/// CVE-DB aged past its exit-1 time-bomb. Letting that trivial success
+/// aggregate to `clean` is exactly the hole that serves an UNSCANNED,
+/// possibly-vulnerable wheel with a 200 under the fail-closed posture. So: if a
+/// CVE-authoritative scanner was APPLICABLE but none completed `Ok`, we return
+/// an error the caller treats as inconclusive (fail-closed -> 423, fail-open ->
+/// loud pending) and no `clean` verdict is ever persisted for this digest. A
+/// single supplementary scanner failing (e.g. an optional Trivy adapter that is
+/// down) still must NOT abort the scan — only the CVE engine is load-bearing.
+async fn run_inline_proxy_scanners(
+    scanners: &[Arc<dyn Scanner>],
+    synthetic: &Artifact,
+    content: &Bytes,
+) -> Result<ProxyScanVerdict> {
+    let mut findings: Vec<RawFinding> = Vec::new();
+    let mut scanner_version: Option<String> = None;
+    // "did SOME applicable scanner run Ok" — necessary but NOT sufficient.
+    let mut any_ran = false;
+    // "was a CVE-authoritative scanner applicable" vs "did one complete Ok".
+    // Conflating these two questions is the #2954 fail-closed hole.
+    let mut cve_scanner_applicable = false;
+    let mut cve_scanner_ran = false;
+
+    for scanner in scanners {
+        // Applicability gates on the synthetic artifact's path/content-type,
+        // exactly as the orchestrator gates a hosted artifact.
+        if !scanner.is_applicable(synthetic) {
+            continue;
+        }
+        let is_cve_authoritative = scanner.is_cve_authoritative();
+        if is_cve_authoritative {
+            cve_scanner_applicable = true;
+        }
+        match scanner.scan(synthetic, None, content).await {
+            Ok(output) => {
+                any_ran = true;
+                if is_cve_authoritative {
+                    cve_scanner_ran = true;
+                }
+                // Capture the first available scanner version as provenance
+                // for CVE-DB freshness (Grype reports one).
+                if scanner_version.is_none() {
+                    scanner_version = scanner.version().await;
+                }
+                findings.extend(output.findings);
+            }
+            Err(e) => {
+                warn!(
+                    "Inline proxy scan: scanner {} failed on {} ({}); skipping this scanner",
+                    scanner.name(),
+                    synthetic.name,
+                    e
+                );
+            }
+        }
+    }
+
+    // The CVE-authoritative scanner (Grype) is applicable to every proxied
+    // wheel/sdist and is always registered, so `cve_scanner_applicable` is
+    // normally true. If it was applicable but did NOT complete `Ok`, the scan
+    // is inconclusive — never `clean`. Returning an error here is what makes
+    // the caller's fail-closed branch 423 instead of serving unscanned bytes,
+    // and stops a poisoned `clean` row from being persisted.
+    if cve_scanner_applicable && !cve_scanner_ran {
+        return Err(AppError::Internal(
+            "CVE-authoritative scanner did not complete for inline proxy scan; \
+             verdict inconclusive (failing closed instead of reporting clean)"
+                .to_string(),
+        ));
+    }
+
+    if !any_ran {
+        return Err(AppError::Internal(
+            "no applicable scanner completed for inline proxy scan".to_string(),
+        ));
+    }
+
+    Ok(aggregate_proxy_verdict(&findings, scanner_version))
+}
+
 /// A pluggable vulnerability scanner.
 #[async_trait]
 pub trait Scanner: Send + Sync {
@@ -2088,6 +2179,30 @@ pub trait Scanner: Send + Sync {
     /// routing context to override only this method.
     fn is_applicable_for_target(&self, target: &ScanTarget<'_>) -> bool {
         self.is_applicable(target.artifact)
+    }
+
+    /// Whether this scanner is the CVE-authoritative engine whose successful
+    /// completion is REQUIRED before an inline proxy scan may report a
+    /// non-error (`clean`/`vulnerable`) verdict.
+    ///
+    /// The inline proxy scan-and-block path ([`ScannerService::scan_content`])
+    /// runs every applicable leaf scanner, but only the CVE engine (Grype —
+    /// the always-bundled, fail-closed vulnerability scanner, #2167) actually
+    /// grades an artifact for known CVEs. The always-on [`DependencyScanner`]
+    /// returns `Ok(ScanOutput::default())` on a binary wheel (non-UTF-8
+    /// content parses to zero dependencies), so "a scanner ran successfully"
+    /// is trivially true even when Grype hard-errored or timed out. Letting
+    /// that trivial success aggregate to `clean` would defeat the fail-closed
+    /// guarantee and serve an UNSCANNED, possibly-vulnerable wheel with a 200.
+    ///
+    /// Returning `false` (the default) means the scanner is a supplementary
+    /// signal whose failure must NOT abort the scan and whose success must NOT
+    /// on its own satisfy the "the CVE scanner ran" condition. Only
+    /// `GrypeScanner` overrides this to `true`. Trivy's filesystem scanner is
+    /// deliberately NOT authoritative here: its engine is optional and, when
+    /// absent or down, must not fail-close the proxy path.
+    fn is_cve_authoritative(&self) -> bool {
+        false
     }
 
     /// Run the scan against artifact content and metadata. Returns both
@@ -3594,51 +3709,7 @@ impl ScannerService {
         // as upload scans instead of contending for unbounded extraction slots.
         let _extraction_permit = acquire_scan_extraction_permit(synthetic.repository_id).await;
 
-        let mut findings: Vec<RawFinding> = Vec::new();
-        let mut scanner_version: Option<String> = None;
-        // Track whether at least one applicable scanner actually ran. A single
-        // scanner failing (e.g. an optional Trivy adapter that is down) must NOT
-        // abort the whole scan — the orchestrator `scan_artifact_inner` skips a
-        // failed scanner and keeps going, and Grype (the always-bundled CVE
-        // engine) is what produces the CVE verdict. If NO scanner ran we return
-        // an error so the caller treats it as inconclusive rather than a false
-        // "clean" (fail-closed then 423s instead of serving unscanned bytes).
-        let mut any_ran = false;
-
-        for scanner in &self.scanners {
-            // Applicability gates on the synthetic artifact's path/content-type,
-            // exactly as the orchestrator gates a hosted artifact.
-            if !scanner.is_applicable(synthetic) {
-                continue;
-            }
-            match scanner.scan(synthetic, None, content).await {
-                Ok(output) => {
-                    any_ran = true;
-                    // Capture the first available scanner version as provenance
-                    // for CVE-DB freshness (Grype reports one).
-                    if scanner_version.is_none() {
-                        scanner_version = scanner.version().await;
-                    }
-                    findings.extend(output.findings);
-                }
-                Err(e) => {
-                    warn!(
-                        "Inline proxy scan: scanner {} failed on {} ({}); skipping this scanner",
-                        scanner.name(),
-                        synthetic.name,
-                        e
-                    );
-                }
-            }
-        }
-
-        if !any_ran {
-            return Err(AppError::Internal(
-                "no applicable scanner completed for inline proxy scan".to_string(),
-            ));
-        }
-
-        Ok(aggregate_proxy_verdict(&findings, scanner_version))
+        run_inline_proxy_scanners(&self.scanners, synthetic, content).await
     }
 
     /// Scan a single artifact: run all applicable scanners, persist results,
@@ -13297,6 +13368,209 @@ mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "scan() must be called once when is_applicable() returns true"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Inline proxy scan fail-closed correctness (#2954)
+    //
+    // The security-critical contract of `run_inline_proxy_scanners` (the loop
+    // behind `ScannerService::scan_content`): a non-error verdict is only
+    // emitted when the CVE-AUTHORITATIVE scanner (Grype) completed `Ok`. A
+    // Grype error/timeout must NOT be masked by a supplementary scanner's
+    // trivial `Ok(ScanOutput::default())` and aggregate to `clean` — that is
+    // the hole that served an unscanned vulnerable wheel 200 under fail-closed.
+    // -----------------------------------------------------------------------
+    mod inline_proxy_scan_fixtures {
+        use super::*;
+
+        /// A CVE-authoritative scanner (mimics Grype) with a configurable
+        /// outcome: hard error, clean Ok, or Ok with a critical finding.
+        pub(super) enum CveOutcome {
+            /// Grype hard-errored / timed out / stale-DB exit-1 / OOM.
+            Error,
+            /// Grype ran and found nothing.
+            Clean,
+            /// Grype ran and found a critical CVE.
+            Critical,
+        }
+
+        pub(super) struct CveAuthoritativeScanner {
+            pub(super) outcome: CveOutcome,
+        }
+
+        #[async_trait::async_trait]
+        impl Scanner for CveAuthoritativeScanner {
+            fn name(&self) -> &str {
+                "cve-authoritative-test-scanner"
+            }
+            fn scan_type(&self) -> &str {
+                "grype"
+            }
+            fn is_cve_authoritative(&self) -> bool {
+                true
+            }
+            async fn scan(
+                &self,
+                _: &Artifact,
+                _: Option<&ArtifactMetadata>,
+                _: &Bytes,
+            ) -> Result<ScanOutput> {
+                match self.outcome {
+                    CveOutcome::Error => Err(AppError::Internal(
+                        "simulated grype failure (exit 1, no stderr)".to_string(),
+                    )),
+                    CveOutcome::Clean => Ok(ScanOutput::default()),
+                    CveOutcome::Critical => Ok(ScanOutput::findings_only(vec![RawFinding {
+                        severity: Severity::Critical,
+                        title: "CVE-2020-0000 test".to_string(),
+                        description: None,
+                        cve_id: Some("CVE-2020-0000".to_string()),
+                        affected_component: Some("pyyaml".to_string()),
+                        affected_version: Some("5.3.1".to_string()),
+                        fixed_version: Some("5.4".to_string()),
+                        source: Some("grype".to_string()),
+                        source_url: None,
+                    }])),
+                }
+            }
+        }
+
+        /// A non-CVE supplementary scanner that always returns
+        /// `Ok(ScanOutput::default())` — exactly what `DependencyScanner` does
+        /// on a binary wheel (non-UTF-8 content -> zero parsed deps). It must
+        /// NOT, on its own, satisfy the "the CVE scanner ran" condition.
+        pub(super) struct TrivialDependencyScanner;
+
+        #[async_trait::async_trait]
+        impl Scanner for TrivialDependencyScanner {
+            fn name(&self) -> &str {
+                "trivial-dependency-test-scanner"
+            }
+            fn scan_type(&self) -> &str {
+                "dependency"
+            }
+            // Inherits is_cve_authoritative = false (default).
+            async fn scan(
+                &self,
+                _: &Artifact,
+                _: Option<&ArtifactMetadata>,
+                _: &Bytes,
+            ) -> Result<ScanOutput> {
+                Ok(ScanOutput::default())
+            }
+        }
+    }
+
+    fn inline_scan_artifact() -> Artifact {
+        test_helpers::make_test_artifact(
+            "PyYAML-5.3.1-cp38-cp38-manylinux1_x86_64.whl",
+            "application/octet-stream",
+            "pypi/pyyaml/5.3.1/PyYAML-5.3.1-cp38-cp38-manylinux1_x86_64.whl",
+        )
+    }
+
+    /// THE #2954 discriminator: DependencyScanner (trivial Ok) + a Grype error
+    /// must yield an INCONCLUSIVE error, NOT a `clean` verdict. Before the fix
+    /// `any_ran` was true (DependencyScanner succeeded), so a Grype-only error
+    /// aggregated to `clean` and the fail-closed serve path returned 200 for an
+    /// unscanned, possibly-vulnerable wheel.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_grype_error_is_inconclusive_not_clean() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Error,
+            }),
+        ];
+        let artifact = inline_scan_artifact();
+        let result = run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new()).await;
+        assert!(
+            result.is_err(),
+            "a Grype error must be inconclusive (Err), never a clean verdict, \
+             even though DependencyScanner returned Ok(default) (#2954)"
+        );
+    }
+
+    /// Ordering must not matter: Grype error first, then a trivially-successful
+    /// supplementary scanner, is still inconclusive.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_grype_error_first_still_inconclusive() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Error,
+            }),
+            Arc::new(TrivialDependencyScanner),
+        ];
+        let artifact = inline_scan_artifact();
+        assert!(
+            run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
+                .await
+                .is_err(),
+            "Grype error remains inconclusive regardless of scanner order (#2954)"
+        );
+    }
+
+    /// A genuinely-clean Grype run (Ok, no findings) alongside the trivial
+    /// dependency scanner still yields a `clean` verdict — the fix must not
+    /// over-correct and block legitimate clean pulls.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_grype_clean_is_clean() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Clean,
+            }),
+        ];
+        let artifact = inline_scan_artifact();
+        let verdict = run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
+            .await
+            .expect("clean Grype run must produce a verdict");
+        assert!(!verdict.is_vulnerable(), "clean run -> not vulnerable");
+        assert_eq!(verdict.findings_count, 0);
+    }
+
+    /// A Grype run that finds a critical CVE yields a `vulnerable` verdict.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_grype_findings_are_vulnerable() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Critical,
+            }),
+        ];
+        let artifact = inline_scan_artifact();
+        let verdict = run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
+            .await
+            .expect("Grype run with findings must produce a verdict");
+        assert!(verdict.is_vulnerable(), "findings -> vulnerable");
+        assert_eq!(verdict.critical_count, 1);
+    }
+
+    /// Defensive: with NO scanner registered at all the result is inconclusive
+    /// (no scanner ran), never a false clean.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_no_scanner_is_inconclusive() {
+        use std::sync::Arc;
+        let scanners: Vec<Arc<dyn Scanner>> = vec![];
+        let artifact = inline_scan_artifact();
+        assert!(
+            run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
+                .await
+                .is_err(),
+            "no scanner at all -> inconclusive, never clean"
         );
     }
 


### PR DESCRIPTION
## Summary

Phase 1 of the 1.7.0 inline scan-and-block feature. It closes two independent
download-path scanning gaps behind one shared mechanism, so scan results and
scan policy are enforced at serve time for both hosted artifacts and PyPI proxy
pulls.

**1. Hosted download gate (all formats).** `PolicyService::evaluate_artifact`
(which enforces `block_unscanned` / `block_on_fail` / `max_severity`) previously
had a single caller — the promotion gate — so the ~30 per-format download
handlers only checked quarantine state and a scan policy was a no-op on the raw
download path. This folds `evaluate_artifact` into the shared
`quarantine_service::check_artifact_download` choke point via a new
`enforce_download_gate` (quarantine check first, then policy), lighting up every
format from one change. Guardrail: `evaluate_artifact` returns `allowed` when no
enabled policy matches, so a repo that has not opted into a scan policy behaves
exactly as before.

**2. PyPI proxy scan-on-fetch.** Proxy-cached bytes are intentionally not written
to `artifacts` (#1278/#1280), so the `artifact_id`-keyed scanner pipeline could
never scan them and `scan_on_proxy` was only a log warning (#1274) — a vulnerable
wheel streamed through on the first pull. A new `ScannerService::scan_content`
runs the leaf Grype scanner over a synthetic in-memory `Artifact` + buffered
`Bytes` with no DB row, wired into the `pypi::serve_file` cache-miss branch. The
verdict is content-addressed in a new `proxy_scan_results` table (migration 181),
so a repeat pull of a known-vulnerable digest is blocked from the verdict cache
without re-fetching upstream or re-scanning.

**3. Bounded + policy-driven.** The buffered fetch is capped hard at
`PROXY_SCAN_MAX_BYTES` (200 MiB) with a bounded inline budget
`PROXY_SCAN_INLINE_BUDGET` (30s) — an over-cap or timed-out object never buffers
unbounded (preserves the #895 OOM relief). A new per-repo `proxy_scan_action`
config (on `scan_configs`) selects fail-open (default) or fail-closed:
- fail-closed scans inline and returns `403` on a vulnerable verdict, or `423`
  when it cannot scan (over-cap / budget / scanner error) — never a 200 of
  unscanned bytes;
- fail-open serves the first pull immediately and loudly (`X-AK-Scan: pending`
  header + structured warn) and scans asynchronously, so the next pull of that
  digest is blocked.

No change to the `scan_results` / `artifacts` schema, preserving the load-bearing
`scan_results.artifact_id` FK invariant.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix (feat/)

## Test Checklist
- [x] Unit tests added/updated — pure-helper coverage for the verdict
      aggregation + severity tokens (`scanner_service`), freshness/TTL +
      version-invalidation + fail-open/closed decision (`proxy_scan_service`),
      the download-gate policy mapping (`quarantine_service`), and
      `proxy_scan_action` normalization (`scan_config_service`).
- [x] Integration tests added/updated (if applicable) — end-to-end behavior is
      covered by three E2E tiers in artifact-keeper-test (proxy-pypi,
      hosted-gate, fail-open); tracked to land in that repo.
- [x] Manually tested locally — see "Manual validation" below.
- [x] No regressions in existing tests

## API Changes
- [x] Migration is reversible (if applicable) — `181_proxy_scan_results.sql` is
      purely additive (new table + a defaulted `scan_configs.proxy_scan_action`
      column); no backfill, no change to existing schema.
- [x] Request/response types have `#[derive(ToSchema)]` — `proxy_scan_action`
      is threaded through the existing `ScanConfigResponse` / upsert request.

## Manual validation
Built the backend image and ran it on an isolated stack with the bundled Grype
scanner:
- Remote PyPI repo (fail-closed), pull of a known-CVE wheel → `403` with a
  `vulnerable` `proxy_scan_results` verdict row; repeat pull → `403` from the
  verdict cache with no second scan; a clean wheel → `200` with
  `X-AK-Scan: clean`.
- Fail-open: first pull of a CVE wheel → `200` with `X-AK-Scan: pending`, the
  async scan lands a `vulnerable` verdict, and the second pull → `403`.
- Hosted maven repo with a `block_unscanned` policy → download `403` (was
  `200`); an identical repo with no policy → `200` (regression guard).

## Notes / follow-ups (Phase 2)
- Proxy scan-on-fetch is PyPI-only in Phase 1; npm and OCI/Docker generalize the
  `serve_scanned_pypi_file` seam into a shared helper in a follow-up.
- The pre-fetch index-`#sha256=` fast path (block before touching even the local
  cache) is deferred; the repeat-pull block already avoids upstream fetches via
  the cache-first buffered fetch + verdict lookup.
- Fail-open currently emits a structured warn + `X-AK-Scan: pending`; wiring a
  dedicated audit-event action is a small follow-up.

Closes #2954
