### PR TITLE
ci(release): gate resolve-candidate-digest on the docker-publish run instead of a 35-min clock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,14 @@ jobs:
           .github/scripts/assert-release-absent.sh "${GITHUB_REF_NAME}"
 
   # ════════════════════════════════════════════════════════════════════════════
-  # RESOLVE CANDIDATE IMAGE DIGEST  (issue #2696)
+  # RESOLVE CANDIDATE IMAGE DIGEST  (issues #2696, #2711)
   #
   # docker-publish.yml runs INDEPENDENTLY on the same tag push and publishes
-  # ghcr.io/.../artifact-keeper-backend:${VERSION} as a manifest list. Nothing
-  # connects the two workflows except this poll of the registry. Once
-  # merge-backend has pushed the tag, the digest-aware republish guard
+  # ghcr.io/.../artifact-keeper-backend:${VERSION} as a manifest list. A
+  # cross-workflow `needs:` is impossible, so this job is the explicit gate:
+  # it follows the docker-publish RUN for this exact commit+tag to completion
+  # via the Actions API, then resolves the published digest from the registry.
+  # Once merge-backend has pushed the tag, the digest-aware republish guard
   # (`assert-version-digest-consistent`) in docker-publish.yml guarantees it can
   # never be re-pointed to DIFFERENT content -- only re-applied to the same
   # digest, a no-op -- so the tag->digest binding is stable the moment it first
@@ -91,27 +93,86 @@ jobs:
   # half-published image set. web is a decoupled SDK consumer and is no
   # longer part of the backend release's version set (issue #2708).
   #
-  # Ordering (A5): preflight -> resolve (blocks <=35 min on the publish) ->
-  # release-gate -> build-binaries -> verify-images-published -> release.
-  # The GitHub Release object still publishes strictly last; this job only
-  # moves the gate's START to after the candidate bytes exist.
+  # Ordering (A5): preflight -> resolve (follows the docker-publish run to
+  # completion, then captures the digest) -> release-gate ->
+  # build-binaries -> verify-images-published -> release. The GitHub Release
+  # object still publishes strictly last; this job only moves the gate's START
+  # to after the candidate bytes exist.
   # ════════════════════════════════════════════════════════════════════════════
 
   resolve-candidate-digest:
     name: Resolve candidate image digest
     needs: [release-preflight]
     runs-on: ubuntu-latest
-    # docker-publish's multi-arch build + cosign + provenance takes 15-25 min
-    # (see verify-images-published comment below); poll with a 35-min internal
-    # deadline inside a 40-min job timeout.
-    timeout-minutes: 40
+    # docker-publish's wall time is dominated by the amd64 backend image build
+    # on the self-hosted runners: with a cold buildx cache it legitimately
+    # takes 60-90 min (arm64 finishes in ~9 min on GitHub-native runners).
+    # A previous fixed 35-min poll deadline here raced that build and failed
+    # releases that were merely slow, not broken (issue #2711). The wait below
+    # is now event-driven -- it follows the docker-publish run for this exact
+    # commit to completion -- so this job timeout is only a hard ceiling
+    # against a genuinely hung publish: cold-cache amd64 worst case (~90 min)
+    # + runner queue + cosign/provenance + margin.
+    timeout-minutes: 130
     permissions:
       packages: read
+      actions: read # to follow the docker-publish run for this commit
     outputs:
       backend_digest: ${{ steps.resolve.outputs.backend_digest }}   # sha256:...
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      - name: Wait for docker-publish to publish :$VERSION and capture its digest
+      - name: Wait for the docker-publish run for this commit to complete
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Locating the docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA}"
+
+          # The same tag push triggers docker-publish.yml independently; find
+          # ITS run for this exact commit+tag. Webhook fan-out can lag, so
+          # allow up to 15 minutes for the run to appear before declaring
+          # docker-publish dead (a dead publish must fail this job RED rather
+          # than let a skipped gate slip the release through).
+          APPEAR_DEADLINE=$(($(date +%s) + 15*60))
+          RUN_ID=""
+          while true; do
+            RUN_ID=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/docker-publish.yml/runs?event=push&head_sha=${GITHUB_SHA}&per_page=20" \
+              --jq '.workflow_runs' 2>/dev/null \
+              | jq -r --arg ref "${GITHUB_REF_NAME}" \
+                  '[.[] | select(.head_branch == $ref)][0].id // empty' || true)
+            [ -n "${RUN_ID}" ] && break
+            if [ "$(date +%s)" -ge "${APPEAR_DEADLINE}" ]; then
+              echo "::error title=docker-publish never started::No docker-publish.yml run found for ${GITHUB_REF_NAME}@${GITHUB_SHA} after 15m. Release blocked."
+              exit 1
+            fi
+            echo "  no docker-publish run visible yet, waiting 30s..."
+            sleep 30
+          done
+          echo "  following docker-publish run ${RUN_ID}"
+
+          # Follow the run to completion. Deliberately NO fixed clock here --
+          # the job-level timeout-minutes above is the only ceiling, sized for
+          # the cold-cache amd64 build (issue #2711). Transient API errors
+          # yield STATUS=unknown and the loop just keeps polling.
+          while true; do
+            STATE=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" \
+              --jq '.status + " " + (.conclusion // "-")' 2>/dev/null || echo "unknown -")
+            STATUS="${STATE%% *}"
+            CONCLUSION="${STATE#* }"
+            if [ "${STATUS}" = "completed" ]; then
+              if [ "${CONCLUSION}" = "success" ]; then
+                echo "  docker-publish run ${RUN_ID} completed successfully."
+                break
+              fi
+              echo "::error title=docker-publish failed::docker-publish run ${RUN_ID} completed with conclusion '${CONCLUSION}'. Release blocked; fix and re-run docker-publish, then re-run this workflow."
+              exit 1
+            fi
+            echo "  docker-publish run ${RUN_ID}: ${STATUS}; waiting 60s..."
+            sleep 60
+          done
+
+      - name: Capture the published :$VERSION digest
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -152,9 +213,11 @@ jobs:
             printf '%s' "${digest}"
           }
 
-          # Poll for up to 35 minutes; a dead docker-publish must fail this job
-          # RED (exit 1) rather than let a skipped gate slip the release through.
-          DEADLINE=$(($(date +%s) + 35*60))
+          # The previous step already followed the docker-publish run to a
+          # successful completion, so the manifests exist; this short deadline
+          # only covers registry propagation/read-path flakes, not the build
+          # (which is what the old fixed 35-min clock raced -- issue #2711).
+          DEADLINE=$(($(date +%s) + 10*60))
 
           BACKEND_DIGEST=""
           echo ""
@@ -166,7 +229,7 @@ jobs:
               break
             fi
             if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
-              echo "::error title=Candidate not published::backend:${VERSION} not on ghcr.io after 35m -- docker-publish.yml did not finish. Release blocked."
+              echo "::error title=Candidate not resolvable::docker-publish reported success but backend:${VERSION} is not resolvable on ghcr.io after 10m. Release blocked."
               exit 1
             fi
             echo "  not yet present, waiting 30s..."
@@ -187,7 +250,7 @@ jobs:
                 break
               fi
               if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
-                echo "::error title=Candidate not published::${extra}:${VERSION} not on ghcr.io after 35m. Release blocked."
+                echo "::error title=Candidate not resolvable::docker-publish reported success but ${extra}:${VERSION} is not resolvable on ghcr.io after 10m. Release blocked."
                 exit 1
               fi
               echo "  not yet present, waiting 30s..."


### PR DESCRIPTION
## Summary

Closes #2711

`resolve-candidate-digest` in `release.yml` raced the docker-publish workflow: it polled ghcr.io for the published `backend:${VERSION}` manifest list with a **fixed 35-minute internal deadline** (`DEADLINE=$(($(date +%s) + 35*60))`) inside a 40-minute job timeout. The amd64 backend image build on the self-hosted runners legitimately takes **60-90 minutes with a cold buildx cache** (arm64 finishes in ~9 min on GitHub-native runners), so a slow-but-healthy publish could outlive the clock and fail the release with a false `Candidate not published` error. This was the root cause of a past release-run miss.

### Before
- Preflight → resolve polls the registry on a 35-min clock → red if the multi-arch publish is merely slow.
- Nothing connected the two workflows except the registry poll; the deadline encoded an outdated 15-25 min publish estimate.

### After
Cross-workflow `needs:` is impossible (docker-publish.yml is a separate workflow triggered by the same tag push), so the job now gates **explicitly on the docker-publish run itself** instead of a magic number:

1. **Locate** the docker-publish run for this exact commit+tag via the Actions API (`event=push`, `head_sha=${GITHUB_SHA}`, `head_branch=${GITHUB_REF_NAME}`), with a 15-min appearance grace for webhook fan-out lag. No run after 15 min → red (a dead publish must not skip the gate).
2. **Follow it to completion** with no fixed clock — polling every 60s; conclusion other than `success` → red with a pointed error.
3. **Capture the digest** with the existing registry poll, now scoped to a 10-min propagation window (the manifests are proven published by step 2).

The job-level `timeout-minutes` (40 → 130) becomes the sole hard ceiling against a genuinely hung publish, sized for the cold-cache amd64 worst case (~90 min) + runner queue + cosign/provenance margin. Job permissions gain `actions: read` for the run lookup.

Why this fixes the race: the wait is now event-driven — it ends when docker-publish actually ends, however long the amd64 arch takes — instead of betting a fixed clock against a build whose duration varies 9→90 min with cache state. All downstream ordering (#2696 digest tripwire, release-gate on exact bytes, verify-images-published) is unchanged and now starts from a strictly stronger precondition: publish fully complete, not just first-manifest-visible.

Note: this also means a red docker-publish run (any job, including Docker Hub publish/scan) blocks the release gate from starting — previously the release could proceed if the ghcr manifests appeared before an unrelated docker-publish job failed. That is the intended direction (verify-images-published requires both registries anyway); docker-publish is idempotent and re-runnable, after which this workflow can be re-run.

### Validation
- `actionlint` (with embedded shellcheck on `run:` blocks): clean.
- Standalone `shellcheck` on the extracted wait script: clean.
- YAML parse: clean.
- Dry-ran the run-lookup query against a real historical tag (`v1.6.2`, an **annotated** tag): the docker-publish run resolves correctly by peeled-commit `head_sha` + `head_branch`, and the sibling release.yml run from the same push records the identical `head_sha` — so `GITHUB_SHA` inside release.yml matches, including for annotated tags.
- Errexit semantics of the `[ -n "$RUN_ID" ] && break` pattern verified under `set -euo pipefail`.

DTF: not applicable — this is release-pipeline plumbing (workflow YAML only), no runtime backend behavior to deploy-test. The real proof point is the next tag cut on a cold amd64 cache.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (CI workflow change; conventional-commit type `ci`. There is no test harness that can exercise a cross-workflow timing race; validation is via actionlint/shellcheck and the API dry-runs above)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (actionlint, shellcheck, live Actions-API dry-run of the run-lookup against v1.6.2)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
