### PR TITLE
fix(composer): preserve all valid composer.json properties on upload

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -102,41 +102,47 @@ fn build_composer_proxy_response(content: Bytes, content_type: Option<String>) -
         .unwrap()
 }
 
-/// Keys from composer.json that should be merged into version entries.
-const COMPOSER_METADATA_KEYS: &[&str] = &[
-    "description",
-    "type",
-    "license",
-    "require",
-    "require-dev",
-    "autoload",
-    "authors",
-    "keywords",
-    "homepage",
-];
+/// Keys of a composer version entry that are OWNED by the metadata builder and
+/// must never be overwritten by values merged from the stored composer.json.
+/// `name`/`version` carry the authoritative artifact identity, `dist`/`source`
+/// the download coordinates the download route matches on, and `uid` the
+/// Composer-required inline identifier — an uploaded composer.json must not be
+/// able to spoof any of them. Every OTHER property is copied through verbatim
+/// (#2846).
+const COMPOSER_RESERVED_ENTRY_KEYS: &[&str] = &["name", "version", "dist", "source", "uid"];
 
 /// Merge composer.json metadata fields into a version entry JSON object.
+///
+/// Every property from the stored `composer` document is preserved EXCEPT the
+/// builder-owned keys in [`COMPOSER_RESERVED_ENTRY_KEYS`]. Previously only a
+/// fixed nine-key allowlist was copied, which silently dropped valid Composer
+/// schema properties such as `bin` and `extra`; that broke `vendor/bin`
+/// symlinks and made composer-plugin installs fail ("composer-plugin packages
+/// should have a class defined in their extra key") (#2846).
 fn merge_composer_metadata(
     version_entry: &mut serde_json::Value,
     metadata: Option<&serde_json::Value>,
 ) {
-    let composer = metadata.and_then(|m| m.get("composer"));
-
-    let Some(composer) = composer else {
+    let Some(composer) = metadata.and_then(|m| m.get("composer")) else {
+        return;
+    };
+    let Some(composer_obj) = composer.as_object() else {
         return;
     };
 
-    for key in COMPOSER_METADATA_KEYS {
-        if let Some(val) = composer.get(*key) {
-            // Skip JSON null so absent optional fields are omitted from the
-            // version entry rather than serialized as `"field": null`. This
-            // matters for records stored before ComposerJson gained
-            // `skip_serializing_if`, whose metadata still carries null fields
-            // (#1781).
-            if !val.is_null() {
-                version_entry[*key] = val.clone();
-            }
+    for (key, val) in composer_obj {
+        if COMPOSER_RESERVED_ENTRY_KEYS.contains(&key.as_str()) {
+            continue;
         }
+        // Skip JSON null so absent optional fields are omitted from the
+        // version entry rather than serialized as `"field": null`. This
+        // matters for records stored before ComposerJson gained
+        // `skip_serializing_if`, whose metadata still carries null fields
+        // (#1781).
+        if val.is_null() {
+            continue;
+        }
+        version_entry[key.as_str()] = val.clone();
     }
 }
 
@@ -257,8 +263,8 @@ fn build_packages_index(
         // Composer's `ComposerRepository` requires a `uid` on every inline
         // ("partial") version object embedded in the root packages.json; inject
         // it here (only the inline root-doc path) so the v2 `p2`/v1 wire shapes
-        // stay untouched. `COMPOSER_METADATA_KEYS` has no `uid`, so the metadata
-        // merge inside `build_version_entry` cannot clobber it (#2250).
+        // stay untouched. `uid` is in `COMPOSER_RESERVED_ENTRY_KEYS`, so the
+        // metadata merge inside `build_version_entry` cannot clobber it (#2250).
         if let Some(obj) = entry.as_object_mut() {
             obj.insert(
                 "uid".to_string(),
@@ -2611,25 +2617,88 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // COMPOSER_METADATA_KEYS
+    // COMPOSER_RESERVED_ENTRY_KEYS
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_composer_metadata_keys_count() {
-        assert_eq!(COMPOSER_METADATA_KEYS.len(), 9);
+    fn test_composer_reserved_entry_keys() {
+        // The builder-owned keys that a merged composer.json must never spoof.
+        for k in ["name", "version", "dist", "source", "uid"] {
+            assert!(
+                COMPOSER_RESERVED_ENTRY_KEYS.contains(&k),
+                "`{}` must be a reserved entry key",
+                k
+            );
+        }
+        // Real composer schema properties must NOT be reserved (they flow
+        // through the merge).
+        for k in ["bin", "extra", "scripts", "require", "type", "autoload"] {
+            assert!(
+                !COMPOSER_RESERVED_ENTRY_KEYS.contains(&k),
+                "`{}` must NOT be reserved — it has to pass through",
+                k
+            );
+        }
     }
 
+    // #2846: every valid composer.json property (not just the old nine-key
+    // allowlist) must survive into the served version entry. `bin` and `extra`
+    // are the fields the reporter needed for composer-plugin installs.
     #[test]
-    fn test_composer_metadata_keys_contains_required() {
-        assert!(COMPOSER_METADATA_KEYS.contains(&"description"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"type"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"license"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"require"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"require-dev"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"autoload"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"authors"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"keywords"));
-        assert!(COMPOSER_METADATA_KEYS.contains(&"homepage"));
+    fn test_merge_composer_metadata_preserves_bin_and_extra() {
+        let mut entry = serde_json::json!({"name": "vendor/pkg", "version": "1.0.0"});
+        let metadata = serde_json::json!({
+            "composer": {
+                "type": "composer-plugin",
+                "bin": ["bin/dummy"],
+                "extra": {"class": "SNSConsulting\\DummyPackage\\Plugin"},
+                "scripts": {"post-install-cmd": "echo hi"},
+                "minimum-stability": "dev",
+                "prefer-stable": true
+            }
+        });
+        merge_composer_metadata(&mut entry, Some(&metadata));
+
+        assert_eq!(entry["type"], "composer-plugin");
+        assert_eq!(entry["bin"], serde_json::json!(["bin/dummy"]));
+        assert_eq!(
+            entry["extra"]["class"],
+            "SNSConsulting\\DummyPackage\\Plugin"
+        );
+        assert_eq!(entry["scripts"]["post-install-cmd"], "echo hi");
+        assert_eq!(entry["minimum-stability"], "dev");
+        assert_eq!(entry["prefer-stable"], true);
+    }
+
+    // #2846: an uploaded composer.json must not be able to overwrite the
+    // builder-owned identity/download keys via the merge.
+    #[test]
+    fn test_merge_composer_metadata_does_not_clobber_reserved_keys() {
+        let mut entry = serde_json::json!({
+            "name": "vendor/pkg",
+            "version": "1.0.0",
+            "dist": {"type": "zip", "url": "https://ak/real.zip", "reference": "abc"},
+        });
+        let metadata = serde_json::json!({
+            "composer": {
+                "name": "attacker/evil",
+                "version": "9.9.9",
+                "dist": {"type": "zip", "url": "https://evil/x.zip"},
+                "source": {"url": "https://evil/src"},
+                "uid": 1,
+                "extra": {"class": "Legit\\Plugin"}
+            }
+        });
+        merge_composer_metadata(&mut entry, Some(&metadata));
+
+        // Reserved keys keep their builder-provided values.
+        assert_eq!(entry["name"], "vendor/pkg");
+        assert_eq!(entry["version"], "1.0.0");
+        assert_eq!(entry["dist"]["url"], "https://ak/real.zip");
+        assert!(entry.get("source").is_none());
+        assert!(entry.get("uid").is_none());
+        // Non-reserved property still flows through.
+        assert_eq!(entry["extra"]["class"], "Legit\\Plugin");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -227,6 +227,16 @@ pub struct ComposerJson {
     pub keywords: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
+    /// Every other valid composer.json property not modelled by an explicit
+    /// field above (e.g. `bin`, `extra`, `scripts`, `conflict`, `replace`,
+    /// `provide`, `suggest`, `support`, `funding`, `minimum-stability`,
+    /// `prefer-stable`, ...). Captured verbatim via `#[serde(flatten)]` so an
+    /// upload preserves the FULL Composer schema through the
+    /// parse -> stored-metadata round-trip. Previously any unmodelled field was
+    /// silently dropped, which broke composer-plugin installs (missing `extra`)
+    /// and vendor/bin symlinks (missing `bin`) (#2846).
+    #[serde(flatten, default)]
+    pub additional: HashMap<String, serde_json::Value>,
 }
 
 /// Composer package author
@@ -590,6 +600,7 @@ mod tests {
             }]),
             keywords: Some(vec!["test".to_string()]),
             homepage: Some("https://example.com".to_string()),
+            additional: HashMap::new(),
         };
         let json = serde_json::to_string(&cj).unwrap();
         let parsed: ComposerJson = serde_json::from_str(&json).unwrap();
@@ -615,6 +626,7 @@ mod tests {
             authors: None,
             keywords: None,
             homepage: None,
+            additional: HashMap::new(),
         };
         let value = serde_json::to_value(&cj).unwrap();
         let obj = value.as_object().unwrap();
@@ -639,5 +651,56 @@ mod tests {
                 absent
             );
         }
+    }
+
+    // #2846: valid composer.json properties not modelled by an explicit field
+    // (here `bin` and `extra`) must survive the parse -> serialize round-trip
+    // via `#[serde(flatten)]` instead of being silently stripped.
+    #[test]
+    fn test_composer_json_preserves_unmodelled_properties() {
+        let json = r#"{
+            "name": "snsconsulting/dummy-package",
+            "type": "composer-plugin",
+            "version": "1.0.0",
+            "bin": ["bin/dummy"],
+            "extra": {"class": "SNSConsulting\\DummyPackage\\Plugin"},
+            "scripts": {"post-install-cmd": "echo hi"},
+            "minimum-stability": "dev",
+            "prefer-stable": true
+        }"#;
+        let cj: ComposerJson = serde_json::from_str(json).unwrap();
+        // Explicitly modelled fields still land in their typed slots.
+        assert_eq!(cj.name, "snsconsulting/dummy-package");
+        assert_eq!(cj.package_type, Some("composer-plugin".to_string()));
+        // Unmodelled properties are captured in `additional`, not dropped.
+        assert_eq!(
+            cj.additional.get("bin"),
+            Some(&serde_json::json!(["bin/dummy"]))
+        );
+        assert_eq!(
+            cj.additional.get("extra"),
+            Some(&serde_json::json!({"class": "SNSConsulting\\DummyPackage\\Plugin"}))
+        );
+        assert!(cj.additional.contains_key("scripts"));
+        assert_eq!(
+            cj.additional.get("prefer-stable"),
+            Some(&serde_json::json!(true))
+        );
+
+        // ...and they re-emit at the top level on serialize (what gets stored
+        // in artifact_metadata and later merged into the served packages.json).
+        let value = serde_json::to_value(&cj).unwrap();
+        let obj = value.as_object().unwrap();
+        assert_eq!(obj.get("bin"), Some(&serde_json::json!(["bin/dummy"])));
+        assert_eq!(
+            obj.get("extra"),
+            Some(&serde_json::json!({"class": "SNSConsulting\\DummyPackage\\Plugin"}))
+        );
+        assert_eq!(
+            obj.get("minimum-stability"),
+            Some(&serde_json::json!("dev"))
+        );
+        // The flattened map must NOT nest under an `additional` key.
+        assert!(obj.get("additional").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Uploading a package to a Composer repository silently dropped valid
`composer.json` properties from the served metadata. The reporter hit this
with composer-plugin packages: the missing `extra.class` makes `composer
install` fail with *"composer-plugin packages should have a class defined in
their extra key to be usable"*, and the missing `bin` stops Composer from
creating the `vendor/bin` symlinks.

Root cause — two clobber points on the publish → `packages.json` path:

1. `ComposerJson` (`backend/src/formats/composer.rs`) is a fixed-field struct.
   Any Composer-schema property it does not model (`bin`, `extra`, `scripts`,
   `minimum-stability`, `conflict`, `replace`, `provide`, `suggest`,
   `funding`, …) was dropped when the uploaded `composer.json` was parsed and
   re-serialized into stored metadata.
2. `merge_composer_metadata` (`backend/src/api/handlers/composer.rs`) copied
   only a fixed nine-key allowlist into each served version entry, so even a
   property that survived storage was filtered out on the wire.

Fix — preserve every valid property end-to-end:

* Add a `#[serde(flatten)]` catch-all (`additional`) to `ComposerJson` so
  unmodelled fields round-trip through parse → stored metadata unchanged.
* Replace the merge allowlist with a builder-owned **denylist**
  (`name`, `version`, `dist`, `source`, `uid`): every other stored composer
  key is copied into the version entry, while the keys carrying the
  authoritative artifact identity + download coordinates stay builder-owned
  and cannot be spoofed by an uploaded `composer.json`. Existing null-skip
  behaviour (#1781) is retained.

Both the root `packages.json` inline entries and the `p2/{vendor}/{package}.json`
metadata go through the same builder, so both wire shapes are fixed. Existing
versions of a package are unaffected — a new upload adds its version entry
without touching the others.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests (fail before this change, pass after):
* `formats::composer::tests::test_composer_json_preserves_unmodelled_properties`
  — `bin`/`extra`/`scripts`/`prefer-stable` survive the parse→serialize round-trip.
* `api::handlers::composer::tests::test_merge_composer_metadata_preserves_bin_and_extra`
  — `bin` + `extra.class` (and other non-allowlist keys) reach the version entry.
* `api::handlers::composer::tests::test_merge_composer_metadata_does_not_clobber_reserved_keys`
  — an uploaded `composer.json` cannot overwrite `name`/`version`/`dist`/`source`/`uid`.
* `api::handlers::composer::tests::test_composer_reserved_entry_keys`
  — the reserved-key set is exactly the builder-owned keys.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification (hosted Composer repo, filesystem storage): published
`v1.0.0` then `v2.0.0` of a `composer-plugin` package carrying `bin` + `extra`;
after the second upload the served `packages.json` and `p2` metadata list BOTH
versions, each retaining `bin`, `extra.class`, `scripts`, and `minimum-stability`.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2846
