### PR TITLE
fix(maven): clear stored maven-metadata.xml on artifact delete

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -103,6 +103,82 @@ pub async fn invalidate_maven_metadata_cache(repo_id: Uuid, group_id: &str, arti
         .await;
 }
 
+/// Storage path (relative to the `maven/` format prefix) of the group/artifact
+/// `maven-metadata.xml` for one GAV, e.g.
+/// `com/example/my-lib/maven-metadata.xml`.
+fn maven_metadata_object_path(group_id: &str, artifact_id: &str) -> String {
+    format!(
+        "{}/{}/maven-metadata.xml",
+        group_id.replace('.', "/"),
+        artifact_id
+    )
+}
+
+/// Drop the *stored* `maven-metadata.xml` document (and its checksum sidecars)
+/// for a `(repo, group, artifact)` GAV, then invalidate the in-memory
+/// generation cache.
+///
+/// `mvn deploy` uploads a verbatim `maven-metadata.xml` alongside each artifact,
+/// and the download path serves that stored document in preference to dynamic
+/// generation (a deliberately-uploaded document is authoritative for its owner —
+/// see `fetch_maven_metadata_bytes`). When a version is deleted, that stored
+/// document is stale: it still advertises the removed version in
+/// `<versions>`/`<latest>`/`<release>`, so a client resolves a version that now
+/// 404s (#2845). Removing the stored object lets the dynamic generator — which
+/// reads only non-deleted `artifacts` rows — take over on the next GET, and also
+/// produce a correct (or absent) document when the last version is deleted.
+///
+/// Best-effort: a missing object or a storage error is ignored (the document may
+/// never have been uploaded, e.g. some Gradle publish flows), and clearing it is
+/// never allowed to fail the delete. Both the repo-scoped (#2624) and legacy flat
+/// key candidates are removed so the fix holds under either
+/// [`StorageKeyScheme`](crate::storage::StorageKeyScheme).
+pub async fn clear_stored_maven_metadata(
+    state: &SharedState,
+    repo_id: Uuid,
+    storage_backend: &str,
+    storage_location: &crate::storage::StorageLocation,
+    group_id: &str,
+    artifact_id: &str,
+) {
+    // Always drop the generation cache, even if there is no stored object.
+    invalidate_maven_metadata_cache(repo_id, group_id, artifact_id).await;
+
+    let storage = match state.storage_for_repo(storage_location) {
+        Ok(storage) => storage,
+        Err(e) => {
+            warn!(error = %e, "clear_stored_maven_metadata: storage unavailable");
+            return;
+        }
+    };
+
+    let meta_path = maven_metadata_object_path(group_id, artifact_id);
+    let scheme = crate::storage::StorageKeyScheme::from_env();
+
+    // Base keys: repo-scoped candidate (cloud RepoScoped) first, then legacy flat.
+    let mut base_keys = Vec::with_capacity(2);
+    if let Some(scoped) = scheme.scoped_read_key(storage_backend, "maven", repo_id, &meta_path) {
+        base_keys.push(scoped);
+    }
+    base_keys.push(format!("maven/{}", meta_path));
+
+    // Remove the document itself plus the checksum sidecars Maven stores beside it.
+    for base in &base_keys {
+        for key in [
+            base.clone(),
+            format!("{}.md5", base),
+            format!("{}.sha1", base),
+            format!("{}.sha256", base),
+        ] {
+            if let Err(e) = storage.delete(&key).await {
+                // A missing object is the common case (never uploaded); log at
+                // debug so it doesn't look like a failure.
+                tracing::debug!(error = %e, key = %key, "clear_stored_maven_metadata: delete miss");
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Virtual-repo GA-level metadata merge cache (#2302)
 // ---------------------------------------------------------------------------
@@ -5707,6 +5783,185 @@ mod maven_prefix_reserved_tests {
             !fx.storage_dir.join("maven").exists(),
             "remote proxy checksum probe must not create anything under maven/ (#1547)"
         );
+        fx.teardown().await;
+    }
+
+    #[test]
+    fn test_maven_metadata_object_path_maps_group_dots_to_slashes() {
+        assert_eq!(
+            super::maven_metadata_object_path("com.example.del", "demo-lib"),
+            "com/example/del/demo-lib/maven-metadata.xml"
+        );
+        // Single-segment group id.
+        assert_eq!(
+            super::maven_metadata_object_path("acme", "widget"),
+            "acme/widget/maven-metadata.xml"
+        );
+    }
+
+    /// #2845 regression. `mvn deploy` uploads a verbatim `maven-metadata.xml`
+    /// which the download path serves in preference to dynamic generation. When
+    /// a version is deleted, that stored document is stale and keeps advertising
+    /// the removed version; clearing it (the delete handler now does) makes the
+    /// next GET regenerate the version list from the live (non-deleted) rows.
+    #[tokio::test]
+    async fn test_delete_clears_stored_metadata_so_version_disappears() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let Some(fx) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        let router = fx.router_with_auth(super::router());
+        let pom = |v: &str| {
+            bytes::Bytes::from(format!(
+                r#"<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.del</groupId>
+  <artifactId>demo</artifactId>
+  <version>{v}</version>
+</project>"#
+            ))
+        };
+
+        // Publish two release versions (each creates an artifacts row).
+        for v in ["1.0.0", "2.0.0"] {
+            let path = format!("com/example/del/demo/{v}/demo-{v}.pom");
+            let (status, body) = tdh::send(
+                router.clone(),
+                tdh::put(format!("/{}/{}", fx.repo_key, path), pom(v)),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::CREATED,
+                "publish {v} must succeed; body={}",
+                String::from_utf8_lossy(&body)
+            );
+        }
+
+        // Publish the verbatim group/artifact maven-metadata.xml listing both,
+        // exactly as the Maven deploy plugin does.
+        let meta_path = "com/example/del/demo/maven-metadata.xml";
+        let stored_meta = bytes::Bytes::from_static(
+            br#"<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example.del</groupId>
+  <artifactId>demo</artifactId>
+  <versioning>
+    <latest>2.0.0</latest>
+    <release>2.0.0</release>
+    <versions>
+      <version>1.0.0</version>
+      <version>2.0.0</version>
+    </versions>
+    <lastUpdated>20260101000000</lastUpdated>
+  </versioning>
+</metadata>"#,
+        );
+        let (status, _) = tdh::send(
+            router.clone(),
+            tdh::put(format!("/{}/{}", fx.repo_key, meta_path), stored_meta),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "metadata upload must succeed");
+
+        let meta_url = format!("/{}/{}", fx.repo_key, meta_path);
+        let get_meta = |r: axum::Router, url: String| async move {
+            let (status, body) = tdh::send(r, tdh::get(url)).await;
+            (status, String::from_utf8(body.to_vec()).expect("utf-8"))
+        };
+
+        // Baseline: the stored document is served and lists both versions.
+        let (status, xml) = get_meta(router.clone(), meta_url.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            xml.contains("<version>1.0.0</version>"),
+            "baseline lists 1.0.0"
+        );
+        assert!(
+            xml.contains("<version>2.0.0</version>"),
+            "baseline lists 2.0.0"
+        );
+
+        // Soft-delete version 2.0.0 (the DB effect of the web-UI delete).
+        sqlx::query(
+            "UPDATE artifacts SET is_deleted = true WHERE repository_id = $1 AND version = $2",
+        )
+        .bind(fx.repo_id)
+        .bind("2.0.0")
+        .execute(&fx.pool)
+        .await
+        .expect("soft-delete 2.0.0");
+
+        // Pre-fix behaviour anchor: with the stored document still in place, the
+        // GET keeps advertising the just-deleted 2.0.0 — this is exactly #2845.
+        let (_, xml_stale) = get_meta(router.clone(), meta_url.clone()).await;
+        assert!(
+            xml_stale.contains("<version>2.0.0</version>"),
+            "stored document shadows dynamic generation until it is cleared (#2845)"
+        );
+
+        // The fix: clear the stored document (as the delete handler now does).
+        let repo_info = fx.repo_info("local", None);
+        super::clear_stored_maven_metadata(
+            &fx.state,
+            fx.repo_id,
+            &repo_info.storage_backend,
+            &repo_info.storage_location(),
+            "com.example.del",
+            "demo",
+        )
+        .await;
+
+        // Now the served metadata is regenerated from the live rows: 2.0.0 is
+        // gone and latest/release fall back to 1.0.0.
+        let (status, xml_fixed) = get_meta(router.clone(), meta_url.clone()).await;
+        assert_eq!(status, StatusCode::OK, "metadata still served after delete");
+        assert!(
+            xml_fixed.contains("<version>1.0.0</version>"),
+            "surviving version 1.0.0 still listed"
+        );
+        assert!(
+            !xml_fixed.contains("<version>2.0.0</version>"),
+            "deleted version 2.0.0 must no longer be advertised (#2845); got: {xml_fixed}"
+        );
+        assert!(
+            xml_fixed.contains("<latest>1.0.0</latest>"),
+            "latest updated to surviving version"
+        );
+        assert!(
+            xml_fixed.contains("<release>1.0.0</release>"),
+            "release updated to surviving version"
+        );
+
+        // Delete the last remaining version too: metadata now has no versions
+        // and 404s (empty-metadata handling), instead of serving a stale list.
+        sqlx::query(
+            "UPDATE artifacts SET is_deleted = true WHERE repository_id = $1 AND version = $2",
+        )
+        .bind(fx.repo_id)
+        .bind("1.0.0")
+        .execute(&fx.pool)
+        .await
+        .expect("soft-delete 1.0.0");
+        super::clear_stored_maven_metadata(
+            &fx.state,
+            fx.repo_id,
+            &repo_info.storage_backend,
+            &repo_info.storage_location(),
+            "com.example.del",
+            "demo",
+        )
+        .await;
+        let (status, _) = get_meta(router.clone(), meta_url.clone()).await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "with every version deleted the metadata must not resurrect a stale list"
+        );
+
         fx.teardown().await;
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -7931,13 +7931,19 @@ pub async fn delete_artifact(
         .delete_with_sync_options(artifact, !is_replication)
         .await?;
 
-    // Deleting a Maven artifact changes the version set for its GAV, so drop
-    // any cached maven-metadata.xml for it; otherwise a GET within the 60s TTL
-    // would keep listing the just-removed version.
+    // Deleting a Maven artifact changes the version set for its GAV. Drop both
+    // the in-memory generation cache AND the *stored* verbatim maven-metadata.xml
+    // that `mvn deploy` uploaded — the download path serves that stored document
+    // in preference to dynamic generation, so leaving it in place keeps
+    // advertising the just-removed version (#2845). Clearing it lets the next GET
+    // regenerate the version list from the live (non-deleted) artifact rows.
     if repo.format == RepositoryFormat::Maven {
         if let Ok(coords) = MavenHandler::parse_coordinates(&path) {
-            crate::api::handlers::maven::invalidate_maven_metadata_cache(
+            crate::api::handlers::maven::clear_stored_maven_metadata(
+                &state,
                 repo.id,
+                &repo.storage_backend,
+                &repo.storage_location(),
                 &coords.group_id,
                 &coords.artifact_id,
             )


### PR DESCRIPTION
## Summary

Closes #2845

`maven-metadata.xml` kept advertising a version after that version was deleted
through the web UI / delete API, so Maven/Gradle clients would try to resolve a
version that now 404s (and a re-deploy of the same coordinates reported a
conflict).

Root cause: `mvn deploy` uploads a verbatim group/artifact `maven-metadata.xml`
alongside each artifact, and the Maven download path
(`api/handlers/maven.rs::fetch_maven_metadata_bytes`) serves that stored
document in preference to dynamically generating it from the live artifact rows
— a deliberately-uploaded document is treated as authoritative for its owner.
The artifact delete handler (`repositories.rs::delete_artifact`) soft-deleted
the rows and invalidated the in-memory generation cache, but left the stored
`maven-metadata.xml` object untouched. As a result the served metadata still
listed the removed version in `<versions>` and still pointed `<latest>` /
`<release>` at it.

The fix clears the stored `maven-metadata.xml` (and its `.md5` / `.sha1` /
`.sha256` checksum sidecars, under both the repo-scoped `#2624` key and the
legacy flat key) when a Maven artifact is deleted. With the stored document
gone, the next GET falls through to the existing dynamic generator, which reads
only non-deleted rows — so the deleted version disappears, `<latest>` /
`<release>` fall back to the surviving version, and deleting the last version
yields a 404 instead of resurrecting a stale list. Clearing is best-effort and
never fails the delete (the document may never have been uploaded).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`test_delete_clears_stored_metadata_so_version_disappears` (DB-backed, in
`api/handlers/maven.rs`) publishes two versions plus the verbatim
`maven-metadata.xml`, soft-deletes one, asserts the stored document still
shadows dynamic generation (the pre-fix behaviour), then clears it and asserts
the deleted version is gone with `<latest>`/`<release>` refreshed — and that
deleting the last version 404s. `test_maven_metadata_object_path_maps_group_dots_to_slashes`
covers the metadata key derivation.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
