### PR TITLE
fix(migration): require global admin for migration source/job routes

### DIFF
--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -921,12 +921,32 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
-        // Migration routes with auth middleware
+        // Migration routes with admin middleware.
+        //
+        // Migration is an instance-provisioning operator workflow: a job imports
+        // whole repositories, users, groups and permissions from an external
+        // source and bulk-writes them into named target repositories (some of
+        // which the job itself creates). Under `auth_middleware` the handlers
+        // gated only on per-user ownership of the SOURCE connection, so ANY
+        // authenticated non-admin could register a source, point a job at
+        // arbitrary target repositories and bulk-populate/poison them — there was
+        // no target-repo write authorization and no admin gate (#2603 G2).
+        //
+        // Because a migration provisions instance-wide resources (and can create
+        // the very repos it writes to), the coherent authorization boundary is a
+        // global admin — the same tier as the other integration/provisioning
+        // surfaces (`/dependency-track`, `/plugins`, `/admin/*`). Gating the whole
+        // nest with `admin_middleware` also makes the authorization decision run
+        // BEFORE the handler body, so a non-admin is rejected before any source
+        // connection is SSRF-validated, encrypted, decrypted or dialed. A global
+        // admin can write every repository (admin bypass in
+        // `check_repository_action`), so the legitimate operator migration path
+        // into any target repo still succeeds.
         .nest(
             "/migrations",
             handlers::migration::router().layer(middleware::from_fn_with_state(
                 auth_service.clone(),
-                auth_middleware,
+                admin_middleware,
             )),
         )
         // Chunked/resumable upload routes with auth middleware
@@ -1062,6 +1082,39 @@ mod tests {
         assert!(
             ROUTES_RS_SRC.contains("\"/dependency-track\","),
             "/dependency-track nest registration missing"
+        );
+    }
+
+    #[test]
+    fn migration_nest_requires_admin() {
+        // #2603 G2: the `/migrations` handlers gated only on per-user ownership
+        // of the source connection, never on admin and never on target-repo
+        // write authz. A migration is an instance-provisioning operator workflow
+        // (imports repos/users/groups/permissions and bulk-writes named target
+        // repositories, some of which it creates), so the whole nest must be
+        // gated by `admin_middleware`, not `auth_middleware` — otherwise any
+        // authenticated non-admin could point a job at arbitrary repositories and
+        // populate/poison them. A runtime test would need full app state + a DB
+        // fixture, so pin the routing decision in source (mirrors
+        // `dependency_track_nest_requires_admin` / `plugin_install_and_lifecycle_require_admin`).
+        let mig_nest = ROUTES_RS_SRC
+            .split("handlers::migration::router()")
+            .nth(1)
+            .expect("migration::router() must be nested under /migrations");
+        let next_middleware = mig_nest
+            .split("from_fn_with_state")
+            .nth(1)
+            .expect("migration nest must attach a middleware layer");
+        assert!(
+            next_middleware.contains("admin_middleware"),
+            "migration source/job routes must be gated by admin_middleware, \
+             not auth_middleware (regression of #2603 G2)"
+        );
+        // Guard against the assertion going vacuously true if the nest is
+        // dropped: the prefix must still be registered.
+        assert!(
+            ROUTES_RS_SRC.contains("\"/migrations\","),
+            "/migrations nest registration missing"
         );
     }
 }


### PR DESCRIPTION
## Summary

Part 2 of 2 of the repository RBAC hardening tracked in #2603. This PR closes the
**migration-surface authorization gap (G2)**: the `/api/v1/migrations/*` nest was
mounted under `auth_middleware` (authentication only), and its handlers gated
solely on per-user ownership of the *source connection*. There was no admin gate
and no target-repository write authorization.

A migration is an instance-provisioning operator workflow: a job imports whole
repositories, users, groups and permissions from an external source and
bulk-writes them into caller-named target repositories (some of which the job
itself creates). Because the nest only required authentication, any authenticated
non-admin could register a source connection, create a migration job whose config
names target repositories, and start it — driving a bulk import into repositories
they are not authorized to write.

**Fix:** move the entire `/migrations` nest under `admin_middleware`
(global-admin-only), the same tier already used for the peer (`/peers`),
dependency-track and plugin admin surfaces. Because a migration provisions
instance-wide resources (and can create the very repositories it writes to), a
global admin is the coherent authorization boundary — a global admin is
authorized to write every repository, so the legitimate operator migration path
into any target repo is unchanged. Gating at the nest also makes the
authorization decision run **before** the handler body, so a non-admin is
rejected before any source connection is validated, encrypted, decrypted or
dialed (this also resolves the authorization-ordering finding for the migration
handlers).

No behavior change for administrators; the change is a single routing-layer edit
plus a source-level routing meta-test. No migration or schema change.

### Behavior change
- Non-admin on any `/api/v1/migrations/*` route → `403` (was: reached the handler).
- Anonymous → `401` (unchanged: `admin_middleware` authenticates before it authorizes).
- Global admin → unchanged (create/start/list migrations into any repository).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Adds `api::routes::tests::migration_nest_requires_admin`, a source-level routing
meta-test (mirrors the existing `dependency_track_nest_requires_admin` and
`plugin_install_and_lifecycle_require_admin`) that fails if the `/migrations`
nest is wired to anything other than `admin_middleware`. A runtime test would
require full app state + a DB fixture; the routing decision is pinned in source.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance (non-admin vs admin):
- Baseline (pre-fix): non-admin `POST /migrations/connections` → 201,
  `POST /migrations` (job naming a repo it cannot write) → 201,
  `POST /migrations/:id/start` → 200.
- Fixed: all of the above → 403; admin create-connection → 201,
  create-migration → 201, `GET /migrations` → 200; anon → 401.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (routing-layer authorization change only)

Closes #2603

---

Part 2 of 2 for #2603. Part 1 (a separate PR) covers the repository mutation
authorization consolidation (G1) and repo-scoped token delegation (G3); this PR
is scoped to the migration admin gate (G2) and touches no files in that surface.
