### PR TITLE
fix(authz): enforce action-specific repository authorization on mutation paths

### DIFF
--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -28,6 +28,7 @@ use tracing::info;
 
 use crate::api::extractors::RequestBaseUrl;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
+use crate::api::handlers::repositories::require_repo_action;
 use crate::api::middleware::auth::{require_auth_basic, require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
 use crate::models::repository::RepositoryType;
@@ -296,9 +297,33 @@ async fn batch(
         ));
     }
 
-    // Upload requires authentication
+    // Upload requires authentication AND repository write authorization.
+    //
+    // `repo_visibility_middleware` routes the batch POST through the read path
+    // because it is the download/upload *negotiation* (a read-only member and a
+    // public-repo non-member must be able to `git lfs pull`). That means the
+    // upload branch is responsible for its own write gate: authentication alone
+    // is not sufficient — a read-only member / public-repo non-member must not
+    // be able to negotiate an upload. Route the check through the canonical
+    // deny-by-default action choke-point (#2603 G1) shared with the artifact
+    // write handlers; the subsequent object `PUT` is independently write-gated
+    // by the same middleware.
     let auth_header = if request.operation == "upload" {
-        let _user_id = require_auth_basic(auth, "git-lfs")?.user_id;
+        let ext = require_auth_basic(auth, "git-lfs")?;
+        require_repo_action(&ext, repo.id, "write", &state.permission_service)
+            .await
+            .map_err(|e| {
+                let status = match &e {
+                    crate::error::AppError::ServiceUnavailable(_) => {
+                        StatusCode::SERVICE_UNAVAILABLE
+                    }
+                    _ => StatusCode::FORBIDDEN,
+                };
+                lfs_error_response(
+                    status,
+                    "You do not have permission to upload to this repository",
+                )
+            })?;
         // Pass auth header through to action hrefs
         headers
             .get(axum::http::header::AUTHORIZATION)

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -524,44 +524,42 @@ fn enforce_token_repo_scope(
 
 /// OCI v2 write/delete authorization — parity with the REST artifact-write gate.
 ///
-/// The REST artifact path enforces a private-repository members-only gate
-/// (`require_repo_write_access` in `handlers/repositories.rs`, the #1764
-/// lineage): admins bypass, public repositories are writable by any
-/// authenticated caller, and every other caller must hold a role assignment
-/// scoped to the repository (direct or global) — exactly
-/// `RepositoryService::user_can_access_repo`. The /v2 write/delete handlers
-/// authenticate the caller and check the OCI token scope, but never consulted
-/// this per-repo membership gate, so a non-admin non-member could push to /
-/// delete from a PRIVATE repository that the REST path denies with 403. Apply
-/// the same decision here.
+/// Routes the per-`action` decision (`write` for blob/manifest push, `delete`
+/// for manifest delete) through the single canonical choke-point
+/// `PermissionService::check_repository_action`, DENY-BY-DEFAULT (#2603 G1),
+/// exactly like the native format middleware (`repo_visibility_middleware`) and
+/// the REST `require_repo_action` helper:
 ///
-/// This is intentionally the per-repo membership check, NOT the fine-grained
-/// permission-rule check (`check_permission`/`has_any_rules_for_target`): the
-/// latter defaults to "no rules => allow", which would leave a freshly-created
-/// private repo with no rules wide open — the gap that the REST gate closes.
+/// * a global admin bypasses (inside the choke-point);
+/// * an applicable fine-grained rule for the caller is authoritative;
+/// * otherwise a role assignment (repo-scoped or global) carrying the action
+///   (or `admin`) is required.
+///
+/// `is_public` confers a read baseline only and NEVER a write/delete, and a
+/// rules-less repository does NOT fall open — this closes the OCI half of the
+/// public / rules-less write hole (any authed caller could push to a public
+/// repo; a read-only member could push/delete on a rules-less private repo).
+/// The OCI token repo-scope (#504/#2290) is enforced first, even for admins.
 ///
 /// Public-pull / anonymous-read paths never reach this helper (it is only
 /// invoked on write/delete handlers after authentication). Proxy/mirror flows
 /// are unaffected: remote/virtual repos reject pushes earlier, and replication
 /// identities hold a repo-scoped or global grant. Fails closed (503) if the
-/// membership lookup errors, mirroring the REST middleware.
+/// authorization lookup errors, mirroring the REST middleware.
 async fn require_oci_repo_write_access(
     state: &SharedState,
     claims: &crate::services::auth_service::Claims,
     repo_id: Uuid,
-    repo_is_public: bool,
+    action: &str,
 ) -> Result<(), Response> {
     // An API-token-scoped bearer may only touch repositories in its declared
     // allow-list — a ceiling that applies even to admins (#2290). This mirrors
-    // the REST #504 gate, which runs `can_access_repo` before the admin
-    // fine-grained bypass. No-op for unscoped tokens / JWT-login sessions.
+    // the REST #504 gate, which runs `can_access_repo` before the admin bypass.
+    // No-op for unscoped tokens / JWT-login sessions.
     enforce_token_repo_scope(claims, repo_id)?;
-    if claims.is_admin || repo_is_public {
-        return Ok(());
-    }
     match state
-        .create_repository_service()
-        .user_can_access_repo(repo_id, claims.sub)
+        .permission_service
+        .check_repository_action(claims.sub, repo_id, action, claims.is_admin)
         .await
     {
         Ok(true) => Ok(()),
@@ -574,61 +572,6 @@ async fn require_oci_repo_write_access(
                 "repository authorization temporarily unavailable",
             ))
         }
-    }
-}
-
-/// Fine-grained per-action OCI gate, applied AFTER `require_oci_repo_write_access`
-/// (the tenant-membership gate) on the destructive manifest-delete path.
-///
-/// `require_oci_repo_write_access` admits any member (incl. a read/write-only
-/// grantee) and any authed caller on a public repo, collapsing write/delete —
-/// the OCI half of #2321 (G2). When the repo has fine-grained permission rules,
-/// require the requested `action` (or `admin`, which implies all actions), the
-/// same `has_rules -> check_permission` block the REST path enforces. Admins
-/// bypass; a repo with no rules falls through unchanged. Fails closed (503) if
-/// the rule lookup errors, mirroring `require_oci_repo_write_access`.
-#[allow(clippy::result_large_err)] // Response-as-error is used throughout this module
-async fn require_oci_repo_fine_grained_action(
-    state: &SharedState,
-    claims: &crate::services::auth_service::Claims,
-    repo_id: Uuid,
-    action: &str,
-) -> Result<(), Response> {
-    if claims.is_admin {
-        return Ok(());
-    }
-    let has_rules = match state
-        .permission_service
-        .has_any_rules_for_target("repository", repo_id)
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!("OCI permission-rule lookup failed: {}", e);
-            return Err(oci_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "DENIED",
-                "repository authorization temporarily unavailable",
-            ));
-        }
-    };
-    if !has_rules {
-        return Ok(());
-    }
-    let has_action = state
-        .permission_service
-        .check_permission(claims.sub, "repository", repo_id, action, false)
-        .await
-        .unwrap_or(false);
-    let has_admin = state
-        .permission_service
-        .check_permission(claims.sub, "repository", repo_id, "admin", false)
-        .await
-        .unwrap_or(false);
-    if has_action || has_admin {
-        Ok(())
-    } else {
-        Err(oci_denied_repo_access())
     }
 }
 
@@ -4607,11 +4550,11 @@ async fn handle_start_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate, parity
-    // with the REST artifact-write path). Without this a non-admin non-member
-    // could open a blob upload against a PRIVATE repo it has no grant on.
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization (#2603 G1): deny-by-default `write` action
+    // gate via `check_repository_action`, parity with the REST artifact-write
+    // path. Public visibility confers no write; a non-member (or a rules-less
+    // public repo) cannot open a blob upload without a write grant.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     // #1776: only repositories that store their own manifests (Local/Staging)
@@ -4947,9 +4890,8 @@ async fn handle_patch_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization (#2603 G1): deny-by-default `write` action gate.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
 
@@ -5193,9 +5135,8 @@ async fn handle_cancel_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization (#2603 G1): deny-by-default `write` action gate.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     let storage = match state.storage_for_repo(&repo.location) {
@@ -5435,9 +5376,8 @@ async fn handle_complete_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization (#2603 G1): deny-by-default `write` action gate.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
 
@@ -7213,9 +7153,8 @@ async fn handle_put_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization (#2603 G1): deny-by-default `write` action gate.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     // #1776: only repositories that store their own manifests (Local/Staging)
@@ -8235,17 +8174,12 @@ async fn handle_delete_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write/delete authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
-        return resp;
-    }
-    // Fine-grained delete gate (#2321 G2): the tenant gate above admits any
-    // member regardless of action, collapsing read/write/delete. Require the
-    // `delete` action when the repo has permission rules, matching the REST
+    // Repository delete authorization (#2603 G1): route the `delete` decision
+    // through the canonical `check_repository_action` choke-point,
+    // deny-by-default. A write-only grantee cannot destroy a manifest, and a
+    // public / rules-less repo confers no delete. Matches the REST
     // `delete_artifact` path.
-    if let Err(resp) = require_oci_repo_fine_grained_action(state, &claims, repo.id, "delete").await
-    {
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "delete").await {
         return resp;
     }
 
@@ -14298,6 +14232,17 @@ mod manifest_digest_db_tests {
         let fx = tdh::Fixture::setup("local", "docker")
             .await
             .expect("fixture setup");
+        // #2603 G1: the manifest DELETE path now requires the `delete` action
+        // (the developer role no longer implies delete). Grant the fixture user
+        // explicit read/write/delete so this test exercises the digest-vs-tag
+        // survival logic it is about, not the authz gate.
+        tdh::grant_repo_actions(
+            &fx.pool,
+            fx.repo_id,
+            fx.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let auth = bearer(&fx).await;
         let name = format!("{}/image", fx.repo_key);
         let ct = "application/vnd.oci.image.manifest.v1+json";
@@ -14598,6 +14543,16 @@ mod manifest_digest_db_tests {
         let fx = tdh::Fixture::setup("local", "docker")
             .await
             .expect("fixture setup");
+        // #2603 G1: manifest DELETE now requires the `delete` action; grant the
+        // fixture user explicit read/write/delete so this test exercises the
+        // cleanup-failure rollback, not the authz gate.
+        tdh::grant_repo_actions(
+            &fx.pool,
+            fx.repo_id,
+            fx.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let auth = bearer(&fx).await;
         let digest = format!("sha256:{}", "c".repeat(64));
 
@@ -14994,6 +14949,16 @@ mod oci_blob_upload_streaming_tests {
         let Some(f) = OciUploadFixture::setup().await else {
             return;
         };
+        // #2603 G1: manifest DELETE now requires the `delete` action (developer
+        // no longer implies delete); grant the fixture user explicit
+        // read/write/delete so this test exercises its blob-ref/gate logic.
+        tdh::grant_repo_actions(
+            &f.inner.pool,
+            f.inner.repo_id,
+            f.inner.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let digest = format!("sha256:{}", "c".repeat(64));
         let seed_tag = |tag: &'static str| {
             let pool = f.inner.pool.clone();
@@ -15242,6 +15207,16 @@ mod oci_blob_upload_streaming_tests {
         let Some(f) = OciUploadFixture::setup().await else {
             return;
         };
+        // #2603 G1: manifest DELETE now requires the `delete` action (developer
+        // no longer implies delete); grant the fixture user explicit
+        // read/write/delete so this test exercises its blob-ref/gate logic.
+        tdh::grant_repo_actions(
+            &f.inner.pool,
+            f.inner.repo_id,
+            f.inner.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let digest = format!("sha256:{}", "a".repeat(64));
         sqlx::query(
             "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
@@ -15285,6 +15260,16 @@ mod oci_blob_upload_streaming_tests {
         let Some(f) = OciUploadFixture::setup().await else {
             return;
         };
+        // #2603 G1: manifest DELETE now requires the `delete` action (developer
+        // no longer implies delete); grant the fixture user explicit
+        // read/write/delete so this test exercises its blob-ref/gate logic.
+        tdh::grant_repo_actions(
+            &f.inner.pool,
+            f.inner.repo_id,
+            f.inner.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let index = format!("sha256:{}", "1".repeat(64));
         let child = format!("sha256:{}", "2".repeat(64));
         sqlx::query(
@@ -22445,10 +22430,11 @@ mod cross_repo_session_regression_tests {
 // OCI v2 write authorization + body-size cap.
 //
 // Authorization: the /v2 blob-upload and manifest write/delete paths must
-// enforce the SAME private-repo members-only gate the REST artifact path
-// enforces (`require_repo_write_access` -> `user_can_access_repo`, the #1764
-// lineage). A non-admin non-member is denied on a PRIVATE repo; admins and
-// granted members are allowed; public repos and anonymous reads are unaffected.
+// enforce the SAME deny-by-default per-action gate the REST artifact path
+// enforces, routed through `check_repository_action` (#2603 G1). A non-admin
+// non-member is denied on private AND public repos (public visibility is a read
+// baseline only); admins and action-granted members are allowed; anonymous
+// reads are unaffected.
 //
 // Size cap: an over-limit body must yield 413 Payload Too Large (declared
 // Content-Length / Content-Range rejection, or the streaming cumulative cap),

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -115,6 +115,69 @@ fn caller_owns_token(auth: &AuthExtension, created_by_user_id: Option<Uuid>) -> 
     auth.is_admin || created_by_user_id == Some(auth.user_id)
 }
 
+/// The repository action a non-admin caller must itself hold on the target
+/// repository in order to DELEGATE the given token scope by minting a
+/// repo-scoped token (#2603 G3). Delegation must not exceed the caller's own
+/// effective repository permission.
+///
+/// Admin-class scopes (`*`, `delete:artifacts`, …) are refused up front by
+/// `enforce_admin_only_scopes`, so the non-admin-mintable scopes that still
+/// confer a mutation are `write:artifacts` (needs the `write` action) and
+/// `write:repositories` (repository administration — needs `admin`). Read
+/// scopes and non-repository scopes require no mutation authority (`None`), so
+/// a member can always self-manage read-scoped tokens on a repo it can see.
+fn delegated_scope_repo_action(scope: &str) -> Option<&'static str> {
+    match scope {
+        "write:artifacts" => Some("write"),
+        "write:repositories" => Some("admin"),
+        _ => None,
+    }
+}
+
+/// Enforce the #2603 G3 delegation ceiling: for a non-admin caller, every
+/// requested token scope that confers a repository mutation must be one the
+/// caller already holds on `repo_id`, decided through the canonical
+/// `check_repository_action` choke-point. A caller lacking the required action
+/// is denied (`Authorization`), so a read-only member cannot mint a
+/// write-scoped token. Global admins bypass.
+async fn require_delegatable_scopes(
+    auth: &AuthExtension,
+    repo_id: Uuid,
+    scopes: &[String],
+    permission_service: &crate::services::permission_service::PermissionService,
+) -> Result<()> {
+    if auth.is_admin {
+        return Ok(());
+    }
+    // Require the strongest action any requested scope needs (`admin` > `write`).
+    let needs_admin = scopes
+        .iter()
+        .any(|s| delegated_scope_repo_action(s) == Some("admin"));
+    let needs_write = scopes
+        .iter()
+        .any(|s| delegated_scope_repo_action(s) == Some("write"));
+    let required_action = if needs_admin {
+        Some("admin")
+    } else if needs_write {
+        Some("write")
+    } else {
+        None
+    };
+    if let Some(action) = required_action {
+        let holds = permission_service
+            .check_repository_action(auth.user_id, repo_id, action, auth.is_admin)
+            .await?;
+        if !holds {
+            return Err(AppError::Authorization(format!(
+                "Minting a token with the requested scopes requires the repository '{}' action; \
+                 a repo-scoped token cannot delegate access you do not hold",
+                action
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Require that the caller is authenticated and has write scope on repos
 /// (or is a global admin).
 fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
@@ -152,13 +215,17 @@ async fn authorize_repo_for_tokens(
         )));
     }
 
-    // Per-repo authorization (mirrors `require_visible` in the repositories
-    // handler). The `can_access_repo` check above only enforces the *token's*
-    // repo scope — a broad `write:repositories` token (`allowed_repo_ids =
-    // None`) passes it for ANY repo. Without this DB-level check, any
-    // authenticated user with the write scope could mint repo-scoped tokens on
-    // a PRIVATE repository they cannot see (#1783). A private repo is visible
-    // only to an admin or a user with a role assignment scoped to it.
+    // Existence hiding (mirrors `require_visible`): a private repository the
+    // caller cannot even see returns `NotFound`, not `Forbidden`, so this
+    // endpoint is not an existence oracle. The `can_access_repo` check above
+    // only enforces the *token's* repo scope — a broad `write:repositories`
+    // token (`allowed_repo_ids = None`) passes it for ANY repo — so this
+    // DB-level visibility check is still required (#1783).
+    //
+    // NB: this remains a VISIBILITY gate only. Whether a caller may DELEGATE a
+    // given capability by minting a token is enforced per-scope in
+    // `create_repo_token` (#2603 G3 delegation ceiling), so a read-only member
+    // can still self-manage read-scoped tokens on a repo it can see.
     if !repo.is_public
         && !auth.is_admin
         && !repo_service
@@ -319,6 +386,17 @@ pub async fn create_repo_token(
     // `token_service::ADMIN_ONLY_SCOPES` for the policy list and rationale.
     crate::services::token_service::enforce_admin_only_scopes(&payload.scopes, auth.is_admin)
         .map_err(AppError::Authorization)?;
+
+    // #2603 G3 — delegation ceiling. Minting a repo-scoped token is an act of
+    // DELEGATION: it must not hand out a capability the caller does not itself
+    // hold on this repository. Before this gate, a read-only `viewer` member
+    // (or, on a public repo, any authenticated user) could mint a
+    // `write:artifacts` token — delegating write access it never had. Route the
+    // required action through the same canonical `check_repository_action`
+    // choke-point as the artifact-write paths, so the ceiling is exactly what
+    // the holder could do directly. Global admins bypass; read-only scopes need
+    // no mutation authority; the admin-class scopes above are already refused.
+    require_delegatable_scopes(&auth, repo.id, &payload.scopes, &state.permission_service).await?;
 
     // Generate the token
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
@@ -614,6 +692,35 @@ mod tests {
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             iat_ms: None,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #2603 G3 delegation ceiling: scope -> required repository action
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_delegated_scope_repo_action_write_needs_write() {
+        assert_eq!(
+            delegated_scope_repo_action("write:artifacts"),
+            Some("write")
+        );
+    }
+
+    #[test]
+    fn test_delegated_scope_repo_action_write_repositories_needs_admin() {
+        assert_eq!(
+            delegated_scope_repo_action("write:repositories"),
+            Some("admin")
+        );
+    }
+
+    #[test]
+    fn test_delegated_scope_repo_action_read_needs_nothing() {
+        // Read scopes and unrelated scopes require no mutation authority, so a
+        // member can always self-manage read-scoped tokens on a visible repo.
+        assert_eq!(delegated_scope_repo_action("read:artifacts"), None);
+        assert_eq!(delegated_scope_repo_action("read:repositories"), None);
+        assert_eq!(delegated_scope_repo_action("read:users"), None);
     }
 
     #[test]
@@ -1088,6 +1195,76 @@ mod admin_scope_policy_tests {
             String::from_utf8_lossy(&body_bytes),
         );
 
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
+    /// #2603 G3 delegation ceiling. On a PUBLIC repo, a caller who does not hold
+    /// the `write` action (here: any authenticated non-member) must NOT be able
+    /// to mint a `write:artifacts` token — that would delegate write access it
+    /// never had — but MAY still mint a `read:artifacts` token (self-service on
+    /// a repo it can read). Granting the `write` action lets it mint the
+    /// write-scoped token. This is the exact viewer-mints-write escalation the
+    /// gap describes; coupled with G1 it keeps delegation within authority.
+    #[tokio::test]
+    async fn non_writer_cannot_mint_write_scoped_repo_token_but_can_mint_read() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        let repo_id: Uuid = sqlx::query_scalar("SELECT id FROM repositories WHERE key = $1")
+            .bind(&repo_key)
+            .fetch_one(&pool)
+            .await
+            .expect("resolve repo id");
+
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.scopes = Some(vec!["write:repositories".to_string()]);
+
+        // (a) non-writer minting write:artifacts -> 403 (exceeds effective perm).
+        let (deny_status, deny_body) = tdh::send(
+            build_app(state.clone(), auth.clone()),
+            post_repo_token_request(&repo_key, "escalate", &["write:artifacts"]),
+        )
+        .await;
+        assert_eq!(
+            deny_status,
+            StatusCode::FORBIDDEN,
+            "non-writer minting a write-scoped token must be denied; got {} body: {}",
+            deny_status,
+            String::from_utf8_lossy(&deny_body),
+        );
+
+        // (b) same non-writer minting read:artifacts -> 200 (within authority).
+        let (read_status, _read_body) = tdh::send(
+            build_app(state.clone(), auth.clone()),
+            post_repo_token_request(&repo_key, "read-ok", &["read:artifacts"]),
+        )
+        .await;
+        assert_eq!(
+            read_status,
+            StatusCode::OK,
+            "a member must still self-manage a read-scoped token on a visible repo"
+        );
+
+        // (c) grant the write action (developer role) -> write token now allowed.
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let (allow_status, allow_body) = tdh::send(
+            build_app(state, auth),
+            post_repo_token_request(&repo_key, "legit-write", &["write:artifacts"]),
+        )
+        .await;
+        assert_eq!(
+            allow_status,
+            StatusCode::OK,
+            "a write-holding member must be able to delegate write; got {} body: {}",
+            allow_status,
+            String::from_utf8_lossy(&allow_body),
+        );
+
+        let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
         cleanup(&pool, user_id, &repo_key).await;
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -128,72 +128,46 @@ pub(crate) async fn require_repo_write_access(
     }
 }
 
-/// Pure fine-grained per-action decision, mirroring `upload_write_decision`
-/// (#817) in the chunked-upload path. Admins always pass; a repository with no
-/// permission rules falls through to the default access model; otherwise the
-/// caller must hold the requested action or `admin` (which implies all actions).
+/// Deny-by-default per-action authorization for a repository MUTATION, routed
+/// through the single canonical choke-point
+/// [`PermissionService::check_repository_action`].
 ///
-/// Factored out so both branches are unit-testable without a database.
-fn repo_fine_grained_action_allowed(
-    is_admin: bool,
-    has_rules: bool,
-    has_action: bool,
-    has_admin: bool,
-) -> bool {
-    if is_admin {
-        return true;
-    }
-    if !has_rules {
-        return true;
-    }
-    has_action || has_admin
-}
-
-/// Fine-grained per-action authorization, applied AFTER `require_repo_write_access`
-/// (the outer tenant gate) on the generic REST artifact write/delete handlers.
+/// This is the one source of truth for "may this caller perform `action`
+/// (`write`/`delete`) on this repository", shared by the generic REST artifact
+/// write/delete handlers and the chunked upload-session path (`upload.rs`), and
+/// mirrored by the native format middleware (`repo_visibility_middleware`) and
+/// the OCI `/v2` write handlers. Its posture is DENY-BY-DEFAULT:
 ///
-/// `require_repo_write_access` is only a tenant-membership gate: it treats a
-/// public repository or ANY role-assignment grantee (including a read-only one)
-/// as authorized, collapsing read/write/delete into a single "has access"
-/// predicate. That is the gap #2321 (G2) reports: on a rules-bearing repo a
-/// read-only grantee could still PUT/DELETE, and on a public repo any authed
-/// caller could write. This adds the SAME `has_rules -> check_permission(action)`
-/// block the chunked upload-session path (`upload.rs::create_session`, #817)
-/// already enforces, so the action actually maps to the granted permission.
+/// * a global admin bypasses (handled inside `check_repository_action`);
+/// * an applicable fine-grained `permissions` rule for the caller is
+///   authoritative — the action (or `admin`) must be granted;
+/// * otherwise the caller must hold a role assignment (repo-scoped or global)
+///   whose role carries the action (or `admin`).
 ///
-/// `action` is `"write"` for uploads and `"delete"` for deletes. Admins bypass;
-/// a repository with no permission rules falls through unchanged (the rules-less
-/// public-repo case is a separate global default-access decision, out of scope
-/// here). A permission-rule lookup error fails closed (503), mirroring
-/// `repo_visibility_middleware` and `create_session`.
-async fn require_repo_fine_grained_action(
+/// `is_public` confers a READ baseline only and NEVER satisfies `write`/`delete`;
+/// a repository with no permission rules does NOT fall through to "allow". This
+/// closes #2603 (G1): a public / rules-less repository must not grant write or
+/// delete to any authenticated caller, and a read-only `viewer` member must not
+/// be able to write or delete. The repository-scoped API-token scope (#504) is
+/// still enforced first via [`require_repo_access`]. A permission-lookup error
+/// fails closed (503), mirroring `repo_visibility_middleware`.
+pub(crate) async fn require_repo_action(
     auth: &AuthExtension,
     repo_id: Uuid,
     action: &str,
     permission_service: &crate::services::permission_service::PermissionService,
 ) -> Result<()> {
-    if auth.is_admin {
-        return Ok(());
-    }
-    let has_rules = permission_service
-        .has_any_rules_for_target("repository", repo_id)
+    // Repository-scoped API tokens must still allow this repo (#504) — enforced
+    // even for admins, matching `require_repo_write_access`.
+    require_repo_access(auth, repo_id)?;
+    let allowed = permission_service
+        .check_repository_action(auth.user_id, repo_id, action, auth.is_admin)
         .await
         .map_err(|_| {
             tracing::error!("permission check failed: database unreachable");
             AppError::ServiceUnavailable("permission service temporarily unavailable".to_string())
         })?;
-    if !has_rules {
-        return Ok(());
-    }
-    let has_action = permission_service
-        .check_permission(auth.user_id, "repository", repo_id, action, false)
-        .await
-        .unwrap_or(false);
-    let has_admin = permission_service
-        .check_permission(auth.user_id, "repository", repo_id, "admin", false)
-        .await
-        .unwrap_or(false);
-    if repo_fine_grained_action_allowed(auth.is_admin, has_rules, has_action, has_admin) {
+    if allowed {
         Ok(())
     } else {
         Err(AppError::Authorization(
@@ -215,8 +189,8 @@ async fn require_repo_fine_grained_action(
 /// behavior (#2603, area 3). Global admins bypass; every other caller must hold
 /// the `admin` action on the repository.
 ///
-/// Unlike [`require_repo_fine_grained_action`], there is deliberately no
-/// rules-less fallthrough: configuration is admin-only regardless of whether
+/// Unlike [`require_repo_action`], this requires the `admin` action
+/// specifically: configuration is admin-only regardless of whether
 /// fine-grained permission rules exist, matching the inline gate already used
 /// by `set_cache_ttl` / `set_npm_scope_policy` / `invalidate_cache`. Callers
 /// should invoke this AFTER [`require_repo_write_access`] (the tenant gate).
@@ -6674,11 +6648,12 @@ async fn authorize_generic_upload(
     require_repo_write_access(auth, &repo, &repo_service)
         .await
         .map_err(|e| e.into_response())?;
-    // Fine-grained write gate (#2321 G2): the tenant gate above admits any
-    // grantee (incl. a read-only one) and any authed caller on a public repo,
-    // collapsing read/write. Require the `write` action when rules exist, the
-    // same block `upload.rs::create_session` applies to the chunked path.
-    require_repo_fine_grained_action(auth, repo.id, "write", &state.permission_service)
+    // Action gate (#2603 G1): the tenant gate above admits any grantee (incl. a
+    // read-only one) and any authed caller on a public repo, collapsing
+    // read/write. Route the `write` decision through the canonical
+    // `check_repository_action` choke-point (deny-by-default): public
+    // visibility and rules-less repositories never confer write.
+    require_repo_action(auth, repo.id, "write", &state.permission_service)
         .await
         .map_err(|e| e.into_response())?;
 
@@ -7859,11 +7834,12 @@ pub async fn delete_artifact(
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
-    // Fine-grained delete gate (#2321 G2): the tenant gate above admits any
-    // grantee (incl. a write-only or read-only one), collapsing write/delete.
-    // Require the `delete` action when rules exist so a write-scoped grantee
-    // cannot destroy artifacts. Mirrors the upload path's `write` gate.
-    require_repo_fine_grained_action(&auth, repo.id, "delete", &state.permission_service).await?;
+    // Action gate (#2603 G1): the tenant gate above admits any grantee (incl. a
+    // write-only or read-only one), collapsing write/delete. Route the `delete`
+    // decision through the canonical `check_repository_action` choke-point
+    // (deny-by-default) so a write-only grantee cannot destroy artifacts and a
+    // rules-less/public repo confers no delete. Mirrors the upload `write` gate.
+    require_repo_action(&auth, repo.id, "delete", &state.permission_service).await?;
 
     // Resolve the npm canonical `/-/` URL shape the Web UI emits to the
     // version-segmented path the tarball is actually stored under (#2269),
@@ -12374,42 +12350,14 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // #2321 G2: pure fine-grained per-action decision (write/delete) applied
-    // after the tenant gate on the generic REST + OCI artifact paths. Mirrors
-    // `upload.rs::upload_write_decision`.
+    // #2603 G1: `require_repo_action` is the single deny-by-default per-action
+    // mutation choke-point. It delegates the decision to
+    // `PermissionService::check_repository_action` (unit-tested with a DB in
+    // `services::permission_service`), so the coverage here is the DB-backed
+    // handler matrix below (`upload_artifact_fine_grained_write_gate_db`,
+    // `delete_artifact_fine_grained_delete_gate_db`,
+    // `require_repo_action_denies_public_and_rulesless_db`).
     // -----------------------------------------------------------------------
-    #[test]
-    fn test_repo_fine_grained_action_admin_always_allowed() {
-        // Admins bypass regardless of rules/actions state.
-        assert!(repo_fine_grained_action_allowed(true, false, false, false));
-        assert!(repo_fine_grained_action_allowed(true, true, false, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_no_rules_falls_through() {
-        // A repo with no permission rules keeps the default access model.
-        assert!(repo_fine_grained_action_allowed(false, false, false, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_rules_require_matching_action() {
-        // Rules exist but the caller holds neither the action nor admin -> deny.
-        // This is the read-only-grantee-cannot-write / write-only-cannot-delete
-        // collapse that #2321 G2 closes.
-        assert!(!repo_fine_grained_action_allowed(false, true, false, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_rules_with_action_allowed() {
-        // Holding the requested action (write or delete) passes.
-        assert!(repo_fine_grained_action_allowed(false, true, true, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_rules_with_admin_action_allowed() {
-        // `admin` implies all actions, so it passes any per-action gate.
-        assert!(repo_fine_grained_action_allowed(false, true, false, true));
-    }
 
     // -----------------------------------------------------------------------
     // xtenant-write-authz-systemic: behavioral coverage for the two shared
@@ -12553,6 +12501,10 @@ mod tests {
         let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        // #2603 G1: the delete path now requires the `delete` action (developer
+        // no longer implies delete); grant explicit read/write/delete so this
+        // test exercises its own logic rather than the authz gate.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
         let auth = Some(tdh::make_auth(user_id, &username));
         // {package}/{version}/{filename} -> a versioned release coordinate.
         let path = "app/1.0.0/app-1.0.0.bin".to_string();
@@ -12885,6 +12837,10 @@ mod tests {
         let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        // #2603 G1: the delete path now requires the `delete` action (developer
+        // no longer implies delete); grant explicit read/write/delete so this
+        // test exercises its own logic rather than the authz gate.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
         let auth = Some(tdh::make_auth(user_id, &username));
         let mut admin_ext = tdh::make_auth(user_id, &username);
         admin_ext.is_admin = true;
@@ -13795,13 +13751,113 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// #2321 G2 binding test: the generic artifact write/delete handlers must
-    /// keep routing through `require_repo_fine_grained_action` after the tenant
-    /// gate. A handler that dropped the call would silently re-collapse
-    /// read/write/delete, so pin it structurally (the DB tests above cannot run
-    /// without a Postgres).
+    /// #2603 G1 core: `require_repo_action` is DENY-BY-DEFAULT. On a RULES-LESS
+    /// repository (no fine-grained rows) it must:
+    ///   * deny a bare authenticated non-member `write`/`delete` on a PUBLIC
+    ///     repo (public visibility is read-only — the headline gap);
+    ///   * deny a read-only `viewer`-role member `write`/`delete` on a PRIVATE
+    ///     repo;
+    ///   * allow a `developer`-role member `write` but still deny `delete`
+    ///     (developer no longer implies delete);
+    ///   * allow a global admin everything.
+    #[tokio::test]
+    async fn require_repo_action_deny_by_default_rulesless_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let perms = crate::services::permission_service::PermissionService::new(pool.clone());
+        let (repo_id, _key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let auth = tdh::make_auth(user_id, &username);
+
+        // Bare non-member on a PRIVATE rules-less repo: no write, no delete.
+        assert!(
+            require_repo_action(&auth, repo_id, "write", &perms)
+                .await
+                .is_err(),
+            "bare non-member must be denied write on a rules-less private repo"
+        );
+
+        // Make it PUBLIC: still no write/delete (public = read baseline only).
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("make repo public");
+        assert!(
+            require_repo_action(&auth, repo_id, "write", &perms)
+                .await
+                .is_err(),
+            "bare authed non-member must be denied write on a rules-less PUBLIC repo (G1a)"
+        );
+        assert!(
+            require_repo_action(&auth, repo_id, "delete", &perms)
+                .await
+                .is_err(),
+            "bare authed non-member must be denied delete on a rules-less public repo"
+        );
+
+        // Read-only `viewer` (reader role) member: still no write/delete.
+        sqlx::query(
+            "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+             SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'reader' \
+             ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("grant reader role");
+        assert!(
+            require_repo_action(&auth, repo_id, "write", &perms)
+                .await
+                .is_err(),
+            "read-only viewer must be denied write (G1b class)"
+        );
+        assert!(
+            require_repo_action(&auth, repo_id, "delete", &perms)
+                .await
+                .is_err(),
+            "read-only viewer must be denied delete (G1b)"
+        );
+
+        // Upgrade to `developer`: write allowed, delete still denied.
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        assert!(
+            require_repo_action(&auth, repo_id, "write", &perms)
+                .await
+                .is_ok(),
+            "developer member must be allowed write (legit path)"
+        );
+        assert!(
+            require_repo_action(&auth, repo_id, "delete", &perms)
+                .await
+                .is_err(),
+            "developer must NOT imply delete"
+        );
+
+        // Global admin bypasses everything.
+        let admin = tdh::admin_auth(user_id, &username);
+        assert!(
+            require_repo_action(&admin, repo_id, "delete", &perms)
+                .await
+                .is_ok(),
+            "global admin must be allowed delete"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #2603 G1 binding test: the generic artifact write/delete handlers must
+    /// keep routing through `require_repo_action` (the canonical
+    /// `check_repository_action` choke-point) after the tenant gate. A handler
+    /// that dropped the call would silently re-collapse read/write/delete and
+    /// re-open the public / rules-less write hole, so pin it structurally (the
+    /// DB tests above cannot run without a Postgres).
     #[test]
-    fn test_generic_artifact_handlers_call_fine_grained_gate() {
+    fn test_generic_artifact_handlers_call_action_gate() {
         let source = include_str!("repositories.rs");
         for (handler, action) in [
             ("upload_artifact", "\"write\""),
@@ -13815,8 +13871,8 @@ mod tests {
             let end = rest.find("\npub async fn ").unwrap_or(rest.len());
             let body = &rest[..end];
             assert!(
-                body.contains("require_repo_fine_grained_action(") && body.contains(action),
-                "handler `{}` must call require_repo_fine_grained_action with {} (#2321 G2)",
+                body.contains("require_repo_action(") && body.contains(action),
+                "handler `{}` must call require_repo_action with {} (#2603 G1)",
                 handler,
                 action
             );
@@ -19881,6 +19937,10 @@ mod tests {
         let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "npm").await;
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        // #2603 G1: the delete path now requires the `delete` action (developer
+        // no longer implies delete); grant explicit read/write/delete so this
+        // test exercises its own logic rather than the authz gate.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
         let auth = Some(tdh::make_auth(user_id, &username));
 
         // Publish tarballs under the exact version-segmented layout

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -21,7 +21,7 @@ use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
 use crate::api::handlers::proxy_helpers;
-use crate::api::handlers::repositories::require_repo_write_access;
+use crate::api::handlers::repositories::{require_repo_action, require_repo_write_access};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::services::package_service::PackageService;
@@ -128,46 +128,6 @@ pub struct CompleteResponse {
 // POST / -- Create upload session
 // ---------------------------------------------------------------------------
 
-/// Pure write-authorization decision for creating a chunked-upload session.
-///
-/// Mirrors the semantics `repo_visibility_middleware` enforces on every other
-/// repository write path, so the body-addressed `/uploads` flow is gated the
-/// same way the URL-addressed legacy artifact PUT is:
-///
-/// * **Token repo-scope (#504):** an API token restricted to a set of repos
-///   (`auth.can_access_repo`) may only target a repo in that set.
-/// * **Admin bypass:** admins skip the fine-grained checks entirely.
-/// * **No-rules fall-through:** a repo with no fine-grained permission rules
-///   keeps working under the default access model (`has_rules == false`).
-/// * **Fine-grained write (#817):** when rules exist, the caller must hold the
-///   `write` (or `admin`) action on the repo.
-///
-/// The permission-service lookups that produce `has_rules`/`has_write`/
-/// `has_admin` are done by the caller; keeping the decision pure makes it
-/// unit-testable without a database.
-fn session_write_authorized(
-    auth: &AuthExtension,
-    repo_id: Uuid,
-    has_rules: bool,
-    has_write: bool,
-    has_admin: bool,
-) -> bool {
-    // #504: token repository scope.
-    if !auth.can_access_repo(repo_id) {
-        return false;
-    }
-    // Admins bypass fine-grained permission checks.
-    if auth.is_admin {
-        return true;
-    }
-    // No fine-grained rules: fall through to the default access model.
-    if !has_rules {
-        return true;
-    }
-    // Rules exist: the caller must hold write (or admin) on this repo.
-    has_write || has_admin
-}
-
 #[utoipa::path(
     post,
     path = "/api/v1/uploads",
@@ -262,113 +222,22 @@ async fn create_session(
         return Err(rejection);
     }
 
-    // Repository write authorization (#817 parity).
-    //
-    // The chunked upload-session create path must enforce the same
-    // fine-grained RBAC write gate that `repo_visibility_middleware` applies to
-    // the rest of the artifact-write surface (see middleware/auth.rs): the
-    // /api/v1/uploads router is layered only with `auth_middleware`
-    // (authentication), so without this check any authenticated user could open
-    // a session against a release/promotion-only repository.
-    //
-    // Admins bypass the check. For a non-admin, if any permission rule exists
-    // for this repository the caller must hold the `write` action (or `admin`,
-    // which implies all actions); a repository with no rules falls through
-    // unchanged. A DB error on the rule lookup fails closed (503), mirroring the
-    // middleware. Authorized peer-replication identities hold write/admin on the
-    // target and continue to pass.
-    let has_rules = if auth.is_admin {
-        false
-    } else {
-        match state
-            .permission_service
-            .has_any_rules_for_target("repository", repo_id)
-            .await
-        {
-            Ok(v) => v,
-            Err(_) => {
-                tracing::error!("permission check failed: database unreachable");
-                return Err(map_err(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "permission service temporarily unavailable",
-                ));
-            }
-        }
-    };
-    let (has_write, has_admin) = if !auth.is_admin && has_rules {
-        (
-            state
-                .permission_service
-                .check_permission(user_id, "repository", repo_id, "write", false)
-                .await
-                .unwrap_or(false),
-            state
-                .permission_service
-                .check_permission(user_id, "repository", repo_id, "admin", false)
-                .await
-                .unwrap_or(false),
-        )
-    } else {
-        (false, false)
-    };
-    if !upload_write_decision(auth.is_admin, has_rules, has_write, has_admin) {
-        return Err(map_err(
-            StatusCode::FORBIDDEN,
-            "You do not have permission to perform this action on this repository",
-        ));
-    }
-
-    // Repository write authorization.
+    // Repository write authorization (#2603 G1).
     //
     // The `/uploads` routes are nested under `auth_middleware` only, not
     // `repo_visibility_middleware`, and the target repo is named in the JSON
-    // body rather than the URL path -- so the repo-scope (#504) and
-    // fine-grained permission (#817) gates that protect every other write
-    // path never see this request. Apply the same decision here, at the single
-    // point where the cross-tenant write would originate, right after the repo
-    // is resolved (the 404-for-unknown-repo behaviour above is unchanged).
-    //
-    // Only consult the permission service for a non-admin caller that is in
-    // token scope for the repo; admins bypass and out-of-scope tokens are
-    // denied without a DB round-trip. Fail closed (503) on a permission lookup
-    // error, matching `repo_visibility_middleware`.
-    let (has_rules, has_write, has_admin) = if auth.is_admin || !auth.can_access_repo(repo.0) {
-        (false, false, false)
-    } else {
-        let has_rules = state
-            .permission_service
-            .has_any_rules_for_target("repository", repo.0)
-            .await
-            .map_err(|_| {
-                tracing::error!("permission check failed: database unreachable");
-                map_err(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "permission service temporarily unavailable",
-                )
-            })?;
-        if has_rules {
-            let has_write = state
-                .permission_service
-                .check_permission(auth.user_id, "repository", repo.0, "write", false)
-                .await
-                .unwrap_or(false);
-            let has_admin = state
-                .permission_service
-                .check_permission(auth.user_id, "repository", repo.0, "admin", false)
-                .await
-                .unwrap_or(false);
-            (true, has_write, has_admin)
-        } else {
-            (false, false, false)
-        }
-    };
-
-    if !session_write_authorized(&auth, repo.0, has_rules, has_write, has_admin) {
-        return Err(map_err(
-            StatusCode::FORBIDDEN,
-            "You do not have permission to perform this action on this repository",
-        ));
-    }
+    // body rather than the URL path -- so the repo-scope (#504) and per-action
+    // permission gates that protect every other write path never see this
+    // request. Route the `write` decision through the single canonical
+    // choke-point (`check_repository_action`), DENY-BY-DEFAULT: opening a
+    // session is a write, so `is_public` never satisfies it and a rules-less
+    // repository does not fall open — the caller must hold the `write` action
+    // (via role assignment, an allowing rule, or `admin`). Admins bypass inside
+    // the choke-point; the token repo-scope (#504) is enforced first. A DB
+    // error fails closed (503), matching `repo_visibility_middleware`.
+    require_repo_action(&auth, repo_id, "write", &state.permission_service)
+        .await
+        .map_err(IntoResponse::into_response)?;
 
     let is_replication = super::is_replication_request(&headers);
     let replication_metadata = replication_session_metadata_from_request(&headers, &req);
@@ -483,6 +352,20 @@ async fn upload_chunk(
     let session = UploadService::get_session(&state.db, session_id, Some(user_id))
         .await
         .map_err(map_upload_err)?;
+
+    // #2603 G1: re-check repository write authorization on every chunk. Session
+    // creation authorized the caller, but a role revocation (or a repo turning
+    // private) between `create_session` and the last chunk must stop further
+    // writes — the session owner cannot keep appending data it may no longer
+    // publish. Routed through the same canonical choke-point.
+    require_repo_action(
+        &auth,
+        session.repository_id,
+        "write",
+        &state.permission_service,
+    )
+    .await
+    .map_err(IntoResponse::into_response)?;
 
     let chunk_index = (start / session.chunk_size as i64) as i32;
 
@@ -626,6 +509,19 @@ async fn complete(
     let session = UploadService::complete_session(&state.db, session_id, user_id)
         .await
         .map_err(map_upload_err)?;
+
+    // #2603 G1: re-check repository write authorization before committing the
+    // artifact. Finalizing a session is the actual write, so access revoked
+    // after the chunks were staged must still block the commit. Routed through
+    // the same canonical choke-point.
+    require_repo_action(
+        &auth,
+        session.repository_id,
+        "write",
+        &state.permission_service,
+    )
+    .await
+    .map_err(IntoResponse::into_response)?;
 
     // Resolve the *repo-scoped* storage backend and use a content-addressable
     // key, matching how non-chunked uploads work (issue #1168 part 3).
@@ -889,28 +785,6 @@ fn map_err(status: StatusCode, e: impl std::fmt::Display) -> Response {
         axum::Json(serde_json::json!({"error": e.to_string()})),
     )
         .into_response()
-}
-
-/// Pure authorization decision for chunked upload-session creation, mirroring
-/// the non-admin RBAC write gate enforced by `repo_visibility_middleware`.
-///
-/// - Admins always pass (any rules state).
-/// - Non-admins on a repository with no permission rules fall through (allowed).
-/// - Non-admins on a rules-bearing repository must hold the `write` action or
-///   the `admin` action (which implies all actions).
-fn upload_write_decision(
-    is_admin: bool,
-    has_rules: bool,
-    has_write: bool,
-    has_admin: bool,
-) -> bool {
-    if is_admin {
-        return true;
-    }
-    if !has_rules {
-        return true;
-    }
-    has_write || has_admin
 }
 
 /// Build the rejection for a direct upload-session create against a
@@ -1255,12 +1129,13 @@ fn replication_session_metadata_from_request<'a>(
 mod tests {
     use super::*;
 
-    /// Cross-tenant authz guard (xtenant-write-authz-systemic). `session_write_authorized`
-    /// (and `upload_write_decision`) fall OPEN when the target repo has no
-    /// fine-grained permission rules (`!has_rules`), so `create_session` must
-    /// ALSO enforce the rule-independent tenant gate `require_repo_write_access`
-    /// (is_public + role_assignments membership). String-grep because the handler
-    /// needs a real DB to run.
+    /// Cross-tenant authz guard (xtenant-write-authz-systemic). `create_session`
+    /// must enforce the tenant/token gate `require_repo_write_access` (visibility
+    /// plus role-assignment membership plus the #504 token scope) in addition to
+    /// the deny-by-default `require_repo_action` (#2603 G1) action choke-point,
+    /// so a non-member non-admin can never open a session against another
+    /// tenant's repository regardless of fine-grained rule existence. String-grep
+    /// because the handler needs a real DB to run.
     #[test]
     fn test_create_session_enforces_tenant_gate() {
         let source = include_str!("upload.rs");
@@ -1431,114 +1306,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // session_write_authorized (pure write-authorization decision)
+    // Repository write authorization for the chunked-upload path is now the
+    // single canonical `require_repo_action` -> `check_repository_action`
+    // choke-point (#2603 G1). Its per-action decision is unit-tested with a DB
+    // in `services::permission_service`, and the handler wiring is covered by
+    // the DB-backed `create_session_*` tests below.
     // -----------------------------------------------------------------------
-
-    /// Build an `AuthExtension` for the pure-helper tests. `allowed` is the
-    /// token repo-scope (`None` = unrestricted, matching a JWT login).
-    fn auth_for(is_admin: bool, allowed: Option<Vec<Uuid>>) -> AuthExtension {
-        AuthExtension {
-            user_id: Uuid::new_v4(),
-            username: "tester".to_string(),
-            email: "tester@example.test".to_string(),
-            is_admin,
-            is_api_token: allowed.is_some(),
-            is_service_account: false,
-            scopes: None,
-            allowed_repo_ids: crate::models::access_scope::AccessScope::from(allowed),
-            iat_ms: None,
-        }
-    }
-
-    #[test]
-    fn session_write_authorized_denies_token_scoped_out() {
-        let repo = Uuid::new_v4();
-        let other = Uuid::new_v4();
-        // Token restricted to a different repo: denied before any rule check.
-        let auth = auth_for(false, Some(vec![other]));
-        assert!(!session_write_authorized(&auth, repo, false, false, false));
-        // Even an admin token is bound by its repo scope.
-        let admin = auth_for(true, Some(vec![other]));
-        assert!(!session_write_authorized(&admin, repo, false, false, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_admin() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(true, None);
-        // Admin bypasses fine-grained rules even when the user holds nothing.
-        assert!(session_write_authorized(&auth, repo, true, false, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_when_no_rules() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        // No fine-grained rules -> default access model (fall-through).
-        assert!(session_write_authorized(&auth, repo, false, false, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_with_write_grant() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        assert!(session_write_authorized(&auth, repo, true, true, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_with_admin_action() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        assert!(session_write_authorized(&auth, repo, true, false, true));
-    }
-
-    #[test]
-    fn session_write_authorized_denies_rules_without_grant() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        // Rules exist but the user holds neither write nor admin: denied.
-        assert!(!session_write_authorized(&auth, repo, true, false, false));
-    }
-
-    // -----------------------------------------------------------------------
-    // artifact_name_from_path
-    // -----------------------------------------------------------------------
-
-    // -----------------------------------------------------------------------
-    // upload_write_decision (#817 parity with repo_visibility_middleware)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_upload_write_decision_admin_always_allowed() {
-        // Admins bypass the check regardless of rules/actions.
-        assert!(upload_write_decision(true, false, false, false));
-        assert!(upload_write_decision(true, true, false, false));
-        assert!(upload_write_decision(true, true, true, true));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_no_rules_allowed() {
-        // A repository with no permission rules falls through unchanged.
-        assert!(upload_write_decision(false, false, false, false));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_rules_with_write_allowed() {
-        assert!(upload_write_decision(false, true, true, false));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_rules_with_admin_action_allowed() {
-        // The `admin` action implies all actions (including write).
-        assert!(upload_write_decision(false, true, false, true));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_rules_neither_denied() {
-        // Release/promotion-only repo: rules exist but caller holds neither
-        // write nor admin -> denied.
-        assert!(!upload_write_decision(false, true, false, false));
-    }
 
     // -----------------------------------------------------------------------
     // reject_session_if_promotion_only (#817 parity with direct upload path)
@@ -3164,12 +2937,22 @@ mod tests {
 
     #[tokio::test]
     async fn create_session_denies_non_admin_without_grant_when_rules_exist() {
-        // (b) The exploit case: a non-admin whose target repo HAS fine-grained
-        // rules, but holds no grant for that user, is denied -> 403. (Mirrors a
-        // cross-tenant write attempt into a repo gated by permission rules.)
+        // (b) The exploit case: a NON-MEMBER (no role assignment, no rule for
+        // them) targeting a repo that has fine-grained rules for someone else is
+        // denied -> 403. Mirrors a cross-tenant write attempt. Under the
+        // deny-by-default `check_repository_action` choke-point (#2603 G1) a
+        // caller needs an action-granting role or an allowing rule; a rule for a
+        // different principal grants this caller nothing.
         let Some(f) = tdh::Fixture::setup("local", "generic").await else {
             return;
         };
+        // Make the fixture user a pure non-member: drop the developer role
+        // assignment that `Fixture::setup` granted, so the only authz signal is
+        // the (absent) per-principal grant.
+        let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
+            .bind(f.repo_id)
+            .execute(&f.pool)
+            .await;
         // Rules exist for the repo, but they grant another principal, not the
         // caller.
         grant_repo_permission(&f.pool, f.repo_id, Uuid::new_v4(), &["read", "write"]).await;
@@ -3186,7 +2969,7 @@ mod tests {
         assert_eq!(
             status,
             StatusCode::FORBIDDEN,
-            "non-admin without a grant on a ruled repo must be denied"
+            "non-member on a ruled repo must be denied"
         );
         // No session must have been created for this repo.
         let count: i64 =

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1469,6 +1469,55 @@ fn is_write_method(method: &Method) -> bool {
     )
 }
 
+/// Is `path` a POST route that is *not* a repository mutation despite using a
+/// write HTTP method?
+///
+/// A handful of format endpoints are `POST` by protocol but are negotiation /
+/// credential-exchange steps rather than artifact writes. The method-based
+/// mutation gate in [`repo_visibility_middleware`] (#2603 G1) would otherwise
+/// reject them with 403 for any caller lacking the repository `write` action,
+/// which breaks legitimate reads/logins:
+///
+/// * **git-lfs batch** — `POST /lfs/<repo_key>/objects/batch` is the mandatory
+///   download/upload negotiation. `git lfs pull` issues an `{"operation":
+///   "download"}` batch, so a read-only member or a public-repo non-member must
+///   be able to reach it. The `batch` handler self-gates uploads: an
+///   `{"operation":"upload"}` batch is authorized as a repository `write`
+///   in-handler, and the subsequent object `PUT` is write-gated by this same
+///   middleware, so exempting the batch POST does not open an upload hole.
+/// * **conan authenticate** — `POST /conan/<repo_key>/v2/users/authenticate` is
+///   a Basic→JWT credential exchange, not a write. The handler requires a valid
+///   credential and mints a scope-ceilinged token; no repository `write` is
+///   needed or implied.
+///
+/// The `#508` write-auth requirement (writes require authentication; anonymous
+/// callers get 401) still applies to these paths independently, so this
+/// exemption never loosens the anonymous contract — it only routes the
+/// *authenticated* caller through the read/visibility path instead of the
+/// deny-by-default write choke-point.
+fn is_non_mutating_format_post(path: &str) -> bool {
+    let trimmed = path.trim_start_matches('/');
+    let mut segments = trimmed.split('/');
+    match segments.next() {
+        // /lfs/<repo_key>/objects/batch
+        Some("lfs") => {
+            matches!(segments.next(), Some(k) if !k.is_empty())
+                && segments.next() == Some("objects")
+                && segments.next() == Some("batch")
+                && segments.next().is_none()
+        }
+        // /conan/<repo_key>/v2/users/authenticate
+        Some("conan") => {
+            matches!(segments.next(), Some(k) if !k.is_empty())
+                && segments.next() == Some("v2")
+                && segments.next() == Some("users")
+                && segments.next() == Some("authenticate")
+                && segments.next().is_none()
+        }
+        _ => false,
+    }
+}
+
 /// Build a 401 response with `WWW-Authenticate` challenges for both Basic
 /// and Bearer schemes.  Package manager clients use the challenge to decide
 /// how to retry with credentials.
@@ -1800,9 +1849,21 @@ pub async fn repo_visibility_middleware(
     // to preserve backward compatibility and avoid unnecessary DB lookups.
     if let Some(ref ext) = auth_ext {
         if !ext.is_admin {
-            let action = action_for_method(request.method());
+            // A few POST routes are negotiation / credential-exchange steps, not
+            // repository mutations, even though the HTTP method is a write (see
+            // `is_non_mutating_format_post`). Classify them as reads so a
+            // read-only member or a public-repo non-member can still perform
+            // download negotiation / token exchange. The #508 write-auth gate
+            // above (401 for anonymous) is unaffected, and actual LFS uploads
+            // remain write-gated by the batch handler and the object-PUT path.
+            let non_mutating_post = is_non_mutating_format_post(&path);
+            let action = if non_mutating_post {
+                "read"
+            } else {
+                action_for_method(request.method())
+            };
 
-            if is_write {
+            if is_write && !non_mutating_post {
                 // #2603 G1: writes and deletes route through the single
                 // canonical action choke-point, DENY-BY-DEFAULT. `is_public`
                 // confers a read baseline only and never satisfies a write, and
@@ -3197,6 +3258,62 @@ mod tests {
     #[test]
     fn test_is_write_method_options_is_not_write() {
         assert!(!is_write_method(&Method::OPTIONS));
+    }
+
+    // -----------------------------------------------------------------------
+    // is_non_mutating_format_post
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_non_mutating_lfs_batch_is_exempt() {
+        assert!(is_non_mutating_format_post("/lfs/myrepo/objects/batch"));
+    }
+
+    #[test]
+    fn test_non_mutating_conan_authenticate_is_exempt() {
+        assert!(is_non_mutating_format_post(
+            "/conan/myrepo/v2/users/authenticate"
+        ));
+    }
+
+    #[test]
+    fn test_non_mutating_lfs_object_put_is_not_exempt() {
+        // The actual object upload (PUT /lfs/<repo>/objects/<oid>) is a real
+        // write and must NOT be exempted from the mutation gate.
+        assert!(!is_non_mutating_format_post(
+            "/lfs/myrepo/objects/abcdef0123456789"
+        ));
+    }
+
+    #[test]
+    fn test_non_mutating_lfs_verify_is_not_exempt() {
+        assert!(!is_non_mutating_format_post("/lfs/myrepo/verify"));
+    }
+
+    #[test]
+    fn test_non_mutating_lfs_batch_missing_repo_key_is_not_exempt() {
+        assert!(!is_non_mutating_format_post("/lfs//objects/batch"));
+    }
+
+    #[test]
+    fn test_non_mutating_conan_upload_is_not_exempt() {
+        // A conan artifact upload path must remain write-gated.
+        assert!(!is_non_mutating_format_post(
+            "/conan/myrepo/v2/conans/pkg/1.0/user/channel/upload_urls"
+        ));
+    }
+
+    #[test]
+    fn test_non_mutating_other_format_batch_is_not_exempt() {
+        // The exemption is scoped to the git-lfs and conan prefixes only.
+        assert!(!is_non_mutating_format_post("/npm/myrepo/objects/batch"));
+    }
+
+    #[test]
+    fn test_non_mutating_lfs_batch_trailing_segment_is_not_exempt() {
+        assert!(!is_non_mutating_format_post(
+            "/lfs/myrepo/objects/batch/extra"
+        ));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1794,101 +1794,136 @@ pub async fn repo_visibility_middleware(
         }
     }
 
-    // #817: Fine-grained repository permission enforcement.
+    // Repository permission enforcement (#817 reads, #2603 G1 writes).
     //
     // If the authenticated user is an admin, skip permission checks entirely
     // to preserve backward compatibility and avoid unnecessary DB lookups.
-    //
-    // For non-admin users, check whether any permission rules exist for this
-    // repository. If no rules exist, fall through to the default access model
-    // (the visibility checks above are sufficient). If rules do exist, the
-    // user must hold the action that matches the HTTP method.
     if let Some(ref ext) = auth_ext {
         if !ext.is_admin {
-            let has_rules = match vis_state
-                .permission_service
-                .has_any_rules_for_target("repository", repo.id)
-                .await
-            {
-                Ok(v) => v,
-                Err(_) => {
-                    // DB error on permission check: fail closed.
-                    tracing::error!("permission check failed: database unreachable");
-                    return Response::builder()
-                        .status(StatusCode::SERVICE_UNAVAILABLE)
-                        .body(axum::body::Body::from(
-                            "permission service temporarily unavailable",
-                        ))
-                        .unwrap();
-                }
-            };
+            let action = action_for_method(request.method());
 
-            if has_rules {
-                let action = action_for_method(request.method());
-                // #2329: On a *public* repository, reads are always allowed
-                // for anonymous callers (visibility check above), so an
-                // authenticated caller must not end up with *less* read
-                // access just because ACL rules exist. Grant the anonymous
-                // read baseline and skip the ACL for reads only; writes and
-                // deletes remain fully ACL-gated, and private repos never
-                // take this shortcut. Anonymous callers never reach this
-                // block at all (no `auth_ext`), so the existing
-                // anonymous-public contract is untouched.
-                if !public_read_satisfies_acl(is_public, action) {
-                    // Check for the specific action first, then fall back to
-                    // "admin" which implies all actions (#827 policy compat).
-                    // Both calls resolve from the same cached action set, so
-                    // the second call is essentially free.
-                    let allowed = vis_state
-                        .permission_service
-                        .check_permission(ext.user_id, "repository", repo.id, action, false)
-                        .await
-                        .unwrap_or(false)
-                        || vis_state
-                            .permission_service
-                            .check_permission(ext.user_id, "repository", repo.id, "admin", false)
-                            .await
-                            .unwrap_or(false);
-
-                    if !allowed {
-                        return forbidden_permission_response();
+            if is_write {
+                // #2603 G1: writes and deletes route through the single
+                // canonical action choke-point, DENY-BY-DEFAULT. `is_public`
+                // confers a read baseline only and never satisfies a write, and
+                // a repository with NO fine-grained rules does not fall open —
+                // the caller must hold a role assignment carrying the action
+                // (or an allowing fine-grained rule, or `admin`), for public
+                // and private repositories alike. This closes the rules-less
+                // public-repo write hole (any authed caller could PUT/DELETE)
+                // and the rules-less private-repo case (a read-only `viewer`
+                // member could write/delete). DB error fails closed (503).
+                match vis_state
+                    .permission_service
+                    .check_repository_action(ext.user_id, repo.id, action, false)
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => return forbidden_permission_response(),
+                    Err(_) => {
+                        tracing::error!("permission check failed: database unreachable");
+                        return service_unavailable_response();
                     }
                 }
-            } else if !is_public {
-                // A private repo with NO fine-grained permission rules must
-                // still not be readable by every authenticated user. Mirror
-                // the REST `require_visible` model: a non-admin needs a role
-                // assignment scoped to this repo (or a global assignment).
-                //
-                // Without this branch the native-protocol path default-ALLOWED
-                // rule-less private repos to any authenticated principal, while
-                // the REST download path denied the same caller (404) — a
-                // cross-tenant private-artifact leak (red-team round 2).
-                //
-                // Uses sqlx::query_scalar (not the macro) so no new entry in
-                // the sqlx offline-query cache is required, matching the rest
-                // of this middleware. Same predicate as
-                // RepositoryService::user_can_access_repo.
-                let granted = sqlx::query_scalar::<_, bool>(
-                    "SELECT EXISTS ( \
-                         SELECT 1 FROM role_assignments ra \
-                         WHERE ra.user_id = $1 \
-                           AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
-                     )",
-                )
-                .bind(ext.user_id)
-                .bind(repo.id)
-                .fetch_one(&vis_state.db)
-                .await;
-
-                match granted {
-                    Ok(true) => {}
-                    // Existence-hiding 404, matching REST `require_visible`.
-                    Ok(false) => return not_found_response(),
+            } else {
+                // Reads: preserve the public-anonymous baseline + private
+                // membership + fine-grained ACL model (#817 / #2329). For a
+                // non-admin user, check whether any permission rules exist for
+                // this repository. If no rules exist, fall through to the
+                // default access model (the visibility checks above are
+                // sufficient for public repos; private repos still require a
+                // role assignment). If rules do exist, the user must hold the
+                // read action.
+                let has_rules = match vis_state
+                    .permission_service
+                    .has_any_rules_for_target("repository", repo.id)
+                    .await
+                {
+                    Ok(v) => v,
                     Err(_) => {
-                        // DB error on access check: fail closed.
-                        tracing::error!("repo access check failed: database unreachable");
-                        return service_unavailable_response();
+                        // DB error on permission check: fail closed.
+                        tracing::error!("permission check failed: database unreachable");
+                        return Response::builder()
+                            .status(StatusCode::SERVICE_UNAVAILABLE)
+                            .body(axum::body::Body::from(
+                                "permission service temporarily unavailable",
+                            ))
+                            .unwrap();
+                    }
+                };
+
+                if has_rules {
+                    // #2329: On a *public* repository, reads are always allowed
+                    // for anonymous callers (visibility check above), so an
+                    // authenticated caller must not end up with *less* read
+                    // access just because ACL rules exist. Grant the anonymous
+                    // read baseline and skip the ACL for reads only; private
+                    // repos never take this shortcut. Anonymous callers never
+                    // reach this block at all (no `auth_ext`), so the existing
+                    // anonymous-public contract is untouched.
+                    if !public_read_satisfies_acl(is_public, action) {
+                        // Check for the specific action first, then fall back to
+                        // "admin" which implies all actions (#827 policy compat).
+                        // Both calls resolve from the same cached action set, so
+                        // the second call is essentially free.
+                        let allowed = vis_state
+                            .permission_service
+                            .check_permission(ext.user_id, "repository", repo.id, action, false)
+                            .await
+                            .unwrap_or(false)
+                            || vis_state
+                                .permission_service
+                                .check_permission(
+                                    ext.user_id,
+                                    "repository",
+                                    repo.id,
+                                    "admin",
+                                    false,
+                                )
+                                .await
+                                .unwrap_or(false);
+
+                        if !allowed {
+                            return forbidden_permission_response();
+                        }
+                    }
+                } else if !is_public {
+                    // A private repo with NO fine-grained permission rules must
+                    // still not be readable by every authenticated user. Mirror
+                    // the REST `require_visible` model: a non-admin needs a role
+                    // assignment scoped to this repo (or a global assignment).
+                    //
+                    // Without this branch the native-protocol path
+                    // default-ALLOWED rule-less private repos to any
+                    // authenticated principal, while the REST download path
+                    // denied the same caller (404) — a cross-tenant
+                    // private-artifact leak (red-team round 2).
+                    //
+                    // Uses sqlx::query_scalar (not the macro) so no new entry in
+                    // the sqlx offline-query cache is required, matching the rest
+                    // of this middleware. Same predicate as
+                    // RepositoryService::user_can_access_repo.
+                    let granted = sqlx::query_scalar::<_, bool>(
+                        "SELECT EXISTS ( \
+                             SELECT 1 FROM role_assignments ra \
+                             WHERE ra.user_id = $1 \
+                               AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
+                         )",
+                    )
+                    .bind(ext.user_id)
+                    .bind(repo.id)
+                    .fetch_one(&vis_state.db)
+                    .await;
+
+                    match granted {
+                        Ok(true) => {}
+                        // Existence-hiding 404, matching REST `require_visible`.
+                        Ok(false) => return not_found_response(),
+                        Err(_) => {
+                            // DB error on access check: fail closed.
+                            tracing::error!("repo access check failed: database unreachable");
+                            return service_unavailable_response();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Repository **mutation** authorization (write/delete) previously conflated a
repository's *visibility* and *coarse membership* with an *action grant*. On a
repository with no fine-grained permission rules, several write paths treated
`is_public` (or "holds any role assignment") as sufficient authority, so:

- an authenticated caller with **no write grant** could create/overwrite/delete
  artifacts on a **public, rules-less** repository, and
- a read-only member could write/delete on a **private, rules-less** repository.

This is a cross-tenant write / supply-chain-integrity gap. This PR closes it by
routing **every repository mutation decision through the single canonical
choke-point** `PermissionService::check_repository_action(user_id, repo_id,
action, is_admin)`, with a **deny-by-default** posture: `is_public` confers a
**read baseline only** and never satisfies a write or delete, and a rules-less
repository does **not** fall open — a mutation requires an action-granting role
assignment (or an allowing fine-grained rule, or global admin).

This is **PART 1 of 2** for #2603:

- **This PR (Part 1)** — the mutation-authz consolidation across the native
  format middleware, the REST artifact + chunked-upload handlers, and the OCI
  `/v2` write/delete handlers, plus the repository-scoped **token-delegation
  ceiling**.
- **Part 2 (separate PR)** — gate the `/migrations` source/job routes behind
  global admin (the remaining item in #2603). Tracked to follow.

**Release-line note:** because the public/rules-less write gap is a cross-tenant
HIGH, this change is a **candidate for backport to the current release line**.
That backport is a separate, gated decision (release freeze in effect) and is
not part of this PR, which targets `main` (1.7.0).

### What changed (single source of truth)

A new `require_repo_action(auth, repo_id, action, permission_service)` helper
(in `handlers/repositories.rs`) wraps `check_repository_action` and is the one
per-action mutation gate. Each write surface now routes through the same
service-level decision:

- **Native format routes** (`middleware/auth.rs`, `repo_visibility_middleware`):
  reads keep the existing public-anonymous baseline + private membership +
  fine-grained ACL; **writes/deletes now call `check_repository_action`
  unconditionally** (no `has_rules` / `is_public` short-circuit). DB errors fail
  closed (503), as before.
- **REST artifact write/delete** (`handlers/repositories.rs`): the generic
  upload/delete handlers keep the tenant/token gate and then decide the action
  via `require_repo_action` (deny-by-default) instead of the previous
  rules-less-fall-through helper.
- **Chunked uploads** (`handlers/upload.rs`): session create routes through
  `require_repo_action("write")`, and each **chunk append** and **complete**
  re-checks it, so access revoked mid-session stops further writes. Session
  `cancel` remains available to the session owner.
- **OCI `/v2` blob/manifest write + manifest delete** (`handlers/oci_v2.rs`):
  the write/delete gate routes through `check_repository_action` with the
  matching action (`write`/`delete`), removing the public-repo bypass so the
  Docker/OCI push path matches the same deny-by-default contract.
- **Repository-scoped token delegation** (`handlers/repo_tokens.rs`, #2603 G3):
  minting a repo token now enforces a **delegation ceiling** — a token may not
  carry a repository capability the caller does not itself hold. A read-only
  member (or any authenticated user on a public repo) can no longer mint a
  `write:artifacts` token; a write-holding member still can, decided through the
  same `check_repository_action` choke-point. Members retain self-service of
  read-scoped tokens on repositories they can see.

### Behavior change (intended)

Consistent with the repository RBAC model, the legacy **`developer` role grants
`read`+`write` but not `delete`**. Destructive operations now require the
`delete` action (a `delete`-granting rule, the repository-owner role, or global
admin). Positive-path tests that used a `developer` fixture for a *destructive*
op were updated to grant explicit `delete`.

### Legitimate access preserved (regression matrix)

- Global admin: writes/deletes/token-mint everywhere (admin bypass).
- A member holding a `write`-granting role or a fine-grained `write` rule: write
  on public and private repos (unchanged).
- Anonymous read of public repos; private-repo member reads (unchanged).
- A member with `delete`/owner authority: delete (unchanged).
- Repo-token minting within the caller's own effective repository permission,
  including read-scoped self-service.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New/updated coverage:

- `repositories::require_repo_action_deny_by_default_rulesless_db` — deny-by-default
  on rules-less repos: bare authed non-member write/delete on a **public** repo →
  denied; read-only `viewer` write/delete → denied; `developer` write allowed,
  delete denied; admin allowed.
- Existing DB matrices `upload_artifact_fine_grained_write_gate_db` /
  `delete_artifact_fine_grained_delete_gate_db` continue to pin the action gate.
- `upload::create_session_denies_non_admin_without_grant_when_rules_exist`
  reframed to a true non-member (principal-scoped model).
- `repo_tokens::non_writer_cannot_mint_write_scoped_repo_token_but_can_mint_read`
  plus pure `delegated_scope_repo_action` unit tests (G3 delegation ceiling).
- Structural pin `test_generic_artifact_handlers_call_action_gate` (handlers must
  route through the choke-point).
- An integration-level regression tier accompanies this change out-of-tree
  (deny-by-default on a public rules-less repo: RED before, GREEN after).

### Verification (isolated instance)

Built and deployed on an isolated instance; gates green (`cargo fmt`, `cargo
clippy --workspace --all-targets -D warnings`, full `--lib` suite: 14277 passed).
Manual matrix against the running fix (public/private rules-less repos):

| Path | Actor | Result |
|---|---|---|
| REST/native write, PUBLIC rules-less | member (write role) | 201 (legit) |
| GET, PUBLIC repo | anonymous | 200 (read baseline intact) |
| REST/native write, PUBLIC rules-less | authenticated non-member | **403** (was 2xx) |
| REST delete, PRIVATE rules-less | read-only member | **403** (was 2xx) |
| REST delete, PRIVATE rules-less | write-only member | **403** (delete needs `delete`) |
| REST delete, PRIVATE rules-less | admin | 200 (legit) |
| token mint `write:artifacts` | read-only member / non-writer | **403** (was 200) |
| token mint `read:artifacts` | member | 200 (self-service) |
| token mint `write:artifacts` | write-holding member | 200 (legit) |

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — no migration (uses existing tables/roles)
- [ ] N/A - no API changes

Closes #2603
