### PR TITLE
security(images): suppress CVE-2026-56852 in the vendored trivy CLI (unblocks v1.6.4)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -85,6 +85,26 @@ CVE-2026-50162
 GHSA-vh4v-2xq2-g5cg
 
 # ---------------------------------------------------------------------------
+# trivy 0.72.0 binary (scanner-adapter image): golang.org/x/text @ v0.38.0
+# Fixed in x/text 0.39.0. trivy 0.72.0 is the latest upstream release and has
+# not been rebuilt against it, so there is no tool version to bump to. Drops
+# off when Aqua ships a trivy release built on x/text >= 0.39.0.
+#
+# Scope verified on 2026-07-29 (v1.6.4 scan): this CVE is present ONLY in the
+# vendored trivy CLI. The scanner-adapter's own binary cannot carry it, since
+# docker/scanner-adapter/go.mod declares no dependencies at all (stdlib only).
+# The backend and openscap images scan clean at 0 findings and do not bundle
+# trivy (#1544), so nothing in the network-reachable service surface is
+# affected. No reachability argument is claimed for the x/text code path
+# itself; the justification here is vendored-binary scope plus the absence of
+# any fixed tool release.
+#
+# The same scan also reported CVE-2026-46600 (golang.org/x/net @ v0.55.0) at
+# UNKNOWN severity. It is not suppressed: CI alerts on CRITICAL/HIGH only, so
+# it does not gate, and it should be re-checked on the next trivy bump.
+CVE-2026-56852
+
+# ---------------------------------------------------------------------------
 # trivy 0.72.0 binary (scanner-adapter image) — sigstore verification stack
 # github.com/sigstore/sigstore-go @ v1.1.4 (fixed 1.2.0) and
 # github.com/sigstore/timestamp-authority/v2 @ v2.0.6 (fixed 2.1.0); trivy


### PR DESCRIPTION
## Summary

Unblocks the v1.6.4 publish. Closes #2963.

The v1.6.4 Security Scan failed on the scanner-adapter image with **CVE-2026-56852** (HIGH, `golang.org/x/text` v0.38.0, fixed in 0.39.0). This adds a suppression for it, matching the existing per-component entries in `.trivyignore`.

### Why this is a suppression and not a bump

`trivy 0.72.0` is the latest upstream release. There is no newer tool version to move to. Aqua has not rebuilt against `x/text >= 0.39.0` yet, so the entry drops off automatically when they do. Same class as the `oras-go` and `sigstore` entries already in the file.

### Scope, verified rather than assumed

| Image | Scan result | Findings |
|---|---|---|
| Backend | success | 0 |
| OpenSCAP | success | 0 |
| Scanner Adapter | failure | 2 |

The CVE is in the **vendored trivy CLI only**. `docker/scanner-adapter/go.mod` declares no dependencies at all (stdlib only), so the adapter's own binary cannot carry `x/text`. The backend and openscap images scan clean and no longer bundle trivy (#1544), so nothing on the network-reachable service surface is affected.

I did not claim a reachability argument for the `x/text` code path itself, unlike some neighbouring entries. The justification here is vendored-binary scope plus the absence of a fixed tool release, and the comment says so explicitly.

`CVE-2026-46600` (`x/net` v0.55.0) was also reported, at UNKNOWN severity. It is deliberately **not** suppressed: CI alerts on CRITICAL/HIGH only so it does not gate, and it should be re-checked on the next trivy bump.

### Note on the gate

This is a scoped suppression, not a bypass. The Security Scan job stays enforcing. The TEMP `continue-on-error` that shipped v1.6.3 remains reverted.

Known follow-up: these entries are plain-format and therefore image-wide. Migrating to `.trivyignore.yaml` with per-entry `paths:` scoping would confine each suppression to the binary it was written for. That is a larger change and is deliberately not bundled into a release-blocking fix.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A

Scanner suppression metadata. The verification is the Security Scan job itself on the re-cut tag.

## Test Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Evidence gathered from the failed v1.6.4 run (docker-publish 30415557608, Security Scan job 90467587421) and the code-scanning analyses for `refs/tags/v1.6.4`: `trivy-backend results=0`, `trivy-openscap results=0`, `trivy-scanner-adapter results=2`.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Release-branch gate rationale (`release-process: approved`)

Same rationale as #2964. This is release-line scanner metadata for the 1.6.x publish. It should also land on main so the next release does not hit the same wall, but the 1.6.x tag needs it first to unblock v1.6.4.

## Re-tag required

Nothing from v1.6.4 published: ghcr `backend:1.6.4` returns 404, all four Multi-Arch Manifest jobs skipped, and no GitHub Release exists. The scan gate reads `.trivyignore` from the tagged tree, so the `v1.6.4` tag must be deleted and re-cut on top of this commit. No consumer has seen the tag, so the re-cut is clean.