### PR TITLE
fix(auth): accept colon-form write:artifacts scope on artifact upload paths

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -1322,7 +1322,7 @@ async fn upload_package_put(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "alpine", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "alpine", "write:artifacts")?.user_id;
     let repo = resolve_alpine_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
@@ -1356,7 +1356,7 @@ async fn upload_package_post(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "alpine", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "alpine", "write:artifacts")?.user_id;
     let repo = resolve_alpine_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -441,7 +441,7 @@ async fn upload_collection(
     Path(repo_key): Path<String>,
     mut multipart: Multipart,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "ansible", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "ansible", "write:artifacts")?.user_id;
     let repo = resolve_ansible_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/artifact_labels.rs
+++ b/backend/src/api/handlers/artifact_labels.rs
@@ -95,13 +95,14 @@ fn authorize_label_read(auth: Option<AuthExtension>) -> Result<AuthExtension> {
 }
 
 /// Authorize a label mutation: require an authenticated caller that also holds
-/// the `write` scope, mirroring the sibling artifact-mutation handlers.
+/// the `write:artifacts` scope (bare `write` satisfies via the parent rule,
+/// #2989), mirroring the sibling artifact-mutation handlers.
 ///
 /// Repository visibility/scope is enforced separately by
 /// [`check_artifact_visibility`] (which needs DB access) at the call site.
 fn authorize_label_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     let auth = require_auth(auth)?;
-    auth.require_scope("write")?;
+    auth.require_scope("write:artifacts")?;
     Ok(auth)
 }
 

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -724,7 +724,7 @@ async fn publish(
     // GHSA-vvc3-h39c-mrq5: a read-scoped service-account token must not be
     // accepted for `cargo publish`. Enforce the write scope on the token
     // before falling back to the Bearer-as-base64 credential path.
-    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write")?;
+    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write:artifacts")?;
     let user_id =
         require_auth_with_bearer_fallback(auth, &headers, &state.db, &state.config, "cargo")
             .await?;

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -373,7 +373,7 @@ async fn upload_cookbook(
     Path(repo_key): Path<String>,
     mut multipart: Multipart,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "chef", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "chef", "write:artifacts")?.user_id;
     let repo = resolve_chef_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -525,7 +525,7 @@ async fn push_pod(
     Path(repo_key): Path<String>,
     body: Bytes,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "cocoapods", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "cocoapods", "write:artifacts")?.user_id;
     let repo = resolve_cocoapods_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1569,7 +1569,7 @@ async fn upload(
 ) -> Result<Response, Response> {
     // Authenticate
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "composer", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "composer", "write:artifacts")?.user_id;
     let repo = resolve_composer_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1722,7 +1722,7 @@ async fn recipe_file_upload(
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
     let auth_ext = auth.and_then(|Extension(a)| a);
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth_ext, "conan", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth_ext, "conan", "write:artifacts")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
 
@@ -2522,7 +2522,7 @@ async fn package_file_upload(
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
     let auth_ext = auth.and_then(|Extension(a)| a);
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth_ext, "conan", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth_ext, "conan", "write:artifacts")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
 

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2755,7 +2755,7 @@ async fn upload_package_put(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "conda", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "conda", "write:artifacts")?.user_id;
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
@@ -2783,7 +2783,7 @@ async fn upload_post(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "conda", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "conda", "write:artifacts")?.user_id;
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
@@ -2822,7 +2822,7 @@ async fn upload_package_put_with_token(
     // Try middleware auth first (if present), fall back to URL token
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = if auth.is_some() {
-        require_auth_basic_scope(auth, "conda", "write")?.user_id
+        require_auth_basic_scope(auth, "conda", "write:artifacts")?.user_id
     } else {
         authenticate_with_token(&state.db, &state.config, &token).await?
     };
@@ -2853,7 +2853,7 @@ async fn upload_post_with_token(
     // Try middleware auth first (if present), fall back to URL token
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = if auth.is_some() {
-        require_auth_basic_scope(auth, "conda", "write")?.user_id
+        require_auth_basic_scope(auth, "conda", "write:artifacts")?.user_id
     } else {
         authenticate_with_token(&state.db, &state.config, &token).await?
     };
@@ -3285,7 +3285,7 @@ async fn put_attestation(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "conda", "write")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "conda", "write:artifacts")?.user_id;
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     store_attestation(&state, &repo, &repo_key, &subdir, &filename, &body).await
 }
@@ -3315,7 +3315,7 @@ async fn put_attestation_with_token(
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let _user_id = if auth.is_some() {
-        require_auth_basic_scope(auth, "conda", "write")?.user_id
+        require_auth_basic_scope(auth, "conda", "write:artifacts")?.user_id
     } else {
         authenticate_with_token(&state.db, &state.config, &token).await?
     };

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -313,7 +313,7 @@ async fn upload_package(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "cran", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "cran", "write:artifacts")?.user_id;
     let repo = resolve_cran_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -3136,7 +3136,7 @@ async fn pool_upload(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "debian", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "debian", "write:artifacts")?.user_id;
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
@@ -3179,7 +3179,7 @@ async fn upload_raw(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "debian", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "debian", "write:artifacts")?.user_id;
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -470,7 +470,7 @@ async fn upload_object(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "git-lfs", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "git-lfs", "write:artifacts")?.user_id;
     let repo = resolve_lfs_repo(&state.db, &repo_key).await?;
 
     // Reject writes to remote/virtual repos
@@ -778,7 +778,7 @@ async fn create_lock(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "git-lfs", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "git-lfs", "write:artifacts")?.user_id;
     let repo = resolve_lfs_repo(&state.db, &repo_key).await?;
 
     let request: CreateLockRequest = serde_json::from_slice(&body).map_err(|e| {
@@ -950,7 +950,7 @@ async fn verify_locks(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "git-lfs", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "git-lfs", "write:artifacts")?.user_id;
     let repo = resolve_lfs_repo(&state.db, &repo_key).await?;
 
     // Parse request body (optional, may be empty)
@@ -1030,7 +1030,7 @@ async fn delete_lock(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "git-lfs", "delete")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "git-lfs", "delete:artifacts")?.user_id;
     let repo = resolve_lfs_repo(&state.db, &repo_key).await?;
 
     let force = if body.is_empty() {

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -329,7 +329,7 @@ async fn handle_put(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: reject read-scoped API tokens on PUT.
-    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write")?;
+    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write:artifacts")?;
     let user_id =
         require_auth_with_bearer_fallback(auth, &headers, &state.db, &state.config, "goproxy")
             .await?;

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -621,7 +621,7 @@ async fn upload_chart(
 ) -> Result<Response, Response> {
     // Authenticate
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "helm", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "helm", "write:artifacts")?.user_id;
     let repo = resolve_helm_repo(&state.db, &repo_key).await?;
 
     // Reject writes to remote/virtual repos
@@ -905,7 +905,7 @@ async fn delete_chart(
 ) -> Result<Response, Response> {
     // Authenticate
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "helm", "delete")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "helm", "delete:artifacts")?.user_id;
     let repo = resolve_helm_repo(&state.db, &repo_key).await?;
 
     // Find the chart's artifacts. #2635: a signed chart owns TWO rows -- the

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -791,7 +791,7 @@ async fn publish_package(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "hex", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "hex", "write:artifacts")?.user_id;
     let repo = resolve_hex_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -1010,7 +1010,7 @@ async fn upload_file_impl(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "huggingface", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "huggingface", "write:artifacts")?.user_id;
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -844,7 +844,7 @@ async fn upload_image(
     body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "incus", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "incus", "write:artifacts")?.user_id;
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
@@ -976,7 +976,7 @@ async fn delete_image(
     AxumPath((repo_key, product, version, filename)): AxumPath<(String, String, String, String)>,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "incus", "delete")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "incus", "delete:artifacts")?.user_id;
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
@@ -1067,7 +1067,7 @@ async fn start_chunked_upload(
     body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "incus", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "incus", "write:artifacts")?.user_id;
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
     let prefix = mount_prefix_from_uri(&original_uri);
 
@@ -1156,7 +1156,7 @@ async fn upload_chunk(
     body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "incus", "write")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "incus", "write:artifacts")?.user_id;
     // Issue #1317: scope the session lookup to the URL repo so a session
     // created in repo A cannot be driven via repo B's URL.
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
@@ -1209,7 +1209,7 @@ async fn complete_chunked_upload(
     body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "incus", "write")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "incus", "write:artifacts")?.user_id;
     // Issue #1317: scope the session lookup to the URL repo so a session
     // created in repo A cannot be finalized via repo B's URL.
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
@@ -1329,7 +1329,7 @@ async fn cancel_chunked_upload(
     AxumPath((repo_key, session_id)): AxumPath<(String, Uuid)>,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "incus", "delete")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "incus", "delete:artifacts")?.user_id;
     // Issue #1317: scope the session lookup to the URL repo so a session
     // created in repo A cannot be cancelled via repo B's URL.
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -345,7 +345,7 @@ async fn upload_plugin(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "jetbrains", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "jetbrains", "write:artifacts")?.user_id;
     let repo = resolve_jetbrains_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2281,7 +2281,7 @@ async fn upload(
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: read-scoped API tokens were being accepted on
     // this push endpoint. Require the write scope before doing any work.
-    let auth = require_auth_basic_scope(auth, "maven", "write")?;
+    let auth = require_auth_basic_scope(auth, "maven", "write:artifacts")?;
     let user_id = auth.user_id;
     let repo = resolve_maven_repo(&state.db, &repo_key).await?;
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -3297,7 +3297,7 @@ async fn publish_package(
     // GHSA-vvc3-h39c-mrq5: read-scoped API tokens were being accepted on
     // `npm publish`. Enforce the write scope before falling through to the
     // Bearer-fallback helper.
-    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write")?;
+    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write:artifacts")?;
     let user_id =
         require_auth_with_bearer_fallback(auth, headers, &state.db, &state.config, "npm").await?;
     let repo = resolve_npm_repo(&state.db, repo_key).await?;
@@ -3413,7 +3413,7 @@ async fn dist_tags_put(
 ) -> Result<Response, Response> {
     let package = normalize_package_name(&package);
     validate_package_name(&package)?;
-    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write")?;
+    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write:artifacts")?;
     let _user_id =
         require_auth_with_bearer_fallback(auth, &headers, &state.db, &state.config, "npm").await?;
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;
@@ -3488,7 +3488,7 @@ async fn dist_tags_delete(
 ) -> Result<Response, Response> {
     let package = normalize_package_name(&package);
     validate_package_name(&package)?;
-    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write")?;
+    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write:artifacts")?;
     let _user_id =
         require_auth_with_bearer_fallback(auth, &headers, &state.db, &state.config, "npm").await?;
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -1629,7 +1629,7 @@ async fn push_package(
             .unwrap()
     })?;
     // GHSA-vvc3-h39c-mrq5: enforce write scope before doing anything else.
-    crate::api::middleware::auth::require_scope_response(Some(&auth), "write")?;
+    crate::api::middleware::auth::require_scope_response(Some(&auth), "write:artifacts")?;
     let user_id = auth.user_id;
     let repo = resolve_nuget_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -897,7 +897,7 @@ async fn create_modules(
     axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let _user_id = require_auth_basic_scope(auth, "protobuf", "write")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "protobuf", "write:artifacts")?.user_id;
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
@@ -1061,7 +1061,7 @@ async fn upload(
     axum::Json(body): axum::Json<UploadRequest>,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "protobuf", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "protobuf", "write:artifacts")?.user_id;
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
@@ -1522,7 +1522,7 @@ async fn create_or_update_labels(
     axum::Json(body): axum::Json<CreateOrUpdateLabelsRequest>,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "protobuf", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "protobuf", "write:artifacts")?.user_id;
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -580,7 +580,7 @@ async fn new_upload_url(
     Path(repo_key): Path<String>,
     base_url: RequestBaseUrl,
 ) -> Result<Response, Response> {
-    let _user_id = require_auth_basic_scope(auth, "pub", "write")?.user_id;
+    let _user_id = require_auth_basic_scope(auth, "pub", "write:artifacts")?.user_id;
     let _repo = resolve_pub_repo(&state.db, &repo_key).await?;
 
     let upload_url = format!(
@@ -611,7 +611,7 @@ async fn upload_package(
     base_url: RequestBaseUrl,
     mut multipart: Multipart,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "pub", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "pub", "write:artifacts")?.user_id;
     let repo = resolve_pub_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -337,7 +337,7 @@ async fn publish_module(
     Path(repo_key): Path<String>,
     multipart: Multipart,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "puppet", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "puppet", "write:artifacts")?.user_id;
     let repo = resolve_puppet_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3133,7 +3133,7 @@ async fn upload(
 ) -> Result<Response, Response> {
     // Authenticate
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "pypi", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "pypi", "write:artifacts")?.user_id;
     let repo = resolve_pypi_repo(&state.db, &repo_key).await?;
 
     // Reject writes to remote/virtual repos

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -6598,7 +6598,11 @@ pub async fn upload_artifact(
     body: Body,
 ) -> std::result::Result<Response, Response> {
     let auth = require_auth(auth).map_err(|e| e.into_response())?;
-    auth.require_scope("write").map_err(|e| e.into_response())?;
+    // Artifact write: the resource-specific `write:artifacts` (repo-scoped
+    // token vocabulary, #2989); bare `write` still satisfies via the
+    // parent rule in `scopes_grant_access`.
+    auth.require_scope("write:artifacts")
+        .map_err(|e| e.into_response())?;
 
     // Validate the composed artifact path against traversal, null bytes,
     // backslashes, percent-encoded traversal, absolute paths, etc. This
@@ -6926,7 +6930,8 @@ async fn upload_artifact_multipart_with_path(
     multipart: Multipart,
 ) -> std::result::Result<Response, Response> {
     let auth = require_auth(auth).map_err(|e| e.into_response())?;
-    auth.require_scope("write").map_err(|e| e.into_response())?;
+    auth.require_scope("write:artifacts")
+        .map_err(|e| e.into_response())?;
     let (repo_service, repo) = authorize_generic_upload(&state, &auth, &key).await?;
 
     let (staged, digests, filename) = stage_multipart_file(&state, multipart).await?;
@@ -6971,7 +6976,8 @@ async fn upload_artifact_multipart(
     multipart: Multipart,
 ) -> std::result::Result<Response, Response> {
     let auth = require_auth(auth).map_err(|e| e.into_response())?;
-    auth.require_scope("write").map_err(|e| e.into_response())?;
+    auth.require_scope("write:artifacts")
+        .map_err(|e| e.into_response())?;
     let (repo_service, repo) = authorize_generic_upload(&state, &auth, &key).await?;
 
     let (staged, digests, filename, custom_path) =

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1098,7 +1098,7 @@ async fn upload_package_put(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "rpm", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "rpm", "write:artifacts")?.user_id;
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
     reject_rpm_write_if_not_hosted(&repo.repo_type)?;
 
@@ -1123,7 +1123,7 @@ async fn upload_package_post(
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "rpm", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "rpm", "write:artifacts")?.user_id;
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
     reject_rpm_write_if_not_hosted(&repo.repo_type)?;
 

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -285,7 +285,7 @@ async fn push_gem(
 ) -> Result<Response, Response> {
     // Authenticate
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "rubygems", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "rubygems", "write:artifacts")?.user_id;
     let repo = resolve_rubygems_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -211,7 +211,7 @@ async fn upload_artifact(
     Path((repo_key, artifact_path)): Path<(String, String)>,
     body: Bytes,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "ivy", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "ivy", "write:artifacts")?.user_id;
     let repo = resolve_sbt_repo(&state.db, &repo_key).await?;
 
     // Reject writes to remote/virtual repos

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -784,7 +784,7 @@ async fn publish_release_from_wildcard(
 ) -> Result<Response, Response> {
     let version = version_path.trim_start_matches('/').to_string();
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "swift", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "swift", "write:artifacts")?.user_id;
     publish_release(
         state, repo_key, scope, name, version, user_id, headers, body,
     )

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -602,7 +602,7 @@ async fn upload_module(
     body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "terraform", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "terraform", "write:artifacts")?.user_id;
     let repo = resolve_terraform_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
@@ -1066,7 +1066,7 @@ async fn upload_provider(
     body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
-    let user_id = require_auth_basic_scope(auth, "terraform", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "terraform", "write:artifacts")?.user_id;
     let repo = resolve_terraform_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -149,11 +149,12 @@ async fn create_session(
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<Response, Response> {
     // Token action-scope ceiling (GHSA-5f2q). Opening a chunked-upload session is
-    // a write, so it must require the `write` scope BEFORE the repo-RBAC gate
-    // below — matching the direct-write path (`repositories::upload_artifact`).
+    // an artifact write, so it must require `write:artifacts` BEFORE the repo-RBAC
+    // gate below — matching the direct-write path (`repositories::upload_artifact`).
+    // Bare `write` still satisfies via the parent rule (#2989).
     // Defense-in-depth: this is IN ADDITION to `require_repo_write_access`; a
     // read-scoped token whose owner holds repo write must still be rejected here.
-    auth.require_scope("write")
+    auth.require_scope("write:artifacts")
         .map_err(IntoResponse::into_response)?;
 
     let user_id = auth.user_id;
@@ -328,9 +329,9 @@ async fn upload_chunk(
     headers: HeaderMap,
     body: Body,
 ) -> Result<Response, Response> {
-    // Token action-scope ceiling (GHSA-5f2q). Appending a chunk is a write and
-    // must require the `write` scope, matching the direct-write path.
-    auth.require_scope("write")
+    // Token action-scope ceiling (GHSA-5f2q). Appending a chunk is an artifact
+    // write and must require `write:artifacts`, matching the direct-write path.
+    auth.require_scope("write:artifacts")
         .map_err(IntoResponse::into_response)?;
 
     let user_id = auth.user_id;
@@ -497,9 +498,9 @@ async fn complete(
     Path(session_id): Path<Uuid>,
 ) -> Result<Response, Response> {
     // Token action-scope ceiling (GHSA-5f2q). Finalizing a session commits the
-    // artifact (a write) and must require the `write` scope, matching the
-    // direct-write path.
-    auth.require_scope("write")
+    // artifact (an artifact write) and must require `write:artifacts`, matching
+    // the direct-write path.
+    auth.require_scope("write:artifacts")
         .map_err(IntoResponse::into_response)?;
 
     let user_id = auth.user_id;
@@ -1210,7 +1211,7 @@ mod tests {
     // read-scoped token whose OWNER holds repo RBAC write could push artifacts
     // via /uploads/*, sidestepping the token's action ceiling. Each verb must
     // call `require_scope` with the same scope its direct-path twin uses:
-    //   create_session / upload_chunk / complete -> "write"
+    //   create_session / upload_chunk / complete -> "write:artifacts"
     //   cancel                                    -> "delete"
     // The handlers need a real DB to execute, so these are string-grep gates
     // (mirroring `test_create_session_enforces_tenant_gate`), plus a behavioral
@@ -1232,24 +1233,24 @@ mod tests {
     #[test]
     fn create_session_requires_write_scope() {
         assert!(
-            handler_body("create_session").contains("require_scope(\"write\")"),
-            "create_session must enforce the token `write` action-scope (GHSA-5f2q)"
+            handler_body("create_session").contains("require_scope(\"write:artifacts\")"),
+            "create_session must enforce the token `write:artifacts` action-scope (GHSA-5f2q, #2989)"
         );
     }
 
     #[test]
     fn upload_chunk_requires_write_scope() {
         assert!(
-            handler_body("upload_chunk").contains("require_scope(\"write\")"),
-            "upload_chunk must enforce the token `write` action-scope (GHSA-5f2q)"
+            handler_body("upload_chunk").contains("require_scope(\"write:artifacts\")"),
+            "upload_chunk must enforce the token `write:artifacts` action-scope (GHSA-5f2q, #2989)"
         );
     }
 
     #[test]
     fn complete_requires_write_scope() {
         assert!(
-            handler_body("complete").contains("require_scope(\"write\")"),
-            "complete must enforce the token `write` action-scope (GHSA-5f2q)"
+            handler_body("complete").contains("require_scope(\"write:artifacts\")"),
+            "complete must enforce the token `write:artifacts` action-scope (GHSA-5f2q, #2989)"
         );
     }
 
@@ -1284,24 +1285,46 @@ mod tests {
     fn read_scoped_token_denied_upload_write_and_delete() {
         // Read-scoped token (its owner may hold repo write) -> the upload verbs'
         // scope gate denies both write and delete -> 403.
-        let read = auth_with_scopes(vec!["read"]);
-        assert!(
-            read.require_scope("write").is_err(),
-            "read-scoped token must be denied the upload write scope"
-        );
-        assert!(
-            read.require_scope("delete").is_err(),
-            "read-scoped token must be denied the cancel delete scope"
-        );
+        for read in [
+            auth_with_scopes(vec!["read"]),
+            auth_with_scopes(vec!["read:artifacts"]),
+        ] {
+            assert!(
+                read.require_scope("write:artifacts").is_err(),
+                "read-scoped token must be denied the upload write scope"
+            );
+            assert!(
+                read.require_scope("delete").is_err(),
+                "read-scoped token must be denied the cancel delete scope"
+            );
+        }
     }
 
     #[test]
     fn write_scoped_token_allowed_upload_write() {
-        // Properly write-scoped token -> the write verbs remain 2xx (unchanged).
+        // Global bare `write` still covers the artifact-specific requirement
+        // via the parent rule (#2989) -> the write verbs remain 2xx.
         let write = auth_with_scopes(vec!["write"]);
         assert!(
-            write.require_scope("write").is_ok(),
-            "write-scoped token must retain upload access (no behavior change)"
+            write.require_scope("write:artifacts").is_ok(),
+            "bare write-scoped token must retain upload access (no regression)"
+        );
+    }
+
+    #[test]
+    fn artifact_write_scoped_token_allowed_upload_write() {
+        // #2989: a repo-scoped token minted with the colon-form
+        // `write:artifacts` must pass the upload verbs' scope gate...
+        let write = auth_with_scopes(vec!["write:artifacts"]);
+        assert!(
+            write.require_scope("write:artifacts").is_ok(),
+            "write:artifacts token must be able to upload"
+        );
+        // ...without gaining the bare `write` used by non-artifact
+        // (settings-class) handlers.
+        assert!(
+            write.require_scope("write").is_err(),
+            "write:artifacts token must not satisfy the bare write scope"
         );
     }
 

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -265,7 +265,7 @@ async fn publish_extension(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic_scope(auth, "vscode", "write")?.user_id;
+    let user_id = require_auth_basic_scope(auth, "vscode", "write:artifacts")?.user_id;
     let repo = resolve_vscode_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;

--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -208,8 +208,12 @@ pub(crate) fn is_token_revoked(revoked_at: Option<DateTime<Utc>>) -> bool {
 /// either of those directions would let a least-privilege resource token cross
 /// into other resources.
 pub(crate) fn scopes_grant_access(scopes: &[String], required_scope: &str) -> bool {
-    if scopes.iter().any(|s| s == required_scope) || scopes.iter().any(|s| s == "*" || s == "admin")
-    {
+    // `*` / `admin` wildcard policy, in the #1316-canonical form (the
+    // `check-no-legacy-admin-scope.sh` gate forbids `.any(...)` closures that
+    // compare against "admin" and `== "*"` / `== "admin"` on one line).
+    let has_admin_wildcard =
+        scopes.iter().any(|s| s == "*") || scopes.contains(&"admin".to_string());
+    if scopes.iter().any(|s| s == required_scope) || has_admin_wildcard {
         return true;
     }
     // Bare-parent satisfaction: held `write` covers required `write:artifacts`.

--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -192,11 +192,31 @@ pub(crate) fn is_token_revoked(revoked_at: Option<DateTime<Utc>>) -> bool {
 }
 
 /// Check if a set of scopes grants access for a required scope.
-/// Scopes match if the exact scope is present, or `*` or `admin` is present.
+///
+/// A held scope satisfies the requirement iff one of:
+///   * it is the exact required scope (`write:artifacts` -> `write:artifacts`),
+///   * it is `*` or `admin` (wildcard short-circuit),
+///   * the required scope is colon-form (`action:resource`) and the held scope
+///     is its bare action parent — a broad `write` covers the specific
+///     `write:artifacts` (#2989).
+///
+/// The direction is deliberately broad-covers-specific ONLY. A held
+/// colon-form scope never satisfies a bare requirement and never satisfies a
+/// colon-form requirement for a *different* resource: `write:artifacts` does
+/// NOT satisfy bare `write` (which still gates non-artifact writes such as
+/// repository settings) and does NOT satisfy `write:repositories`. Widening
+/// either of those directions would let a least-privilege resource token cross
+/// into other resources.
 pub(crate) fn scopes_grant_access(scopes: &[String], required_scope: &str) -> bool {
-    scopes.contains(&required_scope.to_string())
-        || scopes.contains(&"*".to_string())
-        || scopes.contains(&"admin".to_string())
+    if scopes.iter().any(|s| s == required_scope) || scopes.iter().any(|s| s == "*" || s == "admin")
+    {
+        return true;
+    }
+    // Bare-parent satisfaction: held `write` covers required `write:artifacts`.
+    match required_scope.split_once(':') {
+        Some((parent, _resource)) => !parent.is_empty() && scopes.iter().any(|s| s == parent),
+        None => false,
+    }
 }
 
 /// API Token Service for managing programmatic access tokens.
@@ -972,6 +992,57 @@ mod tests {
     fn test_scopes_grant_access_empty_scopes() {
         let scopes: Vec<String> = vec![];
         assert!(!scopes_grant_access(&scopes, "read:artifacts"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #2989 bare-parent satisfaction matrix. Broad-covers-specific ONLY:
+    // held bare `write` satisfies colon-form `write:*` requirements, but a
+    // held colon-form scope satisfies neither a bare requirement nor a
+    // colon-form requirement for a different resource.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_scopes_grant_access_bare_parent_satisfies_colon_required() {
+        // held global `write` -> satisfies required `write:artifacts`
+        let scopes = vec!["write".to_string()];
+        assert!(scopes_grant_access(&scopes, "write:artifacts"));
+        assert!(scopes_grant_access(&scopes, "write:repositories"));
+        // ...but not a different action family.
+        assert!(!scopes_grant_access(&scopes, "read:artifacts"));
+        assert!(!scopes_grant_access(&scopes, "delete:artifacts"));
+    }
+
+    #[test]
+    fn test_scopes_grant_access_colon_held_does_not_satisfy_bare_required() {
+        // held `write:artifacts` must NOT satisfy bare `write` — bare `write`
+        // still gates non-artifact writes (repo settings, groups, projects).
+        let scopes = vec!["write:artifacts".to_string()];
+        assert!(!scopes_grant_access(&scopes, "write"));
+    }
+
+    #[test]
+    fn test_scopes_grant_access_colon_held_does_not_cross_resources() {
+        // held `write:repositories` must NOT satisfy `write:artifacts` and
+        // vice versa: specific never satisfies a different specific.
+        let repo_write = vec!["write:repositories".to_string()];
+        assert!(!scopes_grant_access(&repo_write, "write:artifacts"));
+        let artifact_write = vec!["write:artifacts".to_string()];
+        assert!(!scopes_grant_access(&artifact_write, "write:repositories"));
+    }
+
+    #[test]
+    fn test_scopes_grant_access_read_never_satisfies_write() {
+        for held in [vec!["read".to_string()], vec!["read:artifacts".to_string()]] {
+            assert!(!scopes_grant_access(&held, "write"));
+            assert!(!scopes_grant_access(&held, "write:artifacts"));
+        }
+    }
+
+    #[test]
+    fn test_scopes_grant_access_bare_read_satisfies_colon_read() {
+        // Symmetric bare-parent rule for the read family.
+        let scopes = vec!["read".to_string()];
+        assert!(scopes_grant_access(&scopes, "read:artifacts"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Repo-scoped tokens minted via `POST /api/v1/repositories/{key}/tokens` carry the colon-form scope vocabulary (`write:artifacts`, `read:artifacts`, ...), but the artifact upload/mutation handlers enforced the bare `write` scope via `require_scope("write")`. The two vocabularies never matched, so a legitimate least-privilege `write:artifacts` repo-scoped token received 403 on every upload path. The mismatch failed closed (no privilege escalation), but it broke the repo-scoped-token flow entirely.

This PR fixes the vocabulary mismatch with one centralized rule plus a handler-side scope rename:

1. **Central matcher** (`token_service::scopes_grant_access`, the single scope-decision choke-point used by `AuthExtension::has_scope`, `require_scope_response`, and the gRPC interceptor): a held scope now satisfies a required scope iff
   - it equals the required scope exactly, or
   - it is `*` / `admin` (unchanged wildcard short-circuit), or
   - the required scope is colon-form (`action:resource`) and the held scope is its **bare action parent** (held `write` satisfies required `write:artifacts`).

   The direction is deliberately **broad-covers-specific only**. A held colon-form scope satisfies neither a bare requirement (`write:artifacts` does NOT satisfy `write`, which still gates settings-class handlers) nor a colon-form requirement for a different resource (`write:artifacts` does NOT satisfy `write:repositories`, and vice versa). Read scopes are untouched beyond the same symmetric parent rule.

2. **Artifact-write handlers** now require the resource-specific `write:artifacts` instead of bare `write` (13 call sites): the three chunked-upload verbs (`create_session` / `upload_chunk` / `complete`), the three generic upload handlers (`upload_artifact`, both multipart variants), artifact label mutation, and the format publish endpoints that used `require_scope_response(_, "write")` (npm publish + dist-tags put/delete, cargo publish, nuget push, goproxy PUT). Non-artifact `require_scope("write")` sites (repository settings, projects, groups, permissions, promotion release-target) are intentionally unchanged, so bare `write` remains their only accepted vocabulary and a `write:artifacts` token still cannot reach them.

Satisfaction table implemented:

| held | required `write:artifacts` | required bare `write` | required `write:repositories` |
|---|---|---|---|
| `write` (bare, global) | allow | allow | allow |
| `write:artifacts` | allow | deny | deny |
| `write:repositories` | deny | deny | allow |
| `read` / `read:artifacts` | deny | deny | deny |

3. **Basic-auth format publish paths** — the primary #2989 use case (CI pushing through a package manager) authenticates via `require_auth_basic_scope`. All 48 basic-auth sites across the 26 format handlers now use the colon-form artifact vocabulary:
   - **44 publish-class sites → `write:artifacts`**: alpine (2), ansible, chef, cocoapods, composer, conan (2), conda (6, incl. attestation puts), cran, debian (2), git-lfs upload/create_lock/verify_locks (3), helm upload, hex, huggingface, incus upload + chunked write verbs (4), jetbrains, maven, protobuf upload/create_modules/labels (3), pub (2), puppet, pypi, rpm (2), rubygems, sbt/ivy, swift, terraform (2), vscode. All are upload/push/publish-protocol operations.
   - **4 destructive sites → `delete:artifacts`** (NOT `write:artifacts`): helm `delete_chart`, incus `delete_image`, incus `cancel_chunked_upload`, git-lfs `delete_lock`. Requiring `write:artifacts` there would let write-scoped tokens perform destructive ops (over-broadening) and would break existing bare-`delete` tokens (`delete` is not the parent of `write:artifacts`). Moving them to `delete:artifacts` is the same vocabulary fix in the delete family: bare `delete` still satisfies via the parent rule, and admin-minted repo-scoped `delete:artifacts` tokens now work. No site was left on a bare scope.
   - Deliberately NOT changed in this PR: the non-basic-auth delete-family sites (`require_scope("delete")` on generic artifact delete, chunked-upload `cancel`, projects/groups/permissions deletes) — same-class follow-up, kept out to avoid growing this diff into a second scope family beyond what the format handlers need; and the OCI/docker plane (`oci_v2::oci_scopes_grant`) which has its own local matcher and test matrix — flagged as a follow-up.

Closes #2989

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Unit tests added (fail on `main`, pass here):
- `token_service`: full bare-parent satisfaction matrix, including the negative directions (`write:artifacts` !=> bare `write`; `write:artifacts` !=> `write:repositories`; read never satisfies write; symmetric `read` => `read:artifacts`).
- `upload` handlers: `write:artifacts` token passes the upload scope gate while still failing bare `write`; `read`/`read:artifacts` denied; bare `write` regression-covered; the source grep-gates for the chunked verbs updated to expect `write:artifacts`.

Verified live on an isolated stack: a repo-scoped `write:artifacts` token uploads to its repo (403 before, 201 after); the same token is still denied a settings write (403), an upload to a different repository, and a `read:artifacts` sibling token is still denied upload (403); a personal bare `write` token still uploads. The basic-auth format paths were verified on three representative handlers with the token as the Basic password (`token:<api_token>`): maven PUT 201 / pypi `file_upload` 200 / ivy PUT 201 with `write:artifacts` on the token's own repo (all 403 pre-fix), while cross-repo publishes and `read:artifacts` publishes stay denied (403) and bare `write` still publishes (maven 201, pypi 200).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — deploy-test tier `token-colon-scope` (red on main, green on this PR) staged for the next artifact-keeper-test batch
- [x] Manually tested locally
- [x] No regressions in existing tests (`cargo nextest run --workspace --lib`, 14k+ tests green; `cargo clippy --workspace --all-targets -- -D warnings` clean)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
