### PR TITLE
fix(scan): thread live CVE-scanner version into proxy verdict freshness check

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2918,20 +2918,41 @@ async fn serve_scanned_pypi_file(
         // below (fail-closed: inline re-scan → 403/423; fail-open: serve
         // pending + async re-scan) instead of serving stale-clean for the full
         // TTL window. `Scanner::version()` is VersionCache-backed, so this is
-        // a memory read on the hot path, never a per-download subprocess. When
-        // either side is unknown, `verdict_is_fresh` falls back to the TTL.
+        // a memory read on the hot path, never a per-download subprocess.
+        //
+        // The repo's action is part of the decision, not just the versions:
+        // this fast path runs BEFORE the inline scan, so on a fail-closed repo
+        // an UNKNOWN live version (probe failed mid-upgrade, binary absent,
+        // probe past its timeout) must NOT let a cached `clean` verdict
+        // short-circuit the gate — see `verdict_is_reusable`.
+        //
+        // No per-digest singleflight here: N concurrent pulls of the same
+        // newly-stale digest each re-scan. They queue behind the #2555
+        // fair-share extraction semaphore so this cannot starve upload scans,
+        // and the window closes as soon as the first re-scan upserts the row.
+        // Coalescing is a possible follow-up, not a correctness requirement.
         let current_version = match state.scanner_service.as_deref() {
             Some(scanner) => scanner.cve_scanner_version().await,
             None => None,
         };
-        let fresh = crate::services::proxy_scan_service::verdict_is_fresh(
+        let reusable = crate::services::proxy_scan_service::verdict_is_reusable(
+            &row.verdict,
             row.scanned_at,
             row.scanner_version.as_deref(),
             current_version.as_deref(),
+            action,
             crate::services::scanner_service::DEDUP_TTL_DAYS as i64,
             Utc::now(),
         );
-        if fresh {
+        if !reusable && current_version.is_none() && action.is_fail_closed() {
+            warn!(
+                repo_id = %repo_id, file = %filename, digest = %digest,
+                stored_version = ?row.scanner_version,
+                "live CVE-scanner version unknown; not reusing the cached verdict \
+                 on a fail-closed repo (re-scanning)"
+            );
+        }
+        if reusable {
             if crate::services::proxy_scan_service::verdict_blocks(&row.verdict) {
                 warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: cached vulnerable verdict");
                 return Err(scan_blocked_response(filename));
@@ -9800,6 +9821,19 @@ mod tests {
         }
     }
 
+    /// The cached-`clean` fast path serves 200 `X-AK-Scan: clean` (#2954) —
+    /// exercised here on a FAIL-OPEN repo with no scanner service, where the
+    /// header is the discriminator: without the cached verdict this pull would
+    /// still be a 200, but marked `pending`.
+    ///
+    /// This test used to assert the same 200 under FAIL-CLOSED. That passed
+    /// only because a state with no scanner service reports an unknown live
+    /// scanner version, which the freshness check treated as "not provably
+    /// stale" and served — i.e. it encoded the #2976 fail-open hole: a node
+    /// with no working CVE engine served cached-clean bytes through a
+    /// fail-closed policy that 423s a fresh pull. The fail-closed side of that
+    /// pair now lives in
+    /// `test_serve_file_proxy_scan_unknown_live_version_rescans_under_fail_closed`.
     #[tokio::test]
     async fn test_serve_file_proxy_scan_serves_cached_clean_digest() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -9815,10 +9849,7 @@ mod tests {
 
         let upstream = wiremock::MockServer::start().await;
         mount_scan_upstream(&upstream, project, filename, wheel).await;
-        // Fail-closed: without the fresh clean verdict this pull would 423
-        // (no scanner service on the state), so a 200 here proves the cached
-        // verdict fast path served it.
-        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_open").await;
 
         ProxyScanService::new(fx.pool.clone())
             .record_verdict(
@@ -9865,7 +9896,7 @@ mod tests {
             Err(r) => {
                 let status = r.status();
                 fx.teardown().await;
-                panic!("fresh clean verdict must serve under fail-closed, got {status}");
+                panic!("fresh clean verdict must serve from the cache, got {status}");
             }
         };
         let status = resp.status();
@@ -9906,8 +9937,11 @@ mod tests {
     }
 
     /// CVE-authoritative mock scanner reporting a fixed live version string.
+    /// `live_version: None` models a FAILED version probe — the engine is
+    /// mid-upgrade / absent / past its probe timeout — which is the
+    /// unknown-`current_version` case the fail-closed gate must not fail open on.
     struct VersionedCveScanner {
-        live_version: &'static str,
+        live_version: Option<&'static str>,
         rescan: MockCveRescan,
     }
 
@@ -9923,7 +9957,7 @@ mod tests {
             true
         }
         async fn version(&self) -> Option<String> {
-            Some(self.live_version.to_string())
+            self.live_version.map(str::to_string)
         }
         async fn scan(
             &self,
@@ -10028,7 +10062,7 @@ mod tests {
             &fx,
             &storage_path,
             VersionedCveScanner {
-                live_version: "grype-0.84.0-test",
+                live_version: Some("grype-0.84.0-test"),
                 rescan: MockCveRescan::Vulnerable,
             },
         );
@@ -10112,7 +10146,7 @@ mod tests {
             &fx,
             &storage_path,
             VersionedCveScanner {
-                live_version: "grype-0.84.0-test",
+                live_version: Some("grype-0.84.0-test"),
                 rescan: MockCveRescan::Vulnerable, // would 403 if re-scanned
             },
         );
@@ -10203,7 +10237,7 @@ mod tests {
             &fx,
             &storage_path,
             VersionedCveScanner {
-                live_version: "grype-0.84.0-test",
+                live_version: Some("grype-0.84.0-test"),
                 rescan: MockCveRescan::Error,
             },
         );
@@ -10236,5 +10270,188 @@ mod tests {
             ),
             Err(resp) => assert_eq!(resp.status(), StatusCode::LOCKED),
         }
+    }
+
+    /// THE fail-open hole in the first cut of #2976: when the live version
+    /// probe returns None (engine mid-upgrade / absent / probe timed out),
+    /// `verdict_is_fresh`'s unknown-version arm returns true, so a cached
+    /// `clean` verdict short-circuited the serve path — on a FAIL-CLOSED repo,
+    /// serving bytes nothing on the node could vouch for, while a fresh pull
+    /// on the same node would 423. The freshness fast path runs before the
+    /// inline scan, so it must not fail open here: an unprovable clean verdict
+    /// is stale, the pull re-scans, and the re-scan (vulnerable) blocks 403.
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_unknown_live_version_rescans_under_fail_closed() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "probenone";
+        let filename = "probenone-1.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 probenone-wheel-2976-failclosed";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"PK\x03\x04 probenone-wheel-2976-failclosed",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.83.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed clean verdict");
+
+        // Live engine present but its version probe FAILS (None).
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = scan_state_with_live_scanner(
+            &fx,
+            &storage_path,
+            VersionedCveScanner {
+                live_version: None,
+                rescan: MockCveRescan::Vulnerable,
+            },
+        );
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "an UNKNOWN live scanner version must not let a cached clean \
+                 verdict short-circuit the fail-closed gate; got {} (expected a \
+                 re-scan -> 403)",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "re-scan found the CVE -> 403 (a 200 here is the fail-open hole)"
+            ),
+        }
+    }
+
+    /// Availability control for the tightening above: `fail_open` keeps the
+    /// TTL-only fallback on an unknown live version. A cached clean verdict
+    /// still serves 200 there — the fail-open re-scan branch would serve
+    /// anyway (X-AK-Scan: pending), so nothing is gained by re-scanning and
+    /// the opt-in latency-first posture is preserved.
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_unknown_live_version_serves_under_fail_open() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "probenoneopen";
+        let filename = "probenoneopen-1.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 probenoneopen-wheel-2976-failopen";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"PK\x03\x04 probenoneopen-wheel-2976-failopen",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_open").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.83.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed clean verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = scan_state_with_live_scanner(
+            &fx,
+            &storage_path,
+            VersionedCveScanner {
+                live_version: None,
+                rescan: MockCveRescan::Vulnerable,
+            },
+        );
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("fail-open must stay available on an unknown probe, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan_header = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan_header.as_deref(),
+            Some("clean"),
+            "fail-open keeps the cached-verdict fast path on an unknown probe"
+        );
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2911,12 +2911,23 @@ async fn serve_scanned_pypi_file(
     // (and, since the fetch above was a cache hit on a repeat pull, without any
     // upstream fetch). A fresh clean verdict serves from the buffer.
     let pss = crate::services::proxy_scan_service::ProxyScanService::new(state.db.clone());
-    let current_version = None; // provenance compared only when both sides known
     if let Ok(Some(row)) = pss.lookup_verdict(&digest, PROXY_SCAN_TYPE).await {
+        // #2976: compare the verdict's stored provenance against the LIVE
+        // CVE-scanner version so a verdict recorded against an older scanner /
+        // CVE-DB is treated stale and falls through to the re-scan branches
+        // below (fail-closed: inline re-scan → 403/423; fail-open: serve
+        // pending + async re-scan) instead of serving stale-clean for the full
+        // TTL window. `Scanner::version()` is VersionCache-backed, so this is
+        // a memory read on the hot path, never a per-download subprocess. When
+        // either side is unknown, `verdict_is_fresh` falls back to the TTL.
+        let current_version = match state.scanner_service.as_deref() {
+            Some(scanner) => scanner.cve_scanner_version().await,
+            None => None,
+        };
         let fresh = crate::services::proxy_scan_service::verdict_is_fresh(
             row.scanned_at,
             row.scanner_version.as_deref(),
-            current_version,
+            current_version.as_deref(),
             crate::services::scanner_service::DEDUP_TTL_DAYS as i64,
             Utc::now(),
         );
@@ -9874,5 +9885,356 @@ mod tests {
             "a verdict-backed serve must be marked clean, not pending"
         );
         assert_eq!(&body[..], wheel);
+    }
+
+    // -----------------------------------------------------------------------
+    // #2976: cached-verdict freshness vs the LIVE CVE-scanner version.
+    //
+    // These drive `serve_file` end-to-end with a scanner service on the state
+    // whose CVE-authoritative mock reports an injected "live" version — the
+    // `current_version` side of `verdict_is_fresh`. A cached verdict recorded
+    // by an OLDER version must be treated stale and re-scanned; the SAME
+    // version must keep using the cache (no needless re-scan).
+    // -----------------------------------------------------------------------
+
+    /// Outcome of the mock CVE engine when the serve path re-scans.
+    enum MockCveRescan {
+        /// Re-scan against the bumped CVE-DB now flags the bytes.
+        Vulnerable,
+        /// Re-scan is inconclusive (scanner hard-error).
+        Error,
+    }
+
+    /// CVE-authoritative mock scanner reporting a fixed live version string.
+    struct VersionedCveScanner {
+        live_version: &'static str,
+        rescan: MockCveRescan,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::scanner_service::Scanner for VersionedCveScanner {
+        fn name(&self) -> &str {
+            "versioned-cve-test-scanner"
+        }
+        fn scan_type(&self) -> &str {
+            "grype"
+        }
+        fn is_cve_authoritative(&self) -> bool {
+            true
+        }
+        async fn version(&self) -> Option<String> {
+            Some(self.live_version.to_string())
+        }
+        async fn scan(
+            &self,
+            _: &crate::models::artifact::Artifact,
+            _: Option<&crate::models::artifact::ArtifactMetadata>,
+            _: &Bytes,
+        ) -> crate::error::Result<crate::services::scanner_service::ScanOutput> {
+            match self.rescan {
+                MockCveRescan::Error => Err(AppError::Internal(
+                    "simulated grype failure on re-scan".to_string(),
+                )),
+                MockCveRescan::Vulnerable => {
+                    Ok(crate::services::scanner_service::ScanOutput::findings_only(
+                        vec![crate::models::security::RawFinding {
+                            severity: crate::models::security::Severity::Critical,
+                            title: "CVE-2026-0001 test".to_string(),
+                            description: None,
+                            cve_id: Some("CVE-2026-0001".to_string()),
+                            affected_component: Some("pyyaml".to_string()),
+                            affected_version: Some("5.3.1".to_string()),
+                            fixed_version: None,
+                            source: Some("grype".to_string()),
+                            source_url: None,
+                        }],
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Build a state whose scanner service holds exactly the given mock CVE
+    /// engine, wired over the fixture's storage + a real proxy service.
+    fn scan_state_with_live_scanner(
+        fx: &crate::api::handlers::test_db_helpers::Fixture,
+        storage_path: &str,
+        scanner: VersionedCveScanner,
+    ) -> crate::api::SharedState {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use std::sync::Arc;
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path);
+        let svc = crate::services::scanner_service::ScannerService::new_for_test_with_scanners(
+            fx.pool.clone(),
+            vec![Arc::new(scanner)],
+            fx.state.storage.clone(),
+            fx.state.storage_registry.clone(),
+            storage_path.to_string(),
+            fx.storage_dir
+                .join("scan-workspace")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        tdh::build_state_with_proxy_and_scanner(fx.pool.clone(), storage_path, proxy, Arc::new(svc))
+    }
+
+    /// #2976 discriminator: a cached `clean` verdict recorded by an OLDER
+    /// scanner/CVE-DB version must NOT be reused once the live CVE engine
+    /// reports a newer version. The serve path re-scans, and the re-scan
+    /// (which now knows the new CVE) blocks with 403. Before the fix the call
+    /// site passed `current_version=None`, so `verdict_is_fresh` never saw
+    /// the bump and this pull served 200 stale-clean from cache for the full
+    /// 30-day TTL.
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_rescans_when_scanner_version_advances() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "staleclean";
+        let filename = "staleclean-1.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 staleclean-wheel-2976-bumped";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"PK\x03\x04 staleclean-wheel-2976-bumped",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        // Cached CLEAN verdict recorded at stored version V...
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.83.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed stale clean verdict");
+
+        // ...while the LIVE engine is at V+1 and now flags the bytes.
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = scan_state_with_live_scanner(
+            &fx,
+            &storage_path,
+            VersionedCveScanner {
+                live_version: "grype-0.84.0-test",
+                rescan: MockCveRescan::Vulnerable,
+            },
+        );
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "clean verdict from an older scanner version must be re-scanned \
+                 (and blocked), not served from cache; got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "re-scan against the bumped CVE-DB found the CVE -> 403"
+            ),
+        }
+    }
+
+    /// Same-version control: when the live CVE engine still reports the SAME
+    /// version that produced the cached `clean` verdict, the cache is reused —
+    /// the mock would 403 if a re-scan ran, so a 200 `X-AK-Scan: clean` proves
+    /// there was no needless re-scan (no perf regression from #2976).
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_reuses_cached_verdict_same_version() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "sameversion";
+        let filename = "sameversion-1.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 sameversion-wheel-2976-cached";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"PK\x03\x04 sameversion-wheel-2976-cached",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.84.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed clean verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = scan_state_with_live_scanner(
+            &fx,
+            &storage_path,
+            VersionedCveScanner {
+                live_version: "grype-0.84.0-test",
+                rescan: MockCveRescan::Vulnerable, // would 403 if re-scanned
+            },
+        );
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("same-version clean verdict must serve from cache, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan_header = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan_header.as_deref(),
+            Some("clean"),
+            "cache hit must serve clean (a re-scan would have blocked)"
+        );
+    }
+
+    /// Fail-closed alignment after a version bump: when the invalidating
+    /// re-scan is INCONCLUSIVE (scanner error), the pull must 423, never a
+    /// 200 of the stale-clean cache (#2976 + #2954 fail-closed contract).
+    #[tokio::test]
+    async fn test_serve_file_proxy_scan_version_bump_inconclusive_locks() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let project = "bumplocked";
+        let filename = "bumplocked-1.0.0-py3-none-any.whl";
+        let wheel: &[u8] = b"PK\x03\x04 bumplocked-wheel-2976-locked";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"PK\x03\x04 bumplocked-wheel-2976-locked",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, wheel).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.83.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed stale clean verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = scan_state_with_live_scanner(
+            &fx,
+            &storage_path,
+            VersionedCveScanner {
+                live_version: "grype-0.84.0-test",
+                rescan: MockCveRescan::Error,
+            },
+        );
+        let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
+        repo_info.format = "pypi".to_string();
+
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
+
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(&digest)
+            .execute(&fx.pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "inconclusive re-scan after a version bump must 423 under \
+                 fail-closed, not serve stale-clean; got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(resp.status(), StatusCode::LOCKED),
+        }
     }
 }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1231,6 +1231,23 @@ pub fn build_state_with_proxy(
     Arc::new(state)
 }
 
+/// Like [`build_state_with_proxy`] but also wires a
+/// [`crate::services::scanner_service::ScannerService`] onto the state, so
+/// handler tests can exercise the inline proxy scan + verdict-freshness wiring
+/// end-to-end (#2954/#2976): the serve path only re-scans (and only consults
+/// the live CVE-scanner version) when a scanner service is present.
+pub fn build_state_with_proxy_and_scanner(
+    pool: PgPool,
+    storage_path: &str,
+    proxy: Arc<crate::services::proxy_service::ProxyService>,
+    scanner: Arc<crate::services::scanner_service::ScannerService>,
+) -> crate::api::SharedState {
+    let mut state = app_state_with(cfg(storage_path), pool, storage_path);
+    state.set_proxy_service(proxy);
+    state.set_scanner_service(scanner);
+    Arc::new(state)
+}
+
 /// Like [`build_state_with_proxy`] but also wires an [`AgeGateService`] onto the
 /// state so handler tests can exercise the download age gate end-to-end
 /// (`serve_file` / `serve_tarball` only enforce the gate when the service is

--- a/backend/src/services/proxy_scan_service.rs
+++ b/backend/src/services/proxy_scan_service.rs
@@ -102,6 +102,59 @@ impl ProxyScanAction {
     }
 }
 
+/// Whether a cached verdict may SHORT-CIRCUIT the serve path for this repo's
+/// scan action — the policy-aware gate the serve path actually asks.
+///
+/// [`verdict_is_fresh`] answers the narrower, policy-free question "can we
+/// prove this verdict is stale?", and deliberately fails OPEN when a version
+/// string is unknown on either side (probe failed / legacy row): it cannot
+/// prove a mismatch, so it relies on the TTL. That default is right for
+/// fail-open, but on a `fail_closed` repo it is a hole: the freshness check
+/// runs BEFORE the inline scan, so an unprovable `clean` verdict short-circuits
+/// the whole fail-closed gate (including the #2954 "the CVE engine actually
+/// ran" condition) and serves cached-clean bytes that nothing on this node can
+/// currently vouch for.
+///
+/// That unknown-version window is common exactly when it matters most: a Grype
+/// UPGRADE — the CVE-DB advance #2976 is about — transiently fails
+/// `grype --version` (a >=60s [`VERSION_CACHE_MISS_TTL`] window), a missing
+/// binary makes it permanent, and a loaded host can push the probe past its
+/// 5s timeout. A node that 423s a FRESH pull (provably fail-closed) must not
+/// serve a stale `clean` digest through the same policy.
+///
+/// So under `fail_closed` a CLEAN verdict is reusable only when its provenance
+/// is PROVEN current — both version strings known and equal. Otherwise the
+/// verdict is treated as stale and the caller falls through to the re-scan
+/// branch, whose inconclusive outcome correctly fail-closes (423). This
+/// self-heals: the re-scan records the live version, so the next pull of that
+/// digest hits the cache normally.
+///
+/// Everything else is unchanged: `fail_open` keeps the TTL-only fallback (its
+/// re-scan branch serves-with-pending anyway, so availability is unaffected),
+/// and non-`clean` verdicts keep their existing handling — a cached
+/// `vulnerable` verdict still blocks via [`verdict_blocks`].
+///
+/// [`VERSION_CACHE_MISS_TTL`]: crate::services::scanner_service
+pub fn verdict_is_reusable(
+    verdict: &str,
+    scanned_at: DateTime<Utc>,
+    stored_version: Option<&str>,
+    current_version: Option<&str>,
+    action: ProxyScanAction,
+    ttl_days: i64,
+    now: DateTime<Utc>,
+) -> bool {
+    if !verdict_is_fresh(scanned_at, stored_version, current_version, ttl_days, now) {
+        return false;
+    }
+    if action.is_fail_closed() && verdict == VERDICT_CLEAN {
+        // Fail-closed: "not provably stale" is not good enough for a clean
+        // verdict; require provably-current provenance.
+        return matches!((stored_version, current_version), (Some(_), Some(_)));
+    }
+    true
+}
+
 /// Outcome when the inline scan could NOT produce a conclusive clean/vulnerable
 /// verdict before serve time: the object was over the byte cap, the inline scan
 /// budget was exceeded, or the scanner errored.
@@ -292,6 +345,102 @@ mod tests {
             30,
             now
         ));
+    }
+
+    /// #2976 follow-up: `verdict_is_fresh` fails OPEN on an unknown version
+    /// (it cannot prove a mismatch). `verdict_is_reusable` must NOT let that
+    /// default short-circuit a fail-closed repo for a CLEAN verdict — the
+    /// freshness check runs before the inline scan, so an unprovable clean
+    /// verdict would otherwise serve bytes nothing on this node can vouch for.
+    #[test]
+    fn unknown_version_is_not_reusable_for_clean_under_fail_closed() {
+        let now = Utc::now();
+        let scanned = now - Duration::days(1); // well within TTL
+        let cases = [
+            (None, Some("grype-0.84.0")), // live probe known, legacy row
+            (Some("grype-0.84.0"), None), // stored known, probe failed
+            (None, None),                 // neither known
+        ];
+        for (stored, current) in cases {
+            assert!(
+                verdict_is_fresh(scanned, stored, current, 30, now),
+                "precondition: the policy-free check still fails open"
+            );
+            assert!(
+                !verdict_is_reusable(
+                    VERDICT_CLEAN,
+                    scanned,
+                    stored,
+                    current,
+                    ProxyScanAction::FailClosed,
+                    30,
+                    now
+                ),
+                "fail-closed + clean + unprovable provenance ({stored:?}/{current:?}) \
+                 must re-scan, never serve from cache"
+            );
+            // Fail-open is unchanged: its re-scan branch serves-with-pending
+            // anyway, so the TTL-only fallback costs no availability.
+            assert!(verdict_is_reusable(
+                VERDICT_CLEAN,
+                scanned,
+                stored,
+                current,
+                ProxyScanAction::FailOpen,
+                30,
+                now
+            ));
+            // Non-clean verdicts keep their existing handling under both
+            // actions: a cached `vulnerable` row must still short-circuit to
+            // the block path rather than being re-fetched/re-scanned.
+            assert!(verdict_is_reusable(
+                VERDICT_VULNERABLE,
+                scanned,
+                stored,
+                current,
+                ProxyScanAction::FailClosed,
+                30,
+                now
+            ));
+        }
+    }
+
+    /// The working paths are untouched: a PROVEN version match is reusable
+    /// under both actions, a proven mismatch is not, and an expired TTL is
+    /// never reusable regardless of provenance.
+    #[test]
+    fn reusable_matches_fresh_when_both_versions_known() {
+        let now = Utc::now();
+        let scanned = now - Duration::days(1);
+        for action in [ProxyScanAction::FailClosed, ProxyScanAction::FailOpen] {
+            assert!(verdict_is_reusable(
+                VERDICT_CLEAN,
+                scanned,
+                Some("grype-0.83.0"),
+                Some("grype-0.83.0"),
+                action,
+                30,
+                now
+            ));
+            assert!(!verdict_is_reusable(
+                VERDICT_CLEAN,
+                scanned,
+                Some("grype-0.83.0"),
+                Some("grype-0.84.0"),
+                action,
+                30,
+                now
+            ));
+            assert!(!verdict_is_reusable(
+                VERDICT_CLEAN,
+                now - Duration::days(31),
+                Some("grype-0.83.0"),
+                Some("grype-0.83.0"),
+                action,
+                30,
+                now
+            ));
+        }
     }
 
     #[test]

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -2141,6 +2141,28 @@ async fn run_inline_proxy_scanners(
     Ok(aggregate_proxy_verdict(&findings, scanner_version))
 }
 
+/// Live version string of the CVE-authoritative scanner (Grype), e.g.
+/// `grype-0.83.0` — the SAME provenance string [`run_inline_proxy_scanners`]
+/// persists on a `proxy_scan_results` verdict. Serve paths pass it as
+/// `current_version` to
+/// [`crate::services::proxy_scan_service::verdict_is_fresh`] so a cached
+/// verdict recorded against an older scanner / CVE-DB is invalidated and
+/// re-scanned instead of being reused for the full TTL window (#2976).
+///
+/// Cheap by construction: [`Scanner::version`] implementations are
+/// [`VersionCache`]-backed ([`VERSION_CACHE_HIT_TTL`] on hit), so this never
+/// shells out per download. Returns `None` when no CVE-authoritative scanner
+/// is registered or its version probe failed — `verdict_is_fresh` then falls
+/// back to the TTL alone, exactly as before.
+async fn cve_authoritative_scanner_version(scanners: &[Arc<dyn Scanner>]) -> Option<String> {
+    for scanner in scanners {
+        if scanner.is_cve_authoritative() {
+            return scanner.version().await;
+        }
+    }
+    None
+}
+
 /// A pluggable vulnerability scanner.
 #[async_trait]
 pub trait Scanner: Send + Sync {
@@ -3710,6 +3732,42 @@ impl ScannerService {
         let _extraction_permit = acquire_scan_extraction_permit(synthetic.repository_id).await;
 
         run_inline_proxy_scanners(&self.scanners, synthetic, content).await
+    }
+
+    /// Live version of the CVE-authoritative scanner for verdict-freshness
+    /// checks (#2976): see [`cve_authoritative_scanner_version`]. The PyPI
+    /// proxy serve path threads this into `verdict_is_fresh` as
+    /// `current_version` so a cached verdict from an older scanner / CVE-DB
+    /// forces a re-scan instead of serving stale-clean until the TTL expires.
+    pub async fn cve_scanner_version(&self) -> Option<String> {
+        cve_authoritative_scanner_version(&self.scanners).await
+    }
+
+    /// Test-only constructor with injected leaf scanners, for handler tests
+    /// that need a `ScannerService` on the shared state (e.g. the #2976
+    /// verdict-freshness wiring in the PyPI proxy serve path). Mirrors the
+    /// `scanner_for_fixture` struct literal in this module's tests, which
+    /// sibling modules cannot reach.
+    #[cfg(test)]
+    pub(crate) fn new_for_test_with_scanners(
+        db: PgPool,
+        scanners: Vec<Arc<dyn Scanner>>,
+        storage: Arc<dyn StorageBackend>,
+        storage_registry: Arc<crate::storage::StorageRegistry>,
+        storage_base_path: String,
+        scan_workspace_path: String,
+    ) -> Self {
+        ScannerService {
+            db: db.clone(),
+            scanners,
+            scan_result_service: Arc::new(ScanResultService::new(db.clone())),
+            scan_config_service: Arc::new(ScanConfigService::new(db)),
+            storage,
+            storage_registry,
+            storage_base_path,
+            scan_workspace_path,
+            dependency_track: None,
+        }
     }
 
     /// Scan a single artifact: run all applicable scanners, persist results,
@@ -13588,6 +13646,67 @@ mod tests {
             outcome: CveOutcome::Clean,
         }
         .is_cve_authoritative());
+    }
+
+    /// #2976: `cve_authoritative_scanner_version` returns the CVE engine's
+    /// (cached) version string — skipping non-authoritative scanners
+    /// regardless of registration order — and `None` when no CVE engine is
+    /// registered or its probe failed, so `verdict_is_fresh` falls back to
+    /// the TTL alone rather than inventing a comparison.
+    #[tokio::test]
+    async fn test_cve_authoritative_scanner_version_picks_cve_engine_only() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        struct VersionedCveScanner;
+        #[async_trait::async_trait]
+        impl Scanner for VersionedCveScanner {
+            fn name(&self) -> &str {
+                "versioned-cve-test-scanner"
+            }
+            fn scan_type(&self) -> &str {
+                "grype"
+            }
+            fn is_cve_authoritative(&self) -> bool {
+                true
+            }
+            async fn scan(
+                &self,
+                _: &Artifact,
+                _: Option<&ArtifactMetadata>,
+                _: &Bytes,
+            ) -> Result<ScanOutput> {
+                Ok(ScanOutput::default())
+            }
+            async fn version(&self) -> Option<String> {
+                Some("grype-0.84.0-test".to_string())
+            }
+        }
+
+        // A non-authoritative scanner registered FIRST must not shadow the
+        // CVE engine's version (DependencyScanner precedes Grype in prod).
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(VersionedCveScanner),
+        ];
+        assert_eq!(
+            cve_authoritative_scanner_version(&scanners)
+                .await
+                .as_deref(),
+            Some("grype-0.84.0-test")
+        );
+
+        // No CVE engine at all: None (freshness falls back to TTL).
+        let none: Vec<Arc<dyn Scanner>> = vec![Arc::new(TrivialDependencyScanner)];
+        assert!(cve_authoritative_scanner_version(&none).await.is_none());
+        assert!(cve_authoritative_scanner_version(&[]).await.is_none());
+
+        // CVE engine whose version probe failed (trait default None): the
+        // accessor surfaces None rather than inventing a version.
+        let unprobed: Vec<Arc<dyn Scanner>> = vec![Arc::new(CveAuthoritativeScanner {
+            outcome: CveOutcome::Clean,
+        })];
+        assert!(cve_authoritative_scanner_version(&unprobed).await.is_none());
     }
 
     /// `ScannerService::scan_content` (#2954): the fair-share-permitted wrapper


### PR DESCRIPTION
## Summary

Closes #2976.

At serve time the PyPI proxy verdict fast path called `verdict_is_fresh` with
`current_version=None`, so the scanner-version comparison the function was
built for never ran: a cached `clean` verdict for a content digest was reused
on TTL alone (`DEDUP_TTL_DAYS` = 30d), even after the CVE-DB advanced to newly
know a CVE in those bytes. The proxy kept serving `200 X-AK-Scan: clean` from
the stale cache until TTL expiry or a digest change.

This PR threads the live CVE-engine version into the freshness check:

- `ScannerService::cve_scanner_version()` (new): returns the version string of
  the CVE-authoritative scanner (Grype), i.e. the SAME `grype-X.Y.Z`
  provenance string `run_inline_proxy_scanners` persists on
  `proxy_scan_results.scanner_version`. It reads `Scanner::version()`, which
  is `VersionCache`-backed (1h hit TTL), so the hot path never shells out per
  download.
- The serve-time call site in `serve_scanned_pypi_file` now passes that value
  as `current_version` instead of `None`. The version comparison itself is
  unchanged and still lives in `verdict_is_fresh`: a stored/live mismatch
  (both known) marks the verdict stale.
- A stale verdict falls through to the existing re-scan branches, preserving
  fail-closed alignment: an invalidating re-scan that finds CVEs is a 403, an
  inconclusive re-scan is a 423 — never a 200 of stale-clean bytes.
- `verdict_is_reusable` (new, pure): the policy-aware gate the serve path now
  asks. `verdict_is_fresh` deliberately fails OPEN on an unknown version
  (probe failed / legacy row) — it cannot prove a mismatch, so it relies on
  the TTL. That default is right for fail-open but is a hole under
  `fail_closed`, because the freshness fast path runs BEFORE the inline scan:
  an unprovable `clean` verdict short-circuited the entire fail-closed gate
  (including the #2954 "the CVE engine actually ran" condition) and served
  cached bytes nothing on the node could vouch for — while a fresh pull on the
  same node returned 423. That window is common exactly when it matters: a
  Grype upgrade (the CVE-DB advance this issue is about) transiently fails
  `grype --version` for at least the 60s miss-TTL, a missing binary makes it
  permanent, and a loaded host can push the probe past its 5s timeout. So
  under `fail_closed` a CLEAN verdict is reusable only when its provenance is
  PROVEN current (both versions known and equal); otherwise the pull
  re-scans, and the inconclusive outcome correctly locks. It self-heals: the
  re-scan records the live version, so the next pull hits the cache.

`fail_open` is deliberately untouched (its re-scan branch serves-with-pending
anyway, so availability is unaffected), and non-`clean` verdicts keep their
existing handling — a cached `vulnerable` verdict still blocks.

No schema change, no new sqlx macros.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`test_serve_file_proxy_scan_rescans_when_scanner_version_advances` drives
`serve_file` end-to-end with a seeded `clean` verdict at stored version V and
a mock CVE-authoritative scanner reporting V+1: on `main` the pull serves 200
stale-clean from cache; with this PR the verdict is invalidated, the inline
re-scan runs, and the pull is blocked 403.

## Test Checklist
- [x] Unit tests added/updated
  - `test_cve_authoritative_scanner_version_picks_cve_engine_only` — the
    accessor returns the CVE engine's version (skipping non-authoritative
    scanners regardless of registration order) and `None` when no engine is
    registered / the probe failed.
  - `unknown_version_is_not_reusable_for_clean_under_fail_closed` — the full
    matrix: unknown on either side (or both) is still "fresh" per
    `verdict_is_fresh` but NOT reusable for a `clean` verdict under
    `fail_closed`; fail-open and cached-`vulnerable` handling are unchanged.
  - `reusable_matches_fresh_when_both_versions_known` — a proven match is
    reusable under both actions, a proven mismatch and an expired TTL are not.
- [x] Integration tests added/updated (if applicable)
  - `test_serve_file_proxy_scan_rescans_when_scanner_version_advances` —
    stored V, live V+1, re-scan vulnerable → 403 (was 200 stale-clean).
  - `test_serve_file_proxy_scan_unknown_live_version_rescans_under_fail_closed`
    — stored V, live probe returns None, `fail_closed`: must not serve
    cached-clean; re-scan → 403.
  - `test_serve_file_proxy_scan_unknown_live_version_serves_under_fail_open` —
    the availability control for the above: `fail_open` still serves 200 from
    the cache on an unknown probe.
  - `test_serve_file_proxy_scan_reuses_cached_verdict_same_version` — stored
    version equals live → served from cache (the mock would 403 on a re-scan,
    so the 200 proves no needless re-scan / no perf regression).
  - `test_serve_file_proxy_scan_version_bump_inconclusive_locks` — stored V,
    live V+1, inconclusive re-scan → 423 under fail-closed (never
    stale-clean).
  - `test_serve_file_proxy_scan_serves_cached_clean_digest` (existing, #2954)
    now exercises the cached-clean fast path on a `fail_open` repo. It
    previously asserted the same 200 under `fail_closed`, which passed only
    because a state with no scanner service reports an unknown version — i.e.
    it encoded the fail-open hole described above.
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
  - Isolated instance, fail-closed remote PyPI repo over pypi.org: seeded a
    `clean` verdict for the Jinja2-2.10 wheel digest at an old version while
    the bundled engine is `grype-0.116.0` → pull returned `403 scan_blocked`
    and the row was upserted to `vulnerable | grype-0.116.0` (re-scan
    occurred). A second CVE wheel seeded `clean` AT `grype-0.116.0` served
    `200 X-AK-Scan: clean` with the row untouched (matching provenance is
    honoured).
  - Unknown-probe repro on the same instance: grype binary stubbed and the
    backend restarted (dropping the in-process version cache), so the probe
    returns None. A FRESH digest returns 423 (the node is provably
    fail-closed) and the cached-clean digest now also returns 423 with a
    `live CVE-scanner version unknown; not reusing the cached verdict` warn —
    it returned `200 X-AK-Scan: clean` before this change. The same digest on
    a `fail_open` repo on that same node still serves 200.
- [x] No regressions in existing tests (`cargo nextest run --workspace --lib`
  with a migrated Postgres: 14341 passed / 0 failed; fmt + clippy
  `-D warnings` clean; jscpd 0.98%, no clones in the changed files)

## API Changes
- [x] N/A - no API changes