### PR TITLE
security(images): suppress CVE-2026-46600 in the vendored trivy CLI (unblocks v1.6.4)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -98,11 +98,21 @@ GHSA-vh4v-2xq2-g5cg
 # affected. No reachability argument is claimed for the x/text code path
 # itself; the justification here is vendored-binary scope plus the absence of
 # any fixed tool release.
-#
-# The same scan also reported CVE-2026-46600 (golang.org/x/net @ v0.55.0) at
-# UNKNOWN severity. It is not suppressed: CI alerts on CRITICAL/HIGH only, so
-# it does not gate, and it should be re-checked on the next trivy bump.
 CVE-2026-56852
+
+# ---------------------------------------------------------------------------
+# trivy 0.72.0 binary (scanner-adapter image): golang.org/x/net @ v0.55.0
+# Same vendored-binary scope as the x/text entry above: present only in the
+# bundled trivy CLI, not in the adapter's own binary (no dependencies) and not
+# in the backend or openscap images (0 findings, no bundled trivy, #1544).
+#
+# Note on severity, learned the hard way on the v1.6.4 cut: this CVE exports
+# to SARIF as UNKNOWN/note, so it looks non-gating in the code-scanning UI.
+# It DOES gate. Trivy filters on the vendor severity, not the NVD one, and
+# logs "Using severities from other vendors for some vulnerabilities"; under
+# `severity: CRITICAL,HIGH` this entry still failed the scan. Do not assume an
+# UNKNOWN/note alert is harmless: check whether the scan step actually failed.
+CVE-2026-46600
 
 # ---------------------------------------------------------------------------
 # trivy 0.72.0 binary (scanner-adapter image) — sigstore verification stack


### PR DESCRIPTION
## Summary

Second and final scanner suppression needed to unblock the v1.6.4 publish. Closes #2963.

The re-cut tag got past CVE-2026-56852 (scanner-adapter findings dropped from 2 to 1), but the Security Scan still failed on **CVE-2026-46600** (`golang.org/x/net` v0.55.0) in the same vendored trivy 0.72.0 binary.

### Correcting a wrong claim from #2990

#2990 stated this CVE could not gate, because it reports as UNKNOWN severity and CI filters on `CRITICAL,HIGH`. **That was wrong**, and this PR removes the claim.

Trivy filters on the **vendor** severity, not the NVD one. The scan log shows `WARN Using severities from other vendors for some vulnerabilities`, so the CVE passed the `CRITICAL,HIGH` filter and failed the gate, while still exporting to SARIF as UNKNOWN/note. The code-scanning UI therefore showed it as a harmless `note` on an alert that was actually blocking the release.

The replacement comment records this explicitly so the next person does not repeat the mistake.

### Scope

| Image | Findings |
|---|---|
| Backend | 0 |
| OpenSCAP | 0 |
| Scanner Adapter | 1 (this CVE) |

Same vendored-binary scope as the x/text entry: `docker/scanner-adapter/go.mod` declares no dependencies, so the adapter's own binary cannot carry `x/net`. The backend and openscap images scan clean and no longer bundle trivy (#1544). trivy 0.72.0 remains the latest upstream release, so there is still no tool version to bump to.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A

Scanner suppression metadata. The verification is the Security Scan job on the re-cut tag.

## Test Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Evidence from docker-publish run for the re-cut v1.6.4 tag: code-scanning analyses `trivy-backend results=0`, `trivy-openscap results=0`, `trivy-scanner-adapter results=1`, with the single remaining alert being CVE-2026-46600.

## API Changes

- [x] N/A - no API changes

## Release-branch gate rationale (`release-process: approved`)

Same as #2964 and #2990: release-line scanner metadata, not a change that routes through main first. It should also land on main.

## Re-tag required

Nothing has published: ghcr `backend:1.6.4` is 404, manifest jobs skipped, no GitHub Release. The scan reads `.trivyignore` from the tagged tree, so `v1.6.4` must be re-cut on top of this commit again.

## Follow-up

This is the second suppression cycle on one release, each costing a full build round. That is the argument for decoupling the sidecar images from the backend release trigger: the scanner-adapter is already independently versioned (`docker/scanner-adapter/VERSION`, chart pins `tag: "1"`, release only verifies `scanner-adapter:1`), so it does not need to be rebuilt or re-gated on a backend tag at all.