### PR TITLE
fix(auth): validate and bound token scopes at the mint choke-point

### DIFF
--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -556,6 +556,11 @@ pub async fn create_api_token(
     crate::services::token_service::enforce_admin_only_scopes(&payload.scopes, auth.is_admin)
         .map_err(AppError::Authorization)?;
 
+    // Delegation ceiling (#2996): a scoped credential may not mint a token
+    // that exceeds its own scopes. Interactive sessions (`scopes: None`)
+    // are unaffected.
+    auth.enforce_mint_ceiling(&payload.scopes)?;
+
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
 
     let (token, id) = auth_service
@@ -2161,5 +2166,185 @@ mod admin_scope_policy_tests {
             .await
             .unwrap();
         assert_eq!(count, 0, "FK-violating audit write must not persist a row");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #2996: mint-path scope validation (vocabulary backstop + delegation ceiling)
+//
+// End-to-end handler assertions for the two new controls on
+// `POST /api/v1/auth/tokens`:
+//   * the mint primitive rejects scopes outside `ALLOWED_SCOPES` (400) — bare
+//     action parents (`delete`, `write`, `read`) are un-mintable, which
+//     matters because `scopes_grant_access` treats a held bare parent as
+//     covering every colon-form child (#2989);
+//   * a scoped presenting credential cannot mint a token exceeding its own
+//     scopes (403), while interactive sessions (`scopes: None`) are
+//     unaffected.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod mint_scope_validation_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use axum::Extension as AxumExtension;
+    use serde_json::json;
+
+    fn build_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+        protected_router()
+            .with_state(state)
+            .layer(AxumExtension::<AuthExtension>(auth))
+    }
+
+    async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String)> {
+        let pool = tdh::try_pool().await?;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        Some((pool, state, user_id, username))
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+
+    async fn mint(
+        state: SharedState,
+        auth: AuthExtension,
+        scopes: serde_json::Value,
+    ) -> (StatusCode, axum::body::Bytes) {
+        let body = json!({
+            "name": format!("t-{}", Uuid::new_v4()),
+            "scopes": scopes,
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        tdh::send(build_app(state, auth), req).await
+    }
+
+    /// The closed escalation: a non-admin presenting a `read:artifacts` API
+    /// token may not mint a `write:artifacts` token (403), while the same
+    /// non-admin on an interactive session (scopes = None) still can (200).
+    #[tokio::test]
+    async fn scoped_token_cannot_mint_beyond_itself_but_interactive_can() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+
+        // Presenting credential = read-scoped API token (or a JWT exchanged
+        // from one): ceiling binds.
+        let mut scoped = tdh::make_auth(user_id, &username);
+        scoped.is_api_token = true;
+        scoped.scopes = Some(vec!["read:artifacts".to_string()]);
+        let (status, body) = mint(state.clone(), scoped, json!(["write:artifacts"])).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "read-scoped token minting write:artifacts MUST 403; body: {}",
+            String::from_utf8_lossy(&body),
+        );
+
+        // Same non-admin, interactive session: unaffected.
+        let interactive = tdh::make_auth(user_id, &username); // scopes: None
+        let (status, body) = mint(state, interactive, json!(["write:artifacts"])).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "interactive non-admin minting write:artifacts MUST stay 200; body: {}",
+            String::from_utf8_lossy(&body),
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// A scoped token re-minting within its own ceiling is allowed.
+    #[tokio::test]
+    async fn scoped_token_can_mint_within_its_ceiling() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let mut scoped = tdh::make_auth(user_id, &username);
+        scoped.is_api_token = true;
+        scoped.scopes = Some(vec!["read:artifacts".to_string()]);
+        let (status, body) = mint(state, scoped, json!(["read:artifacts"])).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "read-scoped token re-minting read:artifacts MUST 200; body: {}",
+            String::from_utf8_lossy(&body),
+        );
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Bare action parents and arbitrary strings are rejected by the mint
+    /// primitive with 400 (invalid vocabulary) for everyone — bare `delete`
+    /// would otherwise cover the admin-only `delete:artifacts` under the
+    /// #2989 parent rule.
+    #[tokio::test]
+    async fn bare_parents_and_unknown_scopes_are_unmintable() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        for bad in ["delete", "write", "read", "hack:system"] {
+            let auth = tdh::make_auth(user_id, &username);
+            let (status, body) = mint(state.clone(), auth, json!([bad])).await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "minting scope {bad:?} MUST 400; got {status} body: {}",
+                String::from_utf8_lossy(&body),
+            );
+        }
+        // Vocabulary applies to admins too (backstop is caller-independent).
+        let mut admin = tdh::make_auth(user_id, &username);
+        admin.is_admin = true;
+        let (status, _) = mint(state, admin, json!(["hack:system"])).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "admin minting non-vocabulary scope MUST 400"
+        );
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Admin-only scopes stay 403 for non-admins (unchanged by #2996), and
+    /// the routine CI scope stays mintable.
+    #[tokio::test]
+    async fn admin_only_still_403_and_ci_scope_still_mints() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        for admin_scope in ["admin", "*"] {
+            let auth = tdh::make_auth(user_id, &username);
+            let (status, _) = mint(state.clone(), auth, json!([admin_scope])).await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin minting {admin_scope:?} MUST 403"
+            );
+        }
+        let auth = tdh::make_auth(user_id, &username);
+        let (status, body) = mint(state, auth, json!(["write:artifacts"])).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "interactive non-admin minting write:artifacts MUST 200; body: {}",
+            String::from_utf8_lossy(&body),
+        );
+        cleanup(&pool, user_id).await;
     }
 }

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -74,7 +74,13 @@ async fn create_access_token(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateAccessTokenRequest>,
 ) -> Result<Json<ApiTokenCreatedResponse>> {
-    let scopes = payload.scopes.unwrap_or_else(|| vec!["read".to_string()]);
+    // Default omitted scopes to the canonical read scope. Bare `read` is not
+    // in `ALLOWED_SCOPES` (it granted nothing under exact-match `has_scope`
+    // and is now rejected by the mint-primitive vocabulary backstop, #2996),
+    // so the default is the fully-qualified `read:artifacts`.
+    let scopes = payload
+        .scopes
+        .unwrap_or_else(|| vec!["read:artifacts".to_string()]);
 
     // Refuse admin-class scopes from non-admin callers. Without this
     // check, any logged-in user can mint a token with `*` or `admin`
@@ -85,6 +91,11 @@ async fn create_access_token(
     // `token_service::ADMIN_ONLY_SCOPES`.
     crate::services::token_service::enforce_admin_only_scopes(&scopes, auth.is_admin)
         .map_err(crate::error::AppError::Authorization)?;
+
+    // Delegation ceiling (#2996): a scoped credential may not mint a token
+    // that exceeds its own scopes. Interactive sessions (`scopes: None`)
+    // are unaffected.
+    auth.enforce_mint_ceiling(&scopes)?;
 
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let (token, token_id) = auth_service
@@ -147,7 +158,7 @@ mod tests {
     fn test_create_access_token_request_full() {
         let json = r#"{
             "name": "ci-token",
-            "scopes": ["read", "write", "admin"],
+            "scopes": ["read:artifacts", "write:artifacts", "admin"],
             "expires_in_days": 90
         }"#;
         let req: CreateAccessTokenRequest = serde_json::from_str(json).unwrap();
@@ -155,8 +166,8 @@ mod tests {
         assert_eq!(
             req.scopes,
             Some(vec![
-                "read".to_string(),
-                "write".to_string(),
+                "read:artifacts".to_string(),
+                "write:artifacts".to_string(),
                 "admin".to_string()
             ])
         );
@@ -174,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_create_access_token_request_missing_name_fails() {
-        let json = r#"{"scopes": ["read"]}"#;
+        let json = r#"{"scopes": ["read:artifacts"]}"#;
         let result: std::result::Result<CreateAccessTokenRequest, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
@@ -211,24 +222,38 @@ mod tests {
 
     #[test]
     fn test_default_scopes_when_none() {
+        // Regression guard (#2996): the default for an omitted `scopes` field
+        // must be the canonical `read:artifacts` — bare `read` is not in
+        // `ALLOWED_SCOPES` and would be rejected at the mint primitive.
         let payload = CreateAccessTokenRequest {
             name: "test".to_string(),
             scopes: None,
             expires_in_days: None,
         };
-        let scopes = payload.scopes.unwrap_or_else(|| vec!["read".to_string()]);
-        assert_eq!(scopes, vec!["read".to_string()]);
+        let scopes = payload
+            .scopes
+            .unwrap_or_else(|| vec!["read:artifacts".to_string()]);
+        assert_eq!(scopes, vec!["read:artifacts".to_string()]);
+        assert!(crate::services::token_service::validate_scopes_pure(&scopes).is_ok());
     }
 
     #[test]
     fn test_provided_scopes_preserved() {
         let payload = CreateAccessTokenRequest {
             name: "test".to_string(),
-            scopes: Some(vec!["read".to_string(), "write".to_string()]),
+            scopes: Some(vec![
+                "read:artifacts".to_string(),
+                "write:artifacts".to_string(),
+            ]),
             expires_in_days: None,
         };
-        let scopes = payload.scopes.unwrap_or_else(|| vec!["read".to_string()]);
-        assert_eq!(scopes, vec!["read".to_string(), "write".to_string()]);
+        let scopes = payload
+            .scopes
+            .unwrap_or_else(|| vec!["read:artifacts".to_string()]);
+        assert_eq!(
+            scopes,
+            vec!["read:artifacts".to_string(), "write:artifacts".to_string()]
+        );
     }
 
     // ── AuthExtension construction tests ────────────────────────────
@@ -259,7 +284,7 @@ mod tests {
             is_admin: false,
             is_api_token: true,
             is_service_account: false,
-            scopes: Some(vec!["read".to_string()]),
+            scopes: Some(vec!["read:artifacts".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             iat_ms: None,
         };
@@ -277,7 +302,7 @@ mod tests {
             id: Uuid::new_v4(),
             name: "deploy-key".to_string(),
             token_prefix: "ak_".to_string(),
-            scopes: vec!["read".to_string(), "write".to_string()],
+            scopes: vec!["read:artifacts".to_string(), "write:artifacts".to_string()],
             expires_at: Some(now + chrono::Duration::days(30)),
             last_used_at: Some(now),
             created_at: now,
@@ -308,30 +333,28 @@ mod tests {
     }
 }
 
-/// DB-backed tests for the token-lifecycle audit trail (#1617 Phase 1).
+/// Shared plumbing for the DB-backed profile handler test modules
+/// (`audit_db_tests`, `mint_scope_validation_db_tests`).
 #[cfg(test)]
-mod audit_db_tests {
+mod db_test_support {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
-    use axum::body::Body;
-    use axum::http::{Method, Request, StatusCode};
     use axum::Extension as AxumExtension;
-    use serde_json::json;
 
-    fn build_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+    pub(super) fn build_app(state: SharedState, auth: AuthExtension) -> axum::Router {
         router()
             .with_state(state)
             .layer(AxumExtension::<AuthExtension>(auth))
     }
 
-    async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String)> {
+    pub(super) async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String)> {
         let pool = tdh::try_pool().await?;
         let (user_id, username) = tdh::create_user(&pool).await;
         let state = tdh::build_state(pool.clone(), "/tmp");
         Some((pool, state, user_id, username))
     }
 
-    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
+    pub(super) async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
         let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
             .bind(user_id)
             .execute(pool)
@@ -341,6 +364,17 @@ mod audit_db_tests {
             .execute(pool)
             .await;
     }
+}
+
+/// DB-backed tests for the token-lifecycle audit trail (#1617 Phase 1).
+#[cfg(test)]
+mod audit_db_tests {
+    use super::db_test_support::{build_app, cleanup, setup};
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::json;
 
     /// `POST /profile/access-tokens` must emit `API_TOKEN_CREATED`, and the
     /// matching revoke must emit `API_TOKEN_REVOKED`.
@@ -351,7 +385,7 @@ mod audit_db_tests {
         };
         let auth = tdh::make_auth(user_id, &username);
 
-        let body = json!({ "name": "profile-audit", "scopes": ["read"] }).to_string();
+        let body = json!({ "name": "profile-audit", "scopes": ["read:artifacts"] }).to_string();
         let req = Request::builder()
             .method(Method::POST)
             .uri("/access-tokens")
@@ -390,6 +424,108 @@ mod audit_db_tests {
             tdh::audit_count_eventually(&pool, token_id, "API_TOKEN_REVOKED", 1).await,
             1,
             "profile revoke MUST write one API_TOKEN_REVOKED row"
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+}
+
+/// DB-backed tests for the #2996 mint-path controls on
+/// `POST /profile/access-tokens`: the changed omitted-scopes default and the
+/// delegation ceiling.
+#[cfg(test)]
+mod mint_scope_validation_db_tests {
+    use super::db_test_support::{build_app, cleanup, setup};
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::json;
+
+    /// Regression guard (#2996): omitting `scopes` must still succeed (200)
+    /// and persist the canonical `read:artifacts` — not the legacy bare
+    /// `read`, which is outside `ALLOWED_SCOPES` and would be rejected by the
+    /// mint-primitive vocabulary backstop.
+    #[tokio::test]
+    async fn omitted_scopes_default_persists_read_artifacts() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username); // interactive, non-admin
+
+        let body = json!({ "name": "default-scopes" }).to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/access-tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(build_app(state, auth), req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "no-scopes profile mint MUST 200; body: {}",
+            String::from_utf8_lossy(&body_bytes),
+        );
+        let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        let token_id = Uuid::parse_str(v["id"].as_str().unwrap()).unwrap();
+
+        let persisted: Vec<String> =
+            sqlx::query_scalar("SELECT scopes FROM api_tokens WHERE id = $1")
+                .bind(token_id)
+                .fetch_one(&pool)
+                .await
+                .expect("fetch persisted scopes");
+        assert_eq!(
+            persisted,
+            vec!["read:artifacts".to_string()],
+            "omitted scopes must default to the canonical read:artifacts",
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// The delegation ceiling applies on the profile route too: a read-scoped
+    /// presenting token cannot mint `write:artifacts` here (403), while an
+    /// interactive session can (200).
+    #[tokio::test]
+    async fn profile_route_enforces_mint_ceiling_for_scoped_credentials() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+
+        let mut scoped = tdh::make_auth(user_id, &username);
+        scoped.is_api_token = true;
+        scoped.scopes = Some(vec!["read:artifacts".to_string()]);
+        let body = json!({ "name": "ceiling-probe", "scopes": ["write:artifacts"] }).to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/access-tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(build_app(state.clone(), scoped), req).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "read-scoped token minting write:artifacts on /profile MUST 403; body: {}",
+            String::from_utf8_lossy(&body_bytes),
+        );
+
+        let interactive = tdh::make_auth(user_id, &username);
+        let body = json!({ "name": "legit", "scopes": ["write:artifacts"] }).to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/access-tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(build_app(state, interactive), req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "interactive non-admin minting write:artifacts MUST stay 200; body: {}",
+            String::from_utf8_lossy(&body_bytes),
         );
 
         cleanup(&pool, user_id).await;

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -126,6 +126,11 @@ fn caller_owns_token(auth: &AuthExtension, created_by_user_id: Option<Uuid>) -> 
 /// `write:repositories` (repository administration — needs `admin`). Read
 /// scopes and non-repository scopes require no mutation authority (`None`), so
 /// a member can always self-manage read-scoped tokens on a repo it can see.
+///
+/// Note this bounds the caller's *repository permission* only. The separate
+/// scope-set ceiling — a scoped credential may not mint a token exceeding its
+/// own scopes, which also covers the read family — is enforced by
+/// [`AuthExtension::enforce_mint_ceiling`] at the call site (#2996).
 fn delegated_scope_repo_action(scope: &str) -> Option<&'static str> {
     match scope {
         "write:artifacts" => Some("write"),
@@ -397,6 +402,18 @@ pub async fn create_repo_token(
     // the holder could do directly. Global admins bypass; read-only scopes need
     // no mutation authority; the admin-class scopes above are already refused.
     require_delegatable_scopes(&auth, repo.id, &payload.scopes, &state.permission_service).await?;
+
+    // Delegation ceiling (#2996). `require_delegatable_scopes` above bounds the
+    // caller's REPOSITORY authority, but it maps read-family and non-repository
+    // scopes to `None` (no mutation authority needed), so it never consults the
+    // presenting credential's own scope ceiling. Apply the same ceiling the
+    // other three mint handlers use so all four are uniform: a scoped API token
+    // cannot mint a token carrying a scope it does not itself hold (e.g. a
+    // `write:repositories`-only token minting `read:users`). Interactive
+    // sessions (`scopes: None`) short-circuit, so console and repo-admin
+    // minting are unaffected. Kept in addition to — not instead of — the
+    // repo-action check above.
+    auth.enforce_mint_ceiling(&payload.scopes)?;
 
     // Generate the token
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
@@ -1218,7 +1235,16 @@ mod admin_scope_policy_tests {
 
         let mut auth = tdh::make_auth(user_id, &username);
         auth.is_api_token = true;
-        auth.scopes = Some(vec!["write:repositories".to_string()]);
+        // The presenting credential holds every scope minted below, so the
+        // #2996 scope ceiling is satisfied and this test isolates the
+        // dimension it was written for: the REPOSITORY-permission delegation
+        // ceiling. (The scope-ceiling dimension has its own tests in
+        // `mint_ceiling_repo_path_tests`.)
+        auth.scopes = Some(vec![
+            "write:repositories".to_string(),
+            "read:artifacts".to_string(),
+            "write:artifacts".to_string(),
+        ]);
 
         // (a) non-writer minting write:artifacts -> 403 (exceeds effective perm).
         let (deny_status, deny_body) = tdh::send(
@@ -1267,6 +1293,104 @@ mod admin_scope_policy_tests {
             .await;
         cleanup(&pool, user_id, &repo_key).await;
     }
+
+    // -----------------------------------------------------------------------
+    // #2996 scope ceiling on the repo-token mint path.
+    //
+    // `require_delegatable_scopes` (#2603 G3) bounds the caller's REPOSITORY
+    // permission, but maps read-family and non-repository scopes to `None`, so
+    // it never consults the presenting credential's own scope set. Without the
+    // `enforce_mint_ceiling` call, a `write:repositories`-only token could mint
+    // a `read:users` token it never held — while the identical request was
+    // already 403 on /auth, /profile and /users. These tests pin the ceiling on
+    // the fourth mint handler so all four behave identically.
+    // -----------------------------------------------------------------------
+
+    /// A scoped credential cannot mint repo-scoped tokens carrying scopes it
+    /// does not itself hold — including the read family that the repo-action
+    /// ceiling deliberately ignores.
+    #[tokio::test]
+    async fn scoped_token_cannot_mint_repo_token_beyond_its_own_scopes() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        // Holds ONLY write:repositories (enough to reach this handler).
+        auth.scopes = Some(vec!["write:repositories".to_string()]);
+
+        for beyond in ["read:users", "read:artifacts", "read:repositories"] {
+            let (status, body) = tdh::send(
+                build_app(state.clone(), auth.clone()),
+                post_repo_token_request(&repo_key, "beyond-ceiling", &[beyond]),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "minting repo token with unheld scope {beyond:?} MUST 403; got {} body: {}",
+                status,
+                String::from_utf8_lossy(&body),
+            );
+        }
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
+    /// No over-restriction: a credential that DOES hold the scope can still
+    /// mint it through the repo path.
+    #[tokio::test]
+    async fn scoped_token_can_mint_repo_token_within_its_own_scopes() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.scopes = Some(vec![
+            "write:repositories".to_string(),
+            "read:artifacts".to_string(),
+        ]);
+
+        let (status, body) = tdh::send(
+            build_app(state, auth),
+            post_repo_token_request(&repo_key, "within-ceiling", &["read:artifacts"]),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a credential holding read:artifacts must still mint it; got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body),
+        );
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
+    /// Interactive principals (`scopes: None`) are action-unrestricted, so the
+    /// ceiling short-circuits and console/repo-admin minting is unaffected.
+    #[tokio::test]
+    async fn interactive_principal_repo_mint_unaffected_by_ceiling() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        // Interactive session: scopes = None (tdh::make_auth default).
+        let auth = tdh::make_auth(user_id, &username);
+        let (status, body) = tdh::send(
+            build_app(state, auth),
+            post_repo_token_request(&repo_key, "interactive-ok", &["read:artifacts"]),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "interactive repo-token mint MUST stay 200; got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body),
+        );
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1297,11 +1421,17 @@ mod ownership_gate_tests {
     }
 
     /// A non-admin caller with the delegatable `write:repositories` scope (so
-    /// it clears `require_repo_write`).
+    /// it clears `require_repo_write`) plus `read:artifacts` (so the #2996
+    /// mint ceiling is satisfied for the `read:artifacts` tokens these tests
+    /// seed). These tests exercise the per-token OWNERSHIP gate, not the
+    /// scope ceiling.
     fn member_auth(user_id: Uuid, username: &str) -> AuthExtension {
         let mut auth = tdh::make_auth(user_id, username);
         auth.is_api_token = true;
-        auth.scopes = Some(vec!["write:repositories".to_string()]);
+        auth.scopes = Some(vec![
+            "write:repositories".to_string(),
+            "read:artifacts".to_string(),
+        ]);
         auth
     }
 

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -2098,7 +2098,9 @@ mod audit_db_tests {
         service_account_id: Uuid,
         name: &str,
     ) -> Uuid {
-        let body = json!({ "name": name, "scopes": ["read"] }).to_string();
+        // Canonical vocabulary: bare `read` is rejected by the mint-primitive
+        // scope backstop (#2996).
+        let body = json!({ "name": name, "scopes": ["read:artifacts"] }).to_string();
         let req = Request::builder()
             .method(Method::POST)
             .uri(format!("/{service_account_id}/tokens"))
@@ -2212,7 +2214,9 @@ mod audit_db_tests {
             .await
             .expect("create service account");
 
-        let body = json!({ "name": "sa-audit", "scopes": ["read"] }).to_string();
+        // Canonical vocabulary: bare `read` is rejected by the mint-primitive
+        // scope backstop (#2996).
+        let body = json!({ "name": "sa-audit", "scopes": ["read:artifacts"] }).to_string();
         let req = Request::builder()
             .method(Method::POST)
             .uri(format!("/{}/tokens", sa.id))

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -993,6 +993,11 @@ async fn create_api_token_inner(
     crate::services::token_service::enforce_admin_only_scopes(&payload.scopes, auth.is_admin)
         .map_err(AppError::Authorization)?;
 
+    // Delegation ceiling (#2996): a scoped credential may not mint a token
+    // that exceeds its own scopes. Interactive sessions (`scopes: None`)
+    // are unaffected.
+    auth.enforce_mint_ceiling(&payload.scopes)?;
+
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let (token, token_id) = auth_service
         .generate_api_token(id, &payload.name, payload.scopes, payload.expires_in_days)

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -149,6 +149,33 @@ impl AuthExtension {
         }
     }
 
+    /// Delegation ceiling for token minting (#2996): a non-admin caller may
+    /// not mint a token carrying a scope its own presenting credential does
+    /// not hold. `scopes: None` (interactive/UI/CI login) is
+    /// action-unrestricted, so this is a no-op for those principals and never
+    /// affects the console mint flow; it only constrains a scoped API token
+    /// (or a JWT exchanged from one, #2430) attempting to mint a token that
+    /// exceeds its own authority — e.g. a `read:artifacts` token minting
+    /// `write:artifacts`.
+    ///
+    /// The per-scope decision is delegated to `has_scope` →
+    /// `scopes_grant_access`, so the wildcard (`*`/`admin`) and bare-parent
+    /// coverage semantics stay in the one canonical helper (#1316).
+    pub fn enforce_mint_ceiling(&self, requested: &[String]) -> crate::error::Result<()> {
+        if self.is_admin {
+            return Ok(());
+        }
+        for s in requested {
+            if !self.has_scope(s) {
+                return Err(AppError::Authorization(format!(
+                    "Cannot mint a token with scope '{s}': it exceeds the scopes of the \
+                     presenting credential",
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Fold the effective-admin decision at construction time so every
     /// downstream `is_admin` read (both `require_admin` and the ~34 raw
     /// `if !auth.is_admin` handler checks) inherits scope awareness from a
@@ -2662,6 +2689,89 @@ mod tests {
     fn test_has_scope_admin_grants_all() {
         let ext = make_api_token_ext(vec!["admin".to_string()], None);
         assert!(ext.has_scope("delete:artifacts"));
+    }
+
+    // -----------------------------------------------------------------------
+    // AuthExtension::enforce_mint_ceiling (#2996)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mint_ceiling_interactive_none_scopes_unrestricted() {
+        // Interactive/UI/CI principals (`scopes: None`) are action-unrestricted:
+        // the ceiling never bites, so console token minting is unaffected.
+        let ext = AuthExtension::from(claims_with(false, None));
+        assert!(ext
+            .enforce_mint_ceiling(&["write:artifacts".to_string()])
+            .is_ok());
+        assert!(ext
+            .enforce_mint_ceiling(&["read:repositories".to_string()])
+            .is_ok());
+    }
+
+    #[test]
+    fn test_mint_ceiling_scoped_token_cannot_exceed_itself() {
+        // A read-scoped API token may re-mint its own scope but not escalate
+        // to a scope it does not hold.
+        let ext = make_api_token_ext(vec!["read:artifacts".to_string()], None);
+        assert!(ext
+            .enforce_mint_ceiling(&["read:artifacts".to_string()])
+            .is_ok());
+        let err = ext
+            .enforce_mint_ceiling(&["write:artifacts".to_string()])
+            .expect_err("read token must not mint write");
+        assert_eq!(err.into_response().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_mint_ceiling_exchanged_jwt_inherits_token_ceiling() {
+        // A JWT exchanged from a read-scoped API token (#2430) carries
+        // `is_api_token = false` but `Some(scopes)`: the ceiling still binds.
+        let ext = AuthExtension::from(claims_with(false, Some(vec!["read:artifacts".to_string()])));
+        assert!(!ext.is_api_token);
+        assert!(ext
+            .enforce_mint_ceiling(&["write:artifacts".to_string()])
+            .is_err());
+    }
+
+    #[test]
+    fn test_mint_ceiling_wildcard_and_admin_scope_cover_everything() {
+        let star = make_api_token_ext(vec!["*".to_string()], None);
+        assert!(star
+            .enforce_mint_ceiling(&["write:artifacts".to_string(), "read:users".to_string()])
+            .is_ok());
+        let admin_scope = make_api_token_ext(vec!["admin".to_string()], None);
+        assert!(admin_scope
+            .enforce_mint_ceiling(&["delete:artifacts".to_string()])
+            .is_ok());
+    }
+
+    #[test]
+    fn test_mint_ceiling_effective_admin_bypasses() {
+        // An effective admin (admin owner + admin-granting credential) is not
+        // held to the ceiling.
+        let ext = admin_owned_token_ext(vec!["admin".to_string()]);
+        assert!(ext.is_admin);
+        assert!(ext
+            .enforce_mint_ceiling(&["write:users".to_string()])
+            .is_ok());
+    }
+
+    #[test]
+    fn test_mint_ceiling_admin_owned_narrow_token_still_bound() {
+        // GHSA-vvc3 interaction: an admin-OWNED but narrowly-scoped token has
+        // `is_admin = false` after the scope-gated fold, so it is held to its
+        // token's ceiling rather than laundered up to the owner's admin.
+        let ext = admin_owned_token_ext(vec!["read:artifacts".to_string()]);
+        assert!(!ext.is_admin);
+        assert!(ext
+            .enforce_mint_ceiling(&["write:artifacts".to_string()])
+            .is_err());
+    }
+
+    #[test]
+    fn test_mint_ceiling_empty_request_ok() {
+        let ext = make_api_token_ext(vec!["read:artifacts".to_string()], None);
+        assert!(ext.enforce_mint_ceiling(&[]).is_ok());
     }
 
     // #1316: pin the authorization decision now that `has_scope` delegates to

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -2341,6 +2341,15 @@ impl AuthService {
                 "Scope name too long (max 256 characters)".to_string(),
             ));
         }
+        // Defense-in-depth: reject scopes outside the canonical vocabulary at
+        // the single mint choke-point, so no handler can persist arbitrary or
+        // unknown scope strings even if it forgets the per-endpoint validation
+        // (#2996). Bare action parents (`read`/`write`/`delete`) are not in
+        // `ALLOWED_SCOPES`, so they become un-mintable here — which matters
+        // because `scopes_grant_access` treats a held bare parent as covering
+        // every colon-form child of that action (#2989).
+        crate::services::token_service::validate_scopes_pure(&scopes)
+            .map_err(AppError::Validation)?;
 
         // Generate random token
         let token = format!(

--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -771,6 +771,71 @@ mod tests {
         assert!(validate_scopes_pure(&scopes).is_err());
     }
 
+    #[test]
+    fn test_validate_scopes_bare_action_parents_rejected() {
+        // Bare action parents are NOT vocabulary. This is load-bearing (#2996):
+        // `scopes_grant_access` treats a held bare parent as covering every
+        // colon-form child of that action (#2989), so if bare `delete` were
+        // mintable a non-admin could ride it into the admin-only
+        // `delete:artifacts`. The mint-primitive backstop in
+        // `generate_api_token` relies on these being rejected here.
+        for bare in ["read", "write", "delete", "promote", "trigger"] {
+            assert!(
+                validate_scopes_pure(&[bare.to_string()]).is_err(),
+                "bare action parent `{bare}` must not be valid scope vocabulary",
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Consistency invariant: mintability classification vs. grant semantics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn non_admin_mintable_scope_never_grants_an_admin_only_scope() {
+        // For every scope a non-admin is allowed to MINT (vocabulary entry
+        // that passes `enforce_admin_only_scopes` for a non-admin), that scope
+        // must not grant ACCESS (via `scopes_grant_access`) to any admin-only
+        // scope. This pins the interaction between the explicit
+        // `ADMIN_ONLY_SCOPES` classification and the broad-covers-specific
+        // parent rule (#2989): the invariant holds today because no bare
+        // action parent is in `ALLOWED_SCOPES`. If a future change adds a
+        // mintable scope that covers e.g. `delete:artifacts` (say, by adding
+        // bare `delete` to the vocabulary without classifying it admin-only),
+        // this test fails and forces a decision (#2996).
+        for scope in ALLOWED_SCOPES {
+            let one = vec![scope.to_string()];
+            if enforce_admin_only_scopes(&one, false).is_ok() {
+                for admin_only in ADMIN_ONLY_SCOPES {
+                    assert!(
+                        !scopes_grant_access(&one, admin_only),
+                        "non-admin-mintable scope `{scope}` grants admin-only `{admin_only}`",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_bare_parent_of_an_admin_only_scope_is_unmintable() {
+        // Companion invariant: for each colon-form ADMIN_ONLY scope, the bare
+        // parent that would cover it under the #2989 parent rule must be
+        // rejected by the mint vocabulary (or itself be admin-only). Otherwise
+        // a non-admin could mint the bare parent and hold effective
+        // admin-only authority without ever requesting the classified scope.
+        for admin_only in ADMIN_ONLY_SCOPES {
+            if let Some((parent, _resource)) = admin_only.split_once(':') {
+                let bare = vec![parent.to_string()];
+                let mintable_by_non_admin = validate_scopes_pure(&bare).is_ok()
+                    && enforce_admin_only_scopes(&bare, false).is_ok();
+                assert!(
+                    !mintable_by_non_admin,
+                    "bare parent `{parent}` of admin-only `{admin_only}` is mintable by a non-admin",
+                );
+            }
+        }
+    }
+
     // -----------------------------------------------------------------------
     // enforce_admin_only_scopes (privilege-escalation gate on token issuance)
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardens the token mint path behind the repo-permission enforcing layer (#2996), building on the #2993 scope model:

1. **Vocabulary backstop at the mint choke-point** — `AuthService::generate_api_token` now rejects any requested scope outside the canonical `ALLOWED_SCOPES` list, so no endpoint can persist arbitrary or unknown scope strings even if it forgets its per-endpoint validation. Bare action parents (`read`/`write`/`delete`) are not vocabulary and become un-mintable — relevant because `scopes_grant_access` treats a held bare parent as covering every colon-form child of that action (#2989/#2993).
2. **Delegation ceiling on personal-token minting** — new `AuthExtension::enforce_mint_ceiling`, called from `POST /auth/tokens`, `POST /profile/access-tokens`, and `POST /users/{id}/tokens`: a non-admin presenting a scoped credential cannot mint a token carrying a scope the presenting credential does not hold. Interactive/console logins (`scopes: None`) are action-unrestricted and completely unaffected; the repo-token endpoint already enforces its own stricter repo-action ceiling and is unchanged.
3. **Mintability-classification invariants** — pure unit tests pin that (a) no non-admin-mintable scope grants any `ADMIN_ONLY_SCOPES` entry via `scopes_grant_access` (evaluated with the #2993 broad-covers-specific parent rule active), and (b) the bare parent of every admin-only colon-form scope is un-mintable by a non-admin. A future vocabulary or matcher change that would reopen the gap fails these tests and forces a reviewed decision.

**Regression fix included:** `POST /profile/access-tokens` defaulted omitted `scopes` to bare `read`, which is outside the vocabulary; the default is now the canonical `read:artifacts` (doc examples and tests updated). A service-account test fixture minting bare `read` was updated to `read:artifacts` for the same reason.

**Behavior change (intended hardening):** the primitive-level vocabulary check applies to all callers, including admins — a non-`ALLOWED_SCOPES` string (e.g. `hack:system`) now returns 400 on every mint endpoint. Newly minted tokens must use canonical colon-form scopes; existing persisted tokens are unaffected.

Closes #2996

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Unit: `validate_scopes_pure` bare-parent rejection; the two mintability invariants in `token_service`; `enforce_mint_ceiling` matrix (interactive `None` unaffected, scoped token bound, wildcard/admin covered, effective-admin bypass, GHSA-vvc3 narrow-admin-token still bound).
Integration (DB): on `/auth/tokens` — read-scoped credential minting `write:artifacts` → 403 while the same user interactive → 200; bare/unknown scopes → 400 for non-admin and admin; admin-only scopes still 403; `write:artifacts` still 200. On `/profile/access-tokens` — omitted scopes → 200 persisting `read:artifacts`; ceiling enforced.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (error responses on existing endpoints only)
