### PR TITLE
perf(downloads): bound the download side-effect dispatch (bounded queue + flush-worker pool)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -9746,12 +9746,11 @@ mod tests {
     }
 
     async fn test_pool() -> Option<sqlx::PgPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        sqlx::postgres::PgPoolOptions::new()
-            .max_connections(2)
-            .connect(&url)
-            .await
-            .ok()
+        // Delegate to the shared harness pool: it also installs the bounded
+        // download-event dispatcher (#2522) that `record_redirect_download`'s
+        // stats write now flows through — a bare `PgPoolOptions` connect would
+        // leave the dispatcher uninstalled and the write a designed no-op.
+        crate::testing::try_pool_with(2).await
     }
 
     async fn seed_artifact(pool: &sqlx::PgPool) -> Uuid {

--- a/backend/src/api/middleware/download_telemetry.rs
+++ b/backend/src/api/middleware/download_telemetry.rs
@@ -62,10 +62,19 @@ impl DownloadContext {
         Self {
             client_ip: resolve_client_ip_addr(headers, peer, trusted_proxies),
             user_id: auth.map(|a| a.user_id),
+            // The User-Agent header is the ONLY attacker-controlled free string
+            // that flows from this context into the `download_statistics` row;
+            // clamp it to the column width (VARCHAR(512), mig 004) at capture
+            // so an oversized value can never fail the (batched) INSERT
+            // downstream. The other recorded fields are structurally bounded:
+            // `client_ip` is a parsed `IpAddr` (<= 45 chars textual) and
+            // `user_id` is a UUID. See #2522 batching.
             user_agent: headers
                 .get(header::USER_AGENT)
                 .and_then(|v| v.to_str().ok())
-                .map(str::to_string),
+                .map(|ua| {
+                    crate::services::download_event_dispatch::clamp_user_agent(ua.to_string())
+                }),
             // Method-agnostic constructor: callers that care about HEAD set the
             // flag from the request method (see the `FromRequestParts` impl).
             is_head: false,
@@ -142,6 +151,21 @@ mod tests {
         );
         assert_eq!(ctx.client_ip, Some("203.0.113.9".parse().unwrap()));
         assert_eq!(ctx.user_agent.as_deref(), Some("npm/10.2.0"));
+    }
+
+    /// An oversized User-Agent is clamped to the `download_statistics`
+    /// column width (VARCHAR(512)) at capture, so one crafted request can
+    /// never make the batched stats INSERT fail and take co-batched rows
+    /// with it (#2522 batching hardening).
+    #[test]
+    fn test_context_oversized_user_agent_is_clamped_to_column_width() {
+        let mut headers = HeaderMap::new();
+        let long_ua = "u".repeat(601);
+        headers.insert(header::USER_AGENT, long_ua.parse().unwrap());
+        let ctx = DownloadContext::from_parts_inner(&headers, None, None, &[]);
+        let ua = ctx.user_agent.expect("user agent captured");
+        assert_eq!(ua.chars().count(), 512);
+        assert!(long_ua.starts_with(&ua));
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -859,6 +859,19 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         );
     }
 
+    // Start the bounded download-event dispatcher (#2522): a bounded queue +
+    // fixed pool of flush workers that batch-INSERT the download-path
+    // side-effect writes (download_statistics + ARTIFACT_DOWNLOADED audit).
+    // Replaces the per-request `tokio::spawn`s so a download flood against a
+    // slow/failing event store sheds telemetry (bounded, counted) instead of
+    // growing detached tasks + pool connections without bound. Started before
+    // the HTTP servers bind so no request can observe an uninstalled
+    // dispatcher. Sizing: DOWNLOAD_EVENT_QUEUE_DEPTH / DOWNLOAD_EVENT_FLUSH_WORKERS.
+    artifact_keeper_backend::services::download_event_dispatch::start_download_event_dispatch(
+        app_state.db.clone(),
+        runtime_shutdown_token.clone(),
+    );
+
     app_state
         .setup_required
         .store(setup_required, std::sync::atomic::Ordering::Relaxed);

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1469,13 +1469,17 @@ impl ArtifactService {
 
         // Best-effort audit trail (#2366). An `ARTIFACT_DOWNLOADED` event is the
         // per-access record auditors need to answer "who fetched this artifact,
-        // and when?". Fire-and-forget: a download must never fail because the
-        // audit table is unavailable, mirroring the download-statistics write
-        // above. The IP is parsed leniently; a malformed value is simply omitted.
+        // and when?". Routed through the bounded download-event dispatcher
+        // (#2522) rather than a per-request spawn: a download must never fail
+        // (or slow) because the audit table is unavailable, and a flood must
+        // never grow tasks/connections without bound — mirroring the
+        // download-statistics write above. Only this download hot-path emitter
+        // uses the dispatcher; the non-hot-path `audit_fire_and_forget` call
+        // sites (auth/user/token lifecycle) keep their existing spawn. The IP
+        // is parsed leniently; a malformed value is simply omitted.
         {
-            use crate::services::audit_service::{
-                audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
-            };
+            use crate::services::audit_service::{AuditAction, AuditEntry, ResourceType};
+            use crate::services::download_event_dispatch::{try_enqueue, DownloadEvent};
             let mut entry =
                 AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
                     .resource(artifact_id)
@@ -1495,7 +1499,7 @@ impl ArtifactService {
             if let Some(ip) = ip_address.and_then(|s| s.parse::<std::net::IpAddr>().ok()) {
                 entry = entry.ip(ip);
             }
-            audit_fire_and_forget(self.db.clone(), entry).await;
+            let _ = try_enqueue(DownloadEvent::Audit(Box::new(entry)));
         }
 
         // Trigger AfterDownload hooks (non-blocking)
@@ -2319,7 +2323,12 @@ pub async fn guard_foreign_storage_key_for_backend(
 ///
 /// Call this only after a **local** artifact row has been resolved; remote
 /// pass-through proxy fetches are not our artifacts and stay unrecorded.
-pub async fn record_download(db: &PgPool, artifact_id: Uuid, ctx: &DownloadContext) {
+///
+/// The pool parameter is retained (underscore-bound) purely for call-site
+/// stability: the ~45 format/generic/OCI call sites keep compiling unchanged
+/// while the bounded dispatcher's flush workers own the only side-effect DB
+/// connections (#2522).
+pub async fn record_download(_db: &PgPool, artifact_id: Uuid, ctx: &DownloadContext) {
     // A HEAD request serves no body — it must never write a download row
     // (#2260 §5). This is the single choke point every serving path funnels
     // through (hosted stream, presigned redirect, virtual-member local resolve,
@@ -2330,33 +2339,26 @@ pub async fn record_download(db: &PgPool, artifact_id: Uuid, ctx: &DownloadConte
     if ctx.is_head {
         return;
     }
-    // Move the statistics INSERT OFF the synchronous download hot path (#2522).
-    // Historically this awaited the write on the catalog pool before the byte
-    // stream could return, coupling byte-plane latency/availability to DB-pool
-    // pressure. Spawn a detached best-effort task instead: the caller returns
-    // immediately (no await on the write), the row is still eventually written,
-    // and a failure is logged at `warn` and swallowed exactly as before —
-    // statistics must never block or fail the download itself. The `is_head`
-    // "no body ⇒ no row" contract is preserved (checked synchronously above).
-    let db = db.clone();
-    let user_id = ctx.user_id;
-    let ip_address = ctx.client_ip.map(|ip| ip.to_string());
-    let user_agent = ctx.user_agent.clone();
-    tokio::spawn(async move {
-        if let Err(e) = sqlx::query(
-            "INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent) \
-             VALUES ($1, $2, $3, $4)",
-        )
-        .bind(artifact_id)
-        .bind(user_id)
-        .bind(ip_address)
-        .bind(user_agent)
-        .execute(&db)
-        .await
-        {
-            warn!(%artifact_id, error = %e, "failed to record download statistics");
-        }
-    });
+    // Route the statistics write through the BOUNDED download-event dispatcher
+    // (#2522). The first #2522 slice moved this INSERT off the byte plane with
+    // a per-request `tokio::spawn`, which left task + pool-connection growth
+    // unbounded under a download flood with a slow event store. `try_enqueue`
+    // never blocks, awaits, or spawns: the event is queued for a fixed pool of
+    // batch-flush workers, shed (dropped + counted) on overflow, and silently
+    // skipped when no dispatcher is installed (tests) — statistics must never
+    // block or fail the download itself. Attribution (trusted-proxy client IP,
+    // user, user-agent) is captured HERE, at request time, so it cannot drift
+    // across the async hop. The `is_head` "no body ⇒ no row" contract is
+    // preserved (checked synchronously above).
+    use crate::services::download_event_dispatch::{
+        try_enqueue, DownloadEvent, DownloadStatsEvent,
+    };
+    let _ = try_enqueue(DownloadEvent::Stats(DownloadStatsEvent {
+        artifact_id,
+        user_id: ctx.user_id,
+        ip_address: ctx.client_ip.map(|ip| ip.to_string()),
+        user_agent: ctx.user_agent.clone(),
+    }));
 }
 
 /// URL fields commonly found in package metadata across all formats.
@@ -4138,13 +4140,15 @@ mod tests {
             user_agent: Some("unit-test/1.0".to_string()),
             is_head: false,
         };
-        // Returns without awaiting the INSERT (spawned); the row lands shortly
-        // after. The count must still reach 1 — the eventual-write contract.
+        // Returns without awaiting the INSERT (enqueued to the bounded
+        // dispatcher `tdh::try_pool` installed); the batch flush lands the row
+        // shortly after. The count must still reach 1 — the eventual-write
+        // contract survives the spawn -> bounded-dispatch change (#2522).
         record_download(&pool, artifact_id, &ctx).await;
         let count = poll_dl_count(&pool, artifact_id, 1).await;
         assert_eq!(
             count, 1,
-            "spawned download_statistics write must eventually land"
+            "dispatched download_statistics write must eventually land"
         );
     }
 

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -611,6 +611,69 @@ impl AuditService {
         Ok(id)
     }
 
+    /// Log a batch of audit entries with one multi-row INSERT (#2522).
+    ///
+    /// Used by the bounded download-event dispatcher's flush workers so a
+    /// burst of `ARTIFACT_DOWNLOADED` events costs one round-trip instead of
+    /// one per event. Semantics match [`AuditService::log`] per entry: the
+    /// structured export record is emitted BEFORE the INSERT and regardless of
+    /// its outcome (the stdout stream must not lose the SIEM copy to a DB
+    /// outage), and ids are the client-minted `event_id`s. Parallel-array
+    /// UNNEST, runtime (non-macro) query — same shape as `webhook_producer`'s
+    /// batch insert — so no offline `.sqlx` prepare is needed.
+    pub async fn log_batch(&self, entries: Vec<AuditEntry>) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        for entry in &entries {
+            audit_export::emit_entry(entry);
+        }
+
+        let n = entries.len();
+        let mut ids: Vec<Uuid> = Vec::with_capacity(n);
+        let mut user_ids: Vec<Option<Uuid>> = Vec::with_capacity(n);
+        let mut actions: Vec<&'static str> = Vec::with_capacity(n);
+        let mut resource_types: Vec<&'static str> = Vec::with_capacity(n);
+        let mut resource_ids: Vec<Option<Uuid>> = Vec::with_capacity(n);
+        let mut details: Vec<Option<serde_json::Value>> = Vec::with_capacity(n);
+        let mut ip_addresses: Vec<Option<String>> = Vec::with_capacity(n);
+        let mut correlation_ids: Vec<String> = Vec::with_capacity(n);
+        for entry in entries {
+            ids.push(entry.event_id);
+            user_ids.push(entry.user_id);
+            actions.push(entry.action.as_str());
+            resource_types.push(entry.resource_type.as_str());
+            resource_ids.push(entry.resource_id);
+            details.push(entry.details);
+            ip_addresses.push(entry.ip_address.map(|ip| ip.to_string()));
+            correlation_ids.push(entry.correlation_id);
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO audit_log
+                (id, user_id, action, resource_type, resource_id, details, ip_address, correlation_id)
+            SELECT * FROM UNNEST(
+                $1::uuid[], $2::uuid[], $3::text[], $4::text[],
+                $5::uuid[], $6::jsonb[], $7::text[], $8::text[])
+                AS t(id, user_id, action, resource_type, resource_id, details, ip_address, correlation_id)
+            "#,
+        )
+        .bind(ids)
+        .bind(user_ids)
+        .bind(actions)
+        .bind(resource_types)
+        .bind(resource_ids)
+        .bind(details)
+        .bind(ip_addresses)
+        .bind(correlation_ids)
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// Query audit logs, with each row joined to its actor's username (#2392).
     ///
     /// A `LEFT JOIN` on `users` embeds `actor_username` without ever dropping

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -588,27 +588,35 @@ impl AuditService {
     /// column to this INSERT's column list.
     pub async fn log(&self, entry: AuditEntry) -> Result<Uuid> {
         audit_export::emit_entry(&entry);
-
         let id = entry.event_id;
+        self.insert_row(&entry)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(id)
+    }
+
+    /// Single-row `audit_log` INSERT — the shared statement behind
+    /// [`AuditService::log`] and the per-row fallback in
+    /// [`AuditService::log_batch`]. Does NOT emit the export record (callers
+    /// emit exactly once, before any insert attempt).
+    async fn insert_row(&self, entry: &AuditEntry) -> sqlx::Result<()> {
         sqlx::query(
             r#"
             INSERT INTO audit_log (id, user_id, action, resource_type, resource_id, details, ip_address, correlation_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             "#,
         )
-        .bind(id)
+        .bind(entry.event_id)
         .bind(entry.user_id)
         .bind(entry.action.as_str())
         .bind(entry.resource_type.as_str())
         .bind(entry.resource_id)
-        .bind(entry.details)
+        .bind(&entry.details)
         .bind(entry.ip_address.map(|ip| ip.to_string()))
-        .bind(entry.correlation_id)
+        .bind(&entry.correlation_id)
         .execute(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
-
-        Ok(id)
+        .await?;
+        Ok(())
     }
 
     /// Log a batch of audit entries with one multi-row INSERT (#2522).
@@ -621,32 +629,61 @@ impl AuditService {
     /// outage), and ids are the client-minted `event_id`s. Parallel-array
     /// UNNEST, runtime (non-macro) query — same shape as `webhook_producer`'s
     /// batch insert — so no offline `.sqlx` prepare is needed.
-    pub async fn log_batch(&self, entries: Vec<AuditEntry>) -> Result<()> {
+    ///
+    /// Batching must not amplify loss: if Postgres rejects the multi-row
+    /// statement, every entry is retried individually so one bad row can only
+    /// lose itself, never its co-batched neighbors. Returns the number of
+    /// entries that could not be persisted even via the fallback (0 on the
+    /// happy path); failures are warn-logged, matching the best-effort
+    /// download-audit contract.
+    pub async fn log_batch(&self, entries: Vec<AuditEntry>) -> usize {
         if entries.is_empty() {
-            return Ok(());
+            return 0;
         }
         for entry in &entries {
             audit_export::emit_entry(entry);
         }
 
+        match self.insert_batch_rows(&entries).await {
+            Ok(()) => 0,
+            Err(batch_err) => {
+                tracing::warn!(
+                    rows = entries.len(),
+                    error = %batch_err,
+                    "audit_log batch INSERT failed; retrying rows individually"
+                );
+                let mut lost = 0usize;
+                for entry in &entries {
+                    if let Err(e) = self.insert_row(entry).await {
+                        tracing::warn!(event_id = %entry.event_id, error = %e, "audit log row write failed; ignored (best-effort)");
+                        lost += 1;
+                    }
+                }
+                lost
+            }
+        }
+    }
+
+    /// The batched multi-row INSERT behind [`AuditService::log_batch`].
+    async fn insert_batch_rows(&self, entries: &[AuditEntry]) -> sqlx::Result<()> {
         let n = entries.len();
         let mut ids: Vec<Uuid> = Vec::with_capacity(n);
         let mut user_ids: Vec<Option<Uuid>> = Vec::with_capacity(n);
         let mut actions: Vec<&'static str> = Vec::with_capacity(n);
         let mut resource_types: Vec<&'static str> = Vec::with_capacity(n);
         let mut resource_ids: Vec<Option<Uuid>> = Vec::with_capacity(n);
-        let mut details: Vec<Option<serde_json::Value>> = Vec::with_capacity(n);
+        let mut details: Vec<Option<&serde_json::Value>> = Vec::with_capacity(n);
         let mut ip_addresses: Vec<Option<String>> = Vec::with_capacity(n);
-        let mut correlation_ids: Vec<String> = Vec::with_capacity(n);
+        let mut correlation_ids: Vec<&str> = Vec::with_capacity(n);
         for entry in entries {
             ids.push(entry.event_id);
             user_ids.push(entry.user_id);
             actions.push(entry.action.as_str());
             resource_types.push(entry.resource_type.as_str());
             resource_ids.push(entry.resource_id);
-            details.push(entry.details);
+            details.push(entry.details.as_ref());
             ip_addresses.push(entry.ip_address.map(|ip| ip.to_string()));
-            correlation_ids.push(entry.correlation_id);
+            correlation_ids.push(&entry.correlation_id);
         }
 
         sqlx::query(
@@ -668,9 +705,7 @@ impl AuditService {
         .bind(ip_addresses)
         .bind(correlation_ids)
         .execute(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
-
+        .await?;
         Ok(())
     }
 
@@ -2269,5 +2304,58 @@ mod tests {
             .bind(resource_id)
             .execute(&pool)
             .await;
+    }
+
+    /// #2522 batching must not amplify loss: a row Postgres rejects (here a
+    /// duplicate client-minted id) fails the multi-row INSERT, but the
+    /// per-row fallback persists every innocent co-batched entry and reports
+    /// exactly the poison row as lost.
+    #[tokio::test]
+    async fn test_log_batch_poison_row_only_loses_itself() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let service = AuditService::new(pool.clone());
+
+        let poison_resource = Uuid::new_v4();
+        let innocent_resource = Uuid::new_v4();
+        let poison = AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
+            .resource(poison_resource);
+        // Pre-occupy the poison entry's client-minted id so its INSERT hits a
+        // primary-key violation both in the batch and individually.
+        sqlx::query(
+            "INSERT INTO audit_log (id, action, resource_type, correlation_id) \
+             VALUES ($1, 'ARTIFACT_DOWNLOADED', 'artifact', $2)",
+        )
+        .bind(poison.event_id)
+        .bind(Uuid::new_v4().to_string())
+        .execute(&pool)
+        .await
+        .expect("pre-occupy poison id");
+
+        let innocent = AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
+            .resource(innocent_resource);
+
+        let lost = service.log_batch(vec![poison, innocent]).await;
+        assert_eq!(lost, 1, "exactly the poison entry is lost");
+
+        let innocent_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM audit_log WHERE resource_id = $1")
+                .bind(innocent_resource)
+                .fetch_one(&pool)
+                .await
+                .expect("count innocent");
+        assert_eq!(
+            innocent_rows, 1,
+            "the innocent co-batched entry must persist via the row fallback"
+        );
+
+        for r in [poison_resource, innocent_resource] {
+            let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+                .bind(r)
+                .execute(&pool)
+                .await;
+        }
     }
 }

--- a/backend/src/services/download_event_dispatch.rs
+++ b/backend/src/services/download_event_dispatch.rs
@@ -1,0 +1,509 @@
+//! Bounded dispatch for download-path side-effect writes (#2522).
+//!
+//! The download hot path emits two best-effort telemetry writes per served
+//! body: a `download_statistics` row ([`record_download`]) and an
+//! `ARTIFACT_DOWNLOADED` audit row (the `finish_download` epilogue). #2522
+//! first moved both OFF the byte plane via `tokio::spawn`, which fixed the
+//! latency coupling but left the *bounded* half of the issue open: every
+//! request spawned a detached task that grabbed a catalog-pool connection with
+//! no cap and no backpressure. Under a download flood with a slow or failing
+//! event store, detached tasks and pool waiters grow without bound — memory +
+//! connection exhaustion that couples back into serving (artifact lookup needs
+//! the same pool).
+//!
+//! This module replaces the per-request spawns with the codebase's established
+//! bounded-outbox shape:
+//!
+//! * one process-global **bounded** `mpsc` channel behind an
+//!   `OnceLock<Option<Sender>>` — the same install/degrade idiom as
+//!   `GLOBAL_AUTH_SEMAPHORE` (`auth_service.rs`): tests or embedders that never
+//!   install a dispatcher get a graceful no-op, never a panic;
+//! * a **fixed** pool of background flush workers (modelled on
+//!   `webhook_producer::start_webhook_producer`) that drain the channel and
+//!   **batch-INSERT** into the existing `download_statistics` / `audit_log`
+//!   tables — fewer round-trips than the historical one-INSERT-per-request;
+//! * producers only ever [`try_enqueue`] (a synchronous `try_send`): a full
+//!   queue **sheds** the event (drop + `ak_download_events_dropped_total`
+//!   metric) instead of blocking or growing. The byte plane is never touched.
+//!
+//! These events are best-effort analytics/trail writes (see
+//! `audit_fire_and_forget`: "a side effect, never a gate") — loss on overflow
+//! or crash is the pre-existing contract, not a regression. Strict crash
+//! durability would be a separate durable-outbox slice.
+//!
+//! [`record_download`]: crate::services::artifact_service::record_download
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use sqlx::PgPool;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::services::audit_service::{AuditEntry, AuditService};
+
+/// Default bounded queue depth. Overridable via `DOWNLOAD_EVENT_QUEUE_DEPTH`.
+///
+/// Sized so a burst of ~8k downloads (a few seconds of heavy flood) is
+/// absorbed without shedding while the workers batch-flush, yet the worst-case
+/// resident cost stays small (events are a few hundred bytes each).
+pub const DEFAULT_QUEUE_DEPTH: usize = 8192;
+
+/// Default flush-worker count. Overridable via `DOWNLOAD_EVENT_FLUSH_WORKERS`.
+///
+/// This is the hard cap on concurrent side-effect DB connections: two workers
+/// batch-inserting 256 rows per round-trip drain far faster than the hot path
+/// can produce under normal operation, while a slow event store can never hold
+/// more than `workers` connections.
+pub const DEFAULT_FLUSH_WORKERS: usize = 2;
+
+/// Max events coalesced into one batched multi-row INSERT.
+pub const FLUSH_BATCH_MAX: usize = 256;
+
+/// A completed-download statistics event, fully resolved at request time.
+///
+/// The trusted-proxy client IP is captured (and stringified) by the producer
+/// from the request's [`DownloadContext`] BEFORE the async hop, so attribution
+/// can never drift between enqueue and flush.
+///
+/// [`DownloadContext`]: crate::api::middleware::download_telemetry::DownloadContext
+#[derive(Debug)]
+pub struct DownloadStatsEvent {
+    pub artifact_id: Uuid,
+    pub user_id: Option<Uuid>,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+/// One queued download side-effect. Audit entries are boxed: they are much
+/// larger than the stats variant and would otherwise inflate every queue slot.
+/// (No `Debug` derive: `AuditEntry` deliberately does not implement it —
+/// audit payloads can carry sensitive details.)
+pub enum DownloadEvent {
+    Stats(DownloadStatsEvent),
+    Audit(Box<AuditEntry>),
+}
+
+impl DownloadEvent {
+    /// Stable low-cardinality label for metrics.
+    fn kind(&self) -> &'static str {
+        match self {
+            DownloadEvent::Stats(_) => "stats",
+            DownloadEvent::Audit(_) => "audit",
+        }
+    }
+}
+
+/// Outcome of a non-blocking enqueue attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnqueueOutcome {
+    /// Queued for a background flush worker.
+    Enqueued,
+    /// Queue full (or closed): the event was dropped and counted.
+    Shed,
+    /// No dispatcher installed (tests / embedders): silent best-effort no-op.
+    NoDispatcher,
+}
+
+/// Process-wide dispatcher handle. Same `OnceLock<Option<..>>` shape as
+/// `GLOBAL_AUTH_SEMAPHORE`: set once at startup; when unset (unit tests,
+/// library embedders) producers degrade gracefully instead of panicking.
+static DOWNLOAD_EVENT_DISPATCH: OnceLock<Option<mpsc::Sender<DownloadEvent>>> = OnceLock::new();
+
+/// Total events shed because the bounded queue was full/closed. An in-process
+/// counter alongside the Prometheus metric so unit tests (which run without a
+/// recorder installed) can assert the shed path fires.
+static DOWNLOAD_EVENTS_SHED: AtomicU64 = AtomicU64::new(0);
+
+/// Install the process-wide download-event dispatcher handle. Idempotent —
+/// the first call wins, mirroring `install_global_auth_semaphore`, so
+/// multi-`AppState` test setups cannot re-configure it mid-run. Returns
+/// whether this call installed the handle.
+pub fn install_download_event_dispatch(tx: Option<mpsc::Sender<DownloadEvent>>) -> bool {
+    DOWNLOAD_EVENT_DISPATCH.set(tx).is_ok()
+}
+
+/// Whether a dispatcher handle has been installed (test scaffolding support).
+pub fn dispatch_installed() -> bool {
+    DOWNLOAD_EVENT_DISPATCH
+        .get()
+        .is_some_and(|cell| cell.is_some())
+}
+
+/// Total events shed so far (process lifetime).
+pub fn shed_total() -> u64 {
+    DOWNLOAD_EVENTS_SHED.load(Ordering::Relaxed)
+}
+
+/// Non-blocking enqueue of a download side-effect event.
+///
+/// NEVER blocks, awaits, or spawns: a full queue sheds the event (drop +
+/// metric), an uninstalled dispatcher is a silent no-op. This is the whole
+/// availability contract — the download response can never be coupled to the
+/// event store through this call.
+pub fn try_enqueue(event: DownloadEvent) -> EnqueueOutcome {
+    try_enqueue_with(
+        DOWNLOAD_EVENT_DISPATCH.get().and_then(|cell| cell.as_ref()),
+        event,
+    )
+}
+
+/// Pure enqueue body, extracted (like `acquire_permit_from` in
+/// `auth_service`) so unit tests can exercise the shed/degrade branches on a
+/// fresh channel without contending with the process-wide `OnceLock`.
+fn try_enqueue_with(
+    tx: Option<&mpsc::Sender<DownloadEvent>>,
+    event: DownloadEvent,
+) -> EnqueueOutcome {
+    let Some(tx) = tx else {
+        // Graceful degrade: no dispatcher installed (tests / embedders).
+        // Best-effort telemetry is simply not recorded — never a panic, and
+        // never a fallback to unbounded per-request work.
+        crate::services::metrics_service::record_download_event_dropped(
+            event.kind(),
+            "uninitialised",
+        );
+        return EnqueueOutcome::NoDispatcher;
+    };
+    let kind = event.kind();
+    match tx.try_send(event) {
+        Ok(()) => {
+            crate::services::metrics_service::set_download_event_queue_depth(
+                (tx.max_capacity() - tx.capacity()) as f64,
+            );
+            EnqueueOutcome::Enqueued
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            DOWNLOAD_EVENTS_SHED.fetch_add(1, Ordering::Relaxed);
+            crate::services::metrics_service::record_download_event_dropped(kind, "queue_full");
+            EnqueueOutcome::Shed
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            DOWNLOAD_EVENTS_SHED.fetch_add(1, Ordering::Relaxed);
+            crate::services::metrics_service::record_download_event_dropped(kind, "closed");
+            EnqueueOutcome::Shed
+        }
+    }
+}
+
+/// Read a positive usize from the environment, falling back to `default`.
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(default)
+}
+
+/// Start the bounded download-event dispatcher and install its handle as the
+/// process-wide producer target. Called once from `main.rs` alongside
+/// `start_webhook_producer`; sizing comes from `DOWNLOAD_EVENT_QUEUE_DEPTH` /
+/// `DOWNLOAD_EVENT_FLUSH_WORKERS` (defaults [`DEFAULT_QUEUE_DEPTH`] /
+/// [`DEFAULT_FLUSH_WORKERS`]).
+///
+/// If a dispatcher was already installed (multi-`AppState` test setups), the
+/// freshly spawned workers observe their channel close as this call's unused
+/// sender drops, and exit on their own.
+pub fn start_download_event_dispatch(db: PgPool, shutdown_token: CancellationToken) {
+    let depth = env_usize("DOWNLOAD_EVENT_QUEUE_DEPTH", DEFAULT_QUEUE_DEPTH);
+    let workers = env_usize("DOWNLOAD_EVENT_FLUSH_WORKERS", DEFAULT_FLUSH_WORKERS);
+    let tx = spawn_dispatch(db, depth, workers, shutdown_token);
+    if install_download_event_dispatch(Some(tx)) {
+        tracing::info!(
+            queue_depth = depth,
+            flush_workers = workers,
+            "Download-event dispatcher started (bounded side-effect flush)"
+        );
+    } else {
+        warn!("Download-event dispatcher already installed; keeping the first instance");
+    }
+}
+
+/// Create the bounded channel and spawn the fixed flush-worker pool, returning
+/// the producer handle. Split from [`start_download_event_dispatch`] so tests
+/// can run a private dispatcher against their own pool without touching the
+/// process-global handle.
+fn spawn_dispatch(
+    db: PgPool,
+    depth: usize,
+    workers: usize,
+    shutdown_token: CancellationToken,
+) -> mpsc::Sender<DownloadEvent> {
+    let (tx, rx) = mpsc::channel::<DownloadEvent>(depth);
+    // `mpsc::Receiver` is single-consumer; the fixed worker pool shares it
+    // behind a Mutex held only while collecting a batch (`recv_many`), then
+    // released for the flush so up to `workers` batched INSERTs can overlap.
+    let rx = Arc::new(tokio::sync::Mutex::new(rx));
+    for worker_id in 0..workers.max(1) {
+        let db = db.clone();
+        let rx = Arc::clone(&rx);
+        let shutdown = shutdown_token.clone();
+        tokio::spawn(async move {
+            flush_worker(worker_id, db, rx, shutdown).await;
+        });
+    }
+    tx
+}
+
+/// One flush worker: repeatedly collect up to [`FLUSH_BATCH_MAX`] queued
+/// events and write them as batched multi-row INSERTs. Errors are logged and
+/// swallowed (best-effort contract); the worker itself only exits on shutdown
+/// or channel close.
+async fn flush_worker(
+    worker_id: usize,
+    db: PgPool,
+    rx: Arc<tokio::sync::Mutex<mpsc::Receiver<DownloadEvent>>>,
+    shutdown: CancellationToken,
+) {
+    let mut batch: Vec<DownloadEvent> = Vec::with_capacity(FLUSH_BATCH_MAX);
+    loop {
+        batch.clear();
+        let received = {
+            let mut guard = rx.lock().await;
+            tokio::select! {
+                _ = shutdown.cancelled() => None,
+                n = guard.recv_many(&mut batch, FLUSH_BATCH_MAX) => Some(n),
+            }
+        };
+        match received {
+            // Shutdown: exit without draining — these are best-effort events
+            // and the existing spawn-based path also lost in-flight writes on
+            // shutdown. `recv_many` returning 0 means the channel closed.
+            None | Some(0) => {
+                tracing::debug!(worker_id, "download-event flush worker exiting");
+                break;
+            }
+            Some(_) => flush_batch(&db, &mut batch).await,
+        }
+    }
+}
+
+/// Split a collected batch by table and run one batched INSERT per table.
+async fn flush_batch(db: &PgPool, batch: &mut Vec<DownloadEvent>) {
+    let mut stats: Vec<DownloadStatsEvent> = Vec::new();
+    let mut audits: Vec<AuditEntry> = Vec::new();
+    for event in batch.drain(..) {
+        match event {
+            DownloadEvent::Stats(s) => stats.push(s),
+            DownloadEvent::Audit(a) => audits.push(*a),
+        }
+    }
+    if !stats.is_empty() {
+        let rows = stats.len();
+        if let Err(e) = insert_stats_batch(db, stats).await {
+            warn!(rows, error = %e, "failed to flush download_statistics batch (best-effort; rows dropped)");
+        }
+    }
+    if !audits.is_empty() {
+        let rows = audits.len();
+        if let Err(e) = AuditService::new(db.clone()).log_batch(audits).await {
+            warn!(rows, error = %e, "failed to flush download audit batch (best-effort; rows dropped)");
+        }
+    }
+}
+
+/// Batched multi-row `download_statistics` INSERT via parallel-array UNNEST —
+/// the same shape as `webhook_producer`'s `BATCH_INSERT_DELIVERIES_SQL`.
+/// Runtime (non-macro) query, matching the single-row INSERT this replaces, so
+/// no offline `.sqlx` prepare is needed.
+async fn insert_stats_batch(db: &PgPool, stats: Vec<DownloadStatsEvent>) -> sqlx::Result<()> {
+    let mut artifact_ids: Vec<Uuid> = Vec::with_capacity(stats.len());
+    let mut user_ids: Vec<Option<Uuid>> = Vec::with_capacity(stats.len());
+    let mut ip_addresses: Vec<Option<String>> = Vec::with_capacity(stats.len());
+    let mut user_agents: Vec<Option<String>> = Vec::with_capacity(stats.len());
+    for s in stats {
+        artifact_ids.push(s.artifact_id);
+        user_ids.push(s.user_id);
+        ip_addresses.push(s.ip_address);
+        user_agents.push(s.user_agent);
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent)
+        SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::text[], $4::text[])
+            AS t(artifact_id, user_id, ip_address, user_agent)
+        "#,
+    )
+    .bind(artifact_ids)
+    .bind(user_ids)
+    .bind(ip_addresses)
+    .bind(user_agents)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::audit_service::{AuditAction, ResourceType};
+
+    fn stats_event(artifact_id: Uuid) -> DownloadEvent {
+        DownloadEvent::Stats(DownloadStatsEvent {
+            artifact_id,
+            user_id: None,
+            ip_address: Some("203.0.113.9".to_string()),
+            user_agent: Some("dispatch-test/1.0".to_string()),
+        })
+    }
+
+    /// Uninstalled dispatcher: a producer call is a silent no-op — no panic,
+    /// no spawn, no shed-counter movement (graceful-degrade contract).
+    #[test]
+    fn test_enqueue_without_dispatcher_is_noop_and_never_panics() {
+        // Distinguished outcome: a degrade, not an overflow shed. (The global
+        // shed counter is not asserted here — parallel tests also move it.)
+        let outcome = try_enqueue_with(None, stats_event(Uuid::new_v4()));
+        assert_eq!(outcome, EnqueueOutcome::NoDispatcher);
+    }
+
+    /// Bounded under flood with a stalled sink: no worker consumes (the
+    /// worst-case "event store hung" simulation), so a flood far larger than
+    /// the queue must cap in-flight events at the channel depth and shed the
+    /// rest, counting each shed. `try_enqueue` is synchronous by construction
+    /// — nothing here can block or grow without bound.
+    #[tokio::test]
+    async fn test_flood_beyond_capacity_stays_bounded_and_sheds() {
+        const DEPTH: usize = 64;
+        const FLOOD: usize = 10_000;
+        let (tx, rx) = mpsc::channel::<DownloadEvent>(DEPTH);
+        let shed_before = shed_total();
+
+        let mut enqueued = 0usize;
+        let mut shed = 0usize;
+        for _ in 0..FLOOD {
+            match try_enqueue_with(Some(&tx), stats_event(Uuid::new_v4())) {
+                EnqueueOutcome::Enqueued => enqueued += 1,
+                EnqueueOutcome::Shed => shed += 1,
+                EnqueueOutcome::NoDispatcher => unreachable!("dispatcher handle supplied"),
+            }
+        }
+
+        // In-flight is capped at exactly the channel depth; everything beyond
+        // it was dropped and counted — no unbounded task/memory growth.
+        assert_eq!(enqueued, DEPTH, "in-flight events must cap at queue depth");
+        assert_eq!(shed, FLOOD - DEPTH);
+        assert_eq!(tx.capacity(), 0, "queue full: no hidden growth capacity");
+        // The shed counter is process-global; other tests may bump it
+        // concurrently, so assert at-least (every one of OUR drops counted).
+        assert!(
+            shed_total() - shed_before >= (FLOOD - DEPTH) as u64,
+            "every overflow drop must increment the shed counter"
+        );
+        drop(rx);
+    }
+
+    /// A closed channel (workers gone) sheds instead of erroring or panicking.
+    #[test]
+    fn test_closed_channel_sheds() {
+        let (tx, rx) = mpsc::channel::<DownloadEvent>(4);
+        drop(rx);
+        let shed_before = shed_total();
+        let outcome = try_enqueue_with(Some(&tx), stats_event(Uuid::new_v4()));
+        assert_eq!(outcome, EnqueueOutcome::Shed);
+        // At-least: the counter is process-global (parallel tests also shed).
+        assert!(shed_total() - shed_before >= 1);
+    }
+
+    /// End-to-end through a private dispatcher on a real database: enqueued
+    /// stats + audit events are batch-flushed into their tables with
+    /// attribution (IP / user-agent captured at enqueue time) intact.
+    #[tokio::test]
+    async fn test_dispatch_flushes_stats_and_audit_batches() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let artifact_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, 'com/acme/disp-1.0.jar', 'disp-1.0.jar', 10, repeat('a', 64), \
+                     'application/java-archive', 'k/com/acme/disp-1.0.jar') \
+             RETURNING id",
+        )
+        .bind(repo)
+        .fetch_one(&pool)
+        .await
+        .expect("seed artifact");
+
+        let shutdown = CancellationToken::new();
+        let tx = spawn_dispatch(pool.clone(), 1024, 2, shutdown.clone());
+
+        const STATS_ROWS: usize = 5;
+        for _ in 0..STATS_ROWS {
+            let outcome = try_enqueue_with(Some(&tx), stats_event(artifact_id));
+            assert_eq!(outcome, EnqueueOutcome::Enqueued);
+        }
+        let audit_resource = Uuid::new_v4();
+        let entry = AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
+            .resource(audit_resource)
+            .ip("203.0.113.9".parse().unwrap());
+        let outcome = try_enqueue_with(Some(&tx), DownloadEvent::Audit(Box::new(entry)));
+        assert_eq!(outcome, EnqueueOutcome::Enqueued);
+
+        // Bounded-retry poll (async batch flush) for both tables.
+        let mut stat_count = 0i64;
+        let mut audit_count = 0i64;
+        for _ in 0..50 {
+            stat_count = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1",
+            )
+            .bind(artifact_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count download_statistics");
+            audit_count = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM audit_log WHERE resource_id = $1",
+            )
+            .bind(audit_resource)
+            .fetch_one(&pool)
+            .await
+            .expect("count audit_log");
+            if stat_count >= STATS_ROWS as i64 && audit_count >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            stat_count, STATS_ROWS as i64,
+            "batched download_statistics flush must persist every enqueued event"
+        );
+        assert_eq!(audit_count, 1, "batched audit flush must persist the entry");
+
+        // Attribution captured at enqueue time survives the async hop.
+        let (ip, ua): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT ip_address, user_agent FROM download_statistics \
+             WHERE artifact_id = $1 LIMIT 1",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("read attribution");
+        assert_eq!(ip.as_deref(), Some("203.0.113.9"));
+        assert_eq!(ua.as_deref(), Some("dispatch-test/1.0"));
+
+        shutdown.cancel();
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(audit_resource)
+            .execute(&pool)
+            .await;
+    }
+
+    /// `env_usize` sizing: bad/zero/unset values fall back to the default.
+    #[test]
+    fn test_env_usize_fallbacks() {
+        assert_eq!(env_usize("DOWNLOAD_EVENT_DISPATCH_TEST_UNSET", 7), 7);
+        std::env::set_var("DOWNLOAD_EVENT_DISPATCH_TEST_ZERO", "0");
+        assert_eq!(env_usize("DOWNLOAD_EVENT_DISPATCH_TEST_ZERO", 7), 7);
+        std::env::set_var("DOWNLOAD_EVENT_DISPATCH_TEST_BAD", "not-a-number");
+        assert_eq!(env_usize("DOWNLOAD_EVENT_DISPATCH_TEST_BAD", 7), 7);
+        std::env::set_var("DOWNLOAD_EVENT_DISPATCH_TEST_OK", "42");
+        assert_eq!(env_usize("DOWNLOAD_EVENT_DISPATCH_TEST_OK", 7), 42);
+        std::env::remove_var("DOWNLOAD_EVENT_DISPATCH_TEST_ZERO");
+        std::env::remove_var("DOWNLOAD_EVENT_DISPATCH_TEST_BAD");
+        std::env::remove_var("DOWNLOAD_EVENT_DISPATCH_TEST_OK");
+    }
+}

--- a/backend/src/services/download_event_dispatch.rs
+++ b/backend/src/services/download_event_dispatch.rs
@@ -117,6 +117,31 @@ static DOWNLOAD_EVENT_DISPATCH: OnceLock<Option<mpsc::Sender<DownloadEvent>>> = 
 /// recorder installed) can assert the shed path fires.
 static DOWNLOAD_EVENTS_SHED: AtomicU64 = AtomicU64::new(0);
 
+/// Total rows lost at FLUSH time (batch rejected and the per-row fallback also
+/// failed for that row). Sibling of [`DOWNLOAD_EVENTS_SHED`] for the DB-side
+/// loss path, mirrored to `ak_download_events_dropped_total{reason="flush_failed"}`.
+static DOWNLOAD_EVENTS_FLUSH_LOST: AtomicU64 = AtomicU64::new(0);
+
+/// `download_statistics.user_agent` column width (VARCHAR(512), migration
+/// 004). Everything longer is clamped — never allowed to fail an INSERT.
+pub const STATS_USER_AGENT_MAX_CHARS: usize = 512;
+
+/// Clamp a User-Agent string to the `download_statistics` column width
+/// (character-counted, matching Postgres VARCHAR semantics; safe on any UTF-8
+/// boundary). Applied at request capture (`DownloadContext`) and re-applied at
+/// insert build time so no producer can poison a batched INSERT with an
+/// oversized value.
+pub fn clamp_user_agent(ua: String) -> String {
+    match ua.char_indices().nth(STATS_USER_AGENT_MAX_CHARS) {
+        None => ua,
+        Some((byte_idx, _)) => {
+            let mut clamped = ua;
+            clamped.truncate(byte_idx);
+            clamped
+        }
+    }
+}
+
 /// Install the process-wide download-event dispatcher handle. Idempotent —
 /// the first call wins, mirroring `install_global_auth_semaphore`, so
 /// multi-`AppState` test setups cannot re-configure it mid-run. Returns
@@ -135,6 +160,11 @@ pub fn dispatch_installed() -> bool {
 /// Total events shed so far (process lifetime).
 pub fn shed_total() -> u64 {
     DOWNLOAD_EVENTS_SHED.load(Ordering::Relaxed)
+}
+
+/// Total rows lost at flush time so far (process lifetime).
+pub fn flush_lost_total() -> u64 {
+    DOWNLOAD_EVENTS_FLUSH_LOST.load(Ordering::Relaxed)
 }
 
 /// Non-blocking enqueue of a download side-effect event.
@@ -161,9 +191,10 @@ fn try_enqueue_with(
         // Graceful degrade: no dispatcher installed (tests / embedders).
         // Best-effort telemetry is simply not recorded — never a panic, and
         // never a fallback to unbounded per-request work.
-        crate::services::metrics_service::record_download_event_dropped(
+        crate::services::metrics_service::record_download_events_dropped(
             event.kind(),
             "uninitialised",
+            1,
         );
         return EnqueueOutcome::NoDispatcher;
     };
@@ -177,12 +208,12 @@ fn try_enqueue_with(
         }
         Err(mpsc::error::TrySendError::Full(_)) => {
             DOWNLOAD_EVENTS_SHED.fetch_add(1, Ordering::Relaxed);
-            crate::services::metrics_service::record_download_event_dropped(kind, "queue_full");
+            crate::services::metrics_service::record_download_events_dropped(kind, "queue_full", 1);
             EnqueueOutcome::Shed
         }
         Err(mpsc::error::TrySendError::Closed(_)) => {
             DOWNLOAD_EVENTS_SHED.fetch_add(1, Ordering::Relaxed);
-            crate::services::metrics_service::record_download_event_dropped(kind, "closed");
+            crate::services::metrics_service::record_download_events_dropped(kind, "closed", 1);
             EnqueueOutcome::Shed
         }
     }
@@ -281,6 +312,14 @@ async fn flush_worker(
 }
 
 /// Split a collected batch by table and run one batched INSERT per table.
+///
+/// Batching must never AMPLIFY loss: a row that Postgres rejects fails the
+/// whole multi-row statement, so each table's flush falls back to per-row
+/// inserts on batch failure ([`flush_stats_with_fallback`] /
+/// [`AuditService::log_batch`]) — one bad row can only lose itself, never its
+/// co-batched neighbors. Rows lost even individually are counted
+/// (`flush_failed` reason + [`flush_lost_total`]), so a poison attack or
+/// event-store error always leaves a metric trace.
 async fn flush_batch(db: &PgPool, batch: &mut Vec<DownloadEvent>) {
     let mut stats: Vec<DownloadStatsEvent> = Vec::new();
     let mut audits: Vec<AuditEntry> = Vec::new();
@@ -291,15 +330,49 @@ async fn flush_batch(db: &PgPool, batch: &mut Vec<DownloadEvent>) {
         }
     }
     if !stats.is_empty() {
-        let rows = stats.len();
-        if let Err(e) = insert_stats_batch(db, stats).await {
-            warn!(rows, error = %e, "failed to flush download_statistics batch (best-effort; rows dropped)");
-        }
+        record_flush_lost("stats", flush_stats_with_fallback(db, stats).await);
     }
     if !audits.is_empty() {
-        let rows = audits.len();
-        if let Err(e) = AuditService::new(db.clone()).log_batch(audits).await {
-            warn!(rows, error = %e, "failed to flush download audit batch (best-effort; rows dropped)");
+        record_flush_lost(
+            "audit",
+            AuditService::new(db.clone()).log_batch(audits).await,
+        );
+    }
+}
+
+/// Count rows a flush could not persist even via the per-row fallback.
+fn record_flush_lost(kind: &'static str, lost: usize) {
+    if lost > 0 {
+        DOWNLOAD_EVENTS_FLUSH_LOST.fetch_add(lost as u64, Ordering::Relaxed);
+        crate::services::metrics_service::record_download_events_dropped(
+            kind,
+            "flush_failed",
+            lost as u64,
+        );
+    }
+}
+
+/// Flush a stats batch, isolating row failures. Tries the single batched
+/// INSERT first (the fast path); if Postgres rejects it, retries each row
+/// individually so only genuinely bad rows are lost. Returns the number of
+/// rows that could not be persisted.
+async fn flush_stats_with_fallback(db: &PgPool, stats: Vec<DownloadStatsEvent>) -> usize {
+    match insert_stats_batch(db, &stats).await {
+        Ok(()) => 0,
+        Err(batch_err) => {
+            warn!(
+                rows = stats.len(),
+                error = %batch_err,
+                "download_statistics batch INSERT failed; retrying rows individually"
+            );
+            let mut lost = 0usize;
+            for s in &stats {
+                if let Err(e) = insert_stat_row(db, s).await {
+                    warn!(artifact_id = %s.artifact_id, error = %e, "failed to record download statistics (row dropped)");
+                    lost += 1;
+                }
+            }
+            lost
         }
     }
 }
@@ -308,16 +381,22 @@ async fn flush_batch(db: &PgPool, batch: &mut Vec<DownloadEvent>) {
 /// the same shape as `webhook_producer`'s `BATCH_INSERT_DELIVERIES_SQL`.
 /// Runtime (non-macro) query, matching the single-row INSERT this replaces, so
 /// no offline `.sqlx` prepare is needed.
-async fn insert_stats_batch(db: &PgPool, stats: Vec<DownloadStatsEvent>) -> sqlx::Result<()> {
+///
+/// `user_agent` is re-clamped to the column width here (defense-in-depth:
+/// [`DownloadContext`] already clamps at capture, but events can be built from
+/// synthesized contexts) so no oversized string can ever fail the statement.
+///
+/// [`DownloadContext`]: crate::api::middleware::download_telemetry::DownloadContext
+async fn insert_stats_batch(db: &PgPool, stats: &[DownloadStatsEvent]) -> sqlx::Result<()> {
     let mut artifact_ids: Vec<Uuid> = Vec::with_capacity(stats.len());
     let mut user_ids: Vec<Option<Uuid>> = Vec::with_capacity(stats.len());
-    let mut ip_addresses: Vec<Option<String>> = Vec::with_capacity(stats.len());
+    let mut ip_addresses: Vec<Option<&str>> = Vec::with_capacity(stats.len());
     let mut user_agents: Vec<Option<String>> = Vec::with_capacity(stats.len());
     for s in stats {
         artifact_ids.push(s.artifact_id);
         user_ids.push(s.user_id);
-        ip_addresses.push(s.ip_address);
-        user_agents.push(s.user_agent);
+        ip_addresses.push(s.ip_address.as_deref());
+        user_agents.push(s.user_agent.clone().map(clamp_user_agent));
     }
     sqlx::query(
         r#"
@@ -330,6 +409,22 @@ async fn insert_stats_batch(db: &PgPool, stats: Vec<DownloadStatsEvent>) -> sqlx
     .bind(user_ids)
     .bind(ip_addresses)
     .bind(user_agents)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Single-row stats INSERT — the pre-batching statement, used as the per-row
+/// fallback when a batch is rejected.
+async fn insert_stat_row(db: &PgPool, s: &DownloadStatsEvent) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(s.artifact_id)
+    .bind(s.user_id)
+    .bind(s.ip_address.as_deref())
+    .bind(s.user_agent.clone().map(clamp_user_agent))
     .execute(db)
     .await?;
     Ok(())
@@ -505,5 +600,189 @@ mod tests {
         std::env::remove_var("DOWNLOAD_EVENT_DISPATCH_TEST_ZERO");
         std::env::remove_var("DOWNLOAD_EVENT_DISPATCH_TEST_BAD");
         std::env::remove_var("DOWNLOAD_EVENT_DISPATCH_TEST_OK");
+    }
+
+    /// `clamp_user_agent`: at/under the column width passes through; over it
+    /// truncates to exactly 512 characters, on a char boundary (VARCHAR
+    /// counts characters, and a mid-codepoint cut would be invalid UTF-8).
+    #[test]
+    fn test_clamp_user_agent_column_width_and_utf8_safety() {
+        let exact = "a".repeat(STATS_USER_AGENT_MAX_CHARS);
+        assert_eq!(clamp_user_agent(exact.clone()), exact);
+        let over = "a".repeat(STATS_USER_AGENT_MAX_CHARS + 89);
+        assert_eq!(
+            clamp_user_agent(over).chars().count(),
+            STATS_USER_AGENT_MAX_CHARS
+        );
+        // Multibyte: 600 two-byte chars must clamp to 512 CHARS, not bytes.
+        let multibyte = "é".repeat(600);
+        let clamped = clamp_user_agent(multibyte);
+        assert_eq!(clamped.chars().count(), STATS_USER_AGENT_MAX_CHARS);
+        assert!(clamped.chars().all(|c| c == 'é'));
+    }
+
+    /// Seed a repo + artifact and return the artifact id (shared by the
+    /// flush-fallback DB tests).
+    #[cfg(test)]
+    async fn seed_flush_artifact(pool: &sqlx::PgPool, path: &str) -> Uuid {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let (repo, _, _) = tdh::create_repo(pool, "local", "maven").await;
+        sqlx::query_scalar(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $2, 10, repeat('b', 64), 'application/java-archive', $2) \
+             RETURNING id",
+        )
+        .bind(repo)
+        .bind(path)
+        .fetch_one(pool)
+        .await
+        .expect("seed artifact")
+    }
+
+    /// A 601-char User-Agent among co-batched rows must NOT fail the batch:
+    /// the UA is clamped to the column width at insert build time, the batch
+    /// INSERT succeeds, every co-batched row persists, and the long-UA row
+    /// itself persists truncated to 512 (finding 1a re-verify).
+    #[tokio::test]
+    async fn test_oversized_user_agent_cannot_poison_the_batch() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let artifact_id = seed_flush_artifact(&pool, "com/acme/uaclamp-1.0.jar").await;
+
+        let mut events: Vec<DownloadStatsEvent> = (0..3)
+            .map(|_| DownloadStatsEvent {
+                artifact_id,
+                user_id: None,
+                ip_address: Some("203.0.113.10".to_string()),
+                user_agent: Some("legit/1.0".to_string()),
+            })
+            .collect();
+        events.push(DownloadStatsEvent {
+            artifact_id,
+            user_id: None,
+            ip_address: Some("203.0.113.66".to_string()),
+            user_agent: Some("P".repeat(601)), // > VARCHAR(512): the poison
+        });
+
+        let lost = flush_stats_with_fallback(&pool, events).await;
+        assert_eq!(lost, 0, "a long UA must be clamped, not fail any row");
+
+        let (rows, max_ua_len): (i64, Option<i32>) = sqlx::query_as(
+            "SELECT COUNT(*), MAX(LENGTH(user_agent))::int4 \
+             FROM download_statistics WHERE artifact_id = $1",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count rows");
+        assert_eq!(rows, 4, "all co-batched rows AND the long-UA row persist");
+        assert_eq!(
+            max_ua_len,
+            Some(STATS_USER_AGENT_MAX_CHARS as i32),
+            "the oversized UA is stored truncated to the column width"
+        );
+    }
+
+    /// Defense-in-depth (finding 1b re-verify): when the batched INSERT fails
+    /// for a reason clamping cannot prevent (here: an FK-violating row), the
+    /// per-row fallback saves every innocent co-batched row — only the bad
+    /// row is lost, and the loss is reported.
+    #[tokio::test]
+    async fn test_batch_failure_falls_back_to_row_isolation() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let artifact_id = seed_flush_artifact(&pool, "com/acme/isolate-1.0.jar").await;
+
+        let mut events: Vec<DownloadStatsEvent> = (0..3)
+            .map(|_| DownloadStatsEvent {
+                artifact_id,
+                user_id: None,
+                ip_address: None,
+                user_agent: Some("innocent/1.0".to_string()),
+            })
+            .collect();
+        events.push(DownloadStatsEvent {
+            artifact_id: Uuid::new_v4(), // no such artifact: FK-violating poison
+            user_id: None,
+            ip_address: None,
+            user_agent: Some("poison/1.0".to_string()),
+        });
+
+        let lost = flush_stats_with_fallback(&pool, events).await;
+        assert_eq!(lost, 1, "exactly the poison row is lost");
+
+        let rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1")
+                .bind(artifact_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count rows");
+        assert_eq!(rows, 3, "every innocent co-batched row must persist");
+    }
+
+    /// Finding 2 re-verify at the worker level: `flush_batch` counts rows
+    /// lost at flush time (in-process mirror of
+    /// `ak_download_events_dropped_total{reason="flush_failed"}`), while the
+    /// innocent stats row and the co-batched audit entry still persist.
+    #[tokio::test]
+    async fn test_flush_batch_counts_flush_failed_losses() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::audit_service::{AuditAction, ResourceType};
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let artifact_id = seed_flush_artifact(&pool, "com/acme/lostmetric-1.0.jar").await;
+
+        let audit_resource = Uuid::new_v4();
+        let mut batch: Vec<DownloadEvent> = vec![
+            DownloadEvent::Stats(DownloadStatsEvent {
+                artifact_id,
+                user_id: None,
+                ip_address: None,
+                user_agent: None,
+            }),
+            DownloadEvent::Stats(DownloadStatsEvent {
+                artifact_id: Uuid::new_v4(), // FK-violating poison row
+                user_id: None,
+                ip_address: None,
+                user_agent: None,
+            }),
+            DownloadEvent::Audit(Box::new(
+                AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
+                    .resource(audit_resource),
+            )),
+        ];
+
+        let lost_before = flush_lost_total();
+        flush_batch(&pool, &mut batch).await;
+        assert!(
+            flush_lost_total() - lost_before >= 1,
+            "a flush-time loss must be counted, not silently swallowed"
+        );
+
+        let stat_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1")
+                .bind(artifact_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count stats");
+        assert_eq!(stat_rows, 1, "the innocent stats row persists");
+        let audit_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM audit_log WHERE resource_id = $1")
+                .bind(audit_resource)
+                .fetch_one(&pool)
+                .await
+                .expect("count audit");
+        assert_eq!(audit_rows, 1, "the co-batched audit entry persists");
+
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(audit_resource)
+            .execute(&pool)
+            .await;
     }
 }

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -175,6 +175,29 @@ pub fn record_webhook_dead_letter(event: &str) {
     .increment(1);
 }
 
+/// Record a download side-effect event (stats/audit) dropped by the bounded
+/// dispatcher (#2522). `kind` is `"stats"` or `"audit"`; `reason` is
+/// `"queue_full"` (overflow shed under load), `"closed"` (workers gone), or
+/// `"uninitialised"` (no dispatcher installed — tests/embedders). A sustained
+/// `queue_full` rate is the operator signal that the event store cannot keep
+/// up with download volume; the byte plane is unaffected by design.
+pub fn record_download_event_dropped(kind: &str, reason: &str) {
+    counter!(
+        "ak_download_events_dropped_total",
+        "kind" => kind.to_string(),
+        "reason" => reason.to_string()
+    )
+    .increment(1);
+}
+
+/// Update the bounded download-event queue-depth gauge (#2522). Sampled on
+/// enqueue; a depth pinned at the configured capacity together with a rising
+/// `ak_download_events_dropped_total{reason="queue_full"}` means the flush
+/// workers are saturated.
+pub fn set_download_event_queue_depth(depth: f64) {
+    gauge!("ak_download_event_queue_depth").set(depth);
+}
+
 /// Record an outbound URL that was rejected by SSRF validation, either
 /// at handler entry (`validate_outbound_url`) or on a redirect hop
 /// inside the shared HTTP client. `reason` is `"hostname"` or `"ip"`,

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -175,19 +175,22 @@ pub fn record_webhook_dead_letter(event: &str) {
     .increment(1);
 }
 
-/// Record a download side-effect event (stats/audit) dropped by the bounded
+/// Record download side-effect events (stats/audit) dropped by the bounded
 /// dispatcher (#2522). `kind` is `"stats"` or `"audit"`; `reason` is
-/// `"queue_full"` (overflow shed under load), `"closed"` (workers gone), or
-/// `"uninitialised"` (no dispatcher installed — tests/embedders). A sustained
-/// `queue_full` rate is the operator signal that the event store cannot keep
-/// up with download volume; the byte plane is unaffected by design.
-pub fn record_download_event_dropped(kind: &str, reason: &str) {
+/// `"queue_full"` (overflow shed under load), `"closed"` (workers gone),
+/// `"uninitialised"` (no dispatcher installed — tests/embedders), or
+/// `"flush_failed"` (the DB rejected the row even via the per-row fallback,
+/// e.g. a poison row or event-store error — `count` is the rows lost). A
+/// sustained `queue_full` rate means the event store cannot keep up with
+/// download volume; any `flush_failed` deserves a look at the warn logs. The
+/// byte plane is unaffected by design in every case.
+pub fn record_download_events_dropped(kind: &str, reason: &str, count: u64) {
     counter!(
         "ak_download_events_dropped_total",
         "kind" => kind.to_string(),
         "reason" => reason.to_string()
     )
-    .increment(1);
+    .increment(count);
 }
 
 /// Update the bounded download-event queue-depth gauge (#2522). Sampled on

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -19,6 +19,7 @@ pub mod cluster_lock;
 pub mod cluster_work;
 pub mod declared_dependencies;
 pub mod dependency_track_service;
+pub mod download_event_dispatch;
 pub mod email_dispatcher;
 pub mod email_rate_limiter;
 pub mod encryption;

--- a/backend/src/testing.rs
+++ b/backend/src/testing.rs
@@ -102,7 +102,7 @@ pub fn on_connect_result<T>(result: Result<T, sqlx::Error>) -> Option<T> {
 /// the DB is not required; a connect failure under [`REQUIRE_DB_ENV`] panics.
 pub async fn try_pool_with(max_connections: u32) -> Option<PgPool> {
     let url = require_db_url()?;
-    on_connect_result(
+    let pool = on_connect_result(
         sqlx::postgres::PgPoolOptions::new()
             .max_connections(max_connections)
             // llvm-cov + nextest run DB-backed lib tests in parallel processes.
@@ -111,7 +111,74 @@ pub async fn try_pool_with(max_connections: u32) -> Option<PgPool> {
             .acquire_timeout(std::time::Duration::from_secs(30))
             .connect(&url)
             .await,
-    )
+    )?;
+    ensure_download_event_dispatch(&url).await;
+    Some(pool)
+}
+
+/// Start (once per test process) the bounded download-event dispatcher that
+/// the production binary installs in `main.rs` (#2522), so DB-backed tests
+/// asserting `download_statistics` / download-audit rows exercise the REAL
+/// bounded path. An uninstalled dispatcher degrades to a silent drop by
+/// design, which would otherwise fiction-green those assertions into
+/// timeouts. Living here — the shared body every module-local `try_pool`
+/// delegates to — is what guarantees every DB-backed test gets it.
+///
+/// The flush workers must outlive any single `#[tokio::test]` runtime: under
+/// plain `cargo test` every test builds and drops its own runtime, which would
+/// kill workers spawned on it and strand the process-global sender on a closed
+/// channel. So the dispatcher runs on a dedicated background thread with its
+/// own long-lived current-thread runtime and its own small pool. Under
+/// `cargo nextest` (one process per test) each test process starts its own.
+async fn ensure_download_event_dispatch(url: &str) {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    let url = url.to_string();
+    INIT.call_once(move || {
+        let _ = std::thread::Builder::new()
+            .name("dl-event-dispatch-test".into())
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        eprintln!("test download-event dispatcher: runtime build failed: {e}");
+                        return;
+                    }
+                };
+                rt.block_on(async move {
+                    match sqlx::postgres::PgPoolOptions::new()
+                        .max_connections(2)
+                        .acquire_timeout(std::time::Duration::from_secs(30))
+                        .connect(&url)
+                        .await
+                    {
+                        Ok(pool) => {
+                            crate::services::download_event_dispatch::start_download_event_dispatch(
+                                pool,
+                                tokio_util::sync::CancellationToken::new(),
+                            );
+                            // Keep the worker runtime alive for the process
+                            // lifetime; the thread dies with the process.
+                            std::future::pending::<()>().await;
+                        }
+                        Err(e) => {
+                            eprintln!("test download-event dispatcher: DB connect failed: {e}");
+                        }
+                    }
+                });
+            });
+    });
+    // Wait (bounded) until the dispatcher handle is installed so a test's very
+    // first `record_download` cannot race the background install and no-op.
+    for _ in 0..500 {
+        if crate::services::download_event_dispatch::dispatch_installed() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Bounds the download-path side-effect writes behind a fixed-size dispatch, decoupling serving availability from the event store and capping per-request background work (#2522, the "bounded" half; the earlier slice already moved these writes off the byte plane).

Previously, every served download body spawned a detached `tokio::spawn` per side-effect write — one for the `download_statistics` INSERT (`record_download`, the funnel for ~45 serving call sites) and one for the `ARTIFACT_DOWNLOADED` audit entry (`finish_download`). Each detached task took a catalog-pool connection with no cap and no backpressure, so sustained download traffic against a slow or failing event store grew tasks and pool connections without bound, and the exhausted pool coupled back into serving (artifact lookup uses the same pool).

This PR replaces the per-request spawns with the codebase's established bounded-outbox shape:

- **New `services/download_event_dispatch`**: one process-global bounded `mpsc` queue (default depth 8192, `DOWNLOAD_EVENT_QUEUE_DEPTH`) behind an `OnceLock<Option<Sender>>` — the `GLOBAL_AUTH_SEMAPHORE` install/degrade idiom, so an uninstalled dispatcher (tests, embedders) degrades to a silent no-op and never panics.
- A **fixed pool of flush workers** (default 2, `DOWNLOAD_EVENT_FLUSH_WORKERS`), modelled on `webhook_producer::start_webhook_producer` and started next to it in `main.rs` (before the servers bind), that drain the queue and **batch-INSERT** (parallel-array UNNEST, same shape as the webhook producer's batch insert) into the existing `download_statistics` and `audit_log` tables. Fewer round-trips than one INSERT per request; no migration.
- Producers only `try_send` (never block, await, or spawn). A full queue **sheds** the event — dropped and counted via `ak_download_events_dropped_total{kind,reason}` plus an `ak_download_event_queue_depth` gauge — so worst case under overload is bounded telemetry loss, never byte-plane impact. These writes were already best-effort on `main` (log-and-swallow, lost on crash); this PR preserves that contract and does not upgrade audit durability.

Invariants preserved:

- `is_head` "no body ⇒ no row" is still checked synchronously in `record_download` before any enqueue (#2260).
- Trusted-proxy IP attribution (`DownloadContext`) is captured and stringified at request time, inside the event, so it cannot drift across the async hop (#2365).
- The 37 non-hot-path `audit_fire_and_forget` call sites (auth/user/token lifecycle) are untouched; only the download hot-path emitter routes through the dispatcher.
- Eventual-write semantics: stats/audit rows land after a short batch-flush delay; the existing bounded-retry poll tests still pass.

`crate::testing::try_pool_with` now also installs the dispatcher once per test process (on a dedicated long-lived runtime thread) so every DB-backed test exercises the real bounded path.

**Batching must not amplify loss** (follow-up review findings on this PR):

- The User-Agent header — the only attacker-controlled free string that reaches the stats row — is clamped to the `download_statistics.user_agent` column width (VARCHAR(512)) both at request capture (`DownloadContext`) and at insert build time, so an oversized value can no longer fail a multi-row INSERT and drop up to `FLUSH_BATCH_MAX` co-batched rows (pre-batching blast radius was self-only; this restores that). All other batched fields are structurally bounded (parsed `IpAddr`, UUIDs, enum action strings, clamped correlation id, JSONB details).
- Defense-in-depth split-batch fallback: if a batch INSERT still fails for any reason, both flush paths retry the batch's rows individually — one bad row can only lose itself, never its neighbors (`flush_stats_with_fallback`, `AuditService::log_batch`).
- Flush-time losses are no longer invisible: rows the DB rejects even via the fallback are counted in `ak_download_events_dropped_total{reason="flush_failed"}` (per lost row) alongside the existing `queue_full`/`closed`/`uninitialised` reasons, plus an in-process counter (`flush_lost_total`) that tests assert.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`services::download_event_dispatch::tests::test_flood_beyond_capacity_stays_bounded_and_sheds` drives a 10k-event flood against a stalled sink and asserts in-flight work caps at the queue depth with every overflow counted — on the previous per-request-spawn code there was no bound to assert (task count grew with request count). Additional tests cover the graceful no-op when uninstalled, shed-on-closed, and an end-to-end batch flush (stats + audit) with IP/user-agent attribution intact.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manually verified on an isolated stack: with a `pg_sleep` trigger simulating a slow event store, an 80-request concurrent download flood returned 200 with exact bytes on every request while concurrent `download_statistics` INSERT backends stayed at or below the worker count (previously they climbed toward the pool max); all rows landed after the sink recovered; HEAD recorded nothing.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2522
