### PR TITLE
feat(npm): inline scan-and-block on proxy tarball pulls + shared scan-gate core

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2762,6 +2762,7 @@ async fn serve_tarball(
                     repo.id,
                     repo_key,
                     upstream_url,
+                    package_name,
                     &fetch_path,
                     &response_filename,
                     ctx,
@@ -3044,6 +3045,54 @@ async fn correct_cached_tarball_content_type(db: &PgPool, repository_id: uuid::U
 // synthetic-artifact shape, and response builder.
 // ---------------------------------------------------------------------------
 
+/// The npm version a tarball filename encodes for `package_name`, per the
+/// registry's invariant filename shape `{basename}-{version}.tgz` (#3003).
+///
+/// `basename` is the unscoped half of the name (`@acme/widget` → `widget`), so
+/// this resolves scoped and unscoped packages identically. Returns `None` when
+/// the filename does not have that shape for this package — which the serve
+/// path treats as inconclusive rather than guessing, because the version is
+/// half of the identity the CVE engine must grade.
+fn npm_version_from_tarball_filename(package_name: &str, filename: &str) -> Option<String> {
+    let basename = package_name.rsplit('/').next().unwrap_or(package_name);
+    let stem = filename.strip_suffix(".tgz")?;
+    let version = stem.strip_prefix(&format!("{basename}-"))?;
+    (!version.is_empty()).then(|| version.to_string())
+}
+
+/// The `name`/`version` an npm tarball claims for ITSELF, read from the
+/// `package/package.json` that `npm pack` always writes (#3003).
+///
+/// Returns `None` when the entry is absent, unparseable, or carries a
+/// non-string / empty name or version — including the JSON-number version
+/// shape. Every one of those is "this tarball does not state a usable
+/// identity", which the caller must treat as inconclusive, never clean.
+fn npm_claimed_identity(tarball: &Bytes) -> Option<(String, String)> {
+    let body = crate::util::bounded_archive::read_metadata_from_tar_gz(&tarball[..], |path| {
+        path == std::path::Path::new("package/package.json")
+    })
+    .ok()??;
+    let v: serde_json::Value = serde_json::from_slice(&body).ok()?;
+    let name = v.get("name")?.as_str()?.trim().to_string();
+    let version = v.get("version")?.as_str()?.trim().to_string();
+    (!name.is_empty() && !version.is_empty()).then_some((name, version))
+}
+
+/// Whether the identity a tarball claims for itself agrees with the coordinate
+/// it is being served at (#3003).
+///
+/// npm names are lowercase by construction, but compare case-insensitively so a
+/// legacy mixed-case publication is not spuriously withheld. Version equality
+/// is exact: a tarball claiming a different version than the URL pins is not
+/// the artifact the consumer asked for.
+fn npm_identity_agrees(
+    requested_name: &str,
+    requested_version: &str,
+    claimed: &(String, String),
+) -> bool {
+    claimed.0.eq_ignore_ascii_case(requested_name) && claimed.1 == requested_version
+}
+
 /// Build the synthetic in-memory [`Artifact`](crate::models::artifact::Artifact)
 /// the leaf scanners run over for a proxied npm tarball. There is NO
 /// `artifacts` row (proxy-cached bytes are deliberately not persisted as
@@ -3120,6 +3169,7 @@ async fn serve_scanned_npm_tarball(
     repo_id: uuid::Uuid,
     repo_key: &str,
     upstream_url: &str,
+    package_name: &str,
     fetch_path: &str,
     filename: &str,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
@@ -3199,9 +3249,53 @@ async fn serve_scanned_npm_tarball(
     correct_cached_tarball_content_type(&state.db, repo_id, fetch_path).await;
 
     let digest = proxy_helpers::sha256_hex(&bytes);
+
+    // #3003: establish WHAT these bytes are being served as.
+    //
+    // The coordinate comes from the REQUEST (route package name + the
+    // registry's invariant `{basename}-{version}.tgz` filename), never from
+    // bytes the upstream controls, and the tarball's own `package/package.json`
+    // must agree with it. A tarball that states a different identity, states
+    // none, or states an unusable one (missing/empty/non-string version) is
+    // unassessable: any scan of it would grade something other than the package
+    // the consumer is about to install under this coordinate.
+    //
+    // This is only consulted when the shared gate actually needs to SCAN — a
+    // cached vulnerable verdict for this digest still blocks first, from cache.
+    let identity = match npm_version_from_tarball_filename(package_name, filename) {
+        Some(version) => match npm_claimed_identity(&bytes) {
+            Some(claimed) if npm_identity_agrees(package_name, &version, &claimed) => {
+                proxy_helpers::ProxyScanIdentity::Established(
+                    crate::services::scanner_service::ExpectedComponent::new(
+                        crate::services::scanner_service::ComponentEcosystem::Npm,
+                        package_name,
+                        &version,
+                    ),
+                )
+            }
+            other => {
+                tracing::warn!(
+                    repo_id = %repo_id, file = %filename, digest = %digest,
+                    requested = %format!("{package_name}@{version}"),
+                    claimed = ?other,
+                    "npm proxy tarball does not state the identity it is served as"
+                );
+                proxy_helpers::ProxyScanIdentity::Unestablished
+            }
+        },
+        None => {
+            tracing::warn!(
+                repo_id = %repo_id, file = %filename, digest = %digest,
+                package = %package_name,
+                "npm proxy tarball filename does not encode a version for this package"
+            );
+            proxy_helpers::ProxyScanIdentity::Unestablished
+        }
+    };
+
     let synthetic = npm_synthetic_artifact(repo_id, filename, &digest, bytes.len() as i64);
     match proxy_helpers::gate_proxy_scan_serve(
-        state, repo_id, filename, &digest, synthetic, &bytes, action,
+        state, repo_id, filename, &digest, synthetic, &bytes, action, identity,
     )
     .await
     {
@@ -9175,7 +9269,7 @@ mod proxy_scan_block_tests {
         upstream: &wiremock::MockServer,
         package: &str,
         filename: &str,
-        tarball: &'static [u8],
+        tarball: &[u8],
         expected_fetches: Option<u64>,
     ) {
         use wiremock::matchers::{method, path};
@@ -9184,7 +9278,7 @@ mod proxy_scan_block_tests {
             .and(path(format!("/{package}/-/{filename}")))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_bytes(tarball)
+                    .set_body_bytes(tarball.to_vec())
                     .insert_header("Content-Type", "application/octet-stream"),
             );
         if let Some(n) = expected_fetches {
@@ -9230,6 +9324,272 @@ mod proxy_scan_block_tests {
         assert!(a.storage_key.is_empty());
     }
 
+    /// Build an npm-shaped `.tgz` whose `package/package.json` is exactly
+    /// `body` (or omit the file entirely when `body` is `None`), so the
+    /// crafted-identity shapes are exercised over real tarball bytes.
+    fn crafted_tgz(package_json: Option<&[u8]>) -> Bytes {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut gz);
+            if let Some(body) = package_json {
+                let mut header = tar::Header::new_gnu();
+                header.set_path("package/package.json").unwrap();
+                header.set_size(body.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append(&header, body).unwrap();
+            }
+            let index = b"module.exports = 1;\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_path("package/index.js").unwrap();
+            header.set_size(index.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, index.as_ref()).unwrap();
+            builder.finish().unwrap();
+        }
+        gz.flush().unwrap();
+        Bytes::from(gz.finish().unwrap())
+    }
+
+    /// A real npm-shaped `.tgz` that honestly states `name@version` — what the
+    /// registry serves, and what the identity gate requires before a scan of
+    /// it can be vouched for.
+    fn honest_tgz(name: &str, version: &str) -> Bytes {
+        crafted_tgz(Some(
+            serde_json::json!({ "name": name, "version": version })
+                .to_string()
+                .as_bytes(),
+        ))
+    }
+
+    /// #3003: the served version comes from the registry's invariant filename
+    /// shape, for scoped and unscoped packages alike — never from the bytes.
+    #[test]
+    fn test_npm_version_from_tarball_filename() {
+        assert_eq!(
+            npm_version_from_tarball_filename("lodash", "lodash-4.17.11.tgz").as_deref(),
+            Some("4.17.11")
+        );
+        // Scoped: the filename uses the UNSCOPED basename.
+        assert_eq!(
+            npm_version_from_tarball_filename("@acme/widget", "widget-1.0.0.tgz").as_deref(),
+            Some("1.0.0")
+        );
+        // Prerelease/build metadata is part of the version, not a delimiter.
+        assert_eq!(
+            npm_version_from_tarball_filename("pkg", "pkg-1.0.0-beta.1.tgz").as_deref(),
+            Some("1.0.0-beta.1")
+        );
+        // Shapes we must NOT guess at.
+        assert!(npm_version_from_tarball_filename("lodash", "other-1.0.0.tgz").is_none());
+        assert!(npm_version_from_tarball_filename("lodash", "lodash-.tgz").is_none());
+        assert!(npm_version_from_tarball_filename("lodash", "lodash-1.0.0.tar.gz").is_none());
+    }
+
+    /// #3003: what the tarball claims about itself — and the shapes that mean
+    /// "this tarball states no usable identity" (red-team shapes c and d).
+    #[test]
+    fn test_npm_claimed_identity_shapes() {
+        let honest = crafted_tgz(Some(br#"{"name":"lodash","version":"4.17.11"}"#));
+        assert_eq!(
+            npm_claimed_identity(&honest),
+            Some(("lodash".to_string(), "4.17.11".to_string()))
+        );
+
+        // (c) no package.json at all.
+        assert!(npm_claimed_identity(&crafted_tgz(None)).is_none());
+        // (d) version as a JSON NUMBER, not a string.
+        assert!(
+            npm_claimed_identity(&crafted_tgz(Some(br#"{"name":"lodash","version":4.17}"#)))
+                .is_none()
+        );
+        // Missing / empty halves.
+        assert!(npm_claimed_identity(&crafted_tgz(Some(br#"{"name":"lodash"}"#))).is_none());
+        assert!(
+            npm_claimed_identity(&crafted_tgz(Some(br#"{"name":"","version":"1.0.0"}"#))).is_none()
+        );
+        // Not even valid JSON.
+        assert!(npm_claimed_identity(&crafted_tgz(Some(b"nope"))).is_none());
+    }
+
+    /// #3003 (red-team shape a): a tarball whose package.json was rewritten to
+    /// a benign identity does NOT agree with the coordinate it is served at.
+    #[test]
+    fn test_npm_identity_agreement() {
+        assert!(npm_identity_agrees(
+            "lodash",
+            "4.17.11",
+            &("lodash".into(), "4.17.11".into())
+        ));
+        // Legacy mixed-case publication still agrees.
+        assert!(npm_identity_agrees(
+            "@acme/Widget",
+            "1.0.0",
+            &("@acme/widget".into(), "1.0.0".into())
+        ));
+        // (a) rewritten to a benign name.
+        assert!(!npm_identity_agrees(
+            "lodash",
+            "4.17.11",
+            &("totally-benign".into(), "1.0.0".into())
+        ));
+        // Rewritten to a benign VERSION of the right name (e.g. a patched one).
+        assert!(!npm_identity_agrees(
+            "lodash",
+            "4.17.11",
+            &("lodash".into(), "4.17.21".into())
+        ));
+    }
+
+    /// #3003 END-TO-END, red-team Finding 1: each crafted shape that defeats
+    /// content-derived identity must be WITHHELD under fail_closed (423),
+    /// never served 200-clean. The state has no scanner service, so a 200 here
+    /// could only mean the gate let unassessed bytes through.
+    #[tokio::test]
+    async fn test_serve_tarball_crafted_identity_shapes_are_withheld() {
+        let shapes: Vec<(&str, Option<&[u8]>)> = vec![
+            // (a) identity rewritten to something benign.
+            (
+                "rewritten-identity",
+                Some(br#"{"name":"totally-benign","version":"1.0.0"}"#),
+            ),
+            // (c) package.json removed entirely.
+            ("no-package-json", None),
+            // (d) version as a JSON number.
+            (
+                "numeric-version",
+                Some(br#"{"name":"lodash","version":4.17}"#),
+            ),
+            // Right name, wrong version.
+            (
+                "version-mismatch",
+                Some(br#"{"name":"lodash","version":"4.17.21"}"#),
+            ),
+        ];
+
+        for (label, package_json) in shapes {
+            let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+                return;
+            };
+            let tarball = crafted_tgz(package_json);
+            let upstream = wiremock::MockServer::start().await;
+            {
+                use wiremock::matchers::{method, path};
+                use wiremock::{Mock, ResponseTemplate};
+                Mock::given(method("GET"))
+                    .and(path("/lodash/-/lodash-4.17.11.tgz"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_bytes(tarball.to_vec())
+                            .insert_header("Content-Type", "application/octet-stream"),
+                    )
+                    .mount(&upstream)
+                    .await;
+            }
+            point_upstream(&fx, &upstream).await;
+            enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+            let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+            let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+            let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+            let result = super::serve_tarball(
+                &state,
+                &fx.repo_key,
+                "lodash",
+                "lodash-4.17.11.tgz",
+                &Default::default(),
+            )
+            .await;
+
+            let digest = sha256_hex(&tarball);
+            cleanup_proxy_scan_row(&fx.pool, &digest).await;
+            fx.teardown().await;
+
+            match result {
+                Ok(r) => panic!(
+                    "{label}: a tarball that does not state the identity it is served \
+                     as must be withheld under fail_closed, got {}",
+                    r.status()
+                ),
+                Err(resp) => assert_eq!(
+                    resp.status(),
+                    StatusCode::LOCKED,
+                    "{label}: expected 423 (inconclusive), not a clean serve"
+                ),
+            }
+        }
+    }
+
+    /// Availability control for the shapes above: under fail_OPEN the same
+    /// unassessable tarball still serves, loudly marked pending — the
+    /// hardening tightens fail_closed without changing the latency-first
+    /// posture operators opted into.
+    #[tokio::test]
+    async fn test_serve_tarball_crafted_identity_serves_pending_under_fail_open() {
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball = crafted_tgz(Some(br#"{"name":"totally-benign","version":"1.0.0"}"#));
+        let upstream = wiremock::MockServer::start().await;
+        {
+            use wiremock::matchers::{method, path};
+            use wiremock::{Mock, ResponseTemplate};
+            Mock::given(method("GET"))
+                .and(path("/lodash/-/lodash-4.17.11.tgz"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(tarball.to_vec())
+                        .insert_header("Content-Type", "application/octet-stream"),
+                )
+                .mount(&upstream)
+                .await;
+        }
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_open").await;
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "lodash",
+            "lodash-4.17.11.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("fail_open must still serve, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        cleanup_proxy_scan_row(&fx.pool, &sha256_hex(&tarball)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan.as_deref(),
+            Some("pending"),
+            "an unassessable serve under fail_open must be loudly marked pending"
+        );
+    }
+
     /// Fail-closed + inconclusive scan (no scanner service on the state) must
     /// 423, never serve unscanned tarball bytes — npm inherits the #2954
     /// fail-closed contract through the shared gate.
@@ -9238,14 +9598,14 @@ mod proxy_scan_block_tests {
         let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
             return;
         };
-        let tarball: &[u8] = b"\x1f\x8b sealed-npm-tarball-3003-fail-closed";
+        let tarball = honest_tgz("sealed-widget", "1.0.0");
 
         let upstream = wiremock::MockServer::start().await;
         mount_tarball_upstream(
             &upstream,
             "sealed-widget",
             "sealed-widget-1.0.0.tgz",
-            tarball,
+            &tarball,
             None,
         )
         .await;
@@ -9288,14 +9648,14 @@ mod proxy_scan_block_tests {
         let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
             return;
         };
-        let tarball: &[u8] = b"\x1f\x8b open-npm-tarball-3003-fail-open";
+        let tarball = honest_tgz("open-widget", "2.0.0");
 
         let upstream = wiremock::MockServer::start().await;
         mount_tarball_upstream(
             &upstream,
             "open-widget",
             "open-widget-2.0.0.tgz",
-            tarball,
+            &tarball,
             None,
         )
         .await;
@@ -9339,9 +9699,7 @@ mod proxy_scan_block_tests {
         let body = axum::body::to_bytes(resp.into_body(), 16 * 1024 * 1024)
             .await
             .expect("body");
-        let digest = sha256_hex(&Bytes::from_static(
-            b"\x1f\x8b open-npm-tarball-3003-fail-open",
-        ));
+        let digest = sha256_hex(&tarball);
         cleanup_proxy_scan_row(&fx.pool, &digest).await;
         fx.teardown().await;
 
@@ -9353,7 +9711,11 @@ mod proxy_scan_block_tests {
         );
         assert_eq!(ct.as_deref(), Some(NPM_TARBALL_CONTENT_TYPE));
         assert_eq!(digest_header.as_deref(), Some(digest.as_str()));
-        assert_eq!(&body[..], tarball, "served bytes must equal upstream bytes");
+        assert_eq!(
+            &body[..],
+            &tarball[..],
+            "served bytes must equal upstream bytes"
+        );
     }
 
     /// A fresh cached VULNERABLE verdict for the tarball digest blocks with
@@ -9603,17 +9965,15 @@ mod proxy_scan_block_tests {
         let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
             return;
         };
-        let tarball: &[u8] = b"\x1f\x8b staleclean-npm-tarball-3003-bumped";
-        let digest = sha256_hex(&Bytes::from_static(
-            b"\x1f\x8b staleclean-npm-tarball-3003-bumped",
-        ));
+        let tarball = honest_tgz("staleclean-widget", "1.0.0");
+        let digest = sha256_hex(&tarball);
 
         let upstream = wiremock::MockServer::start().await;
         mount_tarball_upstream(
             &upstream,
             "staleclean-widget",
             "staleclean-widget-1.0.0.tgz",
-            tarball,
+            &tarball,
             None,
         )
         .await;
@@ -9685,17 +10045,15 @@ mod proxy_scan_block_tests {
         let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
             return;
         };
-        let tarball: &[u8] = b"\x1f\x8b probenone-npm-tarball-3003-failclosed";
-        let digest = sha256_hex(&Bytes::from_static(
-            b"\x1f\x8b probenone-npm-tarball-3003-failclosed",
-        ));
+        let tarball = honest_tgz("probenone-widget", "1.0.0");
+        let digest = sha256_hex(&tarball);
 
         let upstream = wiremock::MockServer::start().await;
         mount_tarball_upstream(
             &upstream,
             "probenone-widget",
             "probenone-widget-1.0.0.tgz",
-            tarball,
+            &tarball,
             None,
         )
         .await;

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2743,6 +2743,32 @@ async fn serve_tarball(
                 response_filename = lkg_filename;
             }
 
+            // #3003: when scan-on-proxy is enabled, route through the inline
+            // scan-and-block path (buffered capped fetch + digest-keyed
+            // verdict gate shared with proxy-PyPI, #2954/#2970/#2976). Taken
+            // INSTEAD of the streaming path below, which serves tarball bytes
+            // without consulting a scan verdict. Repos that have not enabled
+            // scan-on-proxy skip this entirely and keep today's untouched
+            // streaming behavior (no regression). Runs after the age gate so
+            // a last-known-good substitution is scanned as what is served.
+            if crate::services::scan_config_service::ScanConfigService::new(state.db.clone())
+                .is_proxy_scan_enabled(repo.id)
+                .await
+                .unwrap_or(false)
+            {
+                return serve_scanned_npm_tarball(
+                    state,
+                    proxy,
+                    repo.id,
+                    repo_key,
+                    upstream_url,
+                    &fetch_path,
+                    &response_filename,
+                    ctx,
+                )
+                .await;
+            }
+
             // #2192 / #1608 Phase 4c: an npm tarball is a package BLOB, not
             // metadata. The buffered fallback (#2181) capped it at
             // LARGE_METADATA_MAX_BYTES and 502'd a tarball larger than the cap
@@ -3005,6 +3031,187 @@ async fn correct_cached_tarball_content_type(db: &PgPool, repository_id: uuid::U
             path,
             e
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #3003: inline scan-and-block on npm proxy tarball download.
+//
+// npm parity with proxy-PyPI (#2954/#2970/#2976): the verdict state machine,
+// the fail-closed scanner loop, and the block/lock responses are the SHARED
+// implementations in `proxy_helpers` / `proxy_scan_service` /
+// `scanner_service` — this section only supplies the npm-specific fetch,
+// synthetic-artifact shape, and response builder.
+// ---------------------------------------------------------------------------
+
+/// Build the synthetic in-memory [`Artifact`](crate::models::artifact::Artifact)
+/// the leaf scanners run over for a proxied npm tarball. There is NO
+/// `artifacts` row (proxy-cached bytes are deliberately not persisted as
+/// artifacts, #1278/#1280). The `.tgz` filename plus the `application/gzip`
+/// content type drive scanner applicability and archive extraction exactly as
+/// for a hosted npm tarball (see [`correct_cached_tarball_content_type`] for
+/// why the content type must be gzip).
+fn npm_synthetic_artifact(
+    repo_id: uuid::Uuid,
+    filename: &str,
+    digest: &str,
+    size: i64,
+) -> crate::models::artifact::Artifact {
+    let now = chrono::Utc::now();
+    crate::models::artifact::Artifact {
+        id: uuid::Uuid::new_v4(),
+        repository_id: repo_id,
+        path: filename.to_string(),
+        name: filename.to_string(),
+        version: None,
+        size_bytes: size,
+        checksum_sha256: digest.to_string(),
+        checksum_md5: None,
+        checksum_sha1: None,
+        content_type: NPM_TARBALL_CONTENT_TYPE.to_string(),
+        storage_key: String::new(),
+        is_deleted: false,
+        uploaded_by: None,
+        quarantine_status: None,
+        quarantine_until: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+/// Build a buffered 200 response for scanned npm tarball bytes. `pending`
+/// selects the loud `X-AK-Scan: pending` header for the fail-open
+/// serve-before-verdict path so a served-unscanned byte is observable.
+fn build_scanned_tarball_response(
+    filename: &str,
+    bytes: Bytes,
+    digest: &str,
+    pending: bool,
+) -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, NPM_TARBALL_CONTENT_TYPE)
+        .header(
+            "Content-Disposition",
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .header(CONTENT_LENGTH, bytes.len().to_string())
+        .header("X-AK-Scan", if pending { "pending" } else { "clean" })
+        .header("X-NPM-Tarball-SHA256", digest)
+        .body(Body::from(bytes))
+        .unwrap()
+}
+
+/// Inline scan-and-block for an npm proxy tarball download (#3003).
+///
+/// Runs ONLY when scan-on-proxy is enabled for the repo; the caller keeps the
+/// untouched streaming path otherwise. Flow mirrors `serve_scanned_pypi_file`:
+/// buffered capped fetch (cache-first, so a repeat pull is served from cache
+/// with no upstream hit) → content digest over the TARBALL bytes (never the
+/// packument or anything the upstream index controls) → shared digest-keyed
+/// verdict gate → serve / block (403) / lock (423) per the repo's
+/// fail-open/closed action. Scoped packages need no special-casing: the
+/// concrete `@scope/pkg/-/file.tgz` fetch path is the single seam every
+/// `npm install` byte passes through, and the verdict is keyed on content.
+#[allow(clippy::too_many_arguments)]
+async fn serve_scanned_npm_tarball(
+    state: &SharedState,
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    filename: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
+) -> Result<Response, Response> {
+    let action = crate::services::scan_config_service::ScanConfigService::new(state.db.clone())
+        .proxy_scan_action(repo_id)
+        .await
+        .unwrap_or(crate::services::proxy_scan_service::ProxyScanAction::FailOpen);
+
+    // Buffered capped fetch (cache-first) under the SAME cache key as the
+    // streaming path (`fetch_path`), so the cache stays warm across the two
+    // paths and a repeat pull returns from cache with NO upstream fetch.
+    let remote_repo = proxy_helpers::build_remote_repo_with_format(
+        repo_id,
+        repo_key,
+        upstream_url,
+        RepositoryFormat::Npm,
+    );
+    let bytes = match proxy
+        .fetch_artifact_with_cache_path_capped(
+            &remote_repo,
+            fetch_path,
+            fetch_path,
+            crate::services::scanner_service::PROXY_SCAN_MAX_BYTES,
+        )
+        .await
+    {
+        Ok((bytes, _upstream_content_type)) => bytes,
+        Err(e) if proxy_helpers::is_over_cap_error(&e) => {
+            // Over the byte cap: never buffer unbounded (#895 OOM).
+            return match crate::services::proxy_scan_service::decide_inconclusive(action) {
+                crate::services::proxy_scan_service::InconclusiveOutcome::Locked => {
+                    tracing::warn!(
+                        repo_id = %repo_id, file = %filename,
+                        "npm proxy tarball exceeds scan byte cap; fail-closed -> 423"
+                    );
+                    Err(proxy_helpers::scan_pending_locked_response(filename))
+                }
+                crate::services::proxy_scan_service::InconclusiveOutcome::ServePending => {
+                    // Fail-open oversized: serve via the untouched streaming
+                    // path (loud: X-AK-Scan pending header on the stream).
+                    tracing::warn!(
+                        repo_id = %repo_id, file = %filename,
+                        "npm proxy tarball exceeds scan byte cap; fail-open -> serving UNSCANNED (streaming)"
+                    );
+                    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key(
+                        proxy,
+                        repo_id,
+                        repo_key,
+                        upstream_url,
+                        fetch_path,
+                        fetch_path,
+                        RepositoryFormat::Npm,
+                    )
+                    .await?;
+                    correct_cached_tarball_content_type(&state.db, repo_id, fetch_path).await;
+                    proxy_helpers::record_proxy_download(state, repo_id, repo_key, fetch_path, ctx)
+                        .await;
+                    let mut resp = build_tarball_response_stream(
+                        result.body,
+                        filename,
+                        npm_virtual_tarball_content_type(result.content_type),
+                        result.content_length,
+                    );
+                    resp.headers_mut()
+                        .insert("X-AK-Scan", axum::http::HeaderValue::from_static("pending"));
+                    Ok(resp)
+                }
+            };
+        }
+        Err(e) => return Err(e.into_response()),
+    };
+
+    // The upstream registry may return application/octet-stream; correct the
+    // cached record so SBOM generation / background scanners see gzip (same
+    // as the streaming path).
+    correct_cached_tarball_content_type(&state.db, repo_id, fetch_path).await;
+
+    let digest = proxy_helpers::sha256_hex(&bytes);
+    let synthetic = npm_synthetic_artifact(repo_id, filename, &digest, bytes.len() as i64);
+    match proxy_helpers::gate_proxy_scan_serve(
+        state, repo_id, filename, &digest, synthetic, &bytes, action,
+    )
+    .await
+    {
+        proxy_helpers::ProxyScanServeOutcome::Deny(resp) => Err(resp),
+        proxy_helpers::ProxyScanServeOutcome::Serve { pending } => {
+            proxy_helpers::record_proxy_download(state, repo_id, repo_key, fetch_path, ctx).await;
+            Ok(build_scanned_tarball_response(
+                filename, bytes, &digest, pending,
+            ))
+        }
     }
 }
 
@@ -8939,5 +9146,667 @@ mod db_cov_tests {
         }
 
         fx.teardown().await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #3003: inline scan-and-block on the npm remote tarball serve path.
+//
+// These drive `serve_tarball` end-to-end into `serve_scanned_npm_tarball`
+// with a wiremock upstream, a real proxy service, and a scan_configs row
+// with scan_on_proxy enabled — mirroring the PyPI #2954/#2976 suite so
+// npm demonstrably inherits the same shared gate. Skip cleanly when
+// DATABASE_URL is unset.
+// ---------------------------------------------------------------------------
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
+#[cfg(test)]
+mod proxy_scan_block_tests {
+    use super::*;
+
+    use crate::api::handlers::proxy_helpers::sha256_hex;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use crate::api::handlers::test_db_helpers::enable_proxy_scan;
+    use crate::services::scanner_service::test_helpers::{MockCveRescan, VersionedCveScanner};
+
+    /// Mount the concrete tarball route (`/{package}/-/{filename}`) — the
+    /// single seam every `npm install` byte passes through.
+    async fn mount_tarball_upstream(
+        upstream: &wiremock::MockServer,
+        package: &str,
+        filename: &str,
+        tarball: &'static [u8],
+        expected_fetches: Option<u64>,
+    ) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        let mut mock = Mock::given(method("GET"))
+            .and(path(format!("/{package}/-/{filename}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(tarball)
+                    .insert_header("Content-Type", "application/octet-stream"),
+            );
+        if let Some(n) = expected_fetches {
+            mock = mock.expect(n);
+        }
+        mock.mount(upstream).await;
+    }
+
+    /// Point the fixture repo's upstream_url at the wiremock server (the
+    /// serve path re-reads the repository row from the DB).
+    async fn point_upstream(fx: &tdh::Fixture, upstream: &wiremock::MockServer) {
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(upstream.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+    }
+
+    async fn cleanup_proxy_scan_row(pool: &sqlx::PgPool, digest: &str) {
+        // proxy_scan_results outlives repo cleanup (repository_id is SET NULL
+        // on delete): remove the digest row explicitly.
+        sqlx::query("DELETE FROM proxy_scan_results WHERE checksum_sha256 = $1")
+            .bind(digest)
+            .execute(pool)
+            .await
+            .expect("cleanup proxy_scan_results");
+    }
+
+    /// The synthetic scan identity for a proxied npm tarball: `.tgz` name +
+    /// `application/gzip` content type (drives Grype applicability + archive
+    /// extraction), digest-keyed, with NO artifacts-row storage key.
+    #[test]
+    fn test_npm_synthetic_artifact_shape() {
+        let repo_id = uuid::Uuid::new_v4();
+        let a = npm_synthetic_artifact(repo_id, "widget-1.0.0.tgz", "ab12", 42);
+        assert_eq!(a.repository_id, repo_id);
+        assert_eq!(a.name, "widget-1.0.0.tgz");
+        assert_eq!(a.path, "widget-1.0.0.tgz");
+        assert_eq!(a.content_type, NPM_TARBALL_CONTENT_TYPE);
+        assert_eq!(a.checksum_sha256, "ab12");
+        assert_eq!(a.size_bytes, 42);
+        assert!(a.storage_key.is_empty());
+    }
+
+    /// Fail-closed + inconclusive scan (no scanner service on the state) must
+    /// 423, never serve unscanned tarball bytes — npm inherits the #2954
+    /// fail-closed contract through the shared gate.
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_fail_closed_inconclusive_is_423() {
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b sealed-npm-tarball-3003-fail-closed";
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "sealed-widget",
+            "sealed-widget-1.0.0.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        // No scanner service on the state: the inline scan is inconclusive.
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "sealed-widget",
+            "sealed-widget-1.0.0.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "fail-closed + inconclusive scan must never serve tarball bytes, got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(
+                resp.status(),
+                StatusCode::LOCKED,
+                "fail-closed inconclusive must be 423 Locked"
+            ),
+        }
+    }
+
+    /// Fail-open first pull serves LOUDLY: 200 with `X-AK-Scan: pending`, the
+    /// digest header, and byte-identical content.
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_fail_open_serves_pending() {
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b open-npm-tarball-3003-fail-open";
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "open-widget",
+            "open-widget-2.0.0.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_open").await;
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "open-widget",
+            "open-widget-2.0.0.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("fail-open first pull must serve, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan_header = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        let ct = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap().to_string());
+        let digest_header = resp
+            .headers()
+            .get("X-NPM-Tarball-SHA256")
+            .map(|v| v.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(resp.into_body(), 16 * 1024 * 1024)
+            .await
+            .expect("body");
+        let digest = sha256_hex(&Bytes::from_static(
+            b"\x1f\x8b open-npm-tarball-3003-fail-open",
+        ));
+        cleanup_proxy_scan_row(&fx.pool, &digest).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan_header.as_deref(),
+            Some("pending"),
+            "a served-before-verdict byte must be observable (X-AK-Scan: pending)"
+        );
+        assert_eq!(ct.as_deref(), Some(NPM_TARBALL_CONTENT_TYPE));
+        assert_eq!(digest_header.as_deref(), Some(digest.as_str()));
+        assert_eq!(&body[..], tarball, "served bytes must equal upstream bytes");
+    }
+
+    /// A fresh cached VULNERABLE verdict for the tarball digest blocks with
+    /// 403 — and a SECOND pull is blocked from the proxy cache with no
+    /// upstream re-fetch (wiremock `expect(1)` verifies on drop), proving the
+    /// verdict is keyed per sha256 and reused.
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_blocks_cached_vulnerable_digest() {
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b poisoned-npm-tarball-3003-vulnerable";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"\x1f\x8b poisoned-npm-tarball-3003-vulnerable",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "poisoned-widget",
+            "poisoned-widget-0.1.0.tgz",
+            tarball,
+            Some(1),
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        // Seed a fresh vulnerable verdict for this digest through the real
+        // service so record_verdict + lookup_verdict are covered end-to-end.
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "vulnerable",
+                3,
+                1,
+                1,
+                1,
+                0,
+                Some("critical"),
+                Some("grype-0.99.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed vulnerable verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        for pull in ["first", "second (cache-served)"] {
+            let result = super::serve_tarball(
+                &state,
+                &fx.repo_key,
+                "poisoned-widget",
+                "poisoned-widget-0.1.0.tgz",
+                &Default::default(),
+            )
+            .await;
+            match result {
+                Ok(r) => {
+                    let status = r.status();
+                    cleanup_proxy_scan_row(&fx.pool, &digest).await;
+                    fx.teardown().await;
+                    panic!("{pull} pull of a vulnerable digest must be blocked, got {status}");
+                }
+                Err(resp) => assert_eq!(
+                    resp.status(),
+                    StatusCode::FORBIDDEN,
+                    "{pull} pull: cached vulnerable digest must be a 403 scan_blocked"
+                ),
+            }
+        }
+
+        cleanup_proxy_scan_row(&fx.pool, &digest).await;
+        fx.teardown().await;
+        // Dropping the mock server verifies expect(1): the second blocked
+        // pull came from the proxy cache, not upstream.
+    }
+
+    /// A SCOPED package (`@scope/pkg`) flows through the same seam and the
+    /// same digest key: a cached vulnerable verdict blocks its tarball too.
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_blocks_scoped_package() {
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b scoped-npm-tarball-3003-vulnerable";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"\x1f\x8b scoped-npm-tarball-3003-vulnerable",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        // Tarball URLs keep the scope separator as a literal `/`.
+        mount_tarball_upstream(
+            &upstream,
+            "@acme/secret-widget",
+            "secret-widget-1.0.0.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "vulnerable",
+                1,
+                1,
+                0,
+                0,
+                0,
+                Some("critical"),
+                Some("grype-0.99.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed vulnerable verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "@acme/secret-widget",
+            "secret-widget-1.0.0.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        cleanup_proxy_scan_row(&fx.pool, &digest).await;
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "scoped vulnerable tarball must be blocked, got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(resp.status(), StatusCode::FORBIDDEN),
+        }
+    }
+
+    /// The cached-`clean` fast path serves 200 `X-AK-Scan: clean` — on a
+    /// FAIL-OPEN repo with no scanner service the header is the
+    /// discriminator (without the verdict this pull would be `pending`).
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_serves_cached_clean_digest() {
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b verified-npm-tarball-3003-clean";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"\x1f\x8b verified-npm-tarball-3003-clean",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "verified-widget",
+            "verified-widget-3.2.1.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_open").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.99.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed clean verdict");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "verified-widget",
+            "verified-widget-3.2.1.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        cleanup_proxy_scan_row(&fx.pool, &digest).await;
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("fresh clean verdict must serve from the cache, got {status}");
+            }
+        };
+        let status = resp.status();
+        let scan_header = resp
+            .headers()
+            .get("X-AK-Scan")
+            .map(|v| v.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(resp.into_body(), 16 * 1024 * 1024)
+            .await
+            .expect("body");
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            scan_header.as_deref(),
+            Some("clean"),
+            "a verdict-backed serve must be marked clean, not pending"
+        );
+        assert_eq!(&body[..], tarball);
+    }
+
+    /// #2976 inherited: a cached `clean` verdict recorded by an OLDER
+    /// scanner/CVE-DB version must NOT be reused once the live CVE engine
+    /// reports a newer version — the pull re-scans and (mock now knows the
+    /// CVE) blocks 403.
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_rescans_when_scanner_version_advances() {
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b staleclean-npm-tarball-3003-bumped";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"\x1f\x8b staleclean-npm-tarball-3003-bumped",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "staleclean-widget",
+            "staleclean-widget-1.0.0.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        // Cached CLEAN verdict recorded at stored version V...
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.83.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed stale clean verdict");
+
+        // ...while the LIVE engine is at V+1 and now flags the bytes.
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = tdh::build_scan_state_with_leaf_scanners(
+            &fx,
+            &storage_path,
+            vec![std::sync::Arc::new(VersionedCveScanner {
+                live_version: Some("grype-0.84.0-test"),
+                rescan: MockCveRescan::Vulnerable,
+            })],
+        );
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "staleclean-widget",
+            "staleclean-widget-1.0.0.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        cleanup_proxy_scan_row(&fx.pool, &digest).await;
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "clean verdict from an older scanner version must be re-scanned \
+                 (and blocked), not served from cache; got {}",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "re-scan against the bumped CVE-DB found the CVE -> 403"
+            ),
+        }
+    }
+
+    /// #2976 probe-None case inherited: an UNKNOWN live scanner version must
+    /// not let a cached clean verdict short-circuit a fail-closed repo — the
+    /// pull re-scans (mock flags it) and blocks 403.
+    #[tokio::test]
+    async fn test_serve_tarball_proxy_scan_unknown_live_version_rescans_under_fail_closed() {
+        use crate::services::proxy_scan_service::ProxyScanService;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b probenone-npm-tarball-3003-failclosed";
+        let digest = sha256_hex(&Bytes::from_static(
+            b"\x1f\x8b probenone-npm-tarball-3003-failclosed",
+        ));
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "probenone-widget",
+            "probenone-widget-1.0.0.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        enable_proxy_scan(&fx.pool, fx.repo_id, "fail_closed").await;
+
+        ProxyScanService::new(fx.pool.clone())
+            .record_verdict(
+                &digest,
+                "grype",
+                "clean",
+                0,
+                0,
+                0,
+                0,
+                0,
+                None,
+                Some("grype-0.83.0-test"),
+                Some(fx.repo_id),
+            )
+            .await
+            .expect("seed clean verdict");
+
+        // Live engine present but its version probe FAILS (None).
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = tdh::build_scan_state_with_leaf_scanners(
+            &fx,
+            &storage_path,
+            vec![std::sync::Arc::new(VersionedCveScanner {
+                live_version: None,
+                rescan: MockCveRescan::Vulnerable,
+            })],
+        );
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "probenone-widget",
+            "probenone-widget-1.0.0.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        cleanup_proxy_scan_row(&fx.pool, &digest).await;
+        fx.teardown().await;
+
+        match result {
+            Ok(r) => panic!(
+                "an UNKNOWN live scanner version must not let a cached clean \
+                 verdict short-circuit the fail-closed gate; got {} (expected \
+                 a re-scan -> 403)",
+                r.status()
+            ),
+            Err(resp) => assert_eq!(resp.status(), StatusCode::FORBIDDEN),
+        }
+    }
+
+    /// Regression guard: a remote repo WITHOUT scan-on-proxy keeps today's
+    /// untouched streaming behavior — 200, no `X-AK-Scan` header.
+    #[tokio::test]
+    async fn test_serve_tarball_without_proxy_scan_streams_untouched() {
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let tarball: &[u8] = b"\x1f\x8b unscanned-npm-tarball-3003-passthrough";
+
+        let upstream = wiremock::MockServer::start().await;
+        mount_tarball_upstream(
+            &upstream,
+            "plain-widget",
+            "plain-widget-1.0.0.tgz",
+            tarball,
+            None,
+        )
+        .await;
+        point_upstream(&fx, &upstream).await;
+        // NO scan_configs row: scan-on-proxy disabled.
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        let result = super::serve_tarball(
+            &state,
+            &fx.repo_key,
+            "plain-widget",
+            "plain-widget-1.0.0.tgz",
+            &Default::default(),
+        )
+        .await;
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(r) => {
+                let status = r.status();
+                fx.teardown().await;
+                panic!("non-opted-in repo must keep streaming, got {status}");
+            }
+        };
+        let status = resp.status();
+        let has_scan_header = resp.headers().contains_key("X-AK-Scan");
+        let body = axum::body::to_bytes(resp.into_body(), 16 * 1024 * 1024)
+            .await
+            .expect("body");
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            !has_scan_header,
+            "repos without scan-on-proxy must be untouched (no X-AK-Scan header)"
+        );
+        assert_eq!(&body[..], tarball);
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -5068,10 +5068,11 @@ pub(crate) async fn proxy_scan_and_record(
     digest: &str,
     synthetic: &crate::models::artifact::Artifact,
     bytes: &Bytes,
+    expected: Option<&crate::services::scanner_service::ExpectedComponent>,
 ) -> Option<crate::services::scanner_service::ProxyScanVerdict> {
     let scanner = state.scanner_service.as_ref()?;
     let filename = synthetic.name.clone();
-    let scan_fut = scanner.scan_content(synthetic, bytes);
+    let scan_fut = scanner.scan_content_expecting(synthetic, bytes, expected);
     let verdict = match tokio::time::timeout(
         crate::services::scanner_service::PROXY_SCAN_INLINE_BUDGET,
         scan_fut,
@@ -5117,6 +5118,29 @@ pub(crate) async fn proxy_scan_and_record(
     Some(verdict)
 }
 
+/// What the serve path was able to establish about WHAT these bytes are being
+/// served as, before any scanning (#3003).
+///
+/// The CVE engine grades a component identity, not a blob, so a scan is only
+/// meaningful once the identity is known — and an engine with nothing to grade
+/// reports zero findings, which is indistinguishable from clean. Formats
+/// therefore state explicitly whether they could establish the coordinate.
+pub(crate) enum ProxyScanIdentity {
+    /// The coordinate these bytes are served as, derived from the REQUEST (not
+    /// from upstream-controlled bytes) and agreed to by the artifact itself.
+    /// Turns on the assessment gate: the engine must actually catalog this
+    /// identity before a `clean` verdict is trusted.
+    Established(crate::services::scanner_service::ExpectedComponent),
+    /// The format expects a coordinate but could NOT establish one for these
+    /// bytes (identity absent, unusable, or disagreeing with the coordinate
+    /// they are served at). Nothing a scanner returned could be vouched for,
+    /// so this is inconclusive — fail-closed withholds, fail-open serves loudly
+    /// pending, exactly like any other inconclusive scan.
+    Unestablished,
+    /// This format does not supply a coordinate. Pre-#3003 behavior, unchanged.
+    NotApplicable,
+}
+
 /// Outcome of [`gate_proxy_scan_serve`], mapped by the caller onto its
 /// format-specific 200 response (`pending` selects the `X-AK-Scan` header
 /// value) or returned as the block/lock response as-is.
@@ -5138,6 +5162,7 @@ pub(crate) enum ProxyScanServeOutcome {
 ///
 /// `synthetic` is the format-specific scan identity for these bytes; it is
 /// also what the async fail-open scan runs over.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn gate_proxy_scan_serve(
     state: &crate::api::SharedState,
     repo_id: Uuid,
@@ -5146,6 +5171,7 @@ pub(crate) async fn gate_proxy_scan_serve(
     synthetic: crate::models::artifact::Artifact,
     bytes: &Bytes,
     action: crate::services::proxy_scan_service::ProxyScanAction,
+    identity: ProxyScanIdentity,
 ) -> ProxyScanServeOutcome {
     use crate::services::proxy_scan_service::{decide_serve, ProxyScanService, ServeDecision};
 
@@ -5178,7 +5204,24 @@ pub(crate) async fn gate_proxy_scan_serve(
         ServeDecision::ServeCached => ProxyScanServeOutcome::Serve { pending: false },
         ServeDecision::ScanInline => {
             // Fail-closed: scan inline before serving a single byte.
-            match proxy_scan_and_record(state, repo_id, digest, &synthetic, bytes).await {
+            //
+            // An artifact whose identity could not be established is withheld
+            // WITHOUT scanning: the scan could only produce a zero-finding
+            // result over content the engine cannot grade, and reporting that
+            // as clean is precisely the hole this closes.
+            let expected = match &identity {
+                ProxyScanIdentity::Unestablished => {
+                    tracing::warn!(
+                        repo_id = %repo_id, file = %filename, digest = %digest,
+                        "cannot establish what these bytes are served as; \
+                         fail-closed -> withholding rather than reporting clean"
+                    );
+                    return ProxyScanServeOutcome::Deny(scan_pending_locked_response(filename));
+                }
+                ProxyScanIdentity::Established(e) => Some(e),
+                ProxyScanIdentity::NotApplicable => None,
+            };
+            match proxy_scan_and_record(state, repo_id, digest, &synthetic, bytes, expected).await {
                 Some(verdict) if verdict.is_vulnerable() => {
                     tracing::warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: inline scan found vulnerabilities");
                     ProxyScanServeOutcome::Deny(scan_blocked_response(filename))
@@ -5213,10 +5256,26 @@ pub(crate) async fn gate_proxy_scan_serve(
             let state_bg = state.clone();
             let digest_bg = digest.to_string();
             let bytes_bg = bytes.clone();
+            let expected = match identity {
+                // Nothing to assess: serve loudly pending (fail-open's
+                // posture) but do not run a scan whose only possible result
+                // would be an unfounded `clean` row for this digest.
+                ProxyScanIdentity::Unestablished => {
+                    return ProxyScanServeOutcome::Serve { pending: true }
+                }
+                ProxyScanIdentity::Established(e) => Some(e),
+                ProxyScanIdentity::NotApplicable => None,
+            };
             tokio::spawn(async move {
-                let _ =
-                    proxy_scan_and_record(&state_bg, repo_id, &digest_bg, &synthetic, &bytes_bg)
-                        .await;
+                let _ = proxy_scan_and_record(
+                    &state_bg,
+                    repo_id,
+                    &digest_bg,
+                    &synthetic,
+                    &bytes_bg,
+                    expected.as_ref(),
+                )
+                .await;
             });
             ProxyScanServeOutcome::Serve { pending: true }
         }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4988,6 +4988,241 @@ pub(crate) fn build_remote_repo_with_format(
     }
 }
 
+// ---------------------------------------------------------------------------
+// #2954/#3003: shared inline scan-and-block glue for proxy downloads.
+//
+// The verdict STATE MACHINE lives in `proxy_scan_service::decide_serve` and
+// the scanner loop (with the #2954 fail-closed gate) in
+// `scanner_service::run_inline_proxy_scanners[_target]`; this section is the
+// handler-side plumbing every format shares — digesting, the scan-or-lookup
+// orchestration, and the block/lock response shapes — so per-format serve
+// paths (pypi.rs, npm.rs) are thin fetch + response-builder call-sites and
+// cannot drift on the carried defenses.
+// ---------------------------------------------------------------------------
+
+/// The scan_type stored for the Grype CVE scanner in `proxy_scan_results`.
+pub(crate) const PROXY_SCAN_TYPE: &str = "grype";
+
+/// SHA-256 hex of the fetched bytes. The verdict cache is keyed on the CONTENT
+/// digest we compute ourselves — never an index-advertised digest — so a lying
+/// upstream index cannot bind a clean verdict to malicious bytes (#2954 inv 4).
+pub(crate) fn sha256_hex(bytes: &Bytes) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// A 403 for a proxy pull blocked by a vulnerable inline-scan verdict. Body is
+/// neutral: it names the file, not the specific CVEs (the download route is
+/// anonymous-readable for public repos).
+pub(crate) fn scan_blocked_response(filename: &str) -> Response {
+    let body = serde_json::json!({
+        "error": "scan_blocked",
+        "file": filename,
+        "reason": "blocked by inline vulnerability scan policy",
+    });
+    (
+        StatusCode::FORBIDDEN,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
+/// A 423 Locked for the fail-closed inconclusive branch (over-cap / budget /
+/// scan error): the object could not be scanned inline and fail-closed must
+/// NEVER serve unscanned bytes.
+pub(crate) fn scan_pending_locked_response(filename: &str) -> Response {
+    let body = serde_json::json!({
+        "error": "scan_pending",
+        "file": filename,
+        "reason": "artifact is being scanned; retry shortly",
+    });
+    (
+        StatusCode::LOCKED,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
+/// Classify a buffered-fetch error as the byte-cap-exceeded case (vs a genuine
+/// upstream 404 / 5xx). Over-cap is the only error the fail-open/closed
+/// inconclusive branch handles specially; every other error is propagated as-is
+/// so a 404 stays a 404.
+pub(crate) fn is_over_cap_error(e: &AppError) -> bool {
+    matches!(e, AppError::BadGateway(m) if m.contains("exceeded") && m.contains("limit"))
+}
+
+/// Run the leaf scanners over the buffered bytes within the inline budget and
+/// persist the digest-keyed verdict. The caller supplies the format-specific
+/// `synthetic` [`Artifact`](crate::models::artifact::Artifact) (filename /
+/// content-type drive scanner applicability + archive extraction). Returns the
+/// verdict, or `None` when the scan was inconclusive (no scanner configured,
+/// budget exceeded, or scanner error) — the caller maps `None` onto the
+/// fail-open/closed decision.
+pub(crate) async fn proxy_scan_and_record(
+    state: &crate::api::SharedState,
+    repo_id: Uuid,
+    digest: &str,
+    synthetic: &crate::models::artifact::Artifact,
+    bytes: &Bytes,
+) -> Option<crate::services::scanner_service::ProxyScanVerdict> {
+    let scanner = state.scanner_service.as_ref()?;
+    let filename = synthetic.name.clone();
+    let scan_fut = scanner.scan_content(synthetic, bytes);
+    let verdict = match tokio::time::timeout(
+        crate::services::scanner_service::PROXY_SCAN_INLINE_BUDGET,
+        scan_fut,
+    )
+    .await
+    {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            tracing::warn!(
+                repo_id = %repo_id, file = %filename, error = %e,
+                "inline proxy scan failed; treating as inconclusive"
+            );
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                repo_id = %repo_id, file = %filename,
+                "inline proxy scan exceeded the budget; treating as inconclusive"
+            );
+            return None;
+        }
+    };
+
+    let pss = crate::services::proxy_scan_service::ProxyScanService::new(state.db.clone());
+    if let Err(e) = pss
+        .record_verdict(
+            digest,
+            PROXY_SCAN_TYPE,
+            verdict.verdict_token(),
+            verdict.findings_count,
+            verdict.critical_count,
+            verdict.high_count,
+            verdict.medium_count,
+            verdict.low_count,
+            verdict.max_severity_token(),
+            verdict.scanner_version.as_deref(),
+            Some(repo_id),
+        )
+        .await
+    {
+        tracing::warn!(repo_id = %repo_id, file = %filename, error = %e, "failed to persist proxy scan verdict");
+    }
+    Some(verdict)
+}
+
+/// Outcome of [`gate_proxy_scan_serve`], mapped by the caller onto its
+/// format-specific 200 response (`pending` selects the `X-AK-Scan` header
+/// value) or returned as the block/lock response as-is.
+pub(crate) enum ProxyScanServeOutcome {
+    /// Serve the buffered bytes; `pending: true` means fail-open served
+    /// before a verdict (loud `X-AK-Scan: pending`, async scan running).
+    Serve { pending: bool },
+    /// The pull is blocked (403 vulnerable) or locked (423 inconclusive
+    /// under fail-closed); the response is fully built.
+    Deny(Response),
+}
+
+/// The shared digest-verdict gate for a buffered proxy download: lookup →
+/// [`crate::services::proxy_scan_service::decide_serve`] → scan-inline /
+/// async-scan per the repo action, persisting verdicts via
+/// [`proxy_scan_and_record`]. Every format serve path calls this after its
+/// buffered capped fetch, so the #2954 fail-closed contract and the #2976
+/// freshness gate are exercised through ONE implementation.
+///
+/// `synthetic` is the format-specific scan identity for these bytes; it is
+/// also what the async fail-open scan runs over.
+pub(crate) async fn gate_proxy_scan_serve(
+    state: &crate::api::SharedState,
+    repo_id: Uuid,
+    filename: &str,
+    digest: &str,
+    synthetic: crate::models::artifact::Artifact,
+    bytes: &Bytes,
+    action: crate::services::proxy_scan_service::ProxyScanAction,
+) -> ProxyScanServeOutcome {
+    use crate::services::proxy_scan_service::{decide_serve, ProxyScanService, ServeDecision};
+
+    let pss = ProxyScanService::new(state.db.clone());
+    let row = pss
+        .lookup_verdict(digest, PROXY_SCAN_TYPE)
+        .await
+        .ok()
+        .flatten();
+    // #2976: compare the verdict's stored provenance against the LIVE
+    // CVE-scanner version (VersionCache-backed — a memory read on the hot
+    // path, never a per-download subprocess). Only probed when a row exists,
+    // exactly as the pre-refactor PyPI path did.
+    let current_version = match (&row, state.scanner_service.as_deref()) {
+        (Some(_), Some(scanner)) => scanner.cve_scanner_version().await,
+        _ => None,
+    };
+
+    match decide_serve(
+        row.as_ref(),
+        current_version.as_deref(),
+        action,
+        crate::services::scanner_service::DEDUP_TTL_DAYS as i64,
+        Utc::now(),
+    ) {
+        ServeDecision::BlockCached => {
+            tracing::warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: cached vulnerable verdict");
+            ProxyScanServeOutcome::Deny(scan_blocked_response(filename))
+        }
+        ServeDecision::ServeCached => ProxyScanServeOutcome::Serve { pending: false },
+        ServeDecision::ScanInline => {
+            // Fail-closed: scan inline before serving a single byte.
+            match proxy_scan_and_record(state, repo_id, digest, &synthetic, bytes).await {
+                Some(verdict) if verdict.is_vulnerable() => {
+                    tracing::warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: inline scan found vulnerabilities");
+                    ProxyScanServeOutcome::Deny(scan_blocked_response(filename))
+                }
+                Some(_) => ProxyScanServeOutcome::Serve { pending: false },
+                // Inconclusive under fail-closed => 423, never unscanned bytes.
+                None => ProxyScanServeOutcome::Deny(scan_pending_locked_response(filename)),
+            }
+        }
+        ServeDecision::ServePendingScanAsync => {
+            // Fail-open: serve immediately (loud: X-AK-Scan pending) and scan
+            // asynchronously so the NEXT pull of this SAME digest is blocked
+            // if bad.
+            //
+            // Honest caveat (#2954, Finding 2): the block is keyed strictly on
+            // the CONTENT digest. That is correct and cannot be relaxed —
+            // binding a verdict to anything an untrusted upstream controls
+            // (filename, index digest) would let a lying index attach a
+            // `clean` verdict to malicious bytes. But it means fail-open does
+            // NOT block an ADAPTIVE upstream that returns byte-varying
+            // vulnerable payloads: each pull is a new digest, hence a fresh
+            // "first pull", served 200 `X-AK-Scan: pending` indefinitely.
+            // This is by-design for the latency-first fail-open posture and is
+            // LOUD — every such serve emits the warn below plus the pending
+            // header. Operators who cannot tolerate serving an unscanned byte
+            // must use `proxy_scan_action=fail_closed`. Do NOT "fix" this by
+            // turning fail-open into fail-closed here.
+            tracing::warn!(
+                repo_id = %repo_id, file = %filename, digest = %digest,
+                "fail-open proxy scan: serving unscanned bytes with X-AK-Scan: pending; scanning async"
+            );
+            let state_bg = state.clone();
+            let digest_bg = digest.to_string();
+            let bytes_bg = bytes.clone();
+            tokio::spawn(async move {
+                let _ =
+                    proxy_scan_and_record(&state_bg, repo_id, &digest_bg, &synthetic, &bytes_bg)
+                        .await;
+            });
+            ProxyScanServeOutcome::Serve { pending: true }
+        }
+    }
+}
+
 #[allow(clippy::disallowed_methods)]
 // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2802,13 +2802,41 @@ async fn serve_scanned_pypi_file(
 
     let digest = sha256_hex(&bytes);
 
+    // #3003: the identity these bytes are being served as. `project` is the
+    // requested distribution and the version comes from the filename, so the
+    // coordinate is request-derived, never upstream-controlled.
+    //
+    // This is what finally grades an SDIST. syft/grype catalog a wheel from its
+    // `.dist-info/METADATA`, but an sdist ships only a ROOT `PKG-INFO`, which
+    // syft does not catalog — so a vulnerable sdist scanned with zero cataloged
+    // components, reported zero findings, and served 200 "clean" while the same
+    // release's wheel was correctly blocked. Pinning the coordinate gives the
+    // CVE engine the component to grade, and the shared assessment gate refuses
+    // to call the result clean unless it actually graded it.
+    //
+    // Filenames we cannot parse a version from keep the prior behavior (no
+    // pin, no assessment gate) rather than newly withholding an odd-but-legit
+    // artifact.
+    let identity = match version_from_pypi_filename(filename) {
+        Some(version) => proxy_helpers::ProxyScanIdentity::Established(
+            crate::services::scanner_service::ExpectedComponent::new(
+                crate::services::scanner_service::ComponentEcosystem::Python,
+                project,
+                &version,
+            ),
+        ),
+        // An unparseable filename keeps the pre-#3003 behavior rather than
+        // newly withholding an odd-but-legitimate artifact.
+        None => proxy_helpers::ProxyScanIdentity::NotApplicable,
+    };
+
     // Digest-keyed verdict gate, shared with every proxy format (#3003):
     // lookup → `decide_serve` (freshness incl. the #2976 unknown-live-version
     // fail-closed tightening) → inline scan / async scan per the action, with
     // the #2954 fail-closed contract enforced inside the shared scanner loop.
     let synthetic = pypi_synthetic_artifact(repo_id, filename, &digest, bytes.len() as i64);
     match proxy_helpers::gate_proxy_scan_serve(
-        state, repo_id, filename, &digest, synthetic, &bytes, action,
+        state, repo_id, filename, &digest, synthetic, &bytes, action, identity,
     )
     .await
     {

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2631,20 +2631,16 @@ fn build_streaming_file_response(
 
 // ---------------------------------------------------------------------------
 // #2954: inline scan-and-block on proxy download (PyPI Phase 1).
+//
+// The format-agnostic pieces — digesting, the verdict state machine, the
+// block/lock response shapes, and the scan-and-record orchestration — were
+// lifted into `proxy_helpers` (#3003) so npm (and later OCI) share ONE
+// implementation of the #2954 fail-closed gate and the #2976 freshness gate.
+// This module keeps only the PyPI-specific glue: index-target resolution, the
+// synthetic-artifact shape, and the PyPI response builders.
 // ---------------------------------------------------------------------------
 
-/// The scan_type stored for the Grype CVE scanner in `proxy_scan_results`.
-const PROXY_SCAN_TYPE: &str = "grype";
-
-/// SHA-256 hex of the fetched bytes. The verdict cache is keyed on the CONTENT
-/// digest we compute ourselves — never an index-advertised digest — so a lying
-/// upstream index cannot bind a clean verdict to malicious bytes (#2954 inv 4).
-fn sha256_hex(bytes: &Bytes) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
-}
+use super::proxy_helpers::{is_over_cap_error, scan_pending_locked_response, sha256_hex};
 
 /// Build the synthetic in-memory [`Artifact`](crate::models::artifact::Artifact)
 /// that [`ScannerService::scan_content`] runs the leaf scanners over. There is
@@ -2679,40 +2675,6 @@ fn pypi_synthetic_artifact(
     }
 }
 
-/// A 403 for a proxy pull blocked by a vulnerable inline-scan verdict. Body is
-/// neutral: it names the file, not the specific CVEs (the download route is
-/// anonymous-readable for public repos).
-fn scan_blocked_response(filename: &str) -> Response {
-    let body = serde_json::json!({
-        "error": "scan_blocked",
-        "file": filename,
-        "reason": "blocked by inline vulnerability scan policy",
-    });
-    (
-        StatusCode::FORBIDDEN,
-        [(CONTENT_TYPE, "application/json")],
-        body.to_string(),
-    )
-        .into_response()
-}
-
-/// A 423 Locked for the fail-closed inconclusive branch (over-cap / budget /
-/// scan error): the object could not be scanned inline and fail-closed must
-/// NEVER serve unscanned bytes.
-fn scan_pending_locked_response(filename: &str) -> Response {
-    let body = serde_json::json!({
-        "error": "scan_pending",
-        "file": filename,
-        "reason": "artifact is being scanned; retry shortly",
-    });
-    (
-        StatusCode::LOCKED,
-        [(CONTENT_TYPE, "application/json")],
-        body.to_string(),
-    )
-        .into_response()
-}
-
 /// Build a buffered 200 response for scanned bytes. `pending` adds the loud
 /// `X-AK-Scan: pending` header for the fail-open serve-before-verdict path so a
 /// served-unscanned byte is observable (kills the #1274 silent gap).
@@ -2737,73 +2699,6 @@ fn build_scanned_file_response(
         builder = builder.header("X-PyPI-File-SHA256", d);
     }
     builder.body(Body::from(bytes)).unwrap()
-}
-
-/// Classify a buffered-fetch error as the byte-cap-exceeded case (vs a genuine
-/// upstream 404 / 5xx). Over-cap is the only error the fail-open/closed
-/// inconclusive branch handles specially; every other error is propagated as-is
-/// so a 404 stays a 404.
-fn is_over_cap_error(e: &AppError) -> bool {
-    matches!(e, AppError::BadGateway(m) if m.contains("exceeded") && m.contains("limit"))
-}
-
-/// Run the leaf scanners over the buffered bytes within the inline budget and
-/// persist the digest-keyed verdict. Returns the verdict, or `None` when the
-/// scan was inconclusive (no scanner configured, budget exceeded, or scanner
-/// error) — the caller maps `None` onto the fail-open/closed decision.
-async fn scan_and_record(
-    state: &SharedState,
-    repo_id: uuid::Uuid,
-    digest: &str,
-    filename: &str,
-    bytes: &Bytes,
-) -> Option<crate::services::scanner_service::ProxyScanVerdict> {
-    let scanner = state.scanner_service.as_ref()?;
-    let synthetic = pypi_synthetic_artifact(repo_id, filename, digest, bytes.len() as i64);
-    let scan_fut = scanner.scan_content(&synthetic, bytes);
-    let verdict = match tokio::time::timeout(
-        crate::services::scanner_service::PROXY_SCAN_INLINE_BUDGET,
-        scan_fut,
-    )
-    .await
-    {
-        Ok(Ok(v)) => v,
-        Ok(Err(e)) => {
-            warn!(
-                repo_id = %repo_id, file = %filename, error = %e,
-                "inline proxy scan failed; treating as inconclusive"
-            );
-            return None;
-        }
-        Err(_) => {
-            warn!(
-                repo_id = %repo_id, file = %filename,
-                "inline proxy scan exceeded the budget; treating as inconclusive"
-            );
-            return None;
-        }
-    };
-
-    let pss = crate::services::proxy_scan_service::ProxyScanService::new(state.db.clone());
-    if let Err(e) = pss
-        .record_verdict(
-            digest,
-            PROXY_SCAN_TYPE,
-            verdict.verdict_token(),
-            verdict.findings_count,
-            verdict.critical_count,
-            verdict.high_count,
-            verdict.medium_count,
-            verdict.low_count,
-            verdict.max_severity_token(),
-            verdict.scanner_version.as_deref(),
-            Some(repo_id),
-        )
-        .await
-    {
-        warn!(repo_id = %repo_id, file = %filename, error = %e, "failed to persist proxy scan verdict");
-    }
-    Some(verdict)
 }
 
 /// Inline scan-and-block for a PyPI proxy file download (#2954).
@@ -2907,135 +2802,28 @@ async fn serve_scanned_pypi_file(
 
     let digest = sha256_hex(&bytes);
 
-    // Verdict fast path: a fresh vulnerable verdict blocks WITHOUT re-scanning
-    // (and, since the fetch above was a cache hit on a repeat pull, without any
-    // upstream fetch). A fresh clean verdict serves from the buffer.
-    let pss = crate::services::proxy_scan_service::ProxyScanService::new(state.db.clone());
-    if let Ok(Some(row)) = pss.lookup_verdict(&digest, PROXY_SCAN_TYPE).await {
-        // #2976: compare the verdict's stored provenance against the LIVE
-        // CVE-scanner version so a verdict recorded against an older scanner /
-        // CVE-DB is treated stale and falls through to the re-scan branches
-        // below (fail-closed: inline re-scan → 403/423; fail-open: serve
-        // pending + async re-scan) instead of serving stale-clean for the full
-        // TTL window. `Scanner::version()` is VersionCache-backed, so this is
-        // a memory read on the hot path, never a per-download subprocess.
-        //
-        // The repo's action is part of the decision, not just the versions:
-        // this fast path runs BEFORE the inline scan, so on a fail-closed repo
-        // an UNKNOWN live version (probe failed mid-upgrade, binary absent,
-        // probe past its timeout) must NOT let a cached `clean` verdict
-        // short-circuit the gate — see `verdict_is_reusable`.
-        //
-        // No per-digest singleflight here: N concurrent pulls of the same
-        // newly-stale digest each re-scan. They queue behind the #2555
-        // fair-share extraction semaphore so this cannot starve upload scans,
-        // and the window closes as soon as the first re-scan upserts the row.
-        // Coalescing is a possible follow-up, not a correctness requirement.
-        let current_version = match state.scanner_service.as_deref() {
-            Some(scanner) => scanner.cve_scanner_version().await,
-            None => None,
-        };
-        let reusable = crate::services::proxy_scan_service::verdict_is_reusable(
-            &row.verdict,
-            row.scanned_at,
-            row.scanner_version.as_deref(),
-            current_version.as_deref(),
-            action,
-            crate::services::scanner_service::DEDUP_TTL_DAYS as i64,
-            Utc::now(),
-        );
-        if !reusable && current_version.is_none() && action.is_fail_closed() {
-            warn!(
-                repo_id = %repo_id, file = %filename, digest = %digest,
-                stored_version = ?row.scanner_version,
-                "live CVE-scanner version unknown; not reusing the cached verdict \
-                 on a fail-closed repo (re-scanning)"
-            );
-        }
-        if reusable {
-            if crate::services::proxy_scan_service::verdict_blocks(&row.verdict) {
-                warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: cached vulnerable verdict");
-                return Err(scan_blocked_response(filename));
-            }
+    // Digest-keyed verdict gate, shared with every proxy format (#3003):
+    // lookup → `decide_serve` (freshness incl. the #2976 unknown-live-version
+    // fail-closed tightening) → inline scan / async scan per the action, with
+    // the #2954 fail-closed contract enforced inside the shared scanner loop.
+    let synthetic = pypi_synthetic_artifact(repo_id, filename, &digest, bytes.len() as i64);
+    match proxy_helpers::gate_proxy_scan_serve(
+        state, repo_id, filename, &digest, synthetic, &bytes, action,
+    )
+    .await
+    {
+        proxy_helpers::ProxyScanServeOutcome::Deny(resp) => Err(resp),
+        proxy_helpers::ProxyScanServeOutcome::Serve { pending } => {
             proxy_helpers::record_proxy_download(state, repo_id, repo_key, &target.cache_path, ctx)
                 .await;
-            return Ok(build_scanned_file_response(
+            Ok(build_scanned_file_response(
                 filename,
                 bytes,
                 content_type,
                 Some(&digest),
-                false,
-            ));
+                pending,
+            ))
         }
-    }
-
-    // No fresh verdict: first pull of this digest.
-    if action.is_fail_closed() {
-        // Fail-closed: scan inline before serving a single byte.
-        match scan_and_record(state, repo_id, &digest, filename, &bytes).await {
-            Some(verdict) if verdict.is_vulnerable() => {
-                warn!(repo_id = %repo_id, file = %filename, digest = %digest, "blocking proxy pull: inline scan found vulnerabilities");
-                Err(scan_blocked_response(filename))
-            }
-            Some(_) => {
-                proxy_helpers::record_proxy_download(
-                    state,
-                    repo_id,
-                    repo_key,
-                    &target.cache_path,
-                    ctx,
-                )
-                .await;
-                Ok(build_scanned_file_response(
-                    filename,
-                    bytes,
-                    content_type,
-                    Some(&digest),
-                    false,
-                ))
-            }
-            // Inconclusive under fail-closed => 423, never serve unscanned bytes.
-            None => Err(scan_pending_locked_response(filename)),
-        }
-    } else {
-        // Fail-open: serve immediately (loud: X-AK-Scan pending) and scan
-        // asynchronously so the NEXT pull of this SAME digest is blocked if bad.
-        //
-        // Honest caveat (#2954, Finding 2): the block is keyed strictly on the
-        // CONTENT digest. That is correct and cannot be relaxed — binding a
-        // verdict to anything an untrusted upstream controls (filename, index
-        // digest) would let a lying index attach a `clean` verdict to malicious
-        // bytes. But it means fail-open does NOT block an ADAPTIVE upstream that
-        // returns byte-varying vulnerable wheels (e.g. random-byte append): each
-        // pull is a new digest, hence a fresh "first pull", so it is served 200
-        // `X-AK-Scan: pending` indefinitely. This is by-design for the
-        // latency-first fail-open posture and is LOUD — every such serve emits
-        // the warn below plus the pending header, so a burst of pending-serves
-        // from one repo is observable in logs/audit and can be alerted on
-        // out-of-band. Operators who cannot tolerate serving an unscanned byte
-        // must use `proxy_scan_action=fail_closed`, which scans inline before
-        // serving and 423s on any inconclusive/adaptive case. Do NOT "fix" this
-        // by turning fail-open into fail-closed here.
-        warn!(
-            repo_id = %repo_id, file = %filename, digest = %digest,
-            "fail-open proxy scan: serving unscanned bytes with X-AK-Scan: pending; scanning async"
-        );
-        let state_bg = state.clone();
-        let digest_bg = digest.clone();
-        let filename_bg = filename.to_string();
-        let bytes_bg = bytes.clone();
-        tokio::spawn(async move {
-            let _ = scan_and_record(&state_bg, repo_id, &digest_bg, &filename_bg, &bytes_bg).await;
-        });
-        proxy_helpers::record_proxy_download(state, repo_id, repo_key, &target.cache_path, ctx)
-            .await;
-        Ok(build_scanned_file_response(
-            filename,
-            bytes,
-            content_type,
-            Some(&digest),
-            true,
-        ))
     }
 }
 
@@ -4142,6 +3930,7 @@ async fn pypi_owned_wheel_profile(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::handlers::proxy_helpers::scan_blocked_response;
     use sha2::{Digest, Sha256};
 
     fn headers_with_replication(value: &str) -> HeaderMap {
@@ -9583,19 +9372,7 @@ mod tests {
     // Skip cleanly when DATABASE_URL is unset.
     // -----------------------------------------------------------------------
 
-    async fn enable_proxy_scan(pool: &sqlx::PgPool, repo_id: uuid::Uuid, action: &str) {
-        sqlx::query(
-            "INSERT INTO scan_configs (repository_id, scan_enabled, scan_on_upload, \
-                 scan_on_proxy, block_on_policy_violation, severity_threshold, \
-                 proxy_scan_action) \
-             VALUES ($1, true, false, true, false, 'high', $2)",
-        )
-        .bind(repo_id)
-        .bind(action)
-        .execute(pool)
-        .await
-        .expect("enable scan-on-proxy");
-    }
+    use crate::api::handlers::test_db_helpers::enable_proxy_scan;
 
     /// Mount a PEP 503 index page (with no matching href, so the fetch target
     /// falls back to the conventional simple/ path) plus the wheel bytes.
@@ -9928,65 +9705,10 @@ mod tests {
     // version must keep using the cache (no needless re-scan).
     // -----------------------------------------------------------------------
 
-    /// Outcome of the mock CVE engine when the serve path re-scans.
-    enum MockCveRescan {
-        /// Re-scan against the bumped CVE-DB now flags the bytes.
-        Vulnerable,
-        /// Re-scan is inconclusive (scanner hard-error).
-        Error,
-    }
-
-    /// CVE-authoritative mock scanner reporting a fixed live version string.
-    /// `live_version: None` models a FAILED version probe — the engine is
-    /// mid-upgrade / absent / past its probe timeout — which is the
-    /// unknown-`current_version` case the fail-closed gate must not fail open on.
-    struct VersionedCveScanner {
-        live_version: Option<&'static str>,
-        rescan: MockCveRescan,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::services::scanner_service::Scanner for VersionedCveScanner {
-        fn name(&self) -> &str {
-            "versioned-cve-test-scanner"
-        }
-        fn scan_type(&self) -> &str {
-            "grype"
-        }
-        fn is_cve_authoritative(&self) -> bool {
-            true
-        }
-        async fn version(&self) -> Option<String> {
-            self.live_version.map(str::to_string)
-        }
-        async fn scan(
-            &self,
-            _: &crate::models::artifact::Artifact,
-            _: Option<&crate::models::artifact::ArtifactMetadata>,
-            _: &Bytes,
-        ) -> crate::error::Result<crate::services::scanner_service::ScanOutput> {
-            match self.rescan {
-                MockCveRescan::Error => Err(AppError::Internal(
-                    "simulated grype failure on re-scan".to_string(),
-                )),
-                MockCveRescan::Vulnerable => {
-                    Ok(crate::services::scanner_service::ScanOutput::findings_only(
-                        vec![crate::models::security::RawFinding {
-                            severity: crate::models::security::Severity::Critical,
-                            title: "CVE-2026-0001 test".to_string(),
-                            description: None,
-                            cve_id: Some("CVE-2026-0001".to_string()),
-                            affected_component: Some("pyyaml".to_string()),
-                            affected_version: Some("5.3.1".to_string()),
-                            fixed_version: None,
-                            source: Some("grype".to_string()),
-                            source_url: None,
-                        }],
-                    ))
-                }
-            }
-        }
-    }
+    // The mock CVE engine (`VersionedCveScanner`/`MockCveRescan`) and the
+    // state builder moved to shared test helpers so the npm inline-scan tests
+    // (#3003) drive the identical mock through the identical wiring.
+    use crate::services::scanner_service::test_helpers::{MockCveRescan, VersionedCveScanner};
 
     /// Build a state whose scanner service holds exactly the given mock CVE
     /// engine, wired over the fixture's storage + a real proxy service.
@@ -9995,21 +9717,11 @@ mod tests {
         storage_path: &str,
         scanner: VersionedCveScanner,
     ) -> crate::api::SharedState {
-        use crate::api::handlers::test_db_helpers as tdh;
-        use std::sync::Arc;
-        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path);
-        let svc = crate::services::scanner_service::ScannerService::new_for_test_with_scanners(
-            fx.pool.clone(),
-            vec![Arc::new(scanner)],
-            fx.state.storage.clone(),
-            fx.state.storage_registry.clone(),
-            storage_path.to_string(),
-            fx.storage_dir
-                .join("scan-workspace")
-                .to_string_lossy()
-                .into_owned(),
-        );
-        tdh::build_state_with_proxy_and_scanner(fx.pool.clone(), storage_path, proxy, Arc::new(svc))
+        crate::api::handlers::test_db_helpers::build_scan_state_with_leaf_scanners(
+            fx,
+            storage_path,
+            vec![std::sync::Arc::new(scanner)],
+        )
     }
 
     /// #2976 discriminator: a cached `clean` verdict recorded by an OLDER

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1383,6 +1383,47 @@ pub fn build_state_with_proxy_and_scanner(
     Arc::new(state)
 }
 
+/// Enable scan-on-proxy for a repository with the given
+/// `proxy_scan_action` (`"fail_open"` / `"fail_closed"`). Shared by the
+/// inline scan-and-block handler tests (#2954 PyPI, #3003 npm).
+pub async fn enable_proxy_scan(pool: &PgPool, repo_id: Uuid, action: &str) {
+    sqlx::query(
+        "INSERT INTO scan_configs (repository_id, scan_enabled, scan_on_upload, \
+             scan_on_proxy, block_on_policy_violation, severity_threshold, \
+             proxy_scan_action) \
+         VALUES ($1, true, false, true, false, 'high', $2)",
+    )
+    .bind(repo_id)
+    .bind(action)
+    .execute(pool)
+    .await
+    .expect("enable scan-on-proxy");
+}
+
+/// Build a state whose scanner service holds exactly the given mock leaf
+/// scanners, wired over the fixture's storage + a real proxy service. Shared
+/// by the #2976 verdict-freshness handler tests across formats so each format
+/// file does not re-assemble the ScannerService by hand.
+pub fn build_scan_state_with_leaf_scanners(
+    fx: &Fixture,
+    storage_path: &str,
+    scanners: Vec<Arc<dyn crate::services::scanner_service::Scanner>>,
+) -> crate::api::SharedState {
+    let proxy = build_proxy_service_with_fs(fx.pool.clone(), storage_path);
+    let svc = crate::services::scanner_service::ScannerService::new_for_test_with_scanners(
+        fx.pool.clone(),
+        scanners,
+        fx.state.storage.clone(),
+        fx.state.storage_registry.clone(),
+        storage_path.to_string(),
+        fx.storage_dir
+            .join("scan-workspace")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    build_state_with_proxy_and_scanner(fx.pool.clone(), storage_path, proxy, Arc::new(svc))
+}
+
 /// Like [`build_state_with_proxy`] but also wires an [`AgeGateService`] onto the
 /// state so handler tests can exercise the download age gate end-to-end
 /// (`serve_file` / `serve_tarball` only enforce the gate when the service is

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Deserializer};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
@@ -34,8 +34,8 @@ use crate::services::auth_service::AuthService;
 use crate::services::scanner_service::{
     cached_cli_version, capture_cli_version, fail_scan, format_grype_version,
     is_oci_image_artifact, join_oci_image_ref, parse_oci_manifest_path, resolve_scan_reference,
-    validate_trivy_purl, ScanOutput, ScanReferenceResolution, ScanTarget, ScanWorkspace, Scanner,
-    VersionCache,
+    validate_trivy_purl, CatalogedComponent, ScanOutput, ScanReferenceResolution, ScanTarget,
+    ScanWorkspace, Scanner, VersionCache,
 };
 use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
 use crate::storage::StorageBackend;
@@ -276,6 +276,35 @@ fn grype_output_indicates_failure(stderr: &str) -> bool {
 ///
 /// Split out from `run_grype_target` as a pure function so the exit-0 error
 /// classification is unit-testable without spawning the real `grype` binary.
+/// Extract the cataloged component list from Grype's `cyclonedx-json` BOM
+/// (#3003): every package syft/grype actually identified in the target,
+/// whether or not it matched a CVE.
+///
+/// Only `type: "library"` components are packages; the BOM also carries
+/// `type: "file"` entries for the files that produced them (e.g. the
+/// lockfile itself), which are not gradeable identities. Returns `None` when
+/// the BOM is unparseable or carries no `components` array at all — an
+/// absent signal, deliberately distinct from `Some(vec![])` ("the engine
+/// cataloged nothing"), which is a fail-closed condition for the caller.
+pub(crate) fn parse_cyclonedx_catalog(bom: &[u8]) -> Option<Vec<CatalogedComponent>> {
+    let v: serde_json::Value = serde_json::from_slice(bom).ok()?;
+    let components = v.get("components")?.as_array()?;
+    Some(
+        components
+            .iter()
+            .filter(|c| c.get("type").and_then(|t| t.as_str()) == Some("library"))
+            .filter_map(|c| {
+                let name = c.get("name")?.as_str()?;
+                let version = c.get("version").and_then(|x| x.as_str()).unwrap_or("");
+                (!name.is_empty() && !version.is_empty()).then(|| CatalogedComponent {
+                    name: name.to_string(),
+                    version: version.to_string(),
+                })
+            })
+            .collect(),
+    )
+}
+
 fn parse_grype_output(
     success: bool,
     status_display: &str,
@@ -711,6 +740,7 @@ impl GrypeScanner {
             findings,
             packages,
             scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
+            cataloged: None,
         })
     }
 
@@ -744,6 +774,7 @@ impl GrypeScanner {
                     findings,
                     packages,
                     scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
+                    cataloged: None,
                 })
             }
             Err(e) => Err(fail_scan(
@@ -966,11 +997,67 @@ impl GrypeScanner {
     }
 
     /// Run grype against the workspace directory.
-    async fn run_grype(&self, workspace: &Path) -> Result<GrypeReport> {
+    /// Dir-mode scan that ALSO captures what Grype cataloged (#3003).
+    ///
+    /// Grype's `json` report only names CVE-MATCHED artifacts, so a
+    /// zero-match report cannot distinguish "nothing vulnerable here" from
+    /// "nothing was catalogable here" — the blindness that let a vulnerable
+    /// npm tarball and an ordinary PyPI sdist serve as clean. Its
+    /// `cyclonedx-json` presenter emits the FULL catalog (every component
+    /// syft found, matched or not), so we ask for both in the SAME
+    /// invocation: no second scan, no extra extraction, one subprocess.
+    ///
+    /// The catalog is a best-effort side channel: if the BOM cannot be
+    /// written or parsed we return `None` (rather than failing the scan), and
+    /// `None` means "no catalog signal", which the caller's assessment gate
+    /// treats as "keep prior behavior".
+    async fn run_grype_dir_with_catalog(
+        &self,
+        workspace: &Path,
+    ) -> Result<(GrypeReport, Option<Vec<CatalogedComponent>>)> {
         let dir_arg = format!("dir:{}", workspace.to_string_lossy());
-        // Directory (local layout) scans never touch the registry, so no
-        // registry-auth env is needed.
-        self.run_grype_target(&dir_arg, &[]).await
+        // Keep the BOM out of the scanned tree: writing it inside `workspace`
+        // would make the next catalog include our own artifact.
+        let bom_path = workspace.with_extension("grype-bom.json");
+
+        let mut command = tokio::process::Command::new("grype");
+        command
+            .args([
+                dir_arg.as_str(),
+                "-o",
+                "json",
+                "-o",
+                &format!("cyclonedx-json={}", bom_path.to_string_lossy()),
+            ])
+            .env("GRYPE_DB_AUTO_UPDATE", "false")
+            .env("GRYPE_DB_VALIDATE_AGE", "false")
+            .env("GRYPE_CHECK_FOR_APP_UPDATE", "false");
+        let output = command
+            .output()
+            .await
+            .map_err(|e| classify_grype_spawn_error(&e))?;
+
+        let report = parse_grype_output(
+            output.status.success(),
+            &output.status.to_string(),
+            &output.stdout,
+            &output.stderr,
+        );
+
+        let catalog = match tokio::fs::read(&bom_path).await {
+            Ok(bytes) => parse_cyclonedx_catalog(&bytes),
+            Err(e) => {
+                debug!(
+                    "Grype catalog BOM unavailable at {}: {}",
+                    bom_path.display(),
+                    e
+                );
+                None
+            }
+        };
+        let _ = tokio::fs::remove_file(&bom_path).await;
+
+        Ok((report?, catalog))
     }
 
     /// Run grype against an arbitrary target string (e.g. `dir:/path`,
@@ -1385,11 +1472,37 @@ impl Scanner for GrypeScanner {
             return self.scan_oci_registry_ref(artifact, image_ref, None).await;
         }
 
-        let workspace =
-            ScanWorkspace::prepare(&self.scan_workspace, None, artifact, content).await?;
+        self.scan_file_pinned(artifact, content, None).await
+    }
 
-        let report = match self.run_grype(&workspace).await {
-            Ok(report) => report,
+    async fn scan_target(
+        &self,
+        target: &ScanTarget<'_>,
+        metadata: Option<&ArtifactMetadata>,
+        content: &Bytes,
+    ) -> Result<ScanOutput> {
+        self.scan_target_inner(target, metadata, content).await
+    }
+}
+
+impl GrypeScanner {
+    /// Filesystem-artifact scan with an optional inline-proxy component PIN
+    /// (#3003). The pin is materialized into the scan workspace so Grype has
+    /// a gradeable component for the artifact being served, and the resulting
+    /// catalog is surfaced on [`ScanOutput::cataloged`] so the caller can tell
+    /// "clean" apart from "nothing was assessed".
+    async fn scan_file_pinned(
+        &self,
+        artifact: &Artifact,
+        content: &Bytes,
+        pin: Option<&crate::services::scanner_service::ExpectedComponent>,
+    ) -> Result<ScanOutput> {
+        let workspace =
+            ScanWorkspace::prepare_pinned(&self.scan_workspace, None, artifact, content, pin)
+                .await?;
+
+        let (report, cataloged) = match self.run_grype_dir_with_catalog(&workspace).await {
+            Ok(pair) => pair,
             Err(e) => {
                 return Err(
                     fail_scan("Grype scan", artifact, &e, &self.scan_workspace, None).await,
@@ -1401,10 +1514,11 @@ impl Scanner for GrypeScanner {
         let packages = Self::convert_packages(&report);
 
         info!(
-            "Grype scan complete for {}: {} vulnerabilities, {} components",
+            "Grype scan complete for {}: {} vulnerabilities, {} components, {} cataloged",
             artifact.name,
             findings.len(),
-            packages.len()
+            packages.len(),
+            cataloged.as_ref().map_or(0, |c| c.len()),
         );
 
         ScanWorkspace::cleanup(&self.scan_workspace, None, artifact).await;
@@ -1424,10 +1538,11 @@ impl Scanner for GrypeScanner {
             findings,
             packages,
             scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
+            cataloged,
         })
     }
 
-    async fn scan_target(
+    async fn scan_target_inner(
         &self,
         target: &ScanTarget<'_>,
         metadata: Option<&ArtifactMetadata>,
@@ -1454,7 +1569,11 @@ impl Scanner for GrypeScanner {
                 .await;
         }
 
-        self.scan(artifact, metadata, content).await
+        // Filesystem artifact: carry the inline-proxy pin (if any) so the
+        // served component is actually cataloged and graded (#3003).
+        let _ = metadata;
+        self.scan_file_pinned(artifact, content, target.expected_component)
+            .await
     }
 }
 
@@ -1465,6 +1584,72 @@ mod tests {
 
     fn make_artifact(name: &str, content_type: &str) -> Artifact {
         make_test_artifact(name, content_type, &format!("test/{}", name))
+    }
+
+    /// #3003: the catalog side channel. Grype's `json` report only names
+    /// CVE-MATCHED artifacts, so the FULL catalog comes from its cyclonedx
+    /// BOM: `library` components are gradeable identities, `file` components
+    /// (the lockfile that produced them) are not.
+    #[test]
+    fn test_parse_cyclonedx_catalog() {
+        let bom = br#"{
+            "components": [
+                {"type": "library", "name": "lodash", "version": "4.17.11"},
+                {"type": "file", "name": "/scan/package-lock.json"},
+                {"type": "library", "name": "isarray", "version": "2.0.5"},
+                {"type": "library", "name": "no-version"}
+            ]
+        }"#;
+        let catalog = parse_cyclonedx_catalog(bom).expect("a BOM with components parses");
+        assert_eq!(
+            catalog,
+            vec![
+                CatalogedComponent {
+                    name: "lodash".into(),
+                    version: "4.17.11".into()
+                },
+                CatalogedComponent {
+                    name: "isarray".into(),
+                    version: "2.0.5".into()
+                },
+            ],
+            "only versioned `library` components are gradeable identities"
+        );
+
+        // The load-bearing distinction: an engine that cataloged NOTHING is
+        // `Some(empty)` (a fail-closed condition), while an unusable/absent
+        // BOM is `None` (no signal — keep prior behavior).
+        assert_eq!(
+            parse_cyclonedx_catalog(br#"{"components": []}"#),
+            Some(vec![])
+        );
+        assert!(parse_cyclonedx_catalog(b"not json").is_none());
+        assert!(parse_cyclonedx_catalog(br#"{"bomFormat":"CycloneDX"}"#).is_none());
+    }
+
+    /// The catalog-capturing dir invocation must ask grype for BOTH the json
+    /// report and the cyclonedx BOM in ONE run — a second scan would double
+    /// the inline budget on every proxy pull.
+    #[test]
+    fn test_catalog_invocation_is_single_run_dual_output() {
+        let src = include_str!("grype_scanner.rs");
+        let start = src
+            .find("async fn run_grype_dir_with_catalog")
+            .expect("run_grype_dir_with_catalog must exist");
+        let body = &src[start..start + 2000];
+        assert!(
+            body.contains("\"-o\",\n                \"json\",") || body.contains("\"json\","),
+            "must request the json report"
+        );
+        assert!(
+            body.contains("cyclonedx-json={}"),
+            "must request the cyclonedx BOM in the same invocation"
+        );
+        assert_eq!(
+            body.matches("Command::new(\"grype\")").count(),
+            1,
+            "exactly one grype subprocess per scan"
+        );
     }
 
     // ---- #2093: registry-auth env builder --------------------------------
@@ -1824,6 +2009,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: Some(helm_body),
+            expected_component: None,
         };
         assert!(
             !grype().is_applicable_for_target(&target),
@@ -1851,6 +2037,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: Some(image_body),
+            expected_component: None,
         };
         assert!(grype().is_applicable_for_target(&target));
     }
@@ -2138,6 +2325,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
 
         // The scan dispatch resolves a routable, repository-scoped ref.
@@ -2184,6 +2372,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
         assert!(
             grype().is_applicable_for_target(&target),
@@ -2250,6 +2439,7 @@ mod tests {
             db: Some(&fx.pool),
             storage: Some(fx.state.storage.as_ref()),
             manifest_body: None,
+            expected_component: None,
         };
 
         let layout = scanner
@@ -2354,6 +2544,7 @@ mod tests {
             db: Some(&fx.pool),
             storage: Some(fx.state.storage.as_ref()),
             manifest_body: None,
+            expected_component: None,
         };
 
         let layout = scanner
@@ -2432,6 +2623,7 @@ mod tests {
             db: None,
             storage: Some(fx.state.storage.as_ref()),
             manifest_body: None,
+            expected_component: None,
         };
 
         let manifest = Bytes::from_static(TEST_IMAGE_MANIFEST);
@@ -2478,6 +2670,7 @@ mod tests {
             db: Some(&fx.pool),
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
         let manifest = Bytes::from_static(TEST_IMAGE_MANIFEST);
 

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -1047,6 +1047,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: Some(helm_body),
+            expected_component: None,
         };
         assert!(!scanner.is_applicable_for_target(&target));
     }
@@ -1070,6 +1071,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: Some(image_body),
+            expected_component: None,
         };
         assert!(scanner.is_applicable_for_target(&target));
     }
@@ -1091,6 +1093,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
         assert!(scanner.is_applicable_for_target(&target));
     }
@@ -1368,6 +1371,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
         let result = scanner.scan_target(&target, None, &Bytes::new()).await;
         assert!(

--- a/backend/src/services/proxy_scan_service.rs
+++ b/backend/src/services/proxy_scan_service.rs
@@ -175,6 +175,77 @@ pub fn decide_inconclusive(action: ProxyScanAction) -> InconclusiveOutcome {
     }
 }
 
+/// What the proxy serve path must do for one pull, given the stored verdict
+/// row (if any), the LIVE CVE-scanner version, and the repo's scan action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeDecision {
+    /// Fresh reusable clean verdict: serve the buffered bytes (`X-AK-Scan:
+    /// clean`), no re-scan.
+    ServeCached,
+    /// Fresh reusable vulnerable verdict: block (403) without re-scanning.
+    BlockCached,
+    /// Fail-closed with no reusable verdict: scan inline before serving a
+    /// single byte; the scan outcome then serves / blocks / 423s.
+    ScanInline,
+    /// Fail-open with no reusable verdict: serve now (`X-AK-Scan: pending`)
+    /// and scan asynchronously so the NEXT pull of this digest is gated.
+    ServePendingScanAsync,
+}
+
+/// The freshness + fail-open/closed serve state machine, single-sourced for
+/// every proxy format (PyPI wheels, npm tarballs, OCI manifests). Lifted from
+/// the PyPI serve path so per-format handlers cannot re-implement — and
+/// silently drift on — the two carried defenses:
+///
+/// * #2976: an UNKNOWN live CVE-scanner version (`current_version = None`)
+///   under `fail_closed` must NOT reuse a cached `clean` verdict — the pull
+///   falls through to the re-scan branch ([`verdict_is_reusable`]).
+/// * #2954: the re-scan branch under `fail_closed` is [`ServeDecision::
+///   ScanInline`], whose inconclusive outcome the caller fail-closes (423)
+///   rather than serving unscanned bytes.
+///
+/// Pure over the row + versions + clock (the one `warn!` is observability,
+/// not behavior), so the regression cases are unit-testable without a DB or a
+/// live scanner.
+pub fn decide_serve(
+    row: Option<&ProxyScanRow>,
+    current_version: Option<&str>,
+    action: ProxyScanAction,
+    ttl_days: i64,
+    now: DateTime<Utc>,
+) -> ServeDecision {
+    if let Some(row) = row {
+        let reusable = verdict_is_reusable(
+            &row.verdict,
+            row.scanned_at,
+            row.scanner_version.as_deref(),
+            current_version,
+            action,
+            ttl_days,
+            now,
+        );
+        if !reusable && current_version.is_none() && action.is_fail_closed() {
+            tracing::warn!(
+                stored_version = ?row.scanner_version,
+                "live CVE-scanner version unknown; not reusing the cached verdict \
+                 on a fail-closed repo (re-scanning)"
+            );
+        }
+        if reusable {
+            return if verdict_blocks(&row.verdict) {
+                ServeDecision::BlockCached
+            } else {
+                ServeDecision::ServeCached
+            };
+        }
+    }
+    if action.is_fail_closed() {
+        ServeDecision::ScanInline
+    } else {
+        ServeDecision::ServePendingScanAsync
+    }
+}
+
 pub struct ProxyScanService {
     db: PgPool,
 }
@@ -546,6 +617,136 @@ mod tests {
             .execute(&pool)
             .await
             .expect("cleanup");
+    }
+
+    fn row(
+        verdict: &str,
+        scanned_at: DateTime<Utc>,
+        scanner_version: Option<&str>,
+    ) -> ProxyScanRow {
+        ProxyScanRow {
+            checksum_sha256: "0".repeat(64),
+            scan_type: "grype".to_string(),
+            verdict: verdict.to_string(),
+            findings_count: i32::from(verdict == VERDICT_VULNERABLE),
+            critical_count: 0,
+            high_count: 0,
+            medium_count: 0,
+            low_count: 0,
+            max_severity: None,
+            scanner_version: scanner_version.map(str::to_string),
+            scanned_at,
+        }
+    }
+
+    /// The serve state machine truth table, single-sourced for every proxy
+    /// format: fresh-clean serves, fresh-vulnerable blocks, and every
+    /// no-reusable-verdict case forks on the action (fail-closed scans
+    /// inline, fail-open serves pending + async scan).
+    #[test]
+    fn decide_serve_truth_table() {
+        let now = Utc::now();
+        let fresh = now - Duration::days(1);
+        let live = Some("grype-0.84.0");
+
+        // Fresh reusable clean -> serve from cache (both actions).
+        for action in [ProxyScanAction::FailClosed, ProxyScanAction::FailOpen] {
+            assert_eq!(
+                decide_serve(
+                    Some(&row(VERDICT_CLEAN, fresh, live)),
+                    live,
+                    action,
+                    30,
+                    now
+                ),
+                ServeDecision::ServeCached
+            );
+            // Fresh reusable vulnerable -> block from cache, no re-scan.
+            assert_eq!(
+                decide_serve(
+                    Some(&row(VERDICT_VULNERABLE, fresh, live)),
+                    live,
+                    action,
+                    30,
+                    now
+                ),
+                ServeDecision::BlockCached
+            );
+        }
+
+        // No row at all: first pull of this digest.
+        assert_eq!(
+            decide_serve(None, live, ProxyScanAction::FailClosed, 30, now),
+            ServeDecision::ScanInline
+        );
+        assert_eq!(
+            decide_serve(None, live, ProxyScanAction::FailOpen, 30, now),
+            ServeDecision::ServePendingScanAsync
+        );
+
+        // Stale rows fall through to the same first-pull fork: past-TTL...
+        let expired = now - Duration::days(31);
+        assert_eq!(
+            decide_serve(
+                Some(&row(VERDICT_CLEAN, expired, live)),
+                live,
+                ProxyScanAction::FailClosed,
+                30,
+                now
+            ),
+            ServeDecision::ScanInline
+        );
+        // ...and a scanner/CVE-DB version bump within the TTL (#2976).
+        assert_eq!(
+            decide_serve(
+                Some(&row(VERDICT_CLEAN, fresh, Some("grype-0.83.0"))),
+                live,
+                ProxyScanAction::FailClosed,
+                30,
+                now
+            ),
+            ServeDecision::ScanInline
+        );
+        assert_eq!(
+            decide_serve(
+                Some(&row(VERDICT_CLEAN, fresh, Some("grype-0.83.0"))),
+                live,
+                ProxyScanAction::FailOpen,
+                30,
+                now
+            ),
+            ServeDecision::ServePendingScanAsync
+        );
+    }
+
+    /// THE #2976 case, pinned at the decision seam every format now shares:
+    /// a cached `clean` verdict whose provenance cannot be proven current
+    /// (live version probe returned `None`) must NOT short-circuit a
+    /// fail-closed repo — the pull re-scans inline. Fail-open keeps the
+    /// TTL-only fallback (its re-scan branch serves-with-pending anyway).
+    #[test]
+    fn decide_serve_probe_none_fail_closed_rescans_clean() {
+        let now = Utc::now();
+        let fresh = now - Duration::days(1);
+        let clean = row(VERDICT_CLEAN, fresh, Some("grype-0.83.0"));
+
+        assert_eq!(
+            decide_serve(Some(&clean), None, ProxyScanAction::FailClosed, 30, now),
+            ServeDecision::ScanInline,
+            "probe-None + fail_closed must re-scan, never serve stale-clean"
+        );
+        assert_eq!(
+            decide_serve(Some(&clean), None, ProxyScanAction::FailOpen, 30, now),
+            ServeDecision::ServeCached,
+            "fail-open keeps the TTL-only fallback on an unknown live version"
+        );
+        // A cached vulnerable verdict still blocks even with no live version:
+        // never re-fetch/re-scan bytes already known bad.
+        let vuln = row(VERDICT_VULNERABLE, fresh, Some("grype-0.83.0"));
+        assert_eq!(
+            decide_serve(Some(&vuln), None, ProxyScanAction::FailClosed, 30, now),
+            ServeDecision::BlockCached
+        );
     }
 
     #[test]

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -23,7 +23,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use sqlx::PgPool;
 use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::error::{AppError, Result};
@@ -922,34 +922,110 @@ impl ScanWorkspace {
     /// Write the ecosystem-native metadata file that makes the CVE engine
     /// catalog — and therefore actually grade — `pin` (#3003).
     ///
-    /// Authoritative by construction: the pin path is truncated/overwritten, so
-    /// a decoy `package-lock.json` packed inside the archive cannot suppress
-    /// grading. A write failure is a HARD error: silently skipping the pin
-    /// would hand the caller a zero-finding "clean" scan of nothing, which is
-    /// the exact failure this closes. (The caller's assessment gate would also
-    /// catch it, but failing here keeps the reason precise.)
+    /// Authoritative for the TOP-LEVEL identity (the request coordinate always
+    /// wins over whatever the archive claims about itself) but NON-DESTRUCTIVE
+    /// for everything else: a lockfile the archive ships lists RESOLVED
+    /// transitive versions, which is real gradeable signal, so it is merged
+    /// into rather than clobbered. See [`merge_npm_lock_pin`].
+    ///
+    /// A write failure is a HARD error: silently skipping the pin would hand
+    /// the caller a zero-finding "clean" scan of nothing, which is the exact
+    /// failure this closes. (The caller's assessment gate would also catch it,
+    /// but failing here keeps the reason precise.)
     async fn write_component_pin(workspace: &Path, pin: &ExpectedComponent) -> Result<()> {
-        let (rel_path, body) = match pin.ecosystem {
-            // npm: a v3 lockfile pinning exactly this one installed package.
-            // Only the package ITSELF is pinned — its declared dependencies are
-            // semver RANGES, not installed artifacts, and materializing a
-            // range's bound would fabricate findings for versions the consumer
-            // may never install.
-            ComponentEcosystem::Npm => (
-                PathBuf::from("package-lock.json"),
-                npm_package_lock_pin_json(&pin.name, &pin.version),
-            ),
+        match pin.ecosystem {
+            ComponentEcosystem::Npm => Self::write_npm_lock_pin(workspace, pin).await,
             // Python: syft catalogs `*.dist-info/METADATA` and
             // `*.egg-info/PKG-INFO`, but NOT the root `PKG-INFO` an sdist
             // ships — which is why an ordinary vulnerable sdist graded clean
-            // while its wheel graded vulnerable.
-            ComponentEcosystem::Python => (
-                PathBuf::from(format!("{}-{}.dist-info", pin.name, pin.version)).join("METADATA"),
-                python_metadata_pin(&pin.name, &pin.version),
-            ),
+            // while its wheel graded vulnerable. There is no lockfile-merge
+            // concept here: the pin lands at its own dist-info path and
+            // cannot collide with anything the sdist shipped.
+            ComponentEcosystem::Python => {
+                let rel_path = PathBuf::from(format!("{}-{}.dist-info", pin.name, pin.version))
+                    .join("METADATA");
+                Self::write_pin_file(
+                    workspace,
+                    &rel_path,
+                    python_metadata_pin(&pin.name, &pin.version),
+                )
+                .await
+            }
+        }
+    }
+
+    /// Materialize the npm pin without destroying gradeable signal the archive
+    /// shipped (#3004 follow-up).
+    ///
+    /// The pin has to land at a lockfile path so syft catalogs it, and the
+    /// natural path — `package-lock.json` at the workspace root — is one an
+    /// archive can itself occupy. Truncating it was a real loss: a shipped
+    /// lockfile enumerates RESOLVED transitive versions (unlike `package.json`,
+    /// whose dependencies are semver ranges and correctly not materialized), so
+    /// clobbering it hid vulnerable transitives that would otherwise have been
+    /// graded. Three cases:
+    ///
+    /// * **No shipped root lockfile** — write the single-entry pin. Nothing to
+    ///   preserve.
+    /// * **Shipped root lockfile we can merge** (v2/v3 `packages` map) — keep
+    ///   every resolved entry and inject/override ONLY the top-level
+    ///   `node_modules/<name>` entry with the request coordinate. Transitives
+    ///   stay graded; a decoy that hides or rewrites the top-level is still
+    ///   defeated because the top-level comes from the request, not the bytes.
+    /// * **Shipped root lockfile we cannot merge** (v1-only, empty, malformed)
+    ///   — leave it exactly where it is and put the pin in its own
+    ///   subdirectory instead. syft catalogs lockfiles at any depth, so both
+    ///   are graded and nothing is lost.
+    ///
+    /// Lockfiles anywhere else in the tree (the usual
+    /// `package/package-lock.json`, or a `npm-shrinkwrap.json`) are never
+    /// written to at all, so they are preserved and catalogued as-is.
+    async fn write_npm_lock_pin(workspace: &Path, pin: &ExpectedComponent) -> Result<()> {
+        const LOCKFILE_READ_CAP: u64 = 16 * 1024 * 1024;
+        let root_lock = PathBuf::from(NPM_LOCKFILE_NAME);
+        let root_lock_path = workspace.join(&root_lock);
+
+        let shipped = match tokio::fs::metadata(&root_lock_path).await {
+            Ok(meta) if meta.is_file() && meta.len() <= LOCKFILE_READ_CAP => {
+                tokio::fs::read_to_string(&root_lock_path).await.ok()
+            }
+            _ => None,
         };
 
-        let pin_path = workspace.join(&rel_path);
+        let Some(shipped) = shipped else {
+            return Self::write_pin_file(
+                workspace,
+                &root_lock,
+                npm_package_lock_pin_json(&pin.name, &pin.version),
+            )
+            .await;
+        };
+
+        match merge_npm_lock_pin(&shipped, &pin.name, &pin.version) {
+            Some(merged) => Self::write_pin_file(workspace, &root_lock, merged).await,
+            None => {
+                // Unmergeable but possibly still meaningful to syft: preserve
+                // it and pin alongside rather than trading their signal for
+                // ours.
+                debug!(
+                    "npm scan pin: root {} is not mergeable; preserving it and pinning \
+                     {}@{} in {}",
+                    NPM_LOCKFILE_NAME, pin.name, pin.version, NPM_PIN_SUBDIR
+                );
+                Self::write_pin_file(
+                    workspace,
+                    &PathBuf::from(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME),
+                    npm_package_lock_pin_json(&pin.name, &pin.version),
+                )
+                .await
+            }
+        }
+    }
+
+    /// Write one pin file (creating parents), mapping IO failure onto the
+    /// hard error described on [`ScanWorkspace::write_component_pin`].
+    async fn write_pin_file(workspace: &Path, rel_path: &Path, body: String) -> Result<()> {
+        let pin_path = workspace.join(rel_path);
         if let Some(parent) = pin_path.parent() {
             tokio::fs::create_dir_all(parent).await.map_err(|e| {
                 AppError::Internal(format!("Failed to create scan pin directory: {}", e))
@@ -1089,6 +1165,80 @@ impl ScanWorkspace {
             .await
             .map_err(|e| AppError::Internal(format!("Extraction task panicked: {}", e)))?
     }
+}
+
+/// The lockfile name the npm component pin is written under. syft catalogs
+/// this name at any depth, which is what makes both the merged root pin and
+/// the preserve-fallback subdirectory pin gradeable.
+pub(crate) const NPM_LOCKFILE_NAME: &str = "package-lock.json";
+
+/// Where the npm pin goes when a shipped root lockfile exists that we cannot
+/// merge into: its own subdirectory, so the shipped one is left untouched.
+pub(crate) const NPM_PIN_SUBDIR: &str = ".ak-scan-pin";
+
+/// Merge the request-coordinate pin INTO a lockfile the archive shipped,
+/// instead of replacing it (#3004 follow-up).
+///
+/// A shipped lockfile enumerates RESOLVED dependency versions — real,
+/// gradeable supply-chain signal. Overwriting it with a single-entry pin hid
+/// vulnerable TRANSITIVES: the CVE engine would then see only a clean
+/// top-level and report zero findings for a tarball that resolves, say, a
+/// known-vulnerable nested `lodash`.
+///
+/// So: keep every entry the lockfile declares, and inject/override ONLY the
+/// top-level `node_modules/<name>` entry with the version from the request
+/// coordinate. That keeps the top-level AUTHORITATIVE (a decoy that omits or
+/// downgrades the served package cannot suppress its grading) while leaving
+/// the transitive graph intact. The root `name`/`version` are also set to the
+/// coordinate so the document describes the package actually being served.
+///
+/// Returns `None` when the document is not a mergeable v2/v3 lockfile — not an
+/// object, no `packages` map, or an empty one. The caller then PRESERVES the
+/// shipped file and writes the pin elsewhere, so an unparseable-to-us lockfile
+/// is never traded away for our pin.
+pub(crate) fn merge_npm_lock_pin(shipped: &str, name: &str, version: &str) -> Option<String> {
+    let mut doc: serde_json::Value = serde_json::from_str(shipped).ok()?;
+    let obj = doc.as_object_mut()?;
+
+    let packages = obj.get_mut("packages")?.as_object_mut()?;
+    if packages.is_empty() {
+        return None;
+    }
+
+    // Authoritative top-level: preserve any other keys the entry carried
+    // (resolved/integrity/dependencies) but force the served version.
+    let key = format!("node_modules/{name}");
+    match packages.get_mut(&key).and_then(|e| e.as_object_mut()) {
+        Some(entry) => {
+            entry.insert(
+                "version".to_string(),
+                serde_json::Value::String(version.to_string()),
+            );
+        }
+        None => {
+            packages.insert(key, serde_json::json!({ "version": version }));
+        }
+    }
+
+    obj.insert(
+        "name".to_string(),
+        serde_json::Value::String(name.to_string()),
+    );
+    obj.insert(
+        "version".to_string(),
+        serde_json::Value::String(version.to_string()),
+    );
+    // A `packages` map is v2+; make sure the declared version agrees so the
+    // parser reads the map we just merged into.
+    let lv_ok = obj
+        .get("lockfileVersion")
+        .and_then(|v| v.as_i64())
+        .is_some_and(|v| v >= 2);
+    if !lv_ok {
+        obj.insert("lockfileVersion".to_string(), serde_json::json!(3));
+    }
+
+    Some(doc.to_string())
 }
 
 /// The `package-lock.json` (lockfileVersion 3) body that pins exactly one
@@ -7576,6 +7726,48 @@ mod tests {
         path
     }
 
+    /// npm-shaped `.tgz` plus one extra entry at an arbitrary archive path.
+    fn write_npm_tgz_with_entry(
+        dir: &Path,
+        name: &str,
+        entry_path: &str,
+        entry_body: &[u8],
+    ) -> PathBuf {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let path = dir.join(name);
+        let file = std::fs::File::create(&path).expect("create tgz");
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(gz);
+
+        let pkg_json = br#"{"name":"widget","version":"1.0.0"}"#;
+        let mut header = tar::Header::new_gnu();
+        header.set_path("package/package.json").unwrap();
+        header.set_size(pkg_json.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, pkg_json.as_ref()).unwrap();
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path(entry_path).unwrap();
+        header.set_size(entry_body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, entry_body).unwrap();
+
+        let gz = builder.into_inner().unwrap();
+        gz.finish().unwrap().flush().unwrap();
+        path
+    }
+
+    /// npm-shaped `.tgz` that ships its own lockfile at the ARCHIVE ROOT —
+    /// the path the component pin also wants, i.e. the collision under test.
+    fn write_npm_tgz_with_root_lock(dir: &Path, name: &str, lock: &[u8]) -> PathBuf {
+        write_npm_tgz_with_entry(dir, name, "package-lock.json", lock)
+    }
+
     fn write_simple_zip(dir: &Path, name: &str) -> PathBuf {
         use std::io::Write;
         use zip::write::SimpleFileOptions;
@@ -7676,6 +7868,209 @@ mod tests {
         }));
     }
 
+    /// #3004 follow-up: merging keeps every RESOLVED entry a shipped lockfile
+    /// declares (so vulnerable transitives stay gradeable) while forcing the
+    /// top-level to the request coordinate.
+    #[test]
+    fn test_merge_npm_lock_pin_keeps_transitives_and_forces_top_level() {
+        let shipped = r#"{
+            "name": "widget",
+            "version": "9.9.9",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {"name": "widget", "version": "9.9.9"},
+                "node_modules/widget": {"version": "9.9.9"},
+                "node_modules/lodash": {"version": "4.17.11", "resolved": "https://r/lodash"}
+            }
+        }"#;
+        let merged = merge_npm_lock_pin(shipped, "widget", "1.0.0").expect("mergeable");
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+
+        // The vulnerable transitive SURVIVES -- this is the whole point.
+        assert_eq!(v["packages"]["node_modules/lodash"]["version"], "4.17.11");
+        assert_eq!(
+            v["packages"]["node_modules/lodash"]["resolved"], "https://r/lodash",
+            "unrelated fields on a preserved entry are untouched"
+        );
+        // The top-level is AUTHORITATIVE: the request coordinate wins over the
+        // version the archive claimed for itself.
+        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
+        assert_eq!(v["name"], "widget");
+        assert_eq!(v["version"], "1.0.0");
+    }
+
+    /// A decoy that omits the served package entirely still gets it pinned,
+    /// and a lockfile with no `lockfileVersion` is normalized to a v3 shape so
+    /// the merged `packages` map is the one that gets parsed.
+    #[test]
+    fn test_merge_npm_lock_pin_injects_missing_top_level() {
+        let shipped = r#"{"packages": {"node_modules/lodash": {"version": "4.17.11"}}}"#;
+        let merged = merge_npm_lock_pin(shipped, "widget", "1.0.0").expect("mergeable");
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
+        assert_eq!(v["packages"]["node_modules/lodash"]["version"], "4.17.11");
+        assert_eq!(v["lockfileVersion"], 3);
+
+        // An explicit v1 declaration alongside a `packages` map is corrected
+        // upward rather than left to be parsed as v1 (which would ignore it).
+        let shipped =
+            r#"{"lockfileVersion": 1, "packages": {"node_modules/a": {"version": "1.0.0"}}}"#;
+        let v: serde_json::Value =
+            serde_json::from_str(&merge_npm_lock_pin(shipped, "w", "2.0.0").unwrap()).unwrap();
+        assert_eq!(v["lockfileVersion"], 3);
+    }
+
+    /// Not-mergeable documents return `None` so the caller PRESERVES them
+    /// instead of trading their signal for the pin.
+    #[test]
+    fn test_merge_npm_lock_pin_rejects_unmergeable() {
+        // No packages map (v1-only lockfile: its `dependencies` are still
+        // gradeable by syft, so it must be kept).
+        assert!(merge_npm_lock_pin(
+            r#"{"lockfileVersion":1,"dependencies":{"lodash":{"version":"4.17.11"}}}"#,
+            "w",
+            "1.0.0"
+        )
+        .is_none());
+        // Empty packages map (the decoy shape).
+        assert!(
+            merge_npm_lock_pin(r#"{"lockfileVersion":3,"packages":{}}"#, "w", "1.0.0").is_none()
+        );
+        // Malformed / wrong root type.
+        assert!(merge_npm_lock_pin("not json", "w", "1.0.0").is_none());
+        assert!(merge_npm_lock_pin("[]", "w", "1.0.0").is_none());
+        assert!(merge_npm_lock_pin(r#"{"packages": 42}"#, "w", "1.0.0").is_none());
+    }
+
+    /// End-to-end through `prepare_pinned`: a tarball that SHIPS a root
+    /// lockfile resolving a vulnerable transitive keeps that transitive in the
+    /// scanned workspace, and gains the authoritative top-level pin.
+    #[tokio::test]
+    async fn test_prepare_pinned_merges_shipped_root_lockfile() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let shipped_lock = br#"{"name":"widget","version":"9.9.9","lockfileVersion":3,"packages":{"node_modules/widget":{"version":"9.9.9"},"node_modules/lodash":{"version":"4.17.11"}}}"#;
+        let tgz = write_npm_tgz_with_root_lock(tmp.path(), "widget-1.0.0.tgz", shipped_lock);
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "widget-1.0.0.tgz",
+            "application/gzip",
+            "widget-1.0.0.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        let body = tokio::fs::read_to_string(workspace.join("package-lock.json"))
+            .await
+            .expect("lockfile");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            v["packages"]["node_modules/lodash"]["version"], "4.17.11",
+            "a shipped lockfile's resolved transitive must survive the pin"
+        );
+        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// An UNMERGEABLE shipped root lockfile (v1) is left byte-for-byte intact
+    /// and the pin goes to its own subdirectory — syft catalogs lockfiles at
+    /// any depth, so both are graded and nothing is traded away.
+    #[tokio::test]
+    async fn test_prepare_pinned_preserves_unmergeable_shipped_lockfile() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let shipped_lock =
+            br#"{"lockfileVersion":1,"dependencies":{"lodash":{"version":"4.17.11"}}}"#;
+        let tgz = write_npm_tgz_with_root_lock(tmp.path(), "widget-1.0.0.tgz", shipped_lock);
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "widget-1.0.0.tgz",
+            "application/gzip",
+            "widget-1.0.0.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        let kept = tokio::fs::read_to_string(workspace.join("package-lock.json"))
+            .await
+            .expect("shipped lockfile must still be there");
+        assert_eq!(
+            kept.as_bytes(),
+            &shipped_lock[..],
+            "an unmergeable shipped lockfile must be preserved byte-for-byte"
+        );
+        let pinned =
+            tokio::fs::read_to_string(workspace.join(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME))
+                .await
+                .expect("pin must be written alongside");
+        let v: serde_json::Value = serde_json::from_str(&pinned).unwrap();
+        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// A lockfile the archive ships at the CONVENTIONAL `package/` location is
+    /// never written to at all — the pin only ever touches the workspace root
+    /// (or its own subdir), so nested lockfiles are untouched by construction.
+    #[tokio::test]
+    async fn test_prepare_pinned_leaves_nested_lockfile_untouched() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested =
+            br#"{"lockfileVersion":3,"packages":{"node_modules/lodash":{"version":"4.17.11"}}}"#;
+        let tgz = write_npm_tgz_with_entry(
+            tmp.path(),
+            "widget-1.0.0.tgz",
+            "package/package-lock.json",
+            nested,
+        );
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "widget-1.0.0.tgz",
+            "application/gzip",
+            "widget-1.0.0.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        let kept = tokio::fs::read_to_string(workspace.join("package").join("package-lock.json"))
+            .await
+            .expect("nested lockfile");
+        assert_eq!(kept.as_bytes(), &nested[..]);
+        // ...and the pin still exists at the root for the top-level identity.
+        assert!(workspace.join("package-lock.json").exists());
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
     /// #3003: the pin is written for an npm tarball so the CVE engine has a
     /// component to grade — syft does not catalog a bare `package.json`.
     #[tokio::test]
@@ -7711,40 +8106,20 @@ mod tests {
     }
 
     /// #3003 (red-team shape b): a decoy `package-lock.json` PACKED INSIDE the
-    /// archive must not suppress grading — the pin is written authoritatively,
-    /// overwriting whatever the attacker shipped.
+    /// archive must not suppress grading of the served package.
+    ///
+    /// The decoy is an EMPTY-`packages` lockfile: it catalogs nothing, and it
+    /// occupies the path the pin wants. It is no longer clobbered (#3004
+    /// follow-up: a shipped lockfile can carry real resolved transitives), so
+    /// the contract is the outcome, not the path — SOME lockfile in the
+    /// workspace must pin the served `name@version`, which is what makes the
+    /// CVE engine grade it.
     #[tokio::test]
-    async fn test_prepare_pinned_overwrites_archive_supplied_lock() {
-        use flate2::write::GzEncoder;
-        use flate2::Compression;
-        use std::io::Write;
-
+    async fn test_prepare_pinned_decoy_lock_cannot_suppress_the_pin() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let path = tmp.path().join("lodash-4.17.11.tgz");
-        {
-            let file = std::fs::File::create(&path).unwrap();
-            let gz = GzEncoder::new(file, Compression::default());
-            let mut builder = tar::Builder::new(gz);
-            // An EMPTY root lockfile: a real lockfile shape that catalogs
-            // nothing, shipped to shadow ours.
-            let decoy = br#"{"lockfileVersion":3,"packages":{}}"#;
-            let mut header = tar::Header::new_gnu();
-            header.set_path("package-lock.json").unwrap();
-            header.set_size(decoy.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder.append(&header, decoy.as_ref()).unwrap();
-            let pkg = br#"{"name":"lodash","version":"4.17.11"}"#;
-            let mut header = tar::Header::new_gnu();
-            header.set_path("package/package.json").unwrap();
-            header.set_size(pkg.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder.append(&header, pkg.as_ref()).unwrap();
-            let gz = builder.into_inner().unwrap();
-            gz.finish().unwrap().flush().unwrap();
-        }
-        let content = Bytes::from(std::fs::read(&path).unwrap());
+        let decoy = br#"{"lockfileVersion":3,"packages":{}}"#;
+        let tgz = write_npm_tgz_with_root_lock(tmp.path(), "lodash-4.17.11.tgz", decoy);
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
         let artifact = test_helpers::make_test_artifact(
             "lodash-4.17.11.tgz",
             "application/gzip",
@@ -7763,16 +8138,44 @@ mod tests {
         .await
         .expect("prepare_pinned");
 
-        let body = tokio::fs::read_to_string(workspace.join("package-lock.json"))
-            .await
-            .expect("lockfile");
-        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(
-            v["packages"]["node_modules/lodash"]["version"], "4.17.11",
-            "the archive-supplied decoy lock must be replaced by our pin"
+        assert!(
+            workspace_pins_component(&workspace, "lodash", "4.17.11").await,
+            "a decoy lockfile must not prevent the served package from being pinned"
         );
 
         ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// True when ANY `package-lock.json` in the workspace tree pins
+    /// `name@version` — syft catalogs lockfiles at any depth, so this is the
+    /// property that actually decides whether the CVE engine grades it.
+    async fn workspace_pins_component(workspace: &Path, name: &str, version: &str) -> bool {
+        let mut dirs = vec![workspace.to_path_buf()];
+        while let Some(dir) = dirs.pop() {
+            let Ok(mut rd) = tokio::fs::read_dir(&dir).await else {
+                continue;
+            };
+            while let Ok(Some(entry)) = rd.next_entry().await {
+                let path = entry.path();
+                if path.is_dir() {
+                    dirs.push(path);
+                    continue;
+                }
+                if path.file_name().and_then(|f| f.to_str()) != Some(NPM_LOCKFILE_NAME) {
+                    continue;
+                }
+                let Ok(body) = tokio::fs::read_to_string(&path).await else {
+                    continue;
+                };
+                let Ok(v) = serde_json::from_str::<serde_json::Value>(&body) else {
+                    continue;
+                };
+                if v["packages"][format!("node_modules/{name}")]["version"] == version {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// #3003: a python pin lands at `<name>-<version>.dist-info/METADATA` —

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -846,6 +846,35 @@ impl ScanWorkspace {
         artifact: &Artifact,
         content: &Bytes,
     ) -> Result<PathBuf> {
+        Self::prepare_pinned(base, prefix, artifact, content, None).await
+    }
+
+    /// [`ScanWorkspace::prepare`] plus the inline-proxy component PIN (#3003).
+    ///
+    /// When `pin` is `Some`, a minimal ecosystem-native metadata file naming
+    /// exactly `pin.name@pin.version` is written into the workspace root so the
+    /// CVE engine has a gradeable component for the artifact being served.
+    /// This is required, not cosmetic: syft/grype do NOT catalog a bare npm
+    /// `package/package.json` or an sdist's root `PKG-INFO`, so without it the
+    /// engine catalogs zero components, reports zero findings, and a vulnerable
+    /// artifact reads as "clean".
+    ///
+    /// The pin is derived from the REQUEST coordinate (route package name +
+    /// filename version), never from bytes the upstream controls, and is
+    /// written AUTHORITATIVELY — it overwrites any same-named file shipped
+    /// inside the archive, so an attacker cannot suppress grading by packing a
+    /// benign/empty decoy lockfile. What the archive itself claims is
+    /// cross-checked separately by the serve path before the scan runs.
+    ///
+    /// `pin: None` (every hosted upload scan and legacy caller) behaves exactly
+    /// as before: no file is fabricated.
+    pub async fn prepare_pinned(
+        base: &str,
+        prefix: Option<&str>,
+        artifact: &Artifact,
+        content: &Bytes,
+        pin: Option<&ExpectedComponent>,
+    ) -> Result<PathBuf> {
         let workspace = Self::workspace_dir(base, prefix, artifact);
         tokio::fs::create_dir_all(&workspace)
             .await
@@ -880,57 +909,59 @@ impl ScanWorkspace {
                         reset_err
                     );
                 }
-            } else {
-                // #3003: an npm registry tarball extracts to `package/` with a
-                // `package.json`, but syft/grype dir-mode deliberately does NOT
-                // catalog a bare package.json (it declares intent, it does not
-                // pin an installed artifact), so the pulled package itself was
-                // never CVE-graded — grype reported 0 components on e.g.
-                // lodash-4.17.11.tgz. Derive a minimal pinned
-                // package-lock.json for exactly that name@version so the CVE
-                // engine grades the package being served. Layout-gated on the
-                // npm-pack `package/package.json` convention (a PyPI sdist
-                // extracts to `<name>-<version>/`, never `package/`) and
-                // best-effort: any parse/IO failure leaves the workspace
-                // exactly as before.
-                Self::derive_npm_package_lock(&workspace).await;
             }
+        }
+
+        if let Some(pin) = pin {
+            Self::write_component_pin(&workspace, pin).await?;
         }
 
         Ok(workspace)
     }
 
-    /// Best-effort #3003 hook: when the extracted tree is an npm registry
-    /// tarball (`package/package.json` with a valid name + version) and no
-    /// lockfile was shipped, write a minimal pinned `package-lock.json` at the
-    /// workspace root so syft/grype catalog — and CVE-match — the package
-    /// itself. No-ops (with a debug log at most) on any other layout.
-    async fn derive_npm_package_lock(workspace: &Path) {
-        const PACKAGE_JSON_READ_CAP: u64 = 1024 * 1024; // 1 MiB is generous
-        let pkg_json = workspace.join("package").join("package.json");
-        let lock_path = workspace.join("package-lock.json");
-        if lock_path.exists() {
-            return; // an actual lockfile (from the archive root) wins
+    /// Write the ecosystem-native metadata file that makes the CVE engine
+    /// catalog — and therefore actually grade — `pin` (#3003).
+    ///
+    /// Authoritative by construction: the pin path is truncated/overwritten, so
+    /// a decoy `package-lock.json` packed inside the archive cannot suppress
+    /// grading. A write failure is a HARD error: silently skipping the pin
+    /// would hand the caller a zero-finding "clean" scan of nothing, which is
+    /// the exact failure this closes. (The caller's assessment gate would also
+    /// catch it, but failing here keeps the reason precise.)
+    async fn write_component_pin(workspace: &Path, pin: &ExpectedComponent) -> Result<()> {
+        let (rel_path, body) = match pin.ecosystem {
+            // npm: a v3 lockfile pinning exactly this one installed package.
+            // Only the package ITSELF is pinned — its declared dependencies are
+            // semver RANGES, not installed artifacts, and materializing a
+            // range's bound would fabricate findings for versions the consumer
+            // may never install.
+            ComponentEcosystem::Npm => (
+                PathBuf::from("package-lock.json"),
+                npm_package_lock_pin_json(&pin.name, &pin.version),
+            ),
+            // Python: syft catalogs `*.dist-info/METADATA` and
+            // `*.egg-info/PKG-INFO`, but NOT the root `PKG-INFO` an sdist
+            // ships — which is why an ordinary vulnerable sdist graded clean
+            // while its wheel graded vulnerable.
+            ComponentEcosystem::Python => (
+                PathBuf::from(format!("{}-{}.dist-info", pin.name, pin.version)).join("METADATA"),
+                python_metadata_pin(&pin.name, &pin.version),
+            ),
+        };
+
+        let pin_path = workspace.join(&rel_path);
+        if let Some(parent) = pin_path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                AppError::Internal(format!("Failed to create scan pin directory: {}", e))
+            })?;
         }
-        let Ok(meta) = tokio::fs::metadata(&pkg_json).await else {
-            return; // not an npm-pack layout
-        };
-        if !meta.is_file() || meta.len() > PACKAGE_JSON_READ_CAP {
-            return;
-        }
-        let Ok(body) = tokio::fs::read_to_string(&pkg_json).await else {
-            return;
-        };
-        let Some(lock) = derive_npm_package_lock_json(&body) else {
-            return;
-        };
-        if let Err(e) = tokio::fs::write(&lock_path, lock).await {
-            warn!(
-                "Failed to write derived npm package-lock.json in {}: {}",
-                workspace.display(),
+        tokio::fs::write(&pin_path, body).await.map_err(|e| {
+            AppError::Internal(format!(
+                "Failed to write scan component pin {}: {}",
+                rel_path.display(),
                 e
-            );
-        }
+            ))
+        })
     }
 
     /// Reset a scan workspace to just the original archive after an extraction
@@ -1060,38 +1091,31 @@ impl ScanWorkspace {
     }
 }
 
-/// Derive a minimal pinned `package-lock.json` (lockfileVersion 3) from an npm
-/// tarball's `package/package.json` body, pinning exactly the package's own
-/// `name@version` (#3003). Pure and defensive: returns `None` on invalid JSON
-/// or a missing/empty/non-string name or version, in which case the workspace
-/// is left un-annotated (today's behavior — the package is simply not graded).
+/// The `package-lock.json` (lockfileVersion 3) body that pins exactly one
+/// installed npm package, so the CVE engine catalogs and grades it (#3003).
 ///
-/// Only the package ITSELF is pinned — its declared dependencies are semver
-/// RANGES, not installed artifacts, and pinning a range's lower bound would
-/// fabricate findings for versions the client may never install. The unit of
-/// grading is the tarball being served, matching the digest the verdict is
-/// keyed on.
-pub(crate) fn derive_npm_package_lock_json(package_json: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(package_json).ok()?;
-    let name = v.get("name")?.as_str()?;
-    let version = v.get("version")?.as_str()?;
-    if name.is_empty() || version.is_empty() {
-        return None;
-    }
+/// Pure and total: the identity comes from the request coordinate, which the
+/// serve path has already validated, so there is nothing to fail on here.
+pub(crate) fn npm_package_lock_pin_json(name: &str, version: &str) -> String {
     let mut packages = serde_json::Map::new();
     packages.insert(
         format!("node_modules/{name}"),
         serde_json::json!({ "version": version }),
     );
-    Some(
-        serde_json::json!({
-            "name": name,
-            "version": version,
-            "lockfileVersion": 3,
-            "packages": packages,
-        })
-        .to_string(),
-    )
+    serde_json::json!({
+        "name": name,
+        "version": version,
+        "lockfileVersion": 3,
+        "packages": packages,
+    })
+    .to_string()
+}
+
+/// The minimal PEP 566 `METADATA` body that pins one installed Python
+/// distribution. Written under `<name>-<version>.dist-info/` because syft
+/// catalogs that layout but not the root `PKG-INFO` an sdist ships (#3003).
+pub(crate) fn python_metadata_pin(name: &str, version: &str) -> String {
+    format!("Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n")
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1966,6 +1990,17 @@ pub struct ScanOutput {
     pub findings: Vec<RawFinding>,
     pub packages: Vec<RawPackage>,
     pub scan_completeness: ScanCompleteness,
+    /// The components this scanner actually CATALOGED for the target — i.e.
+    /// what it was able to grade, independent of whether anything matched a
+    /// CVE (#3003).
+    ///
+    /// `None` means "this scanner does not report a catalog" and is the
+    /// default for every scanner that has not opted in; the inline proxy
+    /// assessment gate then falls back to its prior behavior rather than
+    /// inventing a signal. `Some(vec![])` is the load-bearing case: the
+    /// engine ran and cataloged NOTHING, so a zero-finding result means
+    /// "nothing was assessed", not "clean".
+    pub cataloged: Option<Vec<CatalogedComponent>>,
 }
 
 impl ScanOutput {
@@ -1977,6 +2012,7 @@ impl ScanOutput {
             findings,
             packages: Vec::new(),
             scan_completeness: ScanCompleteness::Complete,
+            cataloged: None,
         }
     }
 
@@ -1995,6 +2031,7 @@ impl ScanOutput {
             findings: convert_trivy_findings(report, source_label),
             packages: convert_trivy_packages(report),
             scan_completeness: ScanCompleteness::Complete,
+            cataloged: None,
         }
     }
 
@@ -2015,6 +2052,7 @@ impl ScanOutput {
             findings: convert_trivy_findings(report, source_label),
             packages: convert_trivy_packages(report),
             scan_completeness: classify_trivy_completeness(report, stderr, known_targets),
+            cataloged: None,
         }
     }
 
@@ -2055,6 +2093,103 @@ pub struct ScanTarget<'a> {
     /// that case the gate falls back to the path/content-type predicate and
     /// must never flip an artifact applicable→not-applicable (#1971).
     pub manifest_body: Option<&'a [u8]>,
+    /// The component identity the served bytes MUST be assessed as, supplied
+    /// by an inline proxy serve path from the REQUEST coordinate (#3003).
+    ///
+    /// `Some` turns on the "the CVE engine actually assessed this artifact"
+    /// gate in [`run_inline_proxy_scanners_target`]: the pin is materialized
+    /// into the scan workspace so the CVE engine catalogs it, and a verdict is
+    /// only allowed to be `clean` when the engine really cataloged that
+    /// identity. `None` (hosted upload scans, legacy callers, unit tests)
+    /// keeps the prior behavior exactly.
+    pub expected_component: Option<&'a ExpectedComponent>,
+}
+
+/// The package ecosystem an [`ExpectedComponent`] belongs to. Selects both the
+/// pin file written into the scan workspace and the name-normalization rules
+/// used to compare against what the CVE engine cataloged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentEcosystem {
+    /// npm registry tarball (`.tgz`): pinned via a `package-lock.json`.
+    Npm,
+    /// Python wheel/sdist: pinned via a `<name>-<version>.dist-info/METADATA`.
+    Python,
+}
+
+/// The identity a proxied artifact is being SERVED AS — derived from the
+/// request coordinate (route package name + filename version), never from
+/// bytes the upstream controls (#3003).
+///
+/// Two jobs, both required to close the "Grype ran but graded nothing"
+/// blindness that let a vulnerable tarball through with a 200:
+///
+/// 1. **Pin** — materialized into the scan workspace
+///    ([`ScanWorkspace::prepare_pinned`]) so the CVE engine has a gradeable
+///    component at all. syft/grype do not catalog a bare npm
+///    `package/package.json` or an sdist's root `PKG-INFO`, so without a pin
+///    the engine runs, catalogs zero components, reports zero findings, and
+///    "clean" means only "nothing was looked at".
+/// 2. **Assessment check** — the engine's catalog must actually contain this
+///    identity before a `clean` verdict is trusted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedComponent {
+    pub ecosystem: ComponentEcosystem,
+    pub name: String,
+    pub version: String,
+}
+
+/// One component the CVE-authoritative engine actually cataloged (and
+/// therefore actually graded) for a scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogedComponent {
+    pub name: String,
+    pub version: String,
+}
+
+impl ExpectedComponent {
+    pub fn new(ecosystem: ComponentEcosystem, name: &str, version: &str) -> Self {
+        Self {
+            ecosystem,
+            name: name.to_string(),
+            version: version.to_string(),
+        }
+    }
+
+    /// Ecosystem-aware name normalization for comparing our coordinate against
+    /// the engine's catalog. Python follows PEP 503 (lowercase, runs of
+    /// `-_.` collapse to `-`) because syft reports `PyYAML` as `pyyaml`; npm
+    /// names are compared case-insensitively.
+    pub fn normalize_name(ecosystem: ComponentEcosystem, name: &str) -> String {
+        let lower = name.trim().to_lowercase();
+        match ecosystem {
+            ComponentEcosystem::Npm => lower,
+            ComponentEcosystem::Python => {
+                let mut out = String::with_capacity(lower.len());
+                let mut prev_sep = false;
+                for ch in lower.chars() {
+                    if matches!(ch, '-' | '_' | '.') {
+                        if !prev_sep {
+                            out.push('-');
+                        }
+                        prev_sep = true;
+                    } else {
+                        out.push(ch);
+                        prev_sep = false;
+                    }
+                }
+                out
+            }
+        }
+    }
+
+    /// Whether a cataloged component is this expected component. Versions are
+    /// compared verbatim (a version the engine graded must be the version we
+    /// are serving); only the NAME is normalized.
+    pub fn matches(&self, cataloged: &CatalogedComponent) -> bool {
+        Self::normalize_name(self.ecosystem, &self.name)
+            == Self::normalize_name(self.ecosystem, &cataloged.name)
+            && self.version.trim() == cataloged.version.trim()
+    }
 }
 
 /// Aggregated verdict from an inline proxy scan over raw bytes (#2954).
@@ -2133,54 +2268,34 @@ pub fn aggregate_proxy_verdict(
 
 /// Run the applicable leaf scanners over raw proxy bytes and fold their output
 /// into a [`ProxyScanVerdict`], or return an error when the result is
-/// INCONCLUSIVE. Extracted from [`ScannerService::scan_content`] (minus the
-/// fair-share permit) so the #2954 fail-closed correctness contract is
-/// unit-testable over mock scanners, with no `ScannerService`/DB/storage.
+/// INCONCLUSIVE. THE single implementation of the inline-proxy scan contract
+/// for every format: file artifacts (PyPI wheels/sdists, npm tarballs) reach it
+/// through [`ScannerService::scan_content_expecting`] with a context-free
+/// [`ScanTarget`], and repository-context callers (the OCI manifest serve path)
+/// supply a full one. Extracted from `scan_content` (minus the fair-share
+/// permit) so the fail-closed correctness contract is unit-testable over mock
+/// scanners, with no `ScannerService`/DB/storage.
 ///
-/// Fail-closed correctness (#2954): a non-error (`clean`/`vulnerable`) verdict
-/// is only trustworthy when the CVE-AUTHORITATIVE scanner (Grype —
-/// [`Scanner::is_cve_authoritative`]) actually completed `Ok`. The always-on
-/// `DependencyScanner` returns `Ok(ScanOutput::default())` on a binary wheel
-/// (non-UTF-8 content -> zero parsed deps), so "some scanner ran" is trivially
-/// true even when Grype hard-errored / timed out / OOM-died or the pre-seeded
-/// CVE-DB aged past its exit-1 time-bomb. Letting that trivial success
-/// aggregate to `clean` is exactly the hole that serves an UNSCANNED,
-/// possibly-vulnerable wheel with a 200 under the fail-closed posture. So: if a
-/// CVE-authoritative scanner was APPLICABLE but none completed `Ok`, we return
-/// an error the caller treats as inconclusive (fail-closed -> 423, fail-open ->
-/// loud pending) and no `clean` verdict is ever persisted for this digest. A
-/// single supplementary scanner failing (e.g. an optional Trivy adapter that is
-/// down) still must NOT abort the scan — only the CVE engine is load-bearing.
-async fn run_inline_proxy_scanners(
-    scanners: &[Arc<dyn Scanner>],
-    synthetic: &Artifact,
-    content: &Bytes,
-) -> Result<ProxyScanVerdict> {
-    // File-mode delegation: a synthetic wheel / npm tarball carries no
-    // repository routing context, so wrap it in a context-free [`ScanTarget`].
-    // The trait defaults make this behavior-preserving: for a non-OCI
-    // artifact `is_applicable_for_target` falls back to `is_applicable` and
-    // `scan_target` to `scan` (Grype's overrides delegate the same way), so
-    // the file path is byte-identical to the pre-refactor loop while the
-    // fail-closed gate below stays SINGLE-SOURCED for every format.
-    let target = ScanTarget {
-        artifact: synthetic,
-        repository_key: "",
-        repository_type: "",
-        db: None,
-        storage: None,
-        manifest_body: None,
-    };
-    run_inline_proxy_scanners_target(scanners, &target, content).await
-}
-
-/// Context-aware sibling of [`run_inline_proxy_scanners`]: the SAME
-/// security-critical loop (including the #2954 `cve_scanner_applicable &&
-/// !cve_scanner_ran` fail-closed gate — there is exactly ONE copy of it, here)
-/// but gating on [`Scanner::is_applicable_for_target`] and scanning via
-/// [`Scanner::scan_target`], so callers that need repository routing context
-/// (the OCI manifest serve path) can supply a full [`ScanTarget`] while file
-/// formats delegate through the wrapper above.
+/// Three conditions must ALL hold before a non-error (`clean`/`vulnerable`)
+/// verdict is returned. Each one is a hole that shipped a vulnerable artifact
+/// with a 200:
+///
+/// 1. **The CVE engine completed `Ok`** (#2954). The always-on
+///    `DependencyScanner` returns `Ok(ScanOutput::default())` on a binary
+///    archive (non-UTF-8 → zero parsed deps), so "some scanner ran" is
+///    trivially true even when Grype hard-errored / timed out / OOM-died or the
+///    pre-seeded CVE-DB aged past its exit-1 time-bomb. A supplementary
+///    scanner failing (an optional Trivy adapter that is down) still must NOT
+///    abort the scan — only the CVE engine is load-bearing.
+/// 2. **The CVE engine cataloged something** (#3003), when the caller supplied
+///    an `expected_component`. `is_vulnerable()` is `findings_count > 0`, so an
+///    engine that ran but had nothing to grade reports "clean".
+/// 3. **What it cataloged is what we are serving** (#3003). A clean grade of
+///    some other identity says nothing about these bytes.
+///
+/// All three return the same inconclusive `Err`, which the caller maps onto the
+/// repo's action (fail-closed → 423, fail-open → serve + loud pending), and no
+/// `clean` verdict is ever persisted for the digest.
 async fn run_inline_proxy_scanners_target(
     scanners: &[Arc<dyn Scanner>],
     target: &ScanTarget<'_>,
@@ -2195,6 +2310,9 @@ async fn run_inline_proxy_scanners_target(
     // Conflating these two questions is the #2954 fail-closed hole.
     let mut cve_scanner_applicable = false;
     let mut cve_scanner_ran = false;
+    // What the CVE-authoritative scanner actually cataloged (#3003). `None`
+    // until a CVE engine that reports a catalog completes.
+    let mut cve_cataloged: Option<Vec<CatalogedComponent>> = None;
 
     for scanner in scanners {
         // Applicability gates on the target artifact's path/content-type
@@ -2212,6 +2330,9 @@ async fn run_inline_proxy_scanners_target(
                 any_ran = true;
                 if is_cve_authoritative {
                     cve_scanner_ran = true;
+                    if let Some(catalog) = output.cataloged {
+                        cve_cataloged.get_or_insert_with(Vec::new).extend(catalog);
+                    }
                 }
                 // Capture the first available scanner version as provenance
                 // for CVE-DB freshness (Grype reports one).
@@ -2249,6 +2370,61 @@ async fn run_inline_proxy_scanners_target(
         return Err(AppError::Internal(
             "no applicable scanner completed for inline proxy scan".to_string(),
         ));
+    }
+
+    // #3003: "the CVE engine ran Ok" is still not enough. `is_vulnerable()` is
+    // `findings_count > 0`, so an engine that RUNS but catalogs nothing to
+    // grade reports zero findings — indistinguishable from a genuinely clean
+    // artifact. That is not a hypothetical: syft/grype do not catalog a bare
+    // npm `package/package.json` or an sdist's root `PKG-INFO`, so a real
+    // vulnerable npm tarball (identity stripped/rewritten, or a lockfile-shaped
+    // decoy added) and an ordinary vulnerable PyPI sdist both scanned "clean"
+    // and served 200 under a fail-closed policy.
+    //
+    // So when the serve path told us what these bytes are being served AS,
+    // require the engine to have actually assessed THAT identity before a
+    // non-error verdict is trusted. Both failure modes below return the same
+    // inconclusive error the #2954 gate uses, so the caller's existing
+    // fail-open/closed handling applies unchanged (fail-closed -> 423,
+    // fail-open -> serve + loud pending), and no `clean` row is persisted.
+    //
+    // Scoped deliberately narrowly: only when `expected_component` is set (the
+    // inline proxy serve paths) AND the engine reports a catalog at all
+    // (`Some`). Hosted upload scans, legacy callers, and scanners that do not
+    // report a catalog keep their prior behavior exactly.
+    if let (Some(expected), Some(cataloged)) = (target.expected_component, cve_cataloged.as_ref()) {
+        if cataloged.is_empty() {
+            warn!(
+                artifact = %synthetic.name,
+                expected = %format!("{}@{}", expected.name, expected.version),
+                "inline proxy scan: CVE engine cataloged NO components; \
+                 zero findings does not mean clean -> inconclusive"
+            );
+            return Err(AppError::Internal(
+                "CVE-authoritative scanner cataloged no gradeable component for inline \
+                 proxy scan; verdict inconclusive (a zero-finding scan of nothing is \
+                 not a clean verdict)"
+                    .to_string(),
+            ));
+        }
+        if !cataloged.iter().any(|c| expected.matches(c)) {
+            warn!(
+                artifact = %synthetic.name,
+                expected = %format!("{}@{}", expected.name, expected.version),
+                cataloged = ?cataloged
+                    .iter()
+                    .map(|c| format!("{}@{}", c.name, c.version))
+                    .collect::<Vec<_>>(),
+                "inline proxy scan: CVE engine graded a DIFFERENT identity than the \
+                 artifact being served -> inconclusive"
+            );
+            return Err(AppError::Internal(
+                "CVE-authoritative scanner did not assess the component identity being \
+                 served for inline proxy scan; verdict inconclusive (the clean result \
+                 does not pertain to these bytes)"
+                    .to_string(),
+            ));
+        }
     }
 
     Ok(aggregate_proxy_verdict(&findings, scanner_version))
@@ -3526,6 +3702,7 @@ impl Scanner for DependencyScanner {
             findings,
             packages,
             scan_completeness: ScanCompleteness::Complete,
+            cataloged: None,
         })
     }
 }
@@ -3840,11 +4017,39 @@ impl ScannerService {
         synthetic: &Artifact,
         content: &Bytes,
     ) -> Result<ProxyScanVerdict> {
+        self.scan_content_expecting(synthetic, content, None).await
+    }
+
+    /// [`ScannerService::scan_content`] plus the #3003 assessment contract:
+    /// `expected` is the identity these bytes are being SERVED AS (derived
+    /// from the request coordinate). Supplying it both PINS that component
+    /// into the scan workspace so the CVE engine can grade it, and requires
+    /// the engine to have actually cataloged it before a non-error verdict is
+    /// returned — so "the engine ran and found nothing" can no longer be
+    /// mistaken for "the artifact is clean".
+    ///
+    /// `expected: None` is exactly today's behavior, for callers with no
+    /// coordinate in hand.
+    pub async fn scan_content_expecting(
+        &self,
+        synthetic: &Artifact,
+        content: &Bytes,
+        expected: Option<&ExpectedComponent>,
+    ) -> Result<ProxyScanVerdict> {
         // Fair-share + global cap: inline scans queue behind the same semaphore
         // as upload scans instead of contending for unbounded extraction slots.
         let _extraction_permit = acquire_scan_extraction_permit(synthetic.repository_id).await;
 
-        run_inline_proxy_scanners(&self.scanners, synthetic, content).await
+        let target = ScanTarget {
+            artifact: synthetic,
+            repository_key: "",
+            repository_type: "",
+            db: None,
+            storage: None,
+            manifest_body: None,
+            expected_component: expected,
+        };
+        run_inline_proxy_scanners_target(&self.scanners, &target, content).await
     }
 
     /// Context-aware sibling of [`ScannerService::scan_content`] for callers
@@ -4033,6 +4238,7 @@ impl ScannerService {
             // share the image manifest mediaType. Only meaningful for OCI
             // manifest artifacts; the gate ignores it for everything else.
             manifest_body: is_oci_image_artifact(&artifact).then(|| content.as_ref()),
+            expected_component: None,
         };
 
         for scanner in &self.scanners {
@@ -4280,6 +4486,7 @@ impl ScannerService {
                     findings,
                     packages,
                     scan_completeness,
+                    cataloged: _,
                 }) => {
                     let total = findings.len() as i32;
                     let count = |sev: Severity| -> i32 {
@@ -6819,6 +7026,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
         assert!(oci_target_is_scannable_image(&target));
     }
@@ -6837,6 +7045,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: Some(HELM_OCI_MANIFEST_BODY),
+            expected_component: None,
         };
         assert!(!oci_target_is_scannable_image(&target));
     }
@@ -7407,39 +7616,203 @@ mod tests {
         assert!(dest.join("package").join("index.js").exists());
     }
 
-    /// #3003: the pure lockfile derivation — a valid npm package.json yields a
-    /// v3 lock pinning exactly `name@version`; anything malformed yields None.
+    /// #3003: the pin bodies are the shapes syft/grype actually catalog —
+    /// a v3 lockfile pinning one installed package, and a PEP 566 METADATA.
     #[test]
-    fn test_derive_npm_package_lock_json() {
-        let lock = derive_npm_package_lock_json(r#"{"name":"lodash","version":"4.17.11"}"#)
-            .expect("valid package.json derives a lock");
-        let v: serde_json::Value = serde_json::from_str(&lock).unwrap();
+    fn test_component_pin_bodies() {
+        let v: serde_json::Value =
+            serde_json::from_str(&npm_package_lock_pin_json("lodash", "4.17.11")).unwrap();
         assert_eq!(v["lockfileVersion"], 3);
         assert_eq!(v["packages"]["node_modules/lodash"]["version"], "4.17.11");
-
         // Scoped names key the node_modules path with the full @scope/name.
-        let lock =
-            derive_npm_package_lock_json(r#"{"name":"@acme/widget","version":"2.0.0"}"#).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&lock).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&npm_package_lock_pin_json("@acme/widget", "2.0.0")).unwrap();
         assert_eq!(
             v["packages"]["node_modules/@acme/widget"]["version"],
             "2.0.0"
         );
 
-        // Defensive Nones: invalid JSON, missing/empty/non-string fields.
-        assert!(derive_npm_package_lock_json("not json").is_none());
-        assert!(derive_npm_package_lock_json(r#"{"name":"x"}"#).is_none());
-        assert!(derive_npm_package_lock_json(r#"{"version":"1.0.0"}"#).is_none());
-        assert!(derive_npm_package_lock_json(r#"{"name":"","version":"1.0.0"}"#).is_none());
-        assert!(derive_npm_package_lock_json(r#"{"name":"x","version":42}"#).is_none());
+        let meta = python_metadata_pin("PyYAML", "5.3.1");
+        assert!(meta.contains("Name: PyYAML"), "{meta}");
+        assert!(meta.contains("Version: 5.3.1"), "{meta}");
+        assert!(meta.starts_with("Metadata-Version:"), "{meta}");
     }
 
-    /// #3003: `ScanWorkspace::prepare` writes the derived pinned lockfile for
-    /// an npm-pack layout (`package/package.json`) so grype grades the package
-    /// itself — syft dir-mode does not catalog a bare package.json, which is
-    /// why a vulnerable tarball previously scanned as 0 components / clean.
+    /// #3003: identity comparison is ecosystem-aware. Python normalizes per
+    /// PEP 503 (syft reports `PyYAML` as `pyyaml`); npm is case-insensitive.
+    /// Versions are never normalized — grading 5.3.1 says nothing about 5.4.
+    #[test]
+    fn test_expected_component_matches() {
+        let py = ExpectedComponent::new(ComponentEcosystem::Python, "PyYAML", "5.3.1");
+        assert!(py.matches(&CatalogedComponent {
+            name: "pyyaml".into(),
+            version: "5.3.1".into()
+        }));
+        let dotted = ExpectedComponent::new(ComponentEcosystem::Python, "zope.interface", "5.4.0");
+        assert!(dotted.matches(&CatalogedComponent {
+            name: "zope-interface".into(),
+            version: "5.4.0".into()
+        }));
+        assert!(!py.matches(&CatalogedComponent {
+            name: "pyyaml".into(),
+            version: "5.4".into()
+        }));
+        assert!(!py.matches(&CatalogedComponent {
+            name: "requests".into(),
+            version: "5.3.1".into()
+        }));
+
+        let npm = ExpectedComponent::new(ComponentEcosystem::Npm, "@acme/Widget", "1.0.0");
+        assert!(npm.matches(&CatalogedComponent {
+            name: "@acme/widget".into(),
+            version: "1.0.0".into()
+        }));
+        // npm must NOT collapse separators the way PEP 503 does: `left-pad`
+        // and `left.pad` are genuinely different packages.
+        let lp = ExpectedComponent::new(ComponentEcosystem::Npm, "left-pad", "1.3.0");
+        assert!(!lp.matches(&CatalogedComponent {
+            name: "left.pad".into(),
+            version: "1.3.0".into()
+        }));
+    }
+
+    /// #3003: the pin is written for an npm tarball so the CVE engine has a
+    /// component to grade — syft does not catalog a bare `package.json`.
     #[tokio::test]
-    async fn test_prepare_derives_npm_package_lock_for_npm_tgz() {
+    async fn test_prepare_pinned_writes_npm_lock_pin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tgz = write_npm_tgz(tmp.path(), "left-pad-1.3.0.tgz");
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "left-pad-1.3.0.tgz",
+            "application/gzip",
+            "left-pad-1.3.0.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "left-pad", "1.3.0");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        let body = tokio::fs::read_to_string(workspace.join("package-lock.json"))
+            .await
+            .expect("pin lockfile must exist");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["packages"]["node_modules/left-pad"]["version"], "1.3.0");
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// #3003 (red-team shape b): a decoy `package-lock.json` PACKED INSIDE the
+    /// archive must not suppress grading — the pin is written authoritatively,
+    /// overwriting whatever the attacker shipped.
+    #[tokio::test]
+    async fn test_prepare_pinned_overwrites_archive_supplied_lock() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("lodash-4.17.11.tgz");
+        {
+            let file = std::fs::File::create(&path).unwrap();
+            let gz = GzEncoder::new(file, Compression::default());
+            let mut builder = tar::Builder::new(gz);
+            // An EMPTY root lockfile: a real lockfile shape that catalogs
+            // nothing, shipped to shadow ours.
+            let decoy = br#"{"lockfileVersion":3,"packages":{}}"#;
+            let mut header = tar::Header::new_gnu();
+            header.set_path("package-lock.json").unwrap();
+            header.set_size(decoy.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, decoy.as_ref()).unwrap();
+            let pkg = br#"{"name":"lodash","version":"4.17.11"}"#;
+            let mut header = tar::Header::new_gnu();
+            header.set_path("package/package.json").unwrap();
+            header.set_size(pkg.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, pkg.as_ref()).unwrap();
+            let gz = builder.into_inner().unwrap();
+            gz.finish().unwrap().flush().unwrap();
+        }
+        let content = Bytes::from(std::fs::read(&path).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "lodash-4.17.11.tgz",
+            "application/gzip",
+            "lodash-4.17.11.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "lodash", "4.17.11");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        let body = tokio::fs::read_to_string(workspace.join("package-lock.json"))
+            .await
+            .expect("lockfile");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            v["packages"]["node_modules/lodash"]["version"], "4.17.11",
+            "the archive-supplied decoy lock must be replaced by our pin"
+        );
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// #3003: a python pin lands at `<name>-<version>.dist-info/METADATA` —
+    /// the layout syft catalogs. An sdist's root `PKG-INFO` is NOT cataloged,
+    /// which is why an ordinary vulnerable sdist previously graded clean.
+    #[tokio::test]
+    async fn test_prepare_pinned_writes_python_dist_info_pin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let content = Bytes::from_static(b"not-a-real-sdist");
+        let artifact = test_helpers::make_test_artifact(
+            "PyYAML-5.3.1.tar.gz",
+            "application/gzip",
+            "PyYAML-5.3.1.tar.gz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Python, "PyYAML", "5.3.1");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        let body =
+            tokio::fs::read_to_string(workspace.join("PyYAML-5.3.1.dist-info").join("METADATA"))
+                .await
+                .expect("dist-info METADATA pin must exist");
+        assert!(body.contains("Name: PyYAML"), "{body}");
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// Blast-radius control: with NO pin (every hosted upload scan) the
+    /// workspace is exactly what it always was — nothing is fabricated.
+    #[tokio::test]
+    async fn test_prepare_without_pin_fabricates_nothing() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let tgz = write_npm_tgz(tmp.path(), "left-pad-1.3.0.tgz");
         let content = Bytes::from(std::fs::read(&tgz).unwrap());
@@ -7454,38 +7827,11 @@ mod tests {
             .await
             .expect("prepare");
 
-        let lock = workspace.join("package-lock.json");
-        let body = tokio::fs::read_to_string(&lock)
-            .await
-            .expect("derived package-lock.json must exist for an npm-pack layout");
-        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["packages"]["node_modules/left-pad"]["version"], "1.3.0");
-
-        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
-    }
-
-    /// Negative control: a non-npm archive layout (a jar) gets NO derived
-    /// lockfile — the hook is strictly gated on `package/package.json`.
-    #[tokio::test]
-    async fn test_prepare_derives_no_lock_for_non_npm_archive() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let jar = write_simple_zip(tmp.path(), "app-1.0.0.jar");
-        let content = Bytes::from(std::fs::read(&jar).unwrap());
-        let artifact = test_helpers::make_test_artifact(
-            "app-1.0.0.jar",
-            "application/java-archive",
-            "app-1.0.0.jar",
-        );
-
-        let base = tmp.path().join("ws-base");
-        let workspace = ScanWorkspace::prepare(base.to_str().unwrap(), None, &artifact, &content)
-            .await
-            .expect("prepare");
-
         assert!(
             !workspace.join("package-lock.json").exists(),
-            "non-npm layouts must not get a fabricated lockfile"
+            "an unpinned (upload-path) scan must not fabricate a lockfile"
         );
+        assert!(workspace.join("package").join("package.json").exists());
 
         ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
     }
@@ -13820,7 +14166,12 @@ mod tests {
             }),
         ];
         let artifact = inline_scan_artifact();
-        let result = run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new()).await;
+        let result = run_inline_proxy_scanners_target(
+            &scanners,
+            &inline_scan_target(&artifact),
+            &Bytes::new(),
+        )
+        .await;
         assert!(
             result.is_err(),
             "a Grype error must be inconclusive (Err), never a clean verdict, \
@@ -13843,9 +14194,13 @@ mod tests {
         ];
         let artifact = inline_scan_artifact();
         assert!(
-            run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
-                .await
-                .is_err(),
+            run_inline_proxy_scanners_target(
+                &scanners,
+                &inline_scan_target(&artifact),
+                &Bytes::new()
+            )
+            .await
+            .is_err(),
             "Grype error remains inconclusive regardless of scanner order (#2954)"
         );
     }
@@ -13865,9 +14220,13 @@ mod tests {
             }),
         ];
         let artifact = inline_scan_artifact();
-        let verdict = run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
-            .await
-            .expect("clean Grype run must produce a verdict");
+        let verdict = run_inline_proxy_scanners_target(
+            &scanners,
+            &inline_scan_target(&artifact),
+            &Bytes::new(),
+        )
+        .await
+        .expect("clean Grype run must produce a verdict");
         assert!(!verdict.is_vulnerable(), "clean run -> not vulnerable");
         assert_eq!(verdict.findings_count, 0);
     }
@@ -13885,9 +14244,13 @@ mod tests {
             }),
         ];
         let artifact = inline_scan_artifact();
-        let verdict = run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
-            .await
-            .expect("Grype run with findings must produce a verdict");
+        let verdict = run_inline_proxy_scanners_target(
+            &scanners,
+            &inline_scan_target(&artifact),
+            &Bytes::new(),
+        )
+        .await
+        .expect("Grype run with findings must produce a verdict");
         assert!(verdict.is_vulnerable(), "findings -> vulnerable");
         assert_eq!(verdict.critical_count, 1);
     }
@@ -13900,9 +14263,13 @@ mod tests {
         let scanners: Vec<Arc<dyn Scanner>> = vec![];
         let artifact = inline_scan_artifact();
         assert!(
-            run_inline_proxy_scanners(&scanners, &artifact, &Bytes::new())
-                .await
-                .is_err(),
+            run_inline_proxy_scanners_target(
+                &scanners,
+                &inline_scan_target(&artifact),
+                &Bytes::new()
+            )
+            .await
+            .is_err(),
             "no scanner at all -> inconclusive, never clean"
         );
     }
@@ -13915,7 +14282,217 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         }
+    }
+
+    /// A CVE-authoritative mock that RAN successfully but reports a specific
+    /// catalog — the #3003 axis. `cataloged: Some(vec![])` is the engine that
+    /// ran and had nothing to grade; `None` models a scanner that reports no
+    /// catalog signal at all.
+    struct CatalogingCveScanner {
+        cataloged: Option<Vec<CatalogedComponent>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Scanner for CatalogingCveScanner {
+        fn name(&self) -> &str {
+            "cataloging-cve-test-scanner"
+        }
+        fn scan_type(&self) -> &str {
+            "grype"
+        }
+        fn is_cve_authoritative(&self) -> bool {
+            true
+        }
+        async fn scan(
+            &self,
+            _: &Artifact,
+            _: Option<&ArtifactMetadata>,
+            _: &Bytes,
+        ) -> Result<ScanOutput> {
+            Ok(ScanOutput {
+                findings: Vec::new(),
+                packages: Vec::new(),
+                scan_completeness: ScanCompleteness::Complete,
+                cataloged: self.cataloged.clone(),
+            })
+        }
+    }
+
+    fn expecting_target<'a>(
+        artifact: &'a Artifact,
+        expected: &'a ExpectedComponent,
+    ) -> ScanTarget<'a> {
+        ScanTarget {
+            artifact,
+            repository_key: "proxy-repo",
+            repository_type: "remote",
+            db: None,
+            storage: None,
+            manifest_body: None,
+            expected_component: Some(expected),
+        }
+    }
+
+    fn lodash_expected() -> ExpectedComponent {
+        ExpectedComponent::new(ComponentEcosystem::Npm, "lodash", "4.17.11")
+    }
+
+    /// THE #3003 discriminator, gap 1: the CVE engine RAN `Ok` with zero
+    /// findings but cataloged NOTHING. Zero findings from a scan of nothing is
+    /// not a clean verdict — it must be inconclusive, so the fail-closed serve
+    /// path 423s instead of serving a vulnerable artifact with a 200.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_zero_cataloged_is_inconclusive() {
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![Arc::new(CatalogingCveScanner {
+            cataloged: Some(Vec::new()),
+        })];
+        let artifact = inline_scan_artifact();
+        let expected = lodash_expected();
+        let target = expecting_target(&artifact, &expected);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_err(),
+            "an engine that cataloged nothing must be inconclusive, never clean"
+        );
+    }
+
+    /// THE #3003 discriminator, gap 2: the engine cataloged a DIFFERENT
+    /// identity than the artifact being served (a rewritten package.json, a
+    /// stray lockfile). A clean grade of something else says nothing about
+    /// these bytes -> inconclusive.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_identity_mismatch_is_inconclusive() {
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![Arc::new(CatalogingCveScanner {
+            cataloged: Some(vec![CatalogedComponent {
+                name: "totally-benign".into(),
+                version: "1.0.0".into(),
+            }]),
+        })];
+        let artifact = inline_scan_artifact();
+        let expected = lodash_expected();
+        let target = expecting_target(&artifact, &expected);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_err(),
+            "grading a different identity must be inconclusive, never clean"
+        );
+
+        // ...and the version half matters just as much as the name half.
+        let scanners: Vec<Arc<dyn Scanner>> = vec![Arc::new(CatalogingCveScanner {
+            cataloged: Some(vec![CatalogedComponent {
+                name: "lodash".into(),
+                version: "4.17.21".into(),
+            }]),
+        })];
+        let target = expecting_target(&artifact, &expected);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_err(),
+            "grading a DIFFERENT VERSION of the right package is still not an \
+             assessment of these bytes"
+        );
+    }
+
+    /// THE control that keeps the gate honest: a genuinely clean package whose
+    /// identity WAS cataloged stays CLEAN (200). The hardening must not turn
+    /// every clean pull into a 423.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_cataloged_match_stays_clean() {
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![Arc::new(CatalogingCveScanner {
+            cataloged: Some(vec![
+                CatalogedComponent {
+                    name: "lodash".into(),
+                    version: "4.17.11".into(),
+                },
+                // Extra co-cataloged components are fine.
+                CatalogedComponent {
+                    name: "some-dep".into(),
+                    version: "1.0.0".into(),
+                },
+            ]),
+        })];
+        let artifact = inline_scan_artifact();
+        let expected = lodash_expected();
+        let target = expecting_target(&artifact, &expected);
+        let verdict = run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+            .await
+            .expect("an assessed, finding-free scan is a clean verdict");
+        assert!(!verdict.is_vulnerable());
+    }
+
+    /// Blast-radius control: a scanner that reports NO catalog signal
+    /// (`cataloged: None` — every non-Grype scanner, and Grype's OCI paths)
+    /// keeps the pre-#3003 behavior even when an identity is expected. The new
+    /// gate only fires on a real signal; it never invents one.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_absent_catalog_signal_keeps_prior_behavior() {
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> =
+            vec![Arc::new(CatalogingCveScanner { cataloged: None })];
+        let artifact = inline_scan_artifact();
+        let expected = lodash_expected();
+        let target = expecting_target(&artifact, &expected);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_ok(),
+            "no catalog signal must not be treated as an empty catalog"
+        );
+    }
+
+    /// And with no expected identity at all (hosted upload scans, legacy
+    /// callers) the assessment gate is entirely inert — an empty catalog is
+    /// still an ordinary clean scan.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_no_expectation_is_unaffected() {
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![Arc::new(CatalogingCveScanner {
+            cataloged: Some(Vec::new()),
+        })];
+        let artifact = inline_scan_artifact();
+        let target = inline_scan_target(&artifact);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_ok(),
+            "callers that supply no coordinate keep the prior behavior exactly"
+        );
+    }
+
+    /// The #2954 gate still outranks the #3003 one: a Grype ERROR is
+    /// inconclusive regardless of any catalog.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_error_outranks_catalog_check() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Error,
+            }),
+        ];
+        let artifact = inline_scan_artifact();
+        let expected = lodash_expected();
+        let target = expecting_target(&artifact, &expected);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_err()
+        );
     }
 
     /// The #2954 discriminator through the CONTEXT-AWARE seam (#3003): the
@@ -14485,6 +15062,7 @@ mod tests {
                 } else {
                     ScanCompleteness::Partial
                 },
+                cataloged: None,
             })
         }
     }
@@ -14504,6 +15082,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
 
         assert!(scanner.is_applicable_for_target(&target));
@@ -14528,6 +15107,7 @@ mod tests {
             db: None,
             storage: None,
             manifest_body: None,
+            expected_component: None,
         };
 
         assert!(scanner.is_applicable_for_target(&target));
@@ -15686,6 +16266,7 @@ mod tests {
                         findings: findings.clone(),
                         packages: packages.clone(),
                         scan_completeness: ScanCompleteness::Complete,
+                        cataloged: None,
                     }),
                     // Displays as "Internal error: <reason>" so the reason is
                     // preserved in scan_results.error_message via fail_scan.

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -23,7 +23,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use sqlx::PgPool;
 use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::error::{AppError, Result};
@@ -954,70 +954,100 @@ impl ScanWorkspace {
         }
     }
 
-    /// Materialize the npm pin without destroying gradeable signal the archive
-    /// shipped (#3004 follow-up).
+    /// Make the npm supply-chain signal gradeable WITHOUT rewriting anything
+    /// the archive shipped (#3004 follow-up 2).
     ///
-    /// The pin has to land at a lockfile path so syft catalogs it, and the
-    /// natural path — `package-lock.json` at the workspace root — is one an
-    /// archive can itself occupy. Truncating it was a real loss: a shipped
-    /// lockfile enumerates RESOLVED transitive versions (unlike `package.json`,
-    /// whose dependencies are semver ranges and correctly not materialized), so
-    /// clobbering it hid vulnerable transitives that would otherwise have been
-    /// graded. Three cases:
+    /// Earlier revisions tried to merge the pin into a shipped
+    /// `package-lock.json` and normalize its `lockfileVersion`. That was the
+    /// wrong shape: every rewrite is a chance to parse npm's lockfile formats
+    /// slightly differently from the scanner, and each mismatch is a silent
+    /// mask. Two real bypasses came out of it — bumping a v1 lockfile to v3
+    /// made the CVE engine read only `packages` and ignore the `dependencies`
+    /// tree where the vulnerable transitives actually were, and a dummy
+    /// `packages` map was enough to trigger that bump. So this no longer reads,
+    /// parses, merges, re-versions, or overwrites ANY shipped file.
     ///
-    /// * **No shipped root lockfile** — write the single-entry pin. Nothing to
-    ///   preserve.
-    /// * **Shipped root lockfile we can merge** (v2/v3 `packages` map) — keep
-    ///   every resolved entry and inject/override ONLY the top-level
-    ///   `node_modules/<name>` entry with the request coordinate. Transitives
-    ///   stay graded; a decoy that hides or rewrites the top-level is still
-    ///   defeated because the top-level comes from the request, not the bytes.
-    /// * **Shipped root lockfile we cannot merge** (v1-only, empty, malformed)
-    ///   — leave it exactly where it is and put the pin in its own
-    ///   subdirectory instead. syft catalogs lockfiles at any depth, so both
-    ///   are graded and nothing is lost.
+    /// Instead every signal is presented to the engine as its own file, at a
+    /// path nothing else claims:
     ///
-    /// Lockfiles anywhere else in the tree (the usual
-    /// `package/package-lock.json`, or a `npm-shrinkwrap.json`) are never
-    /// written to at all, so they are preserved and catalogued as-is.
+    /// * **Shipped `package-lock.json`** (root, `package/`, anywhere) — left
+    ///   exactly as shipped. The engine already grades both v1 `dependencies`
+    ///   and v2/v3 `packages` NATIVELY; it only failed to when we rewrote them.
+    /// * **Shipped `npm-shrinkwrap.json`** — the engine does not catalog this
+    ///   name at all, yet npm HONORS it over `package-lock.json`, so a
+    ///   vulnerable shrinkwrap was completely invisible. Copied VERBATIM (same
+    ///   JSON format, no parsing) to a `package-lock.json` under
+    ///   [`NPM_SHRINKWRAP_SUBDIR`], where the engine does catalog it.
+    /// * **Top-level identity pin** — always written to
+    ///   [`NPM_PIN_SUBDIR`], never at a path an archive can occupy, so a decoy
+    ///   can neither shadow nor suppress it.
+    ///
+    /// The engine globs `package-lock.json` at any depth and grades every one
+    /// it finds (verified: shipped lock + shrinkwrap copy + pin are all
+    /// cataloged in a single scan), so the union of these is what gets graded.
     async fn write_npm_lock_pin(workspace: &Path, pin: &ExpectedComponent) -> Result<()> {
-        const LOCKFILE_READ_CAP: u64 = 16 * 1024 * 1024;
-        let root_lock = PathBuf::from(NPM_LOCKFILE_NAME);
-        let root_lock_path = workspace.join(&root_lock);
+        Self::stage_shrinkwraps_for_grading(workspace).await;
 
-        let shipped = match tokio::fs::metadata(&root_lock_path).await {
-            Ok(meta) if meta.is_file() && meta.len() <= LOCKFILE_READ_CAP => {
-                tokio::fs::read_to_string(&root_lock_path).await.ok()
+        // The pin lives in its own directory, so it never collides with a
+        // shipped lockfile and never has to displace one.
+        Self::write_pin_file(
+            workspace,
+            &PathBuf::from(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME),
+            npm_package_lock_pin_json(&pin.name, &pin.version),
+        )
+        .await
+    }
+
+    /// Copy any shipped `npm-shrinkwrap.json` to a `package-lock.json` the CVE
+    /// engine will actually catalog (#3004 follow-up 2).
+    ///
+    /// A shrinkwrap is the SAME JSON format as a lockfile and takes precedence
+    /// over one for `npm install`, but the engine's cataloger keys on the
+    /// `package-lock.json` filename, so a vulnerable shrinkwrap graded as
+    /// nothing at all. Copied byte-for-byte — no parse, no normalization, so
+    /// there is no format for us to get wrong — under a per-source
+    /// subdirectory, because a tarball may ship both a root and a `package/`
+    /// shrinkwrap and they can legitimately differ.
+    ///
+    /// Best-effort by design: the original is never modified, and a copy that
+    /// fails leaves strictly less signal, never wrong signal. The top-level
+    /// pin (and the assessment gate behind it) is unaffected.
+    async fn stage_shrinkwraps_for_grading(workspace: &Path) {
+        // Generous vs any real lockfile; bounded so a hostile archive cannot
+        // make us duplicate an enormous file into the workspace.
+        const SHRINKWRAP_COPY_CAP: u64 = 64 * 1024 * 1024;
+        // The conventional locations: the archive root and the `package/`
+        // directory every npm tarball unpacks into.
+        const SOURCES: [(&str, &str); 2] = [("root", ""), ("package", "package")];
+
+        for (label, dir) in SOURCES {
+            let src = if dir.is_empty() {
+                workspace.join(NPM_SHRINKWRAP_NAME)
+            } else {
+                workspace.join(dir).join(NPM_SHRINKWRAP_NAME)
+            };
+            match tokio::fs::metadata(&src).await {
+                Ok(meta) if meta.is_file() && meta.len() <= SHRINKWRAP_COPY_CAP => {}
+                _ => continue,
             }
-            _ => None,
-        };
-
-        let Some(shipped) = shipped else {
-            return Self::write_pin_file(
-                workspace,
-                &root_lock,
-                npm_package_lock_pin_json(&pin.name, &pin.version),
-            )
-            .await;
-        };
-
-        match merge_npm_lock_pin(&shipped, &pin.name, &pin.version) {
-            Some(merged) => Self::write_pin_file(workspace, &root_lock, merged).await,
-            None => {
-                // Unmergeable but possibly still meaningful to syft: preserve
-                // it and pin alongside rather than trading their signal for
-                // ours.
-                debug!(
-                    "npm scan pin: root {} is not mergeable; preserving it and pinning \
-                     {}@{} in {}",
-                    NPM_LOCKFILE_NAME, pin.name, pin.version, NPM_PIN_SUBDIR
+            let dest_dir = workspace.join(NPM_SHRINKWRAP_SUBDIR).join(label);
+            if let Err(e) = tokio::fs::create_dir_all(&dest_dir).await {
+                warn!(
+                    "Failed to stage {} for grading ({}): {}",
+                    NPM_SHRINKWRAP_NAME,
+                    dest_dir.display(),
+                    e
                 );
-                Self::write_pin_file(
-                    workspace,
-                    &PathBuf::from(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME),
-                    npm_package_lock_pin_json(&pin.name, &pin.version),
-                )
-                .await
+                continue;
+            }
+            let dest = dest_dir.join(NPM_LOCKFILE_NAME);
+            if let Err(e) = tokio::fs::copy(&src, &dest).await {
+                warn!(
+                    "Failed to copy {} to {} for grading: {}",
+                    src.display(),
+                    dest.display(),
+                    e
+                );
             }
         }
     }
@@ -1172,74 +1202,18 @@ impl ScanWorkspace {
 /// the preserve-fallback subdirectory pin gradeable.
 pub(crate) const NPM_LOCKFILE_NAME: &str = "package-lock.json";
 
-/// Where the npm pin goes when a shipped root lockfile exists that we cannot
-/// merge into: its own subdirectory, so the shipped one is left untouched.
+/// Where the top-level identity pin is written — always its own subdirectory,
+/// never a path an archive can occupy, so no shipped file is ever displaced.
 pub(crate) const NPM_PIN_SUBDIR: &str = ".ak-scan-pin";
 
-/// Merge the request-coordinate pin INTO a lockfile the archive shipped,
-/// instead of replacing it (#3004 follow-up).
-///
-/// A shipped lockfile enumerates RESOLVED dependency versions — real,
-/// gradeable supply-chain signal. Overwriting it with a single-entry pin hid
-/// vulnerable TRANSITIVES: the CVE engine would then see only a clean
-/// top-level and report zero findings for a tarball that resolves, say, a
-/// known-vulnerable nested `lodash`.
-///
-/// So: keep every entry the lockfile declares, and inject/override ONLY the
-/// top-level `node_modules/<name>` entry with the version from the request
-/// coordinate. That keeps the top-level AUTHORITATIVE (a decoy that omits or
-/// downgrades the served package cannot suppress its grading) while leaving
-/// the transitive graph intact. The root `name`/`version` are also set to the
-/// coordinate so the document describes the package actually being served.
-///
-/// Returns `None` when the document is not a mergeable v2/v3 lockfile — not an
-/// object, no `packages` map, or an empty one. The caller then PRESERVES the
-/// shipped file and writes the pin elsewhere, so an unparseable-to-us lockfile
-/// is never traded away for our pin.
-pub(crate) fn merge_npm_lock_pin(shipped: &str, name: &str, version: &str) -> Option<String> {
-    let mut doc: serde_json::Value = serde_json::from_str(shipped).ok()?;
-    let obj = doc.as_object_mut()?;
+/// The lockfile npm HONORS over `package-lock.json` but the CVE engine does
+/// not catalog, so a vulnerable one was invisible until it is staged.
+pub(crate) const NPM_SHRINKWRAP_NAME: &str = "npm-shrinkwrap.json";
 
-    let packages = obj.get_mut("packages")?.as_object_mut()?;
-    if packages.is_empty() {
-        return None;
-    }
-
-    // Authoritative top-level: preserve any other keys the entry carried
-    // (resolved/integrity/dependencies) but force the served version.
-    let key = format!("node_modules/{name}");
-    match packages.get_mut(&key).and_then(|e| e.as_object_mut()) {
-        Some(entry) => {
-            entry.insert(
-                "version".to_string(),
-                serde_json::Value::String(version.to_string()),
-            );
-        }
-        None => {
-            packages.insert(key, serde_json::json!({ "version": version }));
-        }
-    }
-
-    obj.insert(
-        "name".to_string(),
-        serde_json::Value::String(name.to_string()),
-    );
-    obj.insert(
-        "version".to_string(),
-        serde_json::Value::String(version.to_string()),
-    );
-    // A `packages` map is v2+; make sure the declared version agrees so the
-    // parser reads the map we just merged into.
-    let lv_ok = obj
-        .get("lockfileVersion")
-        .and_then(|v| v.as_i64())
-        .is_some_and(|v| v >= 2);
-    if !lv_ok {
-        obj.insert("lockfileVersion".to_string(), serde_json::json!(3));
-    }
-
-    Some(doc.to_string())
-}
+/// Where shipped shrinkwraps are copied (verbatim) so they get graded. One
+/// subdirectory per source location, since a root and a `package/` shrinkwrap
+/// can legitimately differ.
+pub(crate) const NPM_SHRINKWRAP_SUBDIR: &str = ".ak-scan-shrinkwrap";
 
 /// The `package-lock.json` (lockfileVersion 3) body that pins exactly one
 /// installed npm package, so the CVE engine catalogs and grades it (#3003).
@@ -7762,6 +7736,39 @@ mod tests {
         path
     }
 
+    /// npm-shaped `.tgz` plus an arbitrary set of extra archive entries.
+    fn write_npm_tgz_with_entries(dir: &Path, name: &str, entries: &[(&str, &[u8])]) -> PathBuf {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let path = dir.join(name);
+        let file = std::fs::File::create(&path).expect("create tgz");
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(gz);
+
+        let pkg_json = br#"{"name":"widget","version":"1.0.0"}"#;
+        let mut header = tar::Header::new_gnu();
+        header.set_path("package/package.json").unwrap();
+        header.set_size(pkg_json.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, pkg_json.as_ref()).unwrap();
+
+        for (entry_path, body) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(entry_path).unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, *body).unwrap();
+        }
+
+        let gz = builder.into_inner().unwrap();
+        gz.finish().unwrap().flush().unwrap();
+        path
+    }
+
     /// npm-shaped `.tgz` that ships its own lockfile at the ARCHIVE ROOT —
     /// the path the component pin also wants, i.e. the collision under test.
     fn write_npm_tgz_with_root_lock(dir: &Path, name: &str, lock: &[u8]) -> PathBuf {
@@ -7868,179 +7875,77 @@ mod tests {
         }));
     }
 
-    /// #3004 follow-up: merging keeps every RESOLVED entry a shipped lockfile
-    /// declares (so vulnerable transitives stay gradeable) while forcing the
-    /// top-level to the request coordinate.
-    #[test]
-    fn test_merge_npm_lock_pin_keeps_transitives_and_forces_top_level() {
-        let shipped = r#"{
-            "name": "widget",
-            "version": "9.9.9",
-            "lockfileVersion": 3,
-            "packages": {
-                "": {"name": "widget", "version": "9.9.9"},
-                "node_modules/widget": {"version": "9.9.9"},
-                "node_modules/lodash": {"version": "4.17.11", "resolved": "https://r/lodash"}
-            }
-        }"#;
-        let merged = merge_npm_lock_pin(shipped, "widget", "1.0.0").expect("mergeable");
-        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
-
-        // The vulnerable transitive SURVIVES -- this is the whole point.
-        assert_eq!(v["packages"]["node_modules/lodash"]["version"], "4.17.11");
-        assert_eq!(
-            v["packages"]["node_modules/lodash"]["resolved"], "https://r/lodash",
-            "unrelated fields on a preserved entry are untouched"
-        );
-        // The top-level is AUTHORITATIVE: the request coordinate wins over the
-        // version the archive claimed for itself.
-        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
-        assert_eq!(v["name"], "widget");
-        assert_eq!(v["version"], "1.0.0");
-    }
-
-    /// A decoy that omits the served package entirely still gets it pinned,
-    /// and a lockfile with no `lockfileVersion` is normalized to a v3 shape so
-    /// the merged `packages` map is the one that gets parsed.
-    #[test]
-    fn test_merge_npm_lock_pin_injects_missing_top_level() {
-        let shipped = r#"{"packages": {"node_modules/lodash": {"version": "4.17.11"}}}"#;
-        let merged = merge_npm_lock_pin(shipped, "widget", "1.0.0").expect("mergeable");
-        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
-        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
-        assert_eq!(v["packages"]["node_modules/lodash"]["version"], "4.17.11");
-        assert_eq!(v["lockfileVersion"], 3);
-
-        // An explicit v1 declaration alongside a `packages` map is corrected
-        // upward rather than left to be parsed as v1 (which would ignore it).
-        let shipped =
-            r#"{"lockfileVersion": 1, "packages": {"node_modules/a": {"version": "1.0.0"}}}"#;
-        let v: serde_json::Value =
-            serde_json::from_str(&merge_npm_lock_pin(shipped, "w", "2.0.0").unwrap()).unwrap();
-        assert_eq!(v["lockfileVersion"], 3);
-    }
-
-    /// Not-mergeable documents return `None` so the caller PRESERVES them
-    /// instead of trading their signal for the pin.
-    #[test]
-    fn test_merge_npm_lock_pin_rejects_unmergeable() {
-        // No packages map (v1-only lockfile: its `dependencies` are still
-        // gradeable by syft, so it must be kept).
-        assert!(merge_npm_lock_pin(
-            r#"{"lockfileVersion":1,"dependencies":{"lodash":{"version":"4.17.11"}}}"#,
-            "w",
-            "1.0.0"
-        )
-        .is_none());
-        // Empty packages map (the decoy shape).
-        assert!(
-            merge_npm_lock_pin(r#"{"lockfileVersion":3,"packages":{}}"#, "w", "1.0.0").is_none()
-        );
-        // Malformed / wrong root type.
-        assert!(merge_npm_lock_pin("not json", "w", "1.0.0").is_none());
-        assert!(merge_npm_lock_pin("[]", "w", "1.0.0").is_none());
-        assert!(merge_npm_lock_pin(r#"{"packages": 42}"#, "w", "1.0.0").is_none());
-    }
-
-    /// End-to-end through `prepare_pinned`: a tarball that SHIPS a root
-    /// lockfile resolving a vulnerable transitive keeps that transitive in the
-    /// scanned workspace, and gains the authoritative top-level pin.
+    /// #3004 follow-up 2, HIGH-1 regression: a shipped lockfile is left
+    /// BYTE-FOR-BYTE alone. The previous revision merged the pin into it and
+    /// normalized `lockfileVersion` 1 -> 3, which made the CVE engine read only
+    /// `packages` and ignore the `dependencies` tree where the vulnerable
+    /// transitives were -- a dummy `packages` map was enough to trigger that
+    /// bump and mask them.
     #[tokio::test]
-    async fn test_prepare_pinned_merges_shipped_root_lockfile() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let shipped_lock = br#"{"name":"widget","version":"9.9.9","lockfileVersion":3,"packages":{"node_modules/widget":{"version":"9.9.9"},"node_modules/lodash":{"version":"4.17.11"}}}"#;
-        let tgz = write_npm_tgz_with_root_lock(tmp.path(), "widget-1.0.0.tgz", shipped_lock);
-        let content = Bytes::from(std::fs::read(&tgz).unwrap());
-        let artifact = test_helpers::make_test_artifact(
-            "widget-1.0.0.tgz",
-            "application/gzip",
-            "widget-1.0.0.tgz",
-        );
-        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
+    async fn test_prepare_pinned_never_rewrites_a_shipped_lockfile() {
+        // The exact bypass shape: v1 `dependencies` carrying the vulnerable
+        // transitive, plus a dummy `packages` map to bait a merge.
+        let shipped = br#"{"name":"widget","version":"1.0.0","lockfileVersion":1,"dependencies":{"lodash":{"version":"4.17.11"}},"packages":{"node_modules/widget":{"version":"1.0.0"}}}"#;
+        for (label, path) in [
+            ("root", "package-lock.json"),
+            ("nested", "package/package-lock.json"),
+        ] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let tgz = write_npm_tgz_with_entry(tmp.path(), "widget-1.0.0.tgz", path, shipped);
+            let content = Bytes::from(std::fs::read(&tgz).unwrap());
+            let artifact = test_helpers::make_test_artifact(
+                "widget-1.0.0.tgz",
+                "application/gzip",
+                "widget-1.0.0.tgz",
+            );
+            let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
 
-        let base = tmp.path().join("ws-base");
-        let workspace = ScanWorkspace::prepare_pinned(
-            base.to_str().unwrap(),
-            None,
-            &artifact,
-            &content,
-            Some(&pin),
-        )
-        .await
-        .expect("prepare_pinned");
-
-        let body = tokio::fs::read_to_string(workspace.join("package-lock.json"))
+            let base = tmp.path().join("ws-base");
+            let workspace = ScanWorkspace::prepare_pinned(
+                base.to_str().unwrap(),
+                None,
+                &artifact,
+                &content,
+                Some(&pin),
+            )
             .await
-            .expect("lockfile");
-        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(
-            v["packages"]["node_modules/lodash"]["version"], "4.17.11",
-            "a shipped lockfile's resolved transitive must survive the pin"
-        );
-        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
+            .expect("prepare_pinned");
 
-        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+            let kept = tokio::fs::read(workspace.join(path)).await.expect(path);
+            assert_eq!(
+                kept,
+                &shipped[..],
+                "{label}: a shipped lockfile must be graded natively, never rewritten"
+            );
+            assert!(
+                workspace_pins_component(&workspace, "widget", "1.0.0").await,
+                "{label}: the served identity must still be pinned"
+            );
+
+            ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+        }
     }
 
-    /// An UNMERGEABLE shipped root lockfile (v1) is left byte-for-byte intact
-    /// and the pin goes to its own subdirectory — syft catalogs lockfiles at
-    /// any depth, so both are graded and nothing is traded away.
+    /// #3004 follow-up 2, HIGH-2 regression: the CVE engine does not catalog
+    /// `npm-shrinkwrap.json`, yet npm HONORS it over `package-lock.json` -- so a
+    /// vulnerable shrinkwrap was invisible. It is copied VERBATIM to a
+    /// `package-lock.json` the engine does catalog, from both conventional
+    /// locations, with the original untouched.
     #[tokio::test]
-    async fn test_prepare_pinned_preserves_unmergeable_shipped_lockfile() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let shipped_lock =
-            br#"{"lockfileVersion":1,"dependencies":{"lodash":{"version":"4.17.11"}}}"#;
-        let tgz = write_npm_tgz_with_root_lock(tmp.path(), "widget-1.0.0.tgz", shipped_lock);
-        let content = Bytes::from(std::fs::read(&tgz).unwrap());
-        let artifact = test_helpers::make_test_artifact(
-            "widget-1.0.0.tgz",
-            "application/gzip",
-            "widget-1.0.0.tgz",
-        );
-        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
-
-        let base = tmp.path().join("ws-base");
-        let workspace = ScanWorkspace::prepare_pinned(
-            base.to_str().unwrap(),
-            None,
-            &artifact,
-            &content,
-            Some(&pin),
-        )
-        .await
-        .expect("prepare_pinned");
-
-        let kept = tokio::fs::read_to_string(workspace.join("package-lock.json"))
-            .await
-            .expect("shipped lockfile must still be there");
-        assert_eq!(
-            kept.as_bytes(),
-            &shipped_lock[..],
-            "an unmergeable shipped lockfile must be preserved byte-for-byte"
-        );
-        let pinned =
-            tokio::fs::read_to_string(workspace.join(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME))
-                .await
-                .expect("pin must be written alongside");
-        let v: serde_json::Value = serde_json::from_str(&pinned).unwrap();
-        assert_eq!(v["packages"]["node_modules/widget"]["version"], "1.0.0");
-
-        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
-    }
-
-    /// A lockfile the archive ships at the CONVENTIONAL `package/` location is
-    /// never written to at all — the pin only ever touches the workspace root
-    /// (or its own subdir), so nested lockfiles are untouched by construction.
-    #[tokio::test]
-    async fn test_prepare_pinned_leaves_nested_lockfile_untouched() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let nested =
+    async fn test_prepare_pinned_stages_shipped_shrinkwraps() {
+        let root_sw =
             br#"{"lockfileVersion":3,"packages":{"node_modules/lodash":{"version":"4.17.11"}}}"#;
-        let tgz = write_npm_tgz_with_entry(
+        let pkg_sw =
+            br#"{"lockfileVersion":3,"packages":{"node_modules/minimist":{"version":"1.2.0"}}}"#;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tgz = write_npm_tgz_with_entries(
             tmp.path(),
             "widget-1.0.0.tgz",
-            "package/package-lock.json",
-            nested,
+            &[
+                ("npm-shrinkwrap.json", root_sw.as_ref()),
+                ("package/npm-shrinkwrap.json", pkg_sw.as_ref()),
+            ],
         );
         let content = Bytes::from(std::fs::read(&tgz).unwrap());
         let artifact = test_helpers::make_test_artifact(
@@ -8061,12 +7966,64 @@ mod tests {
         .await
         .expect("prepare_pinned");
 
-        let kept = tokio::fs::read_to_string(workspace.join("package").join("package-lock.json"))
-            .await
-            .expect("nested lockfile");
-        assert_eq!(kept.as_bytes(), &nested[..]);
-        // ...and the pin still exists at the root for the top-level identity.
-        assert!(workspace.join("package-lock.json").exists());
+        // Both sources are staged separately (they can legitimately differ)...
+        let staged_root = tokio::fs::read(
+            workspace
+                .join(NPM_SHRINKWRAP_SUBDIR)
+                .join("root")
+                .join(NPM_LOCKFILE_NAME),
+        )
+        .await
+        .expect("root shrinkwrap must be staged for grading");
+        assert_eq!(staged_root, &root_sw[..], "staged verbatim, not rewritten");
+        let staged_pkg = tokio::fs::read(
+            workspace
+                .join(NPM_SHRINKWRAP_SUBDIR)
+                .join("package")
+                .join(NPM_LOCKFILE_NAME),
+        )
+        .await
+        .expect("package/ shrinkwrap must be staged for grading");
+        assert_eq!(staged_pkg, &pkg_sw[..]);
+
+        // ...and the originals are untouched.
+        assert_eq!(
+            tokio::fs::read(workspace.join(NPM_SHRINKWRAP_NAME))
+                .await
+                .unwrap(),
+            &root_sw[..]
+        );
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// No shrinkwrap shipped => nothing staged. The staging step must not
+    /// fabricate a lockfile out of nowhere.
+    #[tokio::test]
+    async fn test_prepare_pinned_stages_nothing_without_a_shrinkwrap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tgz = write_npm_tgz(tmp.path(), "left-pad-1.3.0.tgz");
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "left-pad-1.3.0.tgz",
+            "application/gzip",
+            "left-pad-1.3.0.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "left-pad", "1.3.0");
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await
+        .expect("prepare_pinned");
+
+        assert!(!workspace.join(NPM_SHRINKWRAP_SUBDIR).exists());
+        assert!(workspace_pins_component(&workspace, "left-pad", "1.3.0").await);
 
         ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
     }
@@ -8096,11 +8053,16 @@ mod tests {
         .await
         .expect("prepare_pinned");
 
-        let body = tokio::fs::read_to_string(workspace.join("package-lock.json"))
-            .await
-            .expect("pin lockfile must exist");
+        let body =
+            tokio::fs::read_to_string(workspace.join(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME))
+                .await
+                .expect("pin lockfile must exist in its own directory");
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["packages"]["node_modules/left-pad"]["version"], "1.3.0");
+        assert!(
+            !workspace.join("package-lock.json").exists(),
+            "the pin must never occupy a path an archive could ship"
+        );
 
         ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
     }

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -880,10 +880,57 @@ impl ScanWorkspace {
                         reset_err
                     );
                 }
+            } else {
+                // #3003: an npm registry tarball extracts to `package/` with a
+                // `package.json`, but syft/grype dir-mode deliberately does NOT
+                // catalog a bare package.json (it declares intent, it does not
+                // pin an installed artifact), so the pulled package itself was
+                // never CVE-graded — grype reported 0 components on e.g.
+                // lodash-4.17.11.tgz. Derive a minimal pinned
+                // package-lock.json for exactly that name@version so the CVE
+                // engine grades the package being served. Layout-gated on the
+                // npm-pack `package/package.json` convention (a PyPI sdist
+                // extracts to `<name>-<version>/`, never `package/`) and
+                // best-effort: any parse/IO failure leaves the workspace
+                // exactly as before.
+                Self::derive_npm_package_lock(&workspace).await;
             }
         }
 
         Ok(workspace)
+    }
+
+    /// Best-effort #3003 hook: when the extracted tree is an npm registry
+    /// tarball (`package/package.json` with a valid name + version) and no
+    /// lockfile was shipped, write a minimal pinned `package-lock.json` at the
+    /// workspace root so syft/grype catalog — and CVE-match — the package
+    /// itself. No-ops (with a debug log at most) on any other layout.
+    async fn derive_npm_package_lock(workspace: &Path) {
+        const PACKAGE_JSON_READ_CAP: u64 = 1024 * 1024; // 1 MiB is generous
+        let pkg_json = workspace.join("package").join("package.json");
+        let lock_path = workspace.join("package-lock.json");
+        if lock_path.exists() {
+            return; // an actual lockfile (from the archive root) wins
+        }
+        let Ok(meta) = tokio::fs::metadata(&pkg_json).await else {
+            return; // not an npm-pack layout
+        };
+        if !meta.is_file() || meta.len() > PACKAGE_JSON_READ_CAP {
+            return;
+        }
+        let Ok(body) = tokio::fs::read_to_string(&pkg_json).await else {
+            return;
+        };
+        let Some(lock) = derive_npm_package_lock_json(&body) else {
+            return;
+        };
+        if let Err(e) = tokio::fs::write(&lock_path, lock).await {
+            warn!(
+                "Failed to write derived npm package-lock.json in {}: {}",
+                workspace.display(),
+                e
+            );
+        }
     }
 
     /// Reset a scan workspace to just the original archive after an extraction
@@ -1011,6 +1058,40 @@ impl ScanWorkspace {
             .await
             .map_err(|e| AppError::Internal(format!("Extraction task panicked: {}", e)))?
     }
+}
+
+/// Derive a minimal pinned `package-lock.json` (lockfileVersion 3) from an npm
+/// tarball's `package/package.json` body, pinning exactly the package's own
+/// `name@version` (#3003). Pure and defensive: returns `None` on invalid JSON
+/// or a missing/empty/non-string name or version, in which case the workspace
+/// is left un-annotated (today's behavior — the package is simply not graded).
+///
+/// Only the package ITSELF is pinned — its declared dependencies are semver
+/// RANGES, not installed artifacts, and pinning a range's lower bound would
+/// fabricate findings for versions the client may never install. The unit of
+/// grading is the tarball being served, matching the digest the verdict is
+/// keyed on.
+pub(crate) fn derive_npm_package_lock_json(package_json: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(package_json).ok()?;
+    let name = v.get("name")?.as_str()?;
+    let version = v.get("version")?.as_str()?;
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+    let mut packages = serde_json::Map::new();
+    packages.insert(
+        format!("node_modules/{name}"),
+        serde_json::json!({ "version": version }),
+    );
+    Some(
+        serde_json::json!({
+            "name": name,
+            "version": version,
+            "lockfileVersion": 3,
+            "packages": packages,
+        })
+        .to_string(),
+    )
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2075,6 +2156,37 @@ async fn run_inline_proxy_scanners(
     synthetic: &Artifact,
     content: &Bytes,
 ) -> Result<ProxyScanVerdict> {
+    // File-mode delegation: a synthetic wheel / npm tarball carries no
+    // repository routing context, so wrap it in a context-free [`ScanTarget`].
+    // The trait defaults make this behavior-preserving: for a non-OCI
+    // artifact `is_applicable_for_target` falls back to `is_applicable` and
+    // `scan_target` to `scan` (Grype's overrides delegate the same way), so
+    // the file path is byte-identical to the pre-refactor loop while the
+    // fail-closed gate below stays SINGLE-SOURCED for every format.
+    let target = ScanTarget {
+        artifact: synthetic,
+        repository_key: "",
+        repository_type: "",
+        db: None,
+        storage: None,
+        manifest_body: None,
+    };
+    run_inline_proxy_scanners_target(scanners, &target, content).await
+}
+
+/// Context-aware sibling of [`run_inline_proxy_scanners`]: the SAME
+/// security-critical loop (including the #2954 `cve_scanner_applicable &&
+/// !cve_scanner_ran` fail-closed gate — there is exactly ONE copy of it, here)
+/// but gating on [`Scanner::is_applicable_for_target`] and scanning via
+/// [`Scanner::scan_target`], so callers that need repository routing context
+/// (the OCI manifest serve path) can supply a full [`ScanTarget`] while file
+/// formats delegate through the wrapper above.
+async fn run_inline_proxy_scanners_target(
+    scanners: &[Arc<dyn Scanner>],
+    target: &ScanTarget<'_>,
+    content: &Bytes,
+) -> Result<ProxyScanVerdict> {
+    let synthetic = target.artifact;
     let mut findings: Vec<RawFinding> = Vec::new();
     let mut scanner_version: Option<String> = None;
     // "did SOME applicable scanner run Ok" — necessary but NOT sufficient.
@@ -2085,16 +2197,17 @@ async fn run_inline_proxy_scanners(
     let mut cve_scanner_ran = false;
 
     for scanner in scanners {
-        // Applicability gates on the synthetic artifact's path/content-type,
+        // Applicability gates on the target artifact's path/content-type
+        // (plus repository/manifest context when the scanner uses it),
         // exactly as the orchestrator gates a hosted artifact.
-        if !scanner.is_applicable(synthetic) {
+        if !scanner.is_applicable_for_target(target) {
             continue;
         }
         let is_cve_authoritative = scanner.is_cve_authoritative();
         if is_cve_authoritative {
             cve_scanner_applicable = true;
         }
-        match scanner.scan(synthetic, None, content).await {
+        match scanner.scan_target(target, None, content).await {
             Ok(output) => {
                 any_ran = true;
                 if is_cve_authoritative {
@@ -3734,6 +3847,23 @@ impl ScannerService {
         run_inline_proxy_scanners(&self.scanners, synthetic, content).await
     }
 
+    /// Context-aware sibling of [`ScannerService::scan_content`] for callers
+    /// that need repository routing context threaded to the leaf scanners
+    /// (the OCI proxy manifest gate; see [`ScanTarget`]). File formats (PyPI
+    /// wheels, npm tarballs) keep using `scan_content` — both funnel into the
+    /// single [`run_inline_proxy_scanners_target`] loop, so the #2954
+    /// fail-closed contract is enforced in exactly one place.
+    pub async fn scan_content_target(
+        &self,
+        target: &ScanTarget<'_>,
+        content: &Bytes,
+    ) -> Result<ProxyScanVerdict> {
+        let _extraction_permit =
+            acquire_scan_extraction_permit(target.artifact.repository_id).await;
+
+        run_inline_proxy_scanners_target(&self.scanners, target, content).await
+    }
+
     /// Live version of the CVE-authoritative scanner for verdict-freshness
     /// checks (#2976): see [`cve_authoritative_scanner_version`]. The PyPI
     /// proxy serve path threads this into `verdict_is_fresh` as
@@ -5323,6 +5453,68 @@ pub(crate) mod test_helpers {
             pool,
             std::sync::Arc::new(crate::config::Config::test_config()),
         ))
+    }
+
+    /// Outcome of the mock CVE engine when a proxy serve path re-scans.
+    /// Shared by the #2976 verdict-freshness handler tests (PyPI, npm).
+    pub enum MockCveRescan {
+        /// Re-scan against the bumped CVE-DB now flags the bytes.
+        Vulnerable,
+        /// Re-scan is inconclusive (scanner hard-error).
+        Error,
+    }
+
+    /// CVE-authoritative mock scanner reporting a fixed live version string.
+    /// `live_version: None` models a FAILED version probe — the engine is
+    /// mid-upgrade / absent / past its probe timeout — which is the
+    /// unknown-`current_version` case the fail-closed gate must not fail
+    /// open on (#2976).
+    pub struct VersionedCveScanner {
+        pub live_version: Option<&'static str>,
+        pub rescan: MockCveRescan,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::scanner_service::Scanner for VersionedCveScanner {
+        fn name(&self) -> &str {
+            "versioned-cve-test-scanner"
+        }
+        fn scan_type(&self) -> &str {
+            "grype"
+        }
+        fn is_cve_authoritative(&self) -> bool {
+            true
+        }
+        async fn version(&self) -> Option<String> {
+            self.live_version.map(str::to_string)
+        }
+        async fn scan(
+            &self,
+            _: &Artifact,
+            _: Option<&crate::models::artifact::ArtifactMetadata>,
+            _: &bytes::Bytes,
+        ) -> crate::error::Result<crate::services::scanner_service::ScanOutput> {
+            match self.rescan {
+                MockCveRescan::Error => Err(crate::error::AppError::Internal(
+                    "simulated grype failure on re-scan".to_string(),
+                )),
+                MockCveRescan::Vulnerable => {
+                    Ok(crate::services::scanner_service::ScanOutput::findings_only(
+                        vec![crate::models::security::RawFinding {
+                            severity: crate::models::security::Severity::Critical,
+                            title: "CVE-2026-0001 test".to_string(),
+                            description: None,
+                            cve_id: Some("CVE-2026-0001".to_string()),
+                            affected_component: Some("pyyaml".to_string()),
+                            affected_version: Some("5.3.1".to_string()),
+                            fixed_version: None,
+                            source: Some("grype".to_string()),
+                            source_url: None,
+                        }],
+                    ))
+                }
+            }
+        }
     }
 }
 
@@ -7213,6 +7405,89 @@ mod tests {
             body
         );
         assert!(dest.join("package").join("index.js").exists());
+    }
+
+    /// #3003: the pure lockfile derivation — a valid npm package.json yields a
+    /// v3 lock pinning exactly `name@version`; anything malformed yields None.
+    #[test]
+    fn test_derive_npm_package_lock_json() {
+        let lock = derive_npm_package_lock_json(r#"{"name":"lodash","version":"4.17.11"}"#)
+            .expect("valid package.json derives a lock");
+        let v: serde_json::Value = serde_json::from_str(&lock).unwrap();
+        assert_eq!(v["lockfileVersion"], 3);
+        assert_eq!(v["packages"]["node_modules/lodash"]["version"], "4.17.11");
+
+        // Scoped names key the node_modules path with the full @scope/name.
+        let lock =
+            derive_npm_package_lock_json(r#"{"name":"@acme/widget","version":"2.0.0"}"#).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&lock).unwrap();
+        assert_eq!(
+            v["packages"]["node_modules/@acme/widget"]["version"],
+            "2.0.0"
+        );
+
+        // Defensive Nones: invalid JSON, missing/empty/non-string fields.
+        assert!(derive_npm_package_lock_json("not json").is_none());
+        assert!(derive_npm_package_lock_json(r#"{"name":"x"}"#).is_none());
+        assert!(derive_npm_package_lock_json(r#"{"version":"1.0.0"}"#).is_none());
+        assert!(derive_npm_package_lock_json(r#"{"name":"","version":"1.0.0"}"#).is_none());
+        assert!(derive_npm_package_lock_json(r#"{"name":"x","version":42}"#).is_none());
+    }
+
+    /// #3003: `ScanWorkspace::prepare` writes the derived pinned lockfile for
+    /// an npm-pack layout (`package/package.json`) so grype grades the package
+    /// itself — syft dir-mode does not catalog a bare package.json, which is
+    /// why a vulnerable tarball previously scanned as 0 components / clean.
+    #[tokio::test]
+    async fn test_prepare_derives_npm_package_lock_for_npm_tgz() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tgz = write_npm_tgz(tmp.path(), "left-pad-1.3.0.tgz");
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "left-pad-1.3.0.tgz",
+            "application/gzip",
+            "left-pad-1.3.0.tgz",
+        );
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare(base.to_str().unwrap(), None, &artifact, &content)
+            .await
+            .expect("prepare");
+
+        let lock = workspace.join("package-lock.json");
+        let body = tokio::fs::read_to_string(&lock)
+            .await
+            .expect("derived package-lock.json must exist for an npm-pack layout");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["packages"]["node_modules/left-pad"]["version"], "1.3.0");
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+    }
+
+    /// Negative control: a non-npm archive layout (a jar) gets NO derived
+    /// lockfile — the hook is strictly gated on `package/package.json`.
+    #[tokio::test]
+    async fn test_prepare_derives_no_lock_for_non_npm_archive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let jar = write_simple_zip(tmp.path(), "app-1.0.0.jar");
+        let content = Bytes::from(std::fs::read(&jar).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "app-1.0.0.jar",
+            "application/java-archive",
+            "app-1.0.0.jar",
+        );
+
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::prepare(base.to_str().unwrap(), None, &artifact, &content)
+            .await
+            .expect("prepare");
+
+        assert!(
+            !workspace.join("package-lock.json").exists(),
+            "non-npm layouts must not get a fabricated lockfile"
+        );
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
     }
 
     #[tokio::test]
@@ -13630,6 +13905,78 @@ mod tests {
                 .is_err(),
             "no scanner at all -> inconclusive, never clean"
         );
+    }
+
+    fn inline_scan_target(artifact: &Artifact) -> ScanTarget<'_> {
+        ScanTarget {
+            artifact,
+            repository_key: "proxy-repo",
+            repository_type: "remote",
+            db: None,
+            storage: None,
+            manifest_body: None,
+        }
+    }
+
+    /// The #2954 discriminator through the CONTEXT-AWARE seam (#3003): the
+    /// `cve_scanner_applicable && !cve_scanner_ran` fail-closed gate is
+    /// single-sourced in `run_inline_proxy_scanners_target`, so a Grype error
+    /// masked by a supplementary scanner's trivial `Ok(default)` must be
+    /// inconclusive (Err) for target callers exactly as for file callers.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_target_grype_error_is_inconclusive_not_clean() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        // Reversed registration order vs the file-mode test above: the gate
+        // must be order-insensitive through the target seam as well.
+        let scanners: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Error,
+            }),
+            Arc::new(TrivialDependencyScanner),
+        ];
+        let artifact = inline_scan_artifact();
+        let target = inline_scan_target(&artifact);
+        assert!(
+            run_inline_proxy_scanners_target(&scanners, &target, &Bytes::new())
+                .await
+                .is_err(),
+            "a Grype error must be inconclusive through the target seam too, \
+             never a clean verdict (#2954 via #3003 shared core)"
+        );
+    }
+
+    /// Target-seam control cases: a genuinely-clean CVE run yields `clean`
+    /// and a CVE-bearing run yields `vulnerable` — the delegate refactor must
+    /// not change the file-mode verdicts.
+    #[tokio::test]
+    async fn test_inline_proxy_scan_target_verdicts_match_file_mode() {
+        use inline_proxy_scan_fixtures::*;
+        use std::sync::Arc;
+
+        let artifact = inline_scan_artifact();
+        let target = inline_scan_target(&artifact);
+
+        let clean: Vec<Arc<dyn Scanner>> = vec![
+            Arc::new(TrivialDependencyScanner),
+            Arc::new(CveAuthoritativeScanner {
+                outcome: CveOutcome::Clean,
+            }),
+        ];
+        let verdict = run_inline_proxy_scanners_target(&clean, &target, &Bytes::new())
+            .await
+            .expect("clean CVE run must produce a verdict");
+        assert!(!verdict.is_vulnerable());
+
+        let vuln: Vec<Arc<dyn Scanner>> = vec![Arc::new(CveAuthoritativeScanner {
+            outcome: CveOutcome::Critical,
+        })];
+        let verdict = run_inline_proxy_scanners_target(&vuln, &target, &Bytes::new())
+            .await
+            .expect("CVE run with findings must produce a verdict");
+        assert!(verdict.is_vulnerable());
+        assert_eq!(verdict.critical_count, 1);
     }
 
     /// The `Scanner::is_cve_authoritative` trait DEFAULT is false: a scanner

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -880,9 +880,32 @@ impl ScanWorkspace {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to create scan workspace: {}", e)))?;
 
+        // NAMESPACE ISOLATION (#3004 follow-up 3). When this scan also writes
+        // control files, the archive is unpacked into a dedicated subdirectory
+        // instead of the workspace root, so the archive's namespace and ours
+        // are disjoint. Without that separation a crafted archive could ship an
+        // entry at a control path (e.g. a regular file named
+        // `.ak-scan-shrinkwrap/package`, or a DIRECTORY where a control file
+        // goes) and make the control write fail — silently degrading the scan
+        // to whatever survived. Extraction already rejects `..`/absolute
+        // entries, so confinement here is total.
+        //
+        // Unpinned scans (every hosted upload) write no control files, have no
+        // collision surface, and keep the original flat layout exactly.
+        let extract_root = match pin {
+            Some(_) => {
+                let dir = workspace.join(SCAN_ARCHIVE_SUBDIR);
+                tokio::fs::create_dir_all(&dir).await.map_err(|e| {
+                    AppError::Internal(format!("Failed to create scan archive dir: {}", e))
+                })?;
+                dir
+            }
+            None => workspace.clone(),
+        };
+
         let original_filename = artifact.path.rsplit('/').next().unwrap_or(&artifact.name);
         let safe_filename = sanitize_artifact_filename(original_filename);
-        let artifact_path = workspace.join(&safe_filename);
+        let artifact_path = extract_root.join(&safe_filename);
 
         tokio::fs::write(&artifact_path, content)
             .await
@@ -891,21 +914,22 @@ impl ScanWorkspace {
             })?;
 
         if Self::is_archive(original_filename) {
-            if let Err(e) = Self::extract_archive(&artifact_path, &workspace).await {
+            if let Err(e) = Self::extract_archive(&artifact_path, &extract_root).await {
                 warn!(
                     "Failed to extract archive {}: {}. Cleaning partial output and scanning raw file instead.",
                     artifact.name, e
                 );
                 // A breached extraction may have written a partial (potentially
-                // large) tree before aborting. Reset the workspace to just the
-                // original archive so the raw-file fallback scan does not walk
-                // the partial tree (and a bomb cannot leave GiB on the PVC).
+                // large) tree before aborting. Reset the extraction dir to just
+                // the original archive so the raw-file fallback scan does not
+                // walk the partial tree (and a bomb cannot leave GiB on the
+                // PVC). Control files live outside it and are unaffected.
                 if let Err(reset_err) =
-                    Self::reset_workspace(&workspace, &artifact_path, content).await
+                    Self::reset_workspace(&extract_root, &artifact_path, content).await
                 {
                     warn!(
                         "Failed to reset scan workspace {} after extraction failure: {}",
-                        workspace.display(),
+                        extract_root.display(),
                         reset_err
                     );
                 }
@@ -913,7 +937,7 @@ impl ScanWorkspace {
         }
 
         if let Some(pin) = pin {
-            Self::write_component_pin(&workspace, pin).await?;
+            Self::write_component_pin(&workspace, &extract_root, pin).await?;
         }
 
         Ok(workspace)
@@ -932,9 +956,13 @@ impl ScanWorkspace {
     /// the caller a zero-finding "clean" scan of nothing, which is the exact
     /// failure this closes. (The caller's assessment gate would also catch it,
     /// but failing here keeps the reason precise.)
-    async fn write_component_pin(workspace: &Path, pin: &ExpectedComponent) -> Result<()> {
+    async fn write_component_pin(
+        workspace: &Path,
+        extract_root: &Path,
+        pin: &ExpectedComponent,
+    ) -> Result<()> {
         match pin.ecosystem {
-            ComponentEcosystem::Npm => Self::write_npm_lock_pin(workspace, pin).await,
+            ComponentEcosystem::Npm => Self::write_npm_lock_pin(workspace, extract_root, pin).await,
             // Python: syft catalogs `*.dist-info/METADATA` and
             // `*.egg-info/PKG-INFO`, but NOT the root `PKG-INFO` an sdist
             // ships — which is why an ordinary vulnerable sdist graded clean
@@ -985,8 +1013,12 @@ impl ScanWorkspace {
     /// The engine globs `package-lock.json` at any depth and grades every one
     /// it finds (verified: shipped lock + shrinkwrap copy + pin are all
     /// cataloged in a single scan), so the union of these is what gets graded.
-    async fn write_npm_lock_pin(workspace: &Path, pin: &ExpectedComponent) -> Result<()> {
-        Self::stage_shrinkwraps_for_grading(workspace).await;
+    async fn write_npm_lock_pin(
+        workspace: &Path,
+        extract_root: &Path,
+        pin: &ExpectedComponent,
+    ) -> Result<()> {
+        Self::stage_shrinkwraps_for_grading(workspace, extract_root).await?;
 
         // The pin lives in its own directory, so it never collides with a
         // shipped lockfile and never has to displace one.
@@ -1006,13 +1038,18 @@ impl ScanWorkspace {
     /// `package-lock.json` filename, so a vulnerable shrinkwrap graded as
     /// nothing at all. Copied byte-for-byte — no parse, no normalization, so
     /// there is no format for us to get wrong — under a per-source
-    /// subdirectory, because a tarball may ship both a root and a `package/`
-    /// shrinkwrap and they can legitimately differ.
+    /// subdirectory at the workspace ROOT, because a tarball may ship both a
+    /// root and a `package/` shrinkwrap and they can legitimately differ.
     ///
-    /// Best-effort by design: the original is never modified, and a copy that
-    /// fails leaves strictly less signal, never wrong signal. The top-level
-    /// pin (and the assessment gate behind it) is unaffected.
-    async fn stage_shrinkwraps_for_grading(workspace: &Path) {
+    /// FAIL-CLOSED (#3004 follow-up 3): a staging failure is a HARD error. It
+    /// used to warn-and-continue on the reasoning that a failed copy leaves
+    /// "less signal, never wrong signal" — that reasoning is false. The signal
+    /// being dropped is exactly the vulnerable shrinkwrap, and the assessment
+    /// gate only requires the identity PIN to be cataloged, so the scan would
+    /// still come back "clean" and get cached. Erroring here propagates as an
+    /// inconclusive scan (fail-closed 423), which is the honest outcome for
+    /// "we could not grade something this artifact ships".
+    async fn stage_shrinkwraps_for_grading(workspace: &Path, extract_root: &Path) -> Result<()> {
         // Generous vs any real lockfile; bounded so a hostile archive cannot
         // make us duplicate an enormous file into the workspace.
         const SHRINKWRAP_COPY_CAP: u64 = 64 * 1024 * 1024;
@@ -1022,34 +1059,37 @@ impl ScanWorkspace {
 
         for (label, dir) in SOURCES {
             let src = if dir.is_empty() {
-                workspace.join(NPM_SHRINKWRAP_NAME)
+                extract_root.join(NPM_SHRINKWRAP_NAME)
             } else {
-                workspace.join(dir).join(NPM_SHRINKWRAP_NAME)
+                extract_root.join(dir).join(NPM_SHRINKWRAP_NAME)
             };
             match tokio::fs::metadata(&src).await {
                 Ok(meta) if meta.is_file() && meta.len() <= SHRINKWRAP_COPY_CAP => {}
+                // Nothing shipped here (or something that is not a readable
+                // regular file, e.g. a directory of that name) — nothing to
+                // grade from this location.
                 _ => continue,
             }
             let dest_dir = workspace.join(NPM_SHRINKWRAP_SUBDIR).join(label);
-            if let Err(e) = tokio::fs::create_dir_all(&dest_dir).await {
-                warn!(
-                    "Failed to stage {} for grading ({}): {}",
+            tokio::fs::create_dir_all(&dest_dir).await.map_err(|e| {
+                AppError::Internal(format!(
+                    "Failed to stage {} ({}) for grading: {}",
                     NPM_SHRINKWRAP_NAME,
                     dest_dir.display(),
                     e
-                );
-                continue;
-            }
+                ))
+            })?;
             let dest = dest_dir.join(NPM_LOCKFILE_NAME);
-            if let Err(e) = tokio::fs::copy(&src, &dest).await {
-                warn!(
+            tokio::fs::copy(&src, &dest).await.map_err(|e| {
+                AppError::Internal(format!(
                     "Failed to copy {} to {} for grading: {}",
                     src.display(),
                     dest.display(),
                     e
-                );
-            }
+                ))
+            })?;
         }
+        Ok(())
     }
 
     /// Write one pin file (creating parents), mapping IO failure onto the
@@ -1202,17 +1242,29 @@ impl ScanWorkspace {
 /// the preserve-fallback subdirectory pin gradeable.
 pub(crate) const NPM_LOCKFILE_NAME: &str = "package-lock.json";
 
-/// Where the top-level identity pin is written — always its own subdirectory,
-/// never a path an archive can occupy, so no shipped file is ever displaced.
+/// Where an archive's OWN bytes are unpacked when the scan also writes control
+/// files (#3004 follow-up 3).
+///
+/// Control files (the identity pin, staged shrinkwraps) live at the workspace
+/// ROOT; the archive is confined to this SIBLING subdirectory. Extraction
+/// already rejects `..`/absolute entries, so an archive can only ever create
+/// paths beneath here — it cannot pre-create, shadow, or collide with a
+/// control path. That containment is what makes the control writes reliable,
+/// rather than a list of names we hope no archive ships.
+pub(crate) const SCAN_ARCHIVE_SUBDIR: &str = "pkg";
+
+/// Where the top-level identity pin is written — its own subdirectory at the
+/// workspace ROOT, outside [`SCAN_ARCHIVE_SUBDIR`], so no shipped file can
+/// displace it.
 pub(crate) const NPM_PIN_SUBDIR: &str = ".ak-scan-pin";
 
 /// The lockfile npm HONORS over `package-lock.json` but the CVE engine does
 /// not catalog, so a vulnerable one was invisible until it is staged.
 pub(crate) const NPM_SHRINKWRAP_NAME: &str = "npm-shrinkwrap.json";
 
-/// Where shipped shrinkwraps are copied (verbatim) so they get graded. One
-/// subdirectory per source location, since a root and a `package/` shrinkwrap
-/// can legitimately differ.
+/// Where shipped shrinkwraps are copied (verbatim) so they get graded. At the
+/// workspace ROOT, outside [`SCAN_ARCHIVE_SUBDIR`]. One subdirectory per source
+/// location, since a root and a `package/` shrinkwrap can legitimately differ.
 pub(crate) const NPM_SHRINKWRAP_SUBDIR: &str = ".ak-scan-shrinkwrap";
 
 /// The `package-lock.json` (lockfileVersion 3) body that pins exactly one
@@ -7911,7 +7963,9 @@ mod tests {
             .await
             .expect("prepare_pinned");
 
-            let kept = tokio::fs::read(workspace.join(path)).await.expect(path);
+            let kept = tokio::fs::read(workspace.join(SCAN_ARCHIVE_SUBDIR).join(path))
+                .await
+                .expect(path);
             assert_eq!(
                 kept,
                 &shipped[..],
@@ -7924,6 +7978,162 @@ mod tests {
 
             ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
         }
+    }
+
+    /// #3004 follow-up 3: THE collision class. An archive used to unpack into
+    /// the same directory the control files are written to, so an entry named
+    /// after a control path could make the control write fail. Shrinkwrap
+    /// staging was best-effort, so the failure silently degraded the scan to
+    /// "pin only" and a vulnerable shrinkwrap graded clean.
+    ///
+    /// Namespace isolation removes the collision entirely: the archive can only
+    /// write under its own subdirectory, so these entries land harmlessly there
+    /// and staging still succeeds.
+    #[tokio::test]
+    async fn test_prepare_pinned_archive_cannot_collide_with_control_paths() {
+        let sw =
+            br#"{"lockfileVersion":3,"packages":{"node_modules/lodash":{"version":"4.17.11"}}}"#;
+        // Collision A: a regular FILE where the staging directory goes.
+        // Collision B: a file UNDER the pin's directory path.
+        // Collision C: a benign decoy at the pin's exact path.
+        type Entries<'a> = Vec<(&'a str, &'a [u8])>;
+        let shapes: Vec<(&str, Entries<'_>)> = vec![
+            (
+                "file-at-staging-dir",
+                vec![
+                    ("package/npm-shrinkwrap.json", sw.as_ref()),
+                    (".ak-scan-shrinkwrap/package", b"collide".as_ref()),
+                ],
+            ),
+            (
+                "file-under-staging-path",
+                vec![
+                    ("package/npm-shrinkwrap.json", sw.as_ref()),
+                    (
+                        ".ak-scan-shrinkwrap/package/package-lock.json/x",
+                        b"collide".as_ref(),
+                    ),
+                ],
+            ),
+            (
+                "decoy-at-pin-path",
+                vec![
+                    ("package/npm-shrinkwrap.json", sw.as_ref()),
+                    (
+                        ".ak-scan-pin/package-lock.json",
+                        br#"{"lockfileVersion":3,"packages":{"node_modules/widget":{"version":"0.0.1"}}}"#
+                            .as_ref(),
+                    ),
+                ],
+            ),
+        ];
+
+        for (label, entries) in shapes {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let tgz = write_npm_tgz_with_entries(tmp.path(), "widget-1.0.0.tgz", &entries);
+            let content = Bytes::from(std::fs::read(&tgz).unwrap());
+            let artifact = test_helpers::make_test_artifact(
+                "widget-1.0.0.tgz",
+                "application/gzip",
+                "widget-1.0.0.tgz",
+            );
+            let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
+
+            let base = tmp.path().join("ws-base");
+            let workspace = ScanWorkspace::prepare_pinned(
+                base.to_str().unwrap(),
+                None,
+                &artifact,
+                &content,
+                Some(&pin),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("{label}: prepare_pinned must succeed, got {e}"));
+
+            // The vulnerable shrinkwrap IS staged for grading...
+            let staged = tokio::fs::read(
+                workspace
+                    .join(NPM_SHRINKWRAP_SUBDIR)
+                    .join("package")
+                    .join(NPM_LOCKFILE_NAME),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("{label}: shrinkwrap must still be staged, got {e}"));
+            assert_eq!(staged, &sw[..], "{label}: staged verbatim");
+
+            // ...and the pin is OURS, at the authoritative version, not the
+            // decoy's.
+            let pinned =
+                tokio::fs::read_to_string(workspace.join(NPM_PIN_SUBDIR).join(NPM_LOCKFILE_NAME))
+                    .await
+                    .unwrap_or_else(|e| panic!("{label}: pin must exist, got {e}"));
+            let v: serde_json::Value = serde_json::from_str(&pinned).unwrap();
+            assert_eq!(
+                v["packages"]["node_modules/widget"]["version"], "1.0.0",
+                "{label}: the request coordinate must win over a shipped decoy"
+            );
+
+            // The colliding entries landed in the archive's own namespace.
+            assert!(
+                workspace.join(SCAN_ARCHIVE_SUBDIR).exists(),
+                "{label}: archive namespace"
+            );
+
+            ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
+        }
+    }
+
+    /// Staging is FAIL-CLOSED: if a shipped shrinkwrap cannot be staged for
+    /// grading, `prepare_pinned` errors (-> inconclusive -> 423) instead of
+    /// returning a workspace whose scan would report a confident "clean".
+    /// Simulated by making the staging destination unwritable.
+    #[tokio::test]
+    async fn test_prepare_pinned_staging_failure_is_hard_error() {
+        let sw =
+            br#"{"lockfileVersion":3,"packages":{"node_modules/lodash":{"version":"4.17.11"}}}"#;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tgz = write_npm_tgz_with_entries(
+            tmp.path(),
+            "widget-1.0.0.tgz",
+            &[("npm-shrinkwrap.json", sw.as_ref())],
+        );
+        let content = Bytes::from(std::fs::read(&tgz).unwrap());
+        let artifact = test_helpers::make_test_artifact(
+            "widget-1.0.0.tgz",
+            "application/gzip",
+            "widget-1.0.0.tgz",
+        );
+        let pin = ExpectedComponent::new(ComponentEcosystem::Npm, "widget", "1.0.0");
+
+        // Pre-create the workspace with the staging path occupied by a file the
+        // copy cannot overwrite (a directory in the destination's place).
+        let base = tmp.path().join("ws-base");
+        let workspace = ScanWorkspace::workspace_dir(base.to_str().unwrap(), None, &artifact);
+        tokio::fs::create_dir_all(
+            workspace
+                .join(NPM_SHRINKWRAP_SUBDIR)
+                .join("root")
+                .join(NPM_LOCKFILE_NAME),
+        )
+        .await
+        .expect("occupy the staging destination with a directory");
+
+        let result = ScanWorkspace::prepare_pinned(
+            base.to_str().unwrap(),
+            None,
+            &artifact,
+            &content,
+            Some(&pin),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a shrinkwrap that cannot be staged must fail the scan closed, \
+             never yield a workspace that grades as clean"
+        );
+
+        ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
     }
 
     /// #3004 follow-up 2, HIGH-2 regression: the CVE engine does not catalog
@@ -7986,11 +8196,15 @@ mod tests {
         .expect("package/ shrinkwrap must be staged for grading");
         assert_eq!(staged_pkg, &pkg_sw[..]);
 
-        // ...and the originals are untouched.
+        // ...and the originals are untouched, inside the archive's own namespace.
         assert_eq!(
-            tokio::fs::read(workspace.join(NPM_SHRINKWRAP_NAME))
-                .await
-                .unwrap(),
+            tokio::fs::read(
+                workspace
+                    .join(SCAN_ARCHIVE_SUBDIR)
+                    .join(NPM_SHRINKWRAP_NAME)
+            )
+            .await
+            .unwrap(),
             &root_sw[..]
         );
 
@@ -8063,6 +8277,13 @@ mod tests {
             !workspace.join("package-lock.json").exists(),
             "the pin must never occupy a path an archive could ship"
         );
+        // The archive's own bytes live in their own namespace, disjoint from
+        // every control path.
+        assert!(workspace
+            .join(SCAN_ARCHIVE_SUBDIR)
+            .join("package")
+            .join("package.json")
+            .exists());
 
         ScanWorkspace::cleanup(base.to_str().unwrap(), None, &artifact).await;
     }


### PR DESCRIPTION
## Summary

Part of #3003. Extends the inline scan-and-block gate — proven on the proxy-PyPI
serve path in #2954/#2970/#2976 — to **npm proxy tarball pulls**, and factors the
shared machinery into two reusable seams so npm (and, in the follow-up PR-2, OCI)
are thin call-sites instead of re-implementations.

Before this change, `npm.rs serve_tarball` never consulted a proxy scan verdict:
a known-vulnerable npm tarball pulled through a scan-enabled, fail-closed remote
repo streamed straight through with a `200` on the first `npm install`. The gate
existed only for PyPI.

### Two shared seams (single-sourced defenses)

1. **Scan seam** — `run_inline_proxy_scanners_target(...)` is now THE single
   implementation of the inline-proxy scan contract, reached by file artifacts via
   `ScannerService::scan_content{,_expecting}` (context-free `ScanTarget`) and by
   repository-context callers via `scan_content_target`. The
   `cve_scanner_applicable && !cve_scanner_ran` fail-closed gate therefore exists in
   exactly ONE place: a non-authoritative scanner's `Ok(default)` cannot mask an
   authoritative Grype error → inconclusive → fail-closed, for every format.

2. **Serve-decision seam** — `proxy_scan_service::decide_serve(row, current_version,
   action, ttl_days, now) -> ServeDecision` lifts the freshness + fail-open/closed
   state machine out of `serve_scanned_pypi_file`. `serve_scanned_pypi_file` is
   **rewritten to call it** (proving it is behavior-preserving for PyPI), and npm
   calls it too — so npm inherits the #2976 probe-None-fail-closed fix and the
   #2970 authoritative gate without re-implementing them. The handler-side glue
   (digesting, block/lock responses, scan-and-record) moved into `proxy_helpers`.

### npm wiring

`serve_tarball`'s remote branch, when `scan_on_proxy` is enabled, routes to
`serve_scanned_npm_tarball`: buffered capped fetch via
`fetch_artifact_with_cache_path_capped` (instead of streaming, so the bytes are
available to scan), verdict keyed on `sha256(tarball bytes)` (never the packument
or anything the upstream index controls), the shared `decide_serve` gate, then
`403` (vulnerable) / `423` (inconclusive fail-closed) / `200 + X-AK-Scan` (clean or
fail-open pending). Scoped packages and dist-tags need no special-casing — the
concrete `@scope/pkg/-/file.tgz` GET is the single seam and the content digest keys
the verdict. Repos without `scan_on_proxy` keep today's untouched streaming path.

### "The engine ran" is not "the artifact was assessed"

A review of the first cut found the gate could still pass vulnerable artifacts,
because `is_vulnerable()` is `findings_count > 0`: an engine that RUNS but has
nothing to grade reports zero findings, which is indistinguishable from a
genuinely clean package. That is not hypothetical — syft/grype do not catalog a
bare npm `package/package.json`, nor an sdist's root `PKG-INFO`. Two live
consequences, both serving `200` under a fail-closed policy:

* **npm, crafted.** Real vulnerable `lodash-4.17.11` bytes served at the lodash
  coordinate graded "clean" whenever its identity could not be pinned: identity
  rewritten to something benign, an empty root `package-lock.json` packed in as a
  decoy, `package/package.json` removed, or `version` shipped as a JSON number.
* **PyPI, uncrafted.** An ordinary vulnerable sdist (`PyYAML-5.3.1.tar.gz`,
  CVE-2020-14343) graded clean while the same release's wheel was correctly
  blocked — a pre-existing gap in the merged PyPI path, which this PR's shared
  core now owns.

Closed with one principle in the shared core: **under fail-closed, a verdict is
only `clean` when the CVE-authoritative engine actually assessed the identity
being served.** Three parts:

1. **Catalog capture.** Grype's `json` report names only CVE-MATCHED artifacts,
   so the full catalog comes from its `cyclonedx-json` presenter, requested in
   the SAME invocation (no second scan). It lands on `ScanOutput::cataloged`.
   `None` means "this scanner reports no catalog" (every other scanner, and the
   OCI paths) and changes nothing; `Some(vec![])` means the engine cataloged
   NOTHING, which is now inconclusive rather than clean.
2. **Identity pin + cross-check.** `ExpectedComponent` is derived from the
   REQUEST coordinate (route package name + the registry's invariant
   `{basename}-{version}.tgz` / the PyPI filename version), never from bytes the
   upstream controls. It is materialized into the scan workspace as a
   `package-lock.json` / `<name>-<version>.dist-info/METADATA` so the engine has
   something to grade — written AUTHORITATIVELY, so a decoy lockfile inside the
   archive cannot suppress grading. The engine's catalog must then actually
   contain that identity.
3. **npm content agreement.** The tarball's own `package/package.json` must
   state the identity it is being served as. Absent, unparseable, non-string
   version, or disagreeing => `ProxyScanIdentity::Unestablished` => inconclusive.

### Archive namespace isolation

The archive used to unpack into the very directory the scan writes its control
files to, so a crafted tarball could ship an entry AT a control path — a
regular file named `.ak-scan-shrinkwrap/package`, or a directory where the
staged file goes — and make the control write fail. Staging was best-effort, so
the failure silently reduced the scan to "identity pin only"; because the
assessment gate only requires the PIN to be cataloged, a tarball shipping a
vulnerable `npm-shrinkwrap.json` came back a confident, cached `200`-clean.

Fixed structurally rather than by name-matching: when a scan writes control
files, the archive is unpacked into a dedicated `<workspace>/pkg/` and every
control file goes to the workspace ROOT, a sibling. Extraction already rejects
`..`/absolute entries, so the archive can only write beneath `pkg/` — the two
namespaces are disjoint and no entry can collide with any control path, present
or future. This protects the npm pin, the staged shrinkwraps, and the Python
dist-info pin alike.

Staging is now fail-closed too: any failure to stage a shipped shrinkwrap is a
hard error (→ inconclusive → 423), not warn-and-continue. The old reasoning
that "a failed copy leaves less signal, never wrong signal" was false — the
dropped signal was exactly the vulnerable shrinkwrap.

Unpinned scans (every hosted upload) write no control files, have no collision
surface, and keep the original flat layout unchanged.

### Pinning without touching what the archive shipped

The pin has to land at a lockfile path so the CVE engine catalogs it. Earlier
revisions merged it into a shipped `package-lock.json` and normalized that
file's `lockfileVersion`; both were the wrong shape. Every rewrite is a chance
to parse npm's lockfile formats slightly differently from the scanner, and each
mismatch is a silent mask — two bypasses came out of it, each serving a
vulnerable transitive `200`-clean under fail-closed:

* Bumping a v1 lockfile to v3 made the engine read only `packages` and ignore
  the `dependencies` tree where the vulnerable transitives actually were. A
  dummy `packages` map was enough to trigger the bump, flipping identical
  content from blocked to clean.
* Only `package-lock.json` was considered. The engine does not catalog
  `npm-shrinkwrap.json` at all, yet npm HONORS a shrinkwrap over a lockfile, so
  a vulnerable shrinkwrap was completely invisible.

So nothing shipped is read, parsed, merged, re-versioned or overwritten. Each
signal is presented as its own file, at a path nothing else claims:

* **Shipped `package-lock.json`** (root, `package/`, any depth) — untouched.
  The engine already grades v1 `dependencies` AND v2/v3 `packages` natively; it
  only failed to when we rewrote them.
* **Shipped `npm-shrinkwrap.json`** — copied VERBATIM (no parsing, so no format
  for us to get wrong) to a `package-lock.json` under `.ak-scan-shrinkwrap/`,
  one subdirectory per source location since a root and a `package/` shrinkwrap
  can legitimately differ. The original is left in place.
* **Top-level identity pin** — always `.ak-scan-pin/package-lock.json`, never a
  path an archive can occupy, so a decoy can neither shadow nor suppress it.

The engine globs `package-lock.json` at any depth and grades every one it finds
(verified: shipped lock + shrinkwrap copy + pin all cataloged in one scan), so
the union is what gets assessed — nothing normalized, nothing masked. The
Python path has no lockfile-merge concept and is unchanged.

Ordering is deliberate: the cached-verdict fast path still runs FIRST, so a
known-vulnerable digest is blocked from cache (403) without re-fetching, and the
identity work only happens when a scan is actually required.

Scope is deliberately narrow. The assessment gate fires only when a serve path
supplied a coordinate AND the engine reported a catalog; hosted upload scans,
legacy callers, and scanners with no catalog signal behave exactly as before, and
`prepare` (unpinned) fabricates nothing. Under `fail_open` an unassessable
artifact still serves, loudly marked `X-AK-Scan: pending` — the tightening is
fail-closed only. A clean package whose identity WAS cataloged stays `200 clean`;
holding a genuinely-empty artifact under fail-closed is the accepted trade.

**OCI (Docker/OCI manifest scan-block) is intentionally NOT in this PR** — it is a
separate unit-of-scan (whole image via `oci-dir:`, cold-proxy blob-availability
timing, recursion avoidance) tracked as PR-2, so this stays reviewable. Because
OCI remains, this PR is `Part of #3003`, not `Closes`.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

PyPI behavior is proven preserved through the `decide_serve` refactor: the full
existing `serve_scanned_pypi_file` suite (fail-closed 423, fail-open pending,
cached-vulnerable 403, cached-clean 200, the four #2976 version-freshness cases)
stays green. New npm handler tests mirror them 1:1, plus one per crafted shape.

Unit coverage for the assessment gate: zero-cataloged => inconclusive; cataloged
identity mismatch (name AND version) => inconclusive; **cataloged match with no
findings stays CLEAN** (the control that keeps the gate from withholding
everything); no-catalog-signal and no-expected-coordinate keep prior behavior; a
scanner error still outranks the catalog check. Plus the cyclonedx catalog
parser, the ecosystem-aware identity comparison (PEP 503 vs npm), the pin bodies,
that an archive shipping entries at control paths (file-at-staging-dir,
directory-at-staged-file, decoy-at-pin-path) cannot suppress grading, that a
staging failure is a hard error, that a shipped lockfile is preserved
byte-for-byte at both the root and
`package/` (including the v1-`dependencies`-plus-dummy-`packages` bypass shape),
that shrinkwraps are staged verbatim from both locations with the originals
intact, that nothing is staged when no shrinkwrap ships, that a decoy lockfile
cannot suppress the pin, and the "unpinned scans fabricate nothing"
blast-radius control.

A local deployment-test tier (`npm-scan-block`) reproduces everything end-to-end
against live upstreams and real Grype. Against the pre-fix build all five
blindness cases serve `200`; against this build all are withheld, while both
clean controls pass on BOTH builds — so the cases discriminate the fix, not the
environment.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Reuses the existing `proxy_scan_results` store (digest-keyed, format-agnostic) —
no migration, no new columns, no new `sqlx::query!` macros. `X-AK-Scan` and `X-NPM-Tarball-SHA256` are response
headers on the npm tarball serve path, not new endpoints.

Relates to a customer evaluation requiring active download-block parity across
proxy formats.
