### PR TITLE
feat(curation): Unicode-confusable (homoglyph) + affix typo-squat detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -289,6 +289,8 @@ dependencies = [
  "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "unicode-normalization",
+ "unicode-security",
  "url",
  "urlencoding",
  "utoipa",
@@ -2239,7 +2241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3999,7 +4001,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5556,7 +5558,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5624,7 +5626,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6484,7 +6486,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7231,6 +7233,22 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
 
 [[package]]
 name = "unicode-width"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -182,6 +182,12 @@ lettre.workspace = true
 
 # Allocators
 mimalloc = { version = "0.1", optional = true }
+
+# Unicode confusable (UTS #39 skeleton) + mixed-script detection for
+# typo-squat curation rules (#2956)
+unicode-security = "0.1.2"
+unicode-normalization = "0.1.25"
+
 [target.'cfg(not(windows))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }
 tikv-jemalloc-ctl = { version = "0.6", optional = true, features = ["stats"] }

--- a/backend/src/services/curation/popularity.rs
+++ b/backend/src/services/curation/popularity.rs
@@ -20,6 +20,19 @@
 //!   Block — otherwise a fresh malicious squat (which has no download
 //!   history and so can never trip the threshold check) only ever lands in
 //!   review.
+//! - **Homoglyph / mixed-script** (#2956) — a name whose Unicode-confusable
+//!   skeleton collides with a popular package's while the raw name differs
+//!   (Cyrillic/fullwidth lookalikes), or a name mixing scripts in one
+//!   identifier. Both dodge pure edit distance. Gated by `homoglyph_check`
+//!   (default on, under the `typosquat_check` master toggle) and escalated by
+//!   the same `block_typosquat` opt-in.
+//! - **Affix reputation-riding** (#2956) — a low/unknown-download candidate
+//!   whose name is a popular name plus a bounded ecosystem affix
+//!   (`python-numpy`, `numpy-dev`, `numpy2`) or separator stuffing. The
+//!   candidate-popularity gate (below `affix_max_downloads`, default 1000)
+//!   plus popular-list self-exclusion keep legitimately popular affixed names
+//!   (`python-dateutil`) unflagged. Gated by `affix_check` (default on, under
+//!   `typosquat_check`), escalated by `block_typosquat`.
 //! - **Unknown popularity** — a source outage/rate limit/unlisted package
 //!   yields `Flag("popularity unknown…")` by default, never Block, regardless
 //!   of `action`. Fail-open on the data source, fail-safe on the decision:
@@ -36,7 +49,9 @@
 use crate::models::curation::CurationDecision;
 
 use super::popularity_source::{ecosystem_for_format, PopularityResult, PopularitySource};
-use super::typosquat::{default_popular_packages, is_typosquat};
+use super::typosquat::{
+    default_popular_packages, is_affix_squat, is_homoglyph_squat, is_mixed_script, is_typosquat,
+};
 
 /// Whether this rule type applies to `format` at all — i.e. a public
 /// download-count ecosystem exists for it. The dispatch checks this BEFORE
@@ -51,6 +66,11 @@ const DEFAULT_MAX_DISTANCE: u64 = 2;
 /// Ceiling for the configurable distance. Beyond 2 edits the false-positive
 /// rate on short names makes the signal noise.
 const MAX_DISTANCE_CEILING: u64 = 2;
+/// Default candidate-popularity ceiling for the affix signal (#2956): an
+/// affixed name only counts as reputation-riding while the candidate itself
+/// has fewer recent downloads than this (or an Unknown count). Keeps
+/// legitimately popular affixed packages (`python-dateutil`) unflagged.
+const DEFAULT_AFFIX_MAX_DOWNLOADS: u64 = 1_000;
 
 /// Evaluate the `popularity` rule for one package.
 ///
@@ -62,6 +82,9 @@ const MAX_DISTANCE_CEILING: u64 = 2;
 ///   "window": "month",
 ///   "typosquat_check": true,
 ///   "max_distance": 2,
+///   "homoglyph_check": true,
+///   "affix_check": true,
+///   "affix_max_downloads": 1000,
 ///   "action": "flag",
 ///   "block_unknown": false,
 ///   "block_typosquat": false,
@@ -86,7 +109,14 @@ const MAX_DISTANCE_CEILING: u64 = 2;
 ///   Without `action: "block"` the flag has no effect.
 /// * `block_typosquat` — a typo-squat match **blocks** instead of flagging,
 ///   regardless of `action`. Off by default because lexical proximity has
-///   false positives by construction.
+///   false positives by construction. Applies uniformly to all lexical
+///   signals: edit distance, homoglyph/mixed-script, and affix (#2956).
+///
+/// The #2956 sub-toggles (`homoglyph_check`, `affix_check`, both default
+/// `true`) sit under the `typosquat_check` master toggle: turning
+/// `typosquat_check` off disables every lexical signal, matching the
+/// pre-#2956 meaning of that key. `affix_max_downloads` (default 1000) is the
+/// candidate-popularity ceiling for the affix signal only.
 ///
 /// `version` is accepted for signature-compatibility with the dispatch seam;
 /// popularity is a package-level signal, so it does not influence the
@@ -131,6 +161,19 @@ pub async fn evaluate(
         .get("block_typosquat")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
+    // #2956 sub-toggles, both under the typosquat_check master toggle.
+    let homoglyph_check = config
+        .get("homoglyph_check")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    let affix_check = config
+        .get("affix_check")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    let affix_max_downloads = config
+        .get("affix_max_downloads")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_AFFIX_MAX_DOWNLOADS);
 
     let popular: Vec<String> = match config
         .get("popular_packages")
@@ -183,20 +226,53 @@ pub async fn evaluate(
     }
 
     if typosquat_check {
+        // All lexical signals share the block_typosquat escalation: opt-in
+        // enforcement where the operator accepts the false-positive rate of
+        // lexical matching in exchange for hard-blocking fresh squats that
+        // have no download history to trip on. Default: advisory only.
+        let mut lexical_reasons: Vec<String> = Vec::new();
+
         if let Some(target) = is_typosquat(name, &popular, max_distance) {
-            let reason = format!(
+            lexical_reasons.push(format!(
                 "name '{name}' is within edit distance {max_distance} of popular package '{target}' (possible typo-squat)"
-            );
-            if block_typosquat {
-                // Opt-in enforcement: the operator accepts the false-positive
-                // rate of lexical matching in exchange for hard-blocking
-                // fresh squats that have no download history to trip on.
-                block_reasons.push(reason);
-            } else {
-                // Default: advisory only — lexical proximity alone never
-                // blocks.
-                flag_reasons.push(reason);
+            ));
+        }
+
+        if homoglyph_check {
+            if let Some(target) = is_homoglyph_squat(name, &popular) {
+                lexical_reasons.push(format!(
+                    "name '{name}' is a Unicode-confusable (homoglyph) lookalike of popular package '{target}'"
+                ));
             }
+            if is_mixed_script(name) {
+                lexical_reasons.push(format!(
+                    "name '{name}' mixes Unicode scripts in one identifier (homoglyph-impersonation indicator)"
+                ));
+            }
+        }
+
+        if affix_check {
+            // Reputation-riding requires the candidate itself to be
+            // unpopular: a legitimately popular affixed name (e.g.
+            // `python-dateutil`, were it missing from the popular list) is
+            // not riding anyone's reputation.
+            let candidate_low_popularity = match downloads {
+                PopularityResult::Known(d) => d < affix_max_downloads,
+                PopularityResult::Unknown => true,
+            };
+            if candidate_low_popularity {
+                if let Some(target) = is_affix_squat(name, &popular) {
+                    lexical_reasons.push(format!(
+                        "name '{name}' is popular package '{target}' plus an ecosystem affix, and '{name}' itself has low/unknown downloads (possible reputation-riding)"
+                    ));
+                }
+            }
+        }
+
+        if block_typosquat {
+            block_reasons.extend(lexical_reasons);
+        } else {
+            flag_reasons.extend(lexical_reasons);
         }
     }
 
@@ -405,6 +481,169 @@ mod tests {
             CurationDecision::Block(reason) => {
                 assert!(reason.contains("popularity unknown"), "{reason}");
                 assert!(reason.contains("typo-squat"), "{reason}");
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn homoglyph_lookalike_flags_and_names_the_target() {
+        // Fullwidth ｕ: pixel-identical to numpy, edit distance 1 BUT the
+        // point is full-substitution lookalikes; use Cyrillic multi-swap
+        // "пumру"-style too. Candidate is even "popular" by count — the
+        // homoglyph signal is not popularity-gated.
+        let source = FakePopularitySource::new().with("pypi", "n\u{ff55}mpy", 9_999);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        match evaluate(&cfg, "pypi", "n\u{ff55}mpy", "1.0.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("homoglyph"), "{reason}");
+                assert!(reason.contains("numpy"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cyrillic_multiswap_beyond_edit_distance_is_caught() {
+        // "requests" with FOUR Cyrillic substitutions (е U+0435, у... use
+        // е/а-style): distance > 2 so the pre-#2956 check misses it; the
+        // skeleton collision and mixed-script signals both fire.
+        let name4 = "\u{0433}\u{0435}qu\u{0435}\u{0455}ts"; // г е е ѕ — distance 4
+        let source = FakePopularitySource::new().with("pypi", name4, 100_000);
+        let cfg = config(serde_json::json!({"max_distance": 2}));
+        match evaluate(&cfg, "pypi", name4, "1.0.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("mixes Unicode scripts"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn real_package_not_flagged_by_homoglyph_check() {
+        let source = FakePopularitySource::new().with("pypi", "numpy", 50_000_000);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "numpy", "2.0.0", &source).await,
+            CurationDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn homoglyph_check_can_be_disabled() {
+        let source = FakePopularitySource::new().with("pypi", "n\u{ff55}mpy", 9_999);
+        let cfg = config(serde_json::json!({
+            "min_downloads": 500,
+            "homoglyph_check": false,
+            // distance("nｕmpy","numpy") == 1, so silence the distance
+            // heuristic too to isolate the homoglyph toggle.
+            "max_distance": 1,
+            "popular_packages": ["numpy"]
+        }));
+        // With homoglyph off the only signal left is edit distance 1 — verify
+        // the homoglyph-specific reason is gone when fully disabled.
+        let cfg_off = config(serde_json::json!({
+            "min_downloads": 500,
+            "typosquat_check": false
+        }));
+        assert_eq!(
+            evaluate(&cfg_off, "pypi", "n\u{ff55}mpy", "1.0.0", &source).await,
+            CurationDecision::Allow,
+            "master toggle off: no lexical flagging at all"
+        );
+        match evaluate(&cfg, "pypi", "n\u{ff55}mpy", "1.0.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(!reason.contains("homoglyph"), "{reason}");
+                assert!(!reason.contains("mixes Unicode scripts"), "{reason}");
+            }
+            CurationDecision::Allow => {}
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn affix_squat_low_popularity_flags() {
+        for name in ["python-numpy", "numpy-dev", "numpy2"] {
+            // Fresh squat: no download history at all (Unknown) — the
+            // threshold reason and the affix reason both surface.
+            let source = FakePopularitySource::new();
+            let cfg = config(serde_json::json!({"min_downloads": 500}));
+            match evaluate(&cfg, "pypi", name, "0.0.1", &source).await {
+                CurationDecision::Flag(reason) => {
+                    assert!(reason.contains("reputation-riding"), "{name}: {reason}");
+                    assert!(reason.contains("'numpy'"), "{name}: {reason}");
+                }
+                other => panic!("{name}: expected Flag, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn legitimately_popular_affixed_name_is_not_flagged() {
+        // python-dateutil is on the popular list itself (self-exclusion) AND
+        // has a huge download count — must not be flagged.
+        let source = FakePopularitySource::new().with("pypi", "python-dateutil", 40_000_000);
+        let cfg = config(serde_json::json!({"min_downloads": 500}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "python-dateutil", "2.9.0", &source).await,
+            CurationDecision::Allow
+        );
+        // And the popularity gate alone also protects a popular affixed name
+        // NOT on the list: custom list with only the base name.
+        let source = FakePopularitySource::new().with("pypi", "python-dateutil", 40_000_000);
+        let cfg = config(serde_json::json!({
+            "min_downloads": 500,
+            "popular_packages": ["dateutil"]
+        }));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "python-dateutil", "2.9.0", &source).await,
+            CurationDecision::Allow,
+            "high candidate downloads must gate the affix signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn affix_check_toggle_and_threshold_are_respected() {
+        // Disabled: low-pop python-numpy only gets the threshold flag reason.
+        let source = FakePopularitySource::new().with("pypi", "python-numpy", 10);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "affix_check": false}));
+        match evaluate(&cfg, "pypi", "python-numpy", "0.0.1", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(!reason.contains("reputation-riding"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+        // Custom affix_max_downloads: candidate at 5000 downloads is above
+        // the default 1000 ceiling (no affix flag), but below a raised one.
+        let source = FakePopularitySource::new().with("pypi", "numpy-dev", 5_000);
+        let cfg = config(serde_json::json!({}));
+        assert_eq!(
+            evaluate(&cfg, "pypi", "numpy-dev", "1.0.0", &source).await,
+            CurationDecision::Allow,
+            "default ceiling 1000: 5000-download candidate not reputation-riding"
+        );
+        let cfg = config(serde_json::json!({"affix_max_downloads": 10_000}));
+        match evaluate(&cfg, "pypi", "numpy-dev", "1.0.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("reputation-riding"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn homoglyph_and_affix_escalate_with_block_typosquat() {
+        let source = FakePopularitySource::new().with("pypi", "n\u{ff55}mpy", 9_999);
+        let cfg = config(serde_json::json!({"min_downloads": 500, "block_typosquat": true}));
+        match evaluate(&cfg, "pypi", "n\u{ff55}mpy", "1.0.0", &source).await {
+            CurationDecision::Block(reason) => assert!(reason.contains("homoglyph"), "{reason}"),
+            other => panic!("expected Block, got {other:?}"),
+        }
+        let source = FakePopularitySource::new().with("pypi", "numpy-dev", 10);
+        let cfg = config(serde_json::json!({"block_typosquat": true}));
+        match evaluate(&cfg, "pypi", "numpy-dev", "1.0.0", &source).await {
+            CurationDecision::Block(reason) => {
+                assert!(reason.contains("reputation-riding"), "{reason}")
             }
             other => panic!("expected Block, got {other:?}"),
         }

--- a/backend/src/services/curation/popularity.rs
+++ b/backend/src/services/curation/popularity.rs
@@ -22,17 +22,22 @@
 //!   review.
 //! - **Homoglyph / mixed-script** (#2956) — a name whose Unicode-confusable
 //!   skeleton collides with a popular package's while the raw name differs
-//!   (Cyrillic/fullwidth lookalikes), or a name mixing scripts in one
-//!   identifier. Both dodge pure edit distance. Gated by `homoglyph_check`
-//!   (default on, under the `typosquat_check` master toggle) and escalated by
-//!   the same `block_typosquat` opt-in.
+//!   (Cyrillic/fullwidth lookalikes), or a name that mixes scripts in one
+//!   identifier AND sits near a popular package in skeleton space (mixed
+//!   script alone is not impersonation — internationalized names
+//!   legitimately mix scripts and must not flood review). Both dodge pure
+//!   edit distance. Gated by `homoglyph_check` (default on, under the
+//!   `typosquat_check` master toggle) and escalated by the same
+//!   `block_typosquat` opt-in.
 //! - **Affix reputation-riding** (#2956) — a low/unknown-download candidate
-//!   whose name is a popular name plus a bounded ecosystem affix
-//!   (`python-numpy`, `numpy-dev`, `numpy2`) or separator stuffing. The
-//!   candidate-popularity gate (below `affix_max_downloads`, default 1000)
-//!   plus popular-list self-exclusion keep legitimately popular affixed names
-//!   (`python-dateutil`) unflagged. Gated by `affix_check` (default on, under
-//!   `typosquat_check`), escalated by `block_typosquat`.
+//!   that wraps a popular name in ANY boundary-delimited affix token
+//!   (`python-numpy`, `data-numpy`, `numpy-helper`, `numpy2024`,
+//!   `fastNumpy`) or separator stuffing, matched in confusable-skeleton
+//!   space. The candidate-popularity gate (below `affix_max_downloads`,
+//!   default 1000) plus popular-list self-exclusion keep legitimately
+//!   popular affixed names (`python-dateutil`, `pytest-django`) unflagged.
+//!   Gated by `affix_check` (default on, under `typosquat_check`), escalated
+//!   by `block_typosquat`.
 //! - **Unknown popularity** — a source outage/rate limit/unlisted package
 //!   yields `Flag("popularity unknown…")` by default, never Block, regardless
 //!   of `action`. Fail-open on the data source, fail-safe on the decision:
@@ -51,6 +56,7 @@ use crate::models::curation::CurationDecision;
 use super::popularity_source::{ecosystem_for_format, PopularityResult, PopularitySource};
 use super::typosquat::{
     default_popular_packages, is_affix_squat, is_homoglyph_squat, is_mixed_script, is_typosquat,
+    nearest_popular_skeleton,
 };
 
 /// Whether this rule type applies to `format` at all — i.e. a public
@@ -244,10 +250,18 @@ pub async fn evaluate(
                     "name '{name}' is a Unicode-confusable (homoglyph) lookalike of popular package '{target}'"
                 ));
             }
+            // Mixed script alone is NOT impersonation (internationalized
+            // names legitimately mix scripts); it only signals when the name
+            // ALSO sits near a popular package in confusable-skeleton space
+            // (collision = distance 0, or within max_distance edits).
             if is_mixed_script(name) {
-                lexical_reasons.push(format!(
-                    "name '{name}' mixes Unicode scripts in one identifier (homoglyph-impersonation indicator)"
-                ));
+                if let Some((target, distance)) = nearest_popular_skeleton(name, &popular) {
+                    if distance <= max_distance {
+                        lexical_reasons.push(format!(
+                            "name '{name}' mixes Unicode scripts and visually resembles popular package '{target}' (homoglyph-impersonation indicator)"
+                        ));
+                    }
+                }
             }
         }
 
@@ -558,6 +572,79 @@ mod tests {
             }
             CurationDecision::Allow => {}
             other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn benign_multiscript_name_far_from_popular_is_not_lexically_flagged() {
+        // #3005 red-team finding 2: mixed script alone must NOT flag —
+        // internationalized names that resemble nothing popular stay clean.
+        for name in ["py中文tools", "sigma-δ", "бank-utils"] {
+            let source = FakePopularitySource::new().with("pypi", name, 5_000);
+            let cfg = config(serde_json::json!({"affix_max_downloads": 1}));
+            assert_eq!(
+                evaluate(&cfg, "pypi", name, "1.0.0", &source).await,
+                CurationDecision::Allow,
+                "benign multi-script '{name}' must not be flagged"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_script_near_popular_still_flags() {
+        // A mixed-script homoglyph of a popular name (skeleton distance 0)
+        // still carries the mixed-script reason after the proximity gate.
+        let source = FakePopularitySource::new().with("pypi", "nump\u{0443}", 50_000);
+        let cfg = config(serde_json::json!({}));
+        match evaluate(&cfg, "pypi", "nump\u{0443}", "1.0.0", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("mixes Unicode scripts"), "{reason}");
+                assert!(reason.contains("homoglyph"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn generalized_affix_tokens_flag_when_low_popularity() {
+        // #3005 red-team finding 1: arbitrary (non-allowlisted) affix tokens.
+        for (name, base) in [
+            ("data-numpy", "numpy"),
+            ("fast-numpy", "numpy"),
+            ("numpy-helper", "numpy"),
+            ("numpy-extras", "numpy"),
+            ("awesome-lodash", "lodash"),
+            ("numpy2024", "numpy"),
+            ("numpy-python", "numpy"),
+        ] {
+            let eco = if base == "lodash" { "npm" } else { "pypi" };
+            let source = FakePopularitySource::new().with(eco, name, 3);
+            let cfg = config(serde_json::json!({}));
+            match evaluate(&cfg, eco, name, "0.0.1", &source).await {
+                CurationDecision::Flag(reason) => {
+                    assert!(reason.contains("reputation-riding"), "{name}: {reason}");
+                    assert!(reason.contains(&format!("'{base}'")), "{name}: {reason}");
+                }
+                other => panic!("{name}: expected Flag, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn homoglyph_with_unlisted_affix_is_caught() {
+        // #3005 red-team finding 3: fullwidth ｕ + arbitrary affix `-x`
+        // evaded raw-byte affix matching, whole-name skeleton collision, and
+        // mixed-script (fullwidth is script-Latin). Skeleton-space affix
+        // matching with generalized tokens closes it.
+        let name = "n\u{ff55}mpy-x";
+        let source = FakePopularitySource::new(); // Unknown -> low-popularity
+        let cfg = config(serde_json::json!({}));
+        match evaluate(&cfg, "pypi", name, "0.0.1", &source).await {
+            CurationDecision::Flag(reason) => {
+                assert!(reason.contains("reputation-riding"), "{reason}");
+                assert!(reason.contains("'numpy'"), "{reason}");
+            }
+            other => panic!("expected Flag, got {other:?}"),
         }
     }
 

--- a/backend/src/services/curation/typosquat.rs
+++ b/backend/src/services/curation/typosquat.rs
@@ -190,8 +190,16 @@ fn strip_separators(s: &str) -> String {
 /// - separator stuffing (`l.o.d.a.s.h` collapses to `lodash`).
 ///
 /// Matching is case-insensitive and `name` must not itself be on the popular
-/// list (so a curated list containing `python-dateutil` never flags it). This
-/// function is purely lexical — the caller MUST additionally gate on the
+/// list (so a curated list containing `python-dateutil` never flags it). The
+/// comparison runs in confusable-skeleton space ([`confusable_skeleton`]) so
+/// a homoglyph-obfuscated affix form (`python-nｕmpy` with fullwidth `ｕ`)
+/// cannot dodge the match — a combined affix+homoglyph name neither collides
+/// as a whole-name skeleton nor (for compatibility codepoints) trips the
+/// mixed-script signal, so the affix arm must fold confusables itself. The
+/// bounded affix tokens below are skeleton-stable (none contain `m`, the one
+/// lowercase ASCII letter the UTS #39 table rewrites, to `rn`).
+///
+/// This function is purely lexical — the caller MUST additionally gate on the
 /// candidate's own popularity (low/unknown downloads) before acting, because
 /// a legitimately popular affixed package is not reputation-riding.
 pub fn is_affix_squat(name: &str, popular: &[String]) -> Option<String> {
@@ -200,13 +208,15 @@ pub fn is_affix_squat(name: &str, popular: &[String]) -> Option<String> {
     if popular.iter().any(|p| p.to_lowercase() == name_lc) {
         return None;
     }
+    let name_key = confusable_skeleton(name);
     for candidate in popular {
-        let base = candidate.to_lowercase();
-        if base.is_empty() || name_lc == base {
+        let base = confusable_skeleton(candidate);
+        if base.is_empty() || name_key == base {
+            // Whole-name skeleton collision is the homoglyph signal's job.
             continue;
         }
         // Prefix: <prefix><sep><base>
-        if let Some(rest) = name_lc.strip_suffix(&base) {
+        if let Some(rest) = name_key.strip_suffix(&base) {
             if let Some(prefix) = rest.strip_suffix(AFFIX_SEPARATORS) {
                 if AFFIX_PREFIXES.contains(&prefix) {
                     return Some(candidate.clone());
@@ -214,7 +224,7 @@ pub fn is_affix_squat(name: &str, popular: &[String]) -> Option<String> {
             }
         }
         // Suffix: <base><sep?><suffix> or <base><sep?><1-2 digits>
-        if let Some(rest) = name_lc.strip_prefix(&base) {
+        if let Some(rest) = name_key.strip_prefix(&base) {
             let rest = rest.strip_prefix(AFFIX_SEPARATORS).unwrap_or(rest);
             if AFFIX_SUFFIXES.contains(&rest)
                 || ((1..=2).contains(&rest.len()) && rest.chars().all(|c| c.is_ascii_digit()))
@@ -223,7 +233,7 @@ pub fn is_affix_squat(name: &str, popular: &[String]) -> Option<String> {
             }
         }
         // Separator stuffing: collapsing separators reproduces the base name.
-        if strip_separators(&name_lc) == strip_separators(&base) {
+        if strip_separators(&name_key) == strip_separators(&base) {
             return Some(candidate.clone());
         }
     }
@@ -510,6 +520,25 @@ mod tests {
                 "{name} should be an affix squat"
             );
         }
+    }
+
+    #[test]
+    fn affix_matches_in_skeleton_space_closing_homoglyph_affix_combo() {
+        // Red-team evasion (#2956): homoglyph INSIDE an affix form. Fullwidth
+        // ｕ (U+FF55) is script-Latin (no mixed-script flag) and the whole
+        // name's skeleton includes the prefix (no whole-name collision), so a
+        // raw-byte affix comparison would miss it entirely.
+        let popular = strings(&["numpy"]);
+        assert_eq!(
+            is_affix_squat("python-n\u{ff55}mpy", &popular),
+            Some("numpy".to_string())
+        );
+        // Cyrillic-у variant of the same combo (also caught by mixed-script,
+        // but the affix arm must name the ridden base).
+        assert_eq!(
+            is_affix_squat("nump\u{0443}-dev", &popular),
+            Some("numpy".to_string())
+        );
     }
 
     #[test]

--- a/backend/src/services/curation/typosquat.rs
+++ b/backend/src/services/curation/typosquat.rs
@@ -21,15 +21,16 @@
 //!   confusable *skeleton* (via the `unicode-security` crate — the same
 //!   implementation rustc's `non_ascii_idents` lints use) and flags a skeleton
 //!   collision with a popular name whose raw name differs.
-//! - **Affix** ([`is_affix_squat`]) — a popular name wrapped in a bounded
-//!   ecosystem prefix/suffix (`python-numpy`, `numpy-dev`, `numpy2`) or
-//!   stuffed with separators (`l.o.d.a.s.h`), riding the base name's
-//!   reputation. Lexically this is `len(affix)+1` edits away, again beyond
-//!   `max_distance`. This signal is *popularity-gated by the caller*: a
-//!   legitimately popular affixed name (`python-dateutil`) must not be
-//!   flagged, so [`super::popularity::evaluate`] only applies it to
-//!   low/unknown-download candidates (and self-exclusion covers affixed names
-//!   that are themselves on the popular list).
+//! - **Affix** ([`is_affix_squat`]) — a popular name wrapped in an arbitrary
+//!   boundary-delimited affix token (`python-numpy`, `numpy-helper`,
+//!   `data-numpy`, `numpy2024`, `fastNumpy`) or stuffed with separators
+//!   (`l.o.d.a.s.h`), riding the base name's reputation. Lexically this is
+//!   `len(affix)+1` edits away, again beyond `max_distance`. This signal is
+//!   *popularity-gated by the caller*: a legitimately popular affixed name
+//!   (`python-dateutil`, `pytest-django`) must not be flagged, so
+//!   [`super::popularity::evaluate`] only applies it to low/unknown-download
+//!   candidates (and self-exclusion covers affixed names that are themselves
+//!   on the popular list).
 
 use unicode_normalization::UnicodeNormalization;
 use unicode_security::MixedScript;
@@ -149,29 +150,67 @@ pub fn is_homoglyph_squat(name: &str, popular: &[String]) -> Option<String> {
 }
 
 /// Whether `name` mixes Unicode scripts (e.g. Latin and Cyrillic letters in
-/// one identifier). Package names have no legitimate reason to mix scripts;
-/// mixing is the standard way to smuggle confusables past a reader, so it is
-/// a strong impersonation signal on its own (UTS #39 mixed-script
-/// restriction). ASCII digits and separators are script-Common and never
-/// count as mixing.
+/// one identifier — UTS #39 mixed-script restriction). Mixing is the standard
+/// way to smuggle confusables past a reader, but it is NOT an impersonation
+/// signal on its own: internationalized names legitimately mix scripts.
+/// Callers must pair this predicate with popular-list proximity
+/// ([`nearest_popular_skeleton`]) before flagging. ASCII digits and
+/// separators are script-Common and never count as mixing.
 pub fn is_mixed_script(name: &str) -> bool {
     !name.is_single_script()
 }
 
-/// Ecosystem-style prefixes commonly prepended to a popular base name.
-const AFFIX_PREFIXES: &[&str] = &[
-    "py", "python", "node", "nodejs", "js", "go", "rs", "lib", "the", "dev", "test",
-];
-
-/// Ecosystem-style suffixes commonly appended to a popular base name.
-const AFFIX_SUFFIXES: &[&str] = &[
-    "dev", "devel", "js", "py", "node", "cli", "util", "utils", "lib", "libs", "api", "sdk",
-    "core", "plugin", "tools", "test", "rs", "bin", "beta", "pro", "new", "official", "update",
-    "updated", "secure",
-];
-
 /// Separator characters allowed between a base name and an affix.
 const AFFIX_SEPARATORS: &[char] = &['-', '_', '.'];
+
+/// Insert a `-` at camelCase boundaries (`fastNumpy` → `fast-Numpy`) so case
+/// transitions count as affix separators downstream.
+fn split_camel(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    let mut prev_lower_or_digit = false;
+    for c in name.chars() {
+        if c.is_uppercase() && prev_lower_or_digit {
+            out.push('-');
+        }
+        prev_lower_or_digit = c.is_lowercase() || c.is_ascii_digit();
+        out.push(c);
+    }
+    out
+}
+
+/// Split a skeleton key into affix tokens: on separator characters and on
+/// letter↔digit boundaries (`numpy2024` → `["numpy", "2024"]`).
+fn tokenize(key: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut prev_is_digit: Option<bool> = None;
+    for c in key.chars() {
+        if AFFIX_SEPARATORS.contains(&c) {
+            if !cur.is_empty() {
+                tokens.push(std::mem::take(&mut cur));
+            }
+            prev_is_digit = None;
+            continue;
+        }
+        let is_digit = c.is_ascii_digit();
+        if prev_is_digit.is_some_and(|p| p != is_digit) && !cur.is_empty() {
+            tokens.push(std::mem::take(&mut cur));
+        }
+        cur.push(c);
+        prev_is_digit = Some(is_digit);
+    }
+    if !cur.is_empty() {
+        tokens.push(cur);
+    }
+    tokens
+}
+
+/// Whether `needle` occurs as a CONTIGUOUS token run inside `haystack`.
+fn contains_contiguous(haystack: &[String], needle: &[String]) -> bool {
+    !needle.is_empty()
+        && needle.len() <= haystack.len()
+        && haystack.windows(needle.len()).any(|w| w == needle)
+}
 
 /// Strip every separator character from `s` (for separator-stuffing
 /// comparison, e.g. `l.o.d.a.s.h` → `lodash`).
@@ -181,63 +220,81 @@ fn strip_separators(s: &str) -> String {
         .collect()
 }
 
-/// Return `Some(target)` when `name` is a popular name wrapped in a bounded
-/// affix, riding the base name's reputation:
-///
-/// - a known prefix plus separator (`py-numpy`, `python-numpy`),
-/// - separator? plus a known suffix (`numpy-dev`, `numpy_utils`),
-/// - separator? plus 1–2 trailing digits (`numpy2`, `lodash-4`), or
-/// - separator stuffing (`l.o.d.a.s.h` collapses to `lodash`).
+/// Return `Some(target)` when `name` rides a popular base name's reputation:
+/// the popular name occurs as a contiguous, boundary-delimited token run
+/// inside the candidate with at least one extra affix token on either side
+/// (ANY token, not an allowlist — `data-numpy`, `numpy-helper`,
+/// `awesome-lodash`, `numpy2024`, `fastNumpy` all match), or the candidate is
+/// the base with separators stuffed in (`l.o.d.a.s.h`). Token boundaries are
+/// the separators `-`/`_`/`.`, letter↔digit transitions, and camelCase
+/// transitions; a base merely EMBEDDED without a boundary
+/// (`supernumpyish`) does not match.
 ///
 /// Matching is case-insensitive and `name` must not itself be on the popular
 /// list (so a curated list containing `python-dateutil` never flags it). The
 /// comparison runs in confusable-skeleton space ([`confusable_skeleton`]) so
-/// a homoglyph-obfuscated affix form (`python-nｕmpy` with fullwidth `ｕ`)
-/// cannot dodge the match — a combined affix+homoglyph name neither collides
-/// as a whole-name skeleton nor (for compatibility codepoints) trips the
-/// mixed-script signal, so the affix arm must fold confusables itself. The
-/// bounded affix tokens below are skeleton-stable (none contain `m`, the one
-/// lowercase ASCII letter the UTS #39 table rewrites, to `rn`).
+/// a homoglyph-obfuscated affix form (`python-nｕmpy` with fullwidth `ｕ`, or
+/// `nｕmpy-x` with an arbitrary affix) cannot dodge the match — a combined
+/// affix+homoglyph name neither collides as a whole-name skeleton nor (for
+/// compatibility codepoints) trips the mixed-script signal, so the affix arm
+/// must fold confusables itself.
 ///
 /// This function is purely lexical — the caller MUST additionally gate on the
 /// candidate's own popularity (low/unknown downloads) before acting, because
-/// a legitimately popular affixed package is not reputation-riding.
+/// a legitimately popular affixed package (`pytest-django`,
+/// `django-rest-framework`) is not riding anyone's reputation.
 pub fn is_affix_squat(name: &str, popular: &[String]) -> Option<String> {
     let name_lc = name.to_lowercase();
     // A package that IS popular by name is never a squat of another entry.
     if popular.iter().any(|p| p.to_lowercase() == name_lc) {
         return None;
     }
-    let name_key = confusable_skeleton(name);
+    let name_key = confusable_skeleton(&split_camel(name));
+    let name_tokens = tokenize(&name_key);
+    // Prefer the most specific (longest token run) base for attribution:
+    // `react-dom-utils` rides `react-dom`, not merely `react`. Ties resolve
+    // to list order.
+    let mut best: Option<(String, usize)> = None;
     for candidate in popular {
-        let base = confusable_skeleton(candidate);
-        if base.is_empty() || name_key == base {
+        let base_key = confusable_skeleton(candidate);
+        if base_key.is_empty() || name_key == base_key {
             // Whole-name skeleton collision is the homoglyph signal's job.
             continue;
         }
-        // Prefix: <prefix><sep><base>
-        if let Some(rest) = name_key.strip_suffix(&base) {
-            if let Some(prefix) = rest.strip_suffix(AFFIX_SEPARATORS) {
-                if AFFIX_PREFIXES.contains(&prefix) {
-                    return Some(candidate.clone());
-                }
-            }
-        }
-        // Suffix: <base><sep?><suffix> or <base><sep?><1-2 digits>
-        if let Some(rest) = name_key.strip_prefix(&base) {
-            let rest = rest.strip_prefix(AFFIX_SEPARATORS).unwrap_or(rest);
-            if AFFIX_SUFFIXES.contains(&rest)
-                || ((1..=2).contains(&rest.len()) && rest.chars().all(|c| c.is_ascii_digit()))
-            {
-                return Some(candidate.clone());
-            }
-        }
-        // Separator stuffing: collapsing separators reproduces the base name.
-        if strip_separators(&name_key) == strip_separators(&base) {
+        // Separator stuffing: collapsing separators reproduces the base name
+        // — an exact visual reproduction, always the most specific match.
+        if strip_separators(&name_key) == strip_separators(&base_key) {
             return Some(candidate.clone());
         }
+        // Generalized affix: the base's token run appears intact inside the
+        // candidate, which carries at least one additional affix token.
+        let base_tokens = tokenize(&base_key);
+        if base_tokens.len() < name_tokens.len()
+            && contains_contiguous(&name_tokens, &base_tokens)
+            && best.as_ref().map_or(true, |(_, n)| *n < base_tokens.len())
+        {
+            best = Some((candidate.clone(), base_tokens.len()));
+        }
     }
-    None
+    best.map(|(candidate, _)| candidate)
+}
+
+/// Nearest popular package to `name` in confusable-skeleton space: the entry
+/// whose skeleton has the smallest Damerau-Levenshtein distance to `name`'s
+/// skeleton, with that distance (0 = skeleton collision). `None` for an empty
+/// popular list. Used to proximity-gate the mixed-script signal: a
+/// multi-script name that resembles nothing popular is not an impersonation.
+pub fn nearest_popular_skeleton(name: &str, popular: &[String]) -> Option<(String, usize)> {
+    let name_key = confusable_skeleton(name);
+    let mut best: Option<(String, usize)> = None;
+    for candidate in popular {
+        let d = damerau_levenshtein(&name_key, &confusable_skeleton(candidate));
+        match &best {
+            Some((_, best_d)) if *best_d <= d => {}
+            _ => best = Some((candidate.clone(), d)),
+        }
+    }
+    best
 }
 
 /// Built-in seed list of heavily downloaded package names per ecosystem
@@ -497,6 +554,7 @@ mod tests {
     fn affix_flags_prefix_suffix_digit_and_separator_stuffing() {
         let popular = strings(&["numpy", "lodash"]);
         for name in [
+            // Ecosystem-style affixes.
             "python-numpy",
             "py-numpy",
             "py_numpy",
@@ -505,12 +563,27 @@ mod tests {
             "numpy2",
             "numpy-2",
             "lodash-js",
+            // Arbitrary (non-allowlisted) affix tokens — the 95%-evasion
+            // class from the #3005 red-team.
+            "data-numpy",
+            "fast-numpy",
+            "numpy-helper",
+            "numpy-extras",
+            "awesome-lodash",
+            "numpy2024",
+            "numpy-python",
+            "mycompany-numpy",
+            "numpy-extras-for-science",
+            // camelCase boundary.
+            "fastNumpy",
+            "numpyHelper",
+            // Separator stuffing.
             "l.o.d.a.s.h",
         ] {
             assert_eq!(
                 is_affix_squat(name, &popular),
                 Some(
-                    if name.contains("lodash") || name.contains("l.o") {
+                    if name.to_lowercase().contains("lodash") || name.contains("l.o") {
                         "lodash"
                     } else {
                         "numpy"
@@ -520,6 +593,47 @@ mod tests {
                 "{name} should be an affix squat"
             );
         }
+    }
+
+    #[test]
+    fn affix_requires_a_token_boundary_and_a_full_base_run() {
+        let popular = strings(&["numpy", "react", "react-dom", "s3transfer"]);
+        // Base merely embedded without a boundary: not an affix.
+        assert_eq!(is_affix_squat("supernumpyish", &popular), None);
+        assert_eq!(is_affix_squat("numpyish", &popular), None);
+        // Partial token overlap with the multi-token base `react-dom` is not
+        // a react-dom match — but the first token alone still rides `react`.
+        assert_eq!(
+            is_affix_squat("react-domx", &popular),
+            Some("react".to_string())
+        );
+        // Multi-token base as a contiguous run IS a match.
+        assert_eq!(
+            is_affix_squat("react-dom-utils", &popular),
+            Some("react-dom".to_string())
+        );
+        // Digit-containing base tokenizes consistently on both sides.
+        assert_eq!(
+            is_affix_squat("s3transfer-stubs", &popular),
+            Some("s3transfer".to_string())
+        );
+    }
+
+    #[test]
+    fn nearest_popular_skeleton_distances() {
+        let popular = strings(&["numpy", "requests"]);
+        // Homoglyph collision: distance 0.
+        assert_eq!(
+            nearest_popular_skeleton("nump\u{0443}", &popular),
+            Some(("numpy".to_string(), 0))
+        );
+        // Near miss in skeleton space.
+        let (t, d) = nearest_popular_skeleton("nump\u{0443}1", &popular).unwrap();
+        assert_eq!((t.as_str(), d), ("numpy", 1));
+        // Unrelated multi-script name: far from everything popular.
+        let (_, d) = nearest_popular_skeleton("py中文tools", &popular).unwrap();
+        assert!(d > 2, "unrelated international name must not be near: {d}");
+        assert_eq!(nearest_popular_skeleton("anything", &[]), None);
     }
 
     #[test]
@@ -542,20 +656,14 @@ mod tests {
     }
 
     #[test]
-    fn affix_ignores_popular_unrelated_and_unbounded_names() {
+    fn affix_ignores_popular_and_unrelated_names() {
         let popular = strings(&["numpy", "python-dateutil", "react", "react-dom"]);
         // On the popular list itself: never a squat (the legit-affix guard).
         assert_eq!(is_affix_squat("python-dateutil", &popular), None);
         assert_eq!(is_affix_squat("react-dom", &popular), None);
-        // Unknown affix token: not in the bounded set.
-        assert_eq!(is_affix_squat("numpy-extras-for-science", &popular), None);
-        assert_eq!(is_affix_squat("mycompany-numpy", &popular), None);
-        // 3+ digit suffix is out of bounds (e.g. a year-fork naming scheme).
-        assert_eq!(is_affix_squat("numpy2024", &popular), None);
-        // Unrelated name.
+        // Unrelated names: no popular base token run inside.
         assert_eq!(is_affix_squat("leftpad", &popular), None);
-        // Base embedded mid-name without a bounded affix.
-        assert_eq!(is_affix_squat("supernumpyish", &popular), None);
+        assert_eq!(is_affix_squat("some-random-lib", &popular), None);
     }
 
     #[test]

--- a/backend/src/services/curation/typosquat.rs
+++ b/backend/src/services/curation/typosquat.rs
@@ -1,4 +1,5 @@
-//! Lexical typo-squat detection for the `popularity` curation rule (#2949).
+//! Lexical typo-squat detection for the `popularity` curation rule (#2949,
+//! extended by #2956).
 //!
 //! A classic supply-chain attack registers a package whose name is one or two
 //! keystrokes away from a heavily downloaded package (`reqeusts` vs
@@ -8,6 +9,30 @@
 //! popular-package list, and a small built-in seed list of top packages per
 //! ecosystem. The seed list is a default only — rules can supply their own
 //! list via config.
+//!
+//! #2956 adds two detectors for evasion classes pure edit distance misses:
+//!
+//! - **Homoglyph / Unicode-confusable** ([`is_homoglyph_squat`],
+//!   [`is_mixed_script`]) — a name built from visually-identical-but-different
+//!   codepoints (Cyrillic `а` U+0430 for Latin `a`, fullwidth `ｕ` U+FF55 for
+//!   `u`). Every substituted codepoint costs one edit, so a fully
+//!   confusable-substituted name sits far beyond `max_distance` while looking
+//!   pixel-identical. Detection normalizes through NFKC plus the UTS #39
+//!   confusable *skeleton* (via the `unicode-security` crate — the same
+//!   implementation rustc's `non_ascii_idents` lints use) and flags a skeleton
+//!   collision with a popular name whose raw name differs.
+//! - **Affix** ([`is_affix_squat`]) — a popular name wrapped in a bounded
+//!   ecosystem prefix/suffix (`python-numpy`, `numpy-dev`, `numpy2`) or
+//!   stuffed with separators (`l.o.d.a.s.h`), riding the base name's
+//!   reputation. Lexically this is `len(affix)+1` edits away, again beyond
+//!   `max_distance`. This signal is *popularity-gated by the caller*: a
+//!   legitimately popular affixed name (`python-dateutil`) must not be
+//!   flagged, so [`super::popularity::evaluate`] only applies it to
+//!   low/unknown-download candidates (and self-exclusion covers affixed names
+//!   that are themselves on the popular list).
+
+use unicode_normalization::UnicodeNormalization;
+use unicode_security::MixedScript;
 
 /// Damerau-Levenshtein distance (optimal string alignment variant): the
 /// minimum number of single-character insertions, deletions, substitutions,
@@ -78,14 +103,131 @@ pub fn is_typosquat(name: &str, popular: &[String], max_distance: usize) -> Opti
         return None;
     }
     let (target, distance) = nearest_popular(name, popular)?;
-    // TODO(#2956): pure edit distance misses homoglyph squats (Unicode
-    // confusables, e.g. Cyrillic lookalikes) and affix-style squats
-    // ("requests2", "python-requests"), which can sit beyond max_distance.
+    // Homoglyph and affix squats sit beyond max_distance by construction;
+    // they are handled by `is_homoglyph_squat` / `is_affix_squat` (#2956).
     if distance >= 1 && distance <= max_distance {
         Some(target)
     } else {
         None
     }
+}
+
+/// UTS #39 confusable skeleton of a package name, case-folded.
+///
+/// Pipeline: NFKC (folds compatibility forms such as fullwidth `ｕ` U+FF55
+/// and ligatures) → `unicode-security` confusable skeleton (maps
+/// visually-confusable codepoints, e.g. Cyrillic `а` U+0430, onto a canonical
+/// exemplar) → lowercase. Two names whose skeletons collide are visually
+/// interchangeable to a human reader even when their raw codepoints differ.
+pub fn confusable_skeleton(name: &str) -> String {
+    let nfkc: String = name.nfkc().collect();
+    let skeleton: String = unicode_security::confusable_detection::skeleton(&nfkc).collect();
+    skeleton.to_lowercase()
+}
+
+/// Return `Some(target)` when `name` is a Unicode-confusable (homoglyph)
+/// impersonation of a popular package: its confusable skeleton collides with
+/// a popular name's skeleton while the raw (case-folded) names differ, and
+/// `name` itself is not on the popular list.
+///
+/// Unlike edit distance, this catches full-substitution lookalikes
+/// (`nｕmpy`, Cyrillic `реqueѕts`) that are pixel-identical but many edits
+/// away. A skeleton collision with a differing raw name has essentially no
+/// legitimate cause, so callers may treat this as a stronger signal than the
+/// distance heuristic.
+pub fn is_homoglyph_squat(name: &str, popular: &[String]) -> Option<String> {
+    let name_lc = name.to_lowercase();
+    // A package that IS popular by name is never a squat of another entry.
+    if popular.iter().any(|p| p.to_lowercase() == name_lc) {
+        return None;
+    }
+    let name_skeleton = confusable_skeleton(name);
+    popular
+        .iter()
+        .find(|p| confusable_skeleton(p) == name_skeleton)
+        .cloned()
+}
+
+/// Whether `name` mixes Unicode scripts (e.g. Latin and Cyrillic letters in
+/// one identifier). Package names have no legitimate reason to mix scripts;
+/// mixing is the standard way to smuggle confusables past a reader, so it is
+/// a strong impersonation signal on its own (UTS #39 mixed-script
+/// restriction). ASCII digits and separators are script-Common and never
+/// count as mixing.
+pub fn is_mixed_script(name: &str) -> bool {
+    !name.is_single_script()
+}
+
+/// Ecosystem-style prefixes commonly prepended to a popular base name.
+const AFFIX_PREFIXES: &[&str] = &[
+    "py", "python", "node", "nodejs", "js", "go", "rs", "lib", "the", "dev", "test",
+];
+
+/// Ecosystem-style suffixes commonly appended to a popular base name.
+const AFFIX_SUFFIXES: &[&str] = &[
+    "dev", "devel", "js", "py", "node", "cli", "util", "utils", "lib", "libs", "api", "sdk",
+    "core", "plugin", "tools", "test", "rs", "bin", "beta", "pro", "new", "official", "update",
+    "updated", "secure",
+];
+
+/// Separator characters allowed between a base name and an affix.
+const AFFIX_SEPARATORS: &[char] = &['-', '_', '.'];
+
+/// Strip every separator character from `s` (for separator-stuffing
+/// comparison, e.g. `l.o.d.a.s.h` → `lodash`).
+fn strip_separators(s: &str) -> String {
+    s.chars()
+        .filter(|c| !AFFIX_SEPARATORS.contains(c))
+        .collect()
+}
+
+/// Return `Some(target)` when `name` is a popular name wrapped in a bounded
+/// affix, riding the base name's reputation:
+///
+/// - a known prefix plus separator (`py-numpy`, `python-numpy`),
+/// - separator? plus a known suffix (`numpy-dev`, `numpy_utils`),
+/// - separator? plus 1–2 trailing digits (`numpy2`, `lodash-4`), or
+/// - separator stuffing (`l.o.d.a.s.h` collapses to `lodash`).
+///
+/// Matching is case-insensitive and `name` must not itself be on the popular
+/// list (so a curated list containing `python-dateutil` never flags it). This
+/// function is purely lexical — the caller MUST additionally gate on the
+/// candidate's own popularity (low/unknown downloads) before acting, because
+/// a legitimately popular affixed package is not reputation-riding.
+pub fn is_affix_squat(name: &str, popular: &[String]) -> Option<String> {
+    let name_lc = name.to_lowercase();
+    // A package that IS popular by name is never a squat of another entry.
+    if popular.iter().any(|p| p.to_lowercase() == name_lc) {
+        return None;
+    }
+    for candidate in popular {
+        let base = candidate.to_lowercase();
+        if base.is_empty() || name_lc == base {
+            continue;
+        }
+        // Prefix: <prefix><sep><base>
+        if let Some(rest) = name_lc.strip_suffix(&base) {
+            if let Some(prefix) = rest.strip_suffix(AFFIX_SEPARATORS) {
+                if AFFIX_PREFIXES.contains(&prefix) {
+                    return Some(candidate.clone());
+                }
+            }
+        }
+        // Suffix: <base><sep?><suffix> or <base><sep?><1-2 digits>
+        if let Some(rest) = name_lc.strip_prefix(&base) {
+            let rest = rest.strip_prefix(AFFIX_SEPARATORS).unwrap_or(rest);
+            if AFFIX_SUFFIXES.contains(&rest)
+                || ((1..=2).contains(&rest.len()) && rest.chars().all(|c| c.is_ascii_digit()))
+            {
+                return Some(candidate.clone());
+            }
+        }
+        // Separator stuffing: collapsing separators reproduces the base name.
+        if strip_separators(&name_lc) == strip_separators(&base) {
+            return Some(candidate.clone());
+        }
+    }
+    None
 }
 
 /// Built-in seed list of heavily downloaded package names per ecosystem
@@ -254,6 +396,137 @@ mod tests {
         let popular = strings(&["requests", "request"]);
         assert_eq!(is_typosquat("request", &popular, 2), None);
         assert_eq!(is_typosquat("requests", &popular, 2), None);
+    }
+
+    #[test]
+    fn skeleton_folds_confusables_and_compatibility_forms() {
+        // Skeletons are canonical-exemplar strings, not readable names (the
+        // UTS #39 table maps e.g. `m` → `rn`), so correctness is skeleton
+        // EQUALITY with the impersonated name, not a literal value.
+        // Fullwidth ｕ (U+FF55) and Cyrillic а (U+0430) fold onto their Latin
+        // exemplars:
+        assert_eq!(
+            confusable_skeleton("n\u{ff55}mpy"),
+            confusable_skeleton("numpy")
+        );
+        assert_eq!(
+            confusable_skeleton("p\u{0430}ndas"),
+            confusable_skeleton("pandas")
+        );
+        // Case-insensitive: the cased name collides with the lowercase one.
+        assert_eq!(confusable_skeleton("NumPy"), confusable_skeleton("numpy"));
+        // Distinct real names do NOT collide.
+        assert_ne!(confusable_skeleton("numpy"), confusable_skeleton("pandas"));
+    }
+
+    #[test]
+    fn homoglyph_flags_confusable_lookalikes() {
+        let popular = strings(&["numpy", "requests"]);
+        // Fullwidth ｕ: skeleton collides with numpy, raw differs.
+        assert_eq!(
+            is_homoglyph_squat("n\u{ff55}mpy", &popular),
+            Some("numpy".to_string())
+        );
+        // Cyrillic е/у/р/ѕ substitution of "requests".
+        assert_eq!(
+            is_homoglyph_squat("r\u{0435}quests", &popular),
+            Some("requests".to_string())
+        );
+        // All-Cyrillic-confusable numpy (у U+0443 for y is confusable).
+        assert_eq!(
+            is_homoglyph_squat("nump\u{0443}", &popular),
+            Some("numpy".to_string())
+        );
+    }
+
+    #[test]
+    fn homoglyph_never_flags_the_real_or_unrelated_package() {
+        let popular = strings(&["numpy", "requests"]);
+        // The real package: raw name matches a popular entry.
+        assert_eq!(is_homoglyph_squat("numpy", &popular), None);
+        assert_eq!(is_homoglyph_squat("NumPy", &popular), None);
+        // Unrelated ASCII name: no skeleton collision.
+        assert_eq!(is_homoglyph_squat("leftpad", &popular), None);
+        // Edit-distance-1 ASCII typo is NOT a skeleton collision (that is the
+        // distance heuristic's job).
+        assert_eq!(is_homoglyph_squat("nunpy", &popular), None);
+    }
+
+    #[test]
+    fn mixed_script_detection() {
+        // Latin + Cyrillic in one identifier.
+        assert!(is_mixed_script("num\u{0440}y")); // Cyrillic р
+        assert!(is_mixed_script("lod\u{0430}sh")); // Cyrillic а
+                                                   // Single script (digits and separators are script-Common).
+        assert!(!is_mixed_script("numpy"));
+        assert!(!is_mixed_script("numpy2"));
+        assert!(!is_mixed_script("python-dateutil"));
+        assert!(!is_mixed_script("charset_normalizer.v2"));
+    }
+
+    #[test]
+    fn unicode_edge_cases_do_not_panic_or_mis_skeleton() {
+        let popular = strings(&["numpy"]);
+        // Combining chars: n + u + combining-acute + mpy — NFC-composes to ú,
+        // which is not a plain-u confusable; must not panic either way.
+        let _ = is_homoglyph_squat("nu\u{0301}mpy", &popular);
+        // Multibyte CJK, emoji, empty string, lone combining mark.
+        assert_eq!(is_homoglyph_squat("包管理器", &popular), None);
+        assert_eq!(is_homoglyph_squat("🦀crate", &popular), None);
+        assert_eq!(is_homoglyph_squat("", &popular), None);
+        let _ = confusable_skeleton("\u{0301}");
+        let _ = is_mixed_script("");
+        // NFKC folding of the ﬁ ligature (U+FB01) — collides with "file".
+        assert_eq!(
+            confusable_skeleton("\u{fb01}le"),
+            confusable_skeleton("file")
+        );
+    }
+
+    #[test]
+    fn affix_flags_prefix_suffix_digit_and_separator_stuffing() {
+        let popular = strings(&["numpy", "lodash"]);
+        for name in [
+            "python-numpy",
+            "py-numpy",
+            "py_numpy",
+            "numpy-dev",
+            "numpy_utils",
+            "numpy2",
+            "numpy-2",
+            "lodash-js",
+            "l.o.d.a.s.h",
+        ] {
+            assert_eq!(
+                is_affix_squat(name, &popular),
+                Some(
+                    if name.contains("lodash") || name.contains("l.o") {
+                        "lodash"
+                    } else {
+                        "numpy"
+                    }
+                    .to_string()
+                ),
+                "{name} should be an affix squat"
+            );
+        }
+    }
+
+    #[test]
+    fn affix_ignores_popular_unrelated_and_unbounded_names() {
+        let popular = strings(&["numpy", "python-dateutil", "react", "react-dom"]);
+        // On the popular list itself: never a squat (the legit-affix guard).
+        assert_eq!(is_affix_squat("python-dateutil", &popular), None);
+        assert_eq!(is_affix_squat("react-dom", &popular), None);
+        // Unknown affix token: not in the bounded set.
+        assert_eq!(is_affix_squat("numpy-extras-for-science", &popular), None);
+        assert_eq!(is_affix_squat("mycompany-numpy", &popular), None);
+        // 3+ digit suffix is out of bounds (e.g. a year-fork naming scheme).
+        assert_eq!(is_affix_squat("numpy2024", &popular), None);
+        // Unrelated name.
+        assert_eq!(is_affix_squat("leftpad", &popular), None);
+        // Base embedded mid-name without a bounded affix.
+        assert_eq!(is_affix_squat("supernumpyish", &popular), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extends the `popularity` curation rule's typo-squat arm (#2952 / #2949) with two evasion classes that pure Damerau-Levenshtein (`max_distance <= 2`) misses, per #2956 (raised during a customer evaluation follow-up):

- **Unicode-confusable (homoglyph) detection** — candidate names are folded through NFKC plus the UTS #39 confusable *skeleton* (via the `unicode-security` crate, the same confusables implementation rustc's `non_ascii_idents` lints use). A skeleton collision with a popular name whose raw name differs (e.g. Cyrillic `rеquеѕts`, 3 swaps, distance 3) is flagged. Mixed-script identifiers are flagged only when they ALSO sit near a popular package in skeleton space (collision or within `max_distance`) — a benign internationalized name that resembles nothing popular is never flagged.
- **Affix (reputation-riding) detection** — a candidate that wraps a popular base name in ANY boundary-delimited affix token (`python-numpy`, `data-numpy`, `numpy-helper`, `awesome-lodash`, `numpy2024`, `fastNumpy`) or stuffs separators into it (`l.o.d.a.s.h`). Token boundaries are `-`/`_`/`.`, letter↔digit transitions, and camelCase transitions; matching runs in confusable-skeleton space so a homoglyph inside an affix form (`python-nｕmpy`, `nｕmpy-x`) cannot dodge it. Attribution names the longest matching base (`react-dom-utils` → `react-dom`, not `react`).

False-positive control on the affix signal is carried by popularity, not by an affix allowlist:
- the candidate itself must have **low/unknown downloads** (`affix_max_downloads`, default 1000) — a legitimately popular affixed package (`python-dateutil`, `django-rest-framework`, `pytest-django`) is not riding anyone's reputation;
- a name **on the popular list is never flagged** (self-exclusion);
- a base merely embedded without a token boundary (`supernumpyish`) does not match.

Both signals sit under the existing `typosquat_check` master toggle with `homoglyph_check` / `affix_check` sub-toggles (default on), keep the advisory Flag default, reuse the `block_typosquat` escalation, and introduce **no new enforcement path** — the decision still lands at the staging-catalog re-evaluate seam.

**Scope note (Unicode reachability):** hosted PyPI uploads cannot carry Unicode names (`PypiHandler::normalize_name` folds to ASCII), but hosted npm publishes can (`validate_package_name` does not enforce ASCII), and the curation seam also evaluates names from remote/proxied upstream catalogs which AK's upload validation never touches — so the homoglyph and mixed-script arms are live signals, not theoretical ones.

Closes #2956

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug (unit tests on the new detectors fail on `main`; the `popularity-homoglyph-affix` deployment tier is red on `main` and green here)
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated (`curation::typosquat` + `curation::popularity`: skeleton folding, homoglyph flag/no-flag, mixed-script proximity gating incl. benign-multiscript no-flag, generalized affix tokens incl. camelCase/digit-boundary/separator-stuffing/homoglyph-in-affix, longest-base attribution, `python-dateutil`/high-download-candidate false-positive guards, config gating, `block_typosquat` escalation, Unicode edge cases — combining marks, ligatures, CJK, emoji, empty string)
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (deployment-test tier `popularity-homoglyph-affix`, 8 gates at the `POST /curation/packages/re-evaluate` seam: red on pre-change images, green on this branch)
- [x] Manually tested locally (isolated deployment: homoglyph, generalized-affix, and homoglyph-in-affix names routed to review with signal-specific reasons naming the ridden base; `python-dateutil`, curated-list `django-rest-framework`/`pytest-django`, and a benign multi-script name carry no lexical-squat signal)
- [x] No regressions in existing tests (full workspace lib suite green)

## API Changes

- [x] N/A - no API changes (new optional keys in the existing `popularity` rule JSONB config: `homoglyph_check`, `affix_check`, `affix_max_downloads`; all default-compatible)