### PR TITLE
fix(dtrack): chown provisioned API key file to backend UID so the integration can read it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,11 @@ services:
       - shared_config:/shared
     environment:
       DTRACK_INIT_FORCE_ROTATE: ${DTRACK_INIT_FORCE_ROTATE:-false}
+      # Owner (uid:gid) for /shared/dtrack-api-key (#2865). Must match the UID
+      # the backend runs as so it can read the key; the hardened backend image
+      # runs as artifact = 1001:0 (docker/Dockerfile.backend). Override only if
+      # you run a custom backend image with a different UID.
+      DTRACK_INIT_KEY_OWNER: ${DTRACK_INIT_KEY_OWNER:-1001:0}
       # Opt-in OSV mirror (#1972). NVD-only matches by CPE and misses purl-based
       # language dependencies; set to true to also mirror OSV (purl matching).
       DTRACK_INIT_OSV_ENABLED: ${DTRACK_INIT_OSV_ENABLED:-false}

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -35,6 +35,14 @@ BOOTSTRAP_MARKER="/shared/.dtrack-bootstrapped"
 PUBLIC_ID_MARKER="/shared/.dtrack-publicid"
 FORCE_ROTATE="${DTRACK_INIT_FORCE_ROTATE:-false}"
 
+# Owner for the API key file (#2865). This init container runs as root, but
+# the backend reads the key as the non-root `artifact` user (UID 1001, GID 0
+# — see docker/Dockerfile.backend). A root:root 0600 file on the shared
+# volume is unreadable by UID 1001, so the Dependency-Track integration
+# fails. Hand the file to the backend UID and keep it owner-only (0600)
+# rather than widening the mode to group/world read.
+KEY_OWNER="${DTRACK_INIT_KEY_OWNER:-1001:0}"
+
 # Opt-in OSV mirror (#1972). The bundled bootstrap only enables the NVD mirror,
 # which matches by CPE, so purl-based application dependencies (Maven, PyPI, npm,
 # Go, NuGet, RubyGems, crates.io, Packagist, ...) get few or no findings. OSV
@@ -92,7 +100,22 @@ ensure_team_permissions() {
   done
 }
 
+# Make the key file readable by the backend and only the backend: owner =
+# backend UID (KEY_OWNER), mode 0600. chown needs root; when the script runs
+# unprivileged (regression tests) the file is already owned by the writer,
+# so only the mode is enforced.
+ensure_key_file_access() {
+  if [ "$(id -u)" = "0" ]; then
+    chown "$KEY_OWNER" "$1"
+  fi
+  chmod 600 "$1"
+}
+
 finish_existing_key_path() {
+  # Self-heal deployments whose key file was written root:root 0600 by an
+  # earlier version of this script (#2865): fix owner/mode on the existing
+  # file without rotating the key.
+  ensure_key_file_access "$API_KEY_FILE"
   : > "$BOOTSTRAP_MARKER" 2>/dev/null || true
   echo "[dtrack-init] Existing API key preserved; done"
   exit 0
@@ -282,10 +305,12 @@ TMP_KEY_FILE="$API_KEY_FILE.tmp"
   umask 077
   printf '%s' "$API_KEY" > "$TMP_KEY_FILE"
 )
-chmod 600 "$TMP_KEY_FILE"
+# Set owner + mode on the temp file BEFORE the atomic rename so the key is
+# never observable at its final path with the wrong owner or mode (#2865).
+ensure_key_file_access "$TMP_KEY_FILE"
 mv "$TMP_KEY_FILE" "$API_KEY_FILE"
 
-echo "[dtrack-init] API key written to $API_KEY_FILE (mode 0600)"
+echo "[dtrack-init] API key written to $API_KEY_FILE (owner $KEY_OWNER, mode 0600)"
 
 TMP_PUBLIC_ID_MARKER="$PUBLIC_ID_MARKER.tmp"
 (

--- a/docker/test-init-dtrack.sh
+++ b/docker/test-init-dtrack.sh
@@ -245,9 +245,15 @@ run_init() {
 KEY_FILE="$SHARED_DIR/dtrack-api-key"
 PUBLIC_ID_MARKER="$SHARED_DIR/.dtrack-publicid"
 
+# Portable permission probe (GNU and BSD stat disagree on flags; python3 is
+# already a hard dependency of this test).
+file_mode() {
+  python3 -c 'import os,sys; print(format(os.stat(sys.argv[1]).st_mode & 0o777, "03o"))' "$1"
+}
+
 fail() {
   echo "FAIL: $1" >&2
-  for f in init init2 init2_force init2_authfail init2_permfail init2_unreachable init3 init4 init5 init6 init7 init8; do
+  for f in init init2 init2_permrepair init2_force init2_authfail init2_permfail init2_unreachable init3 init4 init5 init6 init7 init8; do
     if [ -f "$WORK_DIR/${f}.out" ] || [ -f "$WORK_DIR/${f}.err" ]; then
       echo "--- ${f} stdout ---" >&2; cat "$WORK_DIR/${f}.out" >&2 || true
       echo "--- ${f} stderr ---" >&2; cat "$WORK_DIR/${f}.err" >&2 || true
@@ -267,6 +273,13 @@ FIRST_KEY="$(tr -d '\n' < "$KEY_FILE")"
 EXPECTED_FIRST="${EXPECTED_KEY}_run1"
 [ "$FIRST_KEY" = "$EXPECTED_FIRST" ] || \
   fail "Phase 1: API key file '$FIRST_KEY' != expected '$EXPECTED_FIRST'"
+# #2865: the key file must be owner-only (0600). In the container the script
+# additionally chowns it to the backend UID (1001:0); running unprivileged
+# here the chown branch is skipped (the writer already owns the file), but
+# the mode contract is asserted exactly.
+KEY_MODE="$(file_mode "$KEY_FILE")"
+[ "$KEY_MODE" = "600" ] || \
+  fail "Phase 1: key file mode $KEY_MODE != 600"
 [ -s "$PUBLIC_ID_MARKER" ] || fail "Phase 1: $PUBLIC_ID_MARKER missing — ownership not recorded"
 OUR_PUBLIC_ID="$(cat "$PUBLIC_ID_MARKER")"
 [ "$OUR_PUBLIC_ID" = "newpub1" ] || \
@@ -321,6 +334,25 @@ for PERM in "${REQUIRED_PERMISSIONS[@]}"; do
   [ "$COUNT" -eq 2 ] || \
     fail "Phase 2: permission $PERM was granted $COUNT times (expected 2)"
 done
+
+# #2865 self-heal: a warm restart must repair drifted permissions on an
+# existing key file WITHOUT rotating the key. Deployments that minted the key
+# with a pre-fix init (wrong owner/mode) get corrected on the next restart.
+chmod 644 "$KEY_FILE"
+KEY_BEFORE_REPAIR="$(tr -d '\n' < "$KEY_FILE")"
+PUT_COUNT_BEFORE_REPAIR=$(wc -l < "$KEY_LOG" | tr -d ' ')
+INIT_RC2_REPAIR=$(run_init init2_permrepair)
+[ "$INIT_RC2_REPAIR" -eq 0 ] || \
+  fail "Phase 2 perm repair: warm restart exited $INIT_RC2_REPAIR (expected 0)"
+KEY_MODE_AFTER_REPAIR="$(file_mode "$KEY_FILE")"
+[ "$KEY_MODE_AFTER_REPAIR" = "600" ] || \
+  fail "Phase 2 perm repair: key file mode $KEY_MODE_AFTER_REPAIR != 600 after warm restart"
+KEY_AFTER_REPAIR="$(tr -d '\n' < "$KEY_FILE")"
+[ "$KEY_AFTER_REPAIR" = "$KEY_BEFORE_REPAIR" ] || \
+  fail "Phase 2 perm repair: warm restart rotated the key while repairing permissions"
+PUT_COUNT_AFTER_REPAIR=$(wc -l < "$KEY_LOG" | tr -d ' ')
+[ "$PUT_COUNT_AFTER_REPAIR" -eq "$PUT_COUNT_BEFORE_REPAIR" ] || \
+  fail "Phase 2 perm repair: warm restart minted a key unexpectedly"
 
 # Explicit forced rotation must override the existing-key warm path. This is
 # the operator recovery path when /shared/dtrack-api-key is stale or revoked:


### PR DESCRIPTION
## Summary
Launching the stack with the `dtrack` compose profile, the Dependency-Track integration fails in the Security dashboard: `dtrack-init` runs as root and writes `/shared/dtrack-api-key` as `root:root` mode `0600`, while the backend container runs as the non-root `artifact` user (UID 1001, GID 0 — `docker/Dockerfile.backend`). The backend therefore cannot read the provisioned API key.

Rather than widening the mode to group-read (`0640`, as suggested in the issue), this hands the file to its actual reader and keeps it owner-only:

- `docker/init-dtrack.sh` now chowns the key file to the backend UID (default `1001:0`, overridable via `DTRACK_INIT_KEY_OWNER` for custom images) and keeps mode `0600`. Owner + mode are set on the temp file **before** the atomic `mv`, so the key is never observable at its final path with the wrong owner or mode.
- The warm-restart path (`finish_existing_key_path`) self-heals owner/mode on an existing key file **without rotating the key**, so deployments provisioned by the old init (the reported case) are repaired on the next `docker compose up` with no key churn.
- The `chown` branch only runs when the script executes as root (as it does in the init container); the unprivileged regression-test sandbox enforces the mode contract only.
- `docker-compose.yml` documents the new `DTRACK_INIT_KEY_OWNER` knob on the `dtrack-init` service.

Note: `docker-compose.local-dev.yml` has the same pre-existing read issue, but its dev backend runs as `appuser` with a runtime-assigned UID (`docker/Dockerfile.backend.dev`), so the default owner does not cover it; pinning the dev UID (or setting `DTRACK_INIT_KEY_OWNER` there) is left as a follow-up to keep this change surgical for the reported production path.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`docker/test-init-dtrack.sh` (CI job "Shell Tests") now asserts:
- cold mint writes the key file with mode exactly `0600`;
- a warm restart repairs drifted permissions (`chmod 644` injected) back to `0600` without rotating the key and without an extra `PUT /key` mint.

Verified end-to-end in an alpine container as root (mirroring the init container): the suite passes with the `chown` branch active, and the resulting file is `owner=1001:0 mode=600` — readable by UID 1001, `Permission denied` for other non-root users.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2865
