### PR TITLE
fix(tests): make the lib suite green and hang-proof without DATABASE_URL

### DIFF
--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -44,6 +44,35 @@ pub async fn try_pool() -> Option<PgPool> {
     crate::testing::try_pool_with(3).await
 }
 
+/// Open a dedicated Postgres session and take `pg_advisory_lock(lock_key)`,
+/// blocking until the lock is free. Returns `None` — which the `*_serial_lock`
+/// guards below surface as an inert guard — when no database is configured or
+/// the session cannot be established, mirroring [`try_pool`] so DB-free
+/// environments no-op cleanly.
+///
+/// The connect itself is HARD-BOUNDED (#2986): unlike the pooled path in
+/// [`crate::testing::try_pool_with`], whose `acquire_timeout` bounds
+/// connection establishment, a raw `PgConnection::connect` has no client-side
+/// timeout. A listener that accepts TCP but never completes the Postgres
+/// handshake (e.g. a dead container's still-forwarded :5432) therefore parked
+/// the guard — and every test queued behind the same module lock — forever.
+/// The 30s bound matches the pooled path's pressure budget; an expired bound
+/// routes through the same skip-or-fail decision as a connect error.
+async fn serial_lock_session(lock_key: i64) -> Option<sqlx::PgConnection> {
+    let url = crate::testing::require_db_url()?;
+    let connect = crate::testing::bounded_connect(&url).await;
+    let mut conn = crate::testing::on_connect_result(connect)?;
+    if sqlx::query("SELECT pg_advisory_lock($1)")
+        .bind(lock_key)
+        .execute(&mut conn)
+        .await
+        .is_err()
+    {
+        return None;
+    }
+    Some(conn)
+}
+
 /// Advisory-lock key for [`scan_dedup_serial_lock`] (#2000).
 ///
 /// A single-key `pg_advisory_lock(bigint)` — a lock space distinct from the
@@ -78,23 +107,9 @@ pub struct ScanDedupSerialGuard {
 /// still no-op cleanly. Call this as the first line of a scan-dedup DB test
 /// and bind the result for the whole test body.
 pub async fn scan_dedup_serial_lock() -> ScanDedupSerialGuard {
-    use sqlx::Connection;
-    let Some(url) = crate::testing::require_db_url() else {
-        return ScanDedupSerialGuard { _conn: None };
-    };
-    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
-    else {
-        return ScanDedupSerialGuard { _conn: None };
-    };
-    if sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(SCAN_DEDUP_TEST_LOCK_KEY)
-        .execute(&mut conn)
-        .await
-        .is_err()
-    {
-        return ScanDedupSerialGuard { _conn: None };
+    ScanDedupSerialGuard {
+        _conn: serial_lock_session(SCAN_DEDUP_TEST_LOCK_KEY).await,
     }
-    ScanDedupSerialGuard { _conn: Some(conn) }
 }
 
 /// Advisory-lock key for [`blob_gc_serial_lock`] (#1660).
@@ -127,23 +142,9 @@ pub struct BlobGcSerialGuard {
 /// still no-op cleanly. Call this as the first line of a DB-backed blob-GC
 /// test and bind the result for the whole test body.
 pub async fn blob_gc_serial_lock() -> BlobGcSerialGuard {
-    use sqlx::Connection;
-    let Some(url) = crate::testing::require_db_url() else {
-        return BlobGcSerialGuard { _conn: None };
-    };
-    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
-    else {
-        return BlobGcSerialGuard { _conn: None };
-    };
-    if sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(BLOB_GC_TEST_LOCK_KEY)
-        .execute(&mut conn)
-        .await
-        .is_err()
-    {
-        return BlobGcSerialGuard { _conn: None };
+    BlobGcSerialGuard {
+        _conn: serial_lock_session(BLOB_GC_TEST_LOCK_KEY).await,
     }
-    BlobGcSerialGuard { _conn: Some(conn) }
 }
 
 /// Advisory-lock key for [`usage_ledger_serial_lock`] (#2992).
@@ -176,23 +177,9 @@ pub struct UsageLedgerSerialGuard {
 /// still no-op cleanly. Call this as the first line of a DB-backed
 /// usage-ledger test and bind the result for the whole test body.
 pub async fn usage_ledger_serial_lock() -> UsageLedgerSerialGuard {
-    use sqlx::Connection;
-    let Some(url) = crate::testing::require_db_url() else {
-        return UsageLedgerSerialGuard { _conn: None };
-    };
-    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
-    else {
-        return UsageLedgerSerialGuard { _conn: None };
-    };
-    if sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(USAGE_LEDGER_TEST_LOCK_KEY)
-        .execute(&mut conn)
-        .await
-        .is_err()
-    {
-        return UsageLedgerSerialGuard { _conn: None };
+    UsageLedgerSerialGuard {
+        _conn: serial_lock_session(USAGE_LEDGER_TEST_LOCK_KEY).await,
     }
-    UsageLedgerSerialGuard { _conn: Some(conn) }
 }
 
 /// Advisory-lock key for [`sso_provider_serial_lock`] (#2621).
@@ -225,23 +212,9 @@ pub struct SsoProviderSerialGuard {
 /// that seeds or asserts on enabled SSO providers and bind the result for the
 /// whole test body.
 pub async fn sso_provider_serial_lock() -> SsoProviderSerialGuard {
-    use sqlx::Connection;
-    let Some(url) = crate::testing::require_db_url() else {
-        return SsoProviderSerialGuard { _conn: None };
-    };
-    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
-    else {
-        return SsoProviderSerialGuard { _conn: None };
-    };
-    if sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(SSO_PROVIDER_TEST_LOCK_KEY)
-        .execute(&mut conn)
-        .await
-        .is_err()
-    {
-        return SsoProviderSerialGuard { _conn: None };
+    SsoProviderSerialGuard {
+        _conn: serial_lock_session(SSO_PROVIDER_TEST_LOCK_KEY).await,
     }
-    SsoProviderSerialGuard { _conn: Some(conn) }
 }
 
 /// Advisory-lock key for [`curation_global_serial_lock`] (#2947).
@@ -276,23 +249,9 @@ pub struct CurationGlobalSerialGuard {
 /// that seeds global curation rules and asserts on rule evaluation, and bind
 /// the result for the whole test body.
 pub async fn curation_global_serial_lock() -> CurationGlobalSerialGuard {
-    use sqlx::Connection;
-    let Some(url) = crate::testing::require_db_url() else {
-        return CurationGlobalSerialGuard { _conn: None };
-    };
-    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
-    else {
-        return CurationGlobalSerialGuard { _conn: None };
-    };
-    if sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(CURATION_GLOBAL_TEST_LOCK_KEY)
-        .execute(&mut conn)
-        .await
-        .is_err()
-    {
-        return CurationGlobalSerialGuard { _conn: None };
+    CurationGlobalSerialGuard {
+        _conn: serial_lock_session(CURATION_GLOBAL_TEST_LOCK_KEY).await,
     }
-    CurationGlobalSerialGuard { _conn: Some(conn) }
 }
 
 /// Advisory-lock key for [`path_stats_serial_lock`] (#2601).
@@ -328,23 +287,9 @@ pub struct PathStatsSerialGuard {
 /// still no-op cleanly. Call this as the first line of a DB-backed path-stats
 /// test and bind the result for the whole test body.
 pub async fn path_stats_serial_lock() -> PathStatsSerialGuard {
-    use sqlx::Connection;
-    let Some(url) = crate::testing::require_db_url() else {
-        return PathStatsSerialGuard { _conn: None };
-    };
-    let Some(mut conn) = crate::testing::on_connect_result(sqlx::PgConnection::connect(&url).await)
-    else {
-        return PathStatsSerialGuard { _conn: None };
-    };
-    if sqlx::query("SELECT pg_advisory_lock($1)")
-        .bind(PATH_STATS_TEST_LOCK_KEY)
-        .execute(&mut conn)
-        .await
-        .is_err()
-    {
-        return PathStatsSerialGuard { _conn: None };
+    PathStatsSerialGuard {
+        _conn: serial_lock_session(PATH_STATS_TEST_LOCK_KEY).await,
     }
-    PathStatsSerialGuard { _conn: Some(conn) }
 }
 
 /// Refresh the materialized storage stats for a test, absorbing transient

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1591,6 +1591,16 @@ mod tests {
     // We use a mutex to prevent parallel test interference.
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+    // The sentinel DATABASE_URL these tests export deliberately points at
+    // `127.0.0.1:1` (a port nothing listens on, so connects are REFUSED
+    // instantly) rather than `localhost:5432`. `std::env` is process-global
+    // and ENV_MUTEX only serializes THIS module, so while any of these tests
+    // runs, concurrently-starting DB-gated tests elsewhere in the suite can
+    // observe the sentinel via `testing::require_db_url()`. Pointing it at a
+    // real Postgres port meant those tests tried to speak to whatever squats
+    // on :5432 — and a listener that accepts but never answers turned each
+    // observation into a long (pre-#2986: unbounded) stall. An
+    // instantly-refused sentinel makes a window-sampled URL cost microseconds.
     /// Restore an env var to a previously captured value (or remove it if it
     /// was unset), so env-mutating tests do not leak state to other tests.
     fn restore_env(key: &str, saved: Option<String>) {
@@ -1647,10 +1657,19 @@ mod tests {
     #[test]
     fn test_config_rate_limit_enabled_by_default() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_flag = env::var("RATE_LIMIT_ENABLED").ok();
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("RATE_LIMIT_ENABLED");
         let config = Config::from_env().expect("config should load");
+        // Restore BEFORE asserting: a leaked `DATABASE_URL` outlives this
+        // test and re-routes every later DB-gated test in the process from
+        // "skip cleanly" to "connect to a bogus localhost database" (#2986).
+        restore_env("DATABASE_URL", saved_db);
+        restore_env("JWT_SECRET", saved_jwt);
+        restore_env("RATE_LIMIT_ENABLED", saved_flag);
         assert!(
             config.rate_limit_enabled,
             "rate limiting must be ON by default (#1602)"
@@ -1660,11 +1679,16 @@ mod tests {
     #[test]
     fn test_config_rate_limit_disabled_via_env() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_flag = env::var("RATE_LIMIT_ENABLED").ok();
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("RATE_LIMIT_ENABLED", "false");
         let config = Config::from_env().expect("config should load");
-        env::remove_var("RATE_LIMIT_ENABLED");
+        restore_env("DATABASE_URL", saved_db);
+        restore_env("JWT_SECRET", saved_jwt);
+        restore_env("RATE_LIMIT_ENABLED", saved_flag);
         assert!(
             !config.rate_limit_enabled,
             "RATE_LIMIT_ENABLED=false must disable rate limiting"
@@ -1674,11 +1698,15 @@ mod tests {
     #[test]
     fn test_config_login_rate_limit_env_override() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("RATE_LIMIT_LOGIN_PER_WINDOW", "3");
         env::set_var("RATE_LIMIT_LOGIN_WINDOW_SECS", "600");
         let config = Config::from_env().expect("config should load");
+        restore_env("DATABASE_URL", saved_db);
+        restore_env("JWT_SECRET", saved_jwt);
         env::remove_var("RATE_LIMIT_LOGIN_PER_WINDOW");
         env::remove_var("RATE_LIMIT_LOGIN_WINDOW_SECS");
         assert_eq!(
@@ -1698,7 +1726,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("BLOB_GC_ENABLED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("BLOB_GC_ENABLED");
 
@@ -1798,7 +1826,7 @@ mod tests {
         let saved_conc = env::var("GLOBAL_MAX_CONCURRENCY").ok();
         let saved_to = env::var("GLOBAL_REQUEST_TIMEOUT_SECS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("GLOBAL_MAX_CONCURRENCY", "0");
         env::set_var("GLOBAL_REQUEST_TIMEOUT_SECS", "0");
@@ -1835,7 +1863,7 @@ mod tests {
         let saved_conc = env::var("GLOBAL_MAX_CONCURRENCY").ok();
         let saved_to = env::var("GLOBAL_REQUEST_TIMEOUT_SECS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("GLOBAL_MAX_CONCURRENCY", "1024");
         env::set_var("GLOBAL_REQUEST_TIMEOUT_SECS", "300");
@@ -2015,7 +2043,7 @@ mod tests {
         let _lock = ENV_MUTEX.lock().unwrap();
         let saved_db = env::var("DATABASE_URL").ok();
         let saved_jwt = env::var("JWT_SECRET").ok();
-        env::set_var("DATABASE_URL", "postgresql://localhost/test");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/test");
         env::remove_var("JWT_SECRET");
 
         let result = Config::from_env();
@@ -2046,7 +2074,7 @@ mod tests {
         let saved_demo = env::var("DEMO_MODE").ok();
 
         // Set only required vars
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         // Remove optional vars to test defaults
@@ -2063,7 +2091,7 @@ mod tests {
 
         let config = Config::from_env().expect("Config should load with required vars");
 
-        assert_eq!(config.database_url, "postgresql://localhost/testdb");
+        assert_eq!(config.database_url, "postgresql://127.0.0.1:1/testdb");
         assert_eq!(config.jwt_secret, STRONG_SECRET);
         assert_eq!(config.bind_address, "0.0.0.0:8080");
         assert_eq!(config.log_level, "info");
@@ -2150,7 +2178,7 @@ mod tests {
         let saved_idle = env::var("DATABASE_IDLE_TIMEOUT_SECS").ok();
         let saved_life = env::var("DATABASE_MAX_LIFETIME_SECS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("DATABASE_MAX_CONNECTIONS", "50");
         env::set_var("DATABASE_MIN_CONNECTIONS", "10");
@@ -2198,7 +2226,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_max = env::var("DATABASE_MAX_CONNECTIONS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("DATABASE_MAX_CONNECTIONS", "not-a-number");
 
@@ -2232,7 +2260,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_demo = env::var("DEMO_MODE").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("DEMO_MODE", "true");
 
@@ -2277,7 +2305,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("AK_GUEST_ACCESS_ENABLED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("AK_GUEST_ACCESS_ENABLED");
 
@@ -2312,7 +2340,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_hint = env::var("SETUP_PASSWORD_HINT").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         // Unset -> None (default behavior unchanged).
@@ -2362,7 +2390,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("AK_GUEST_ACCESS_ENABLED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         env::set_var("AK_GUEST_ACCESS_ENABLED", "false");
@@ -2418,7 +2446,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("EXPOSE_DETAILED_HEALTH").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("EXPOSE_DETAILED_HEALTH");
 
@@ -2438,7 +2466,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("EXPOSE_DETAILED_HEALTH").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         env::set_var("EXPOSE_DETAILED_HEALTH", "true");
@@ -2468,7 +2496,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("GRPC_REFLECTION_ENABLED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("GRPC_REFLECTION_ENABLED");
 
@@ -2487,7 +2515,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("GRPC_REFLECTION_ENABLED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         env::set_var("GRPC_REFLECTION_ENABLED", "true");
@@ -2524,7 +2552,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("PLUGINS_REQUIRE_SIGNED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("PLUGINS_REQUIRE_SIGNED");
 
@@ -2544,7 +2572,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("PLUGINS_REQUIRE_SIGNED").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         env::set_var("PLUGINS_REQUIRE_SIGNED", "false");
@@ -2578,7 +2606,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_key = env::var("PLUGINS_TRUSTED_PUBKEY").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         env::remove_var("PLUGINS_TRUSTED_PUBKEY");
@@ -2608,7 +2636,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("ALLOW_LOCAL_ADMIN_LOGIN").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         // Default is false
@@ -2656,7 +2684,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_flag = env::var("SSO_DISABLE_ADMIN_BREAK_GLASS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         // Default is false: the admin break-glass stays enabled (#2018).
@@ -2693,7 +2721,7 @@ mod tests {
         let saved_access = env::var("JWT_ACCESS_TOKEN_EXPIRY_MINUTES").ok();
         let saved_refresh = env::var("JWT_REFRESH_TOKEN_EXPIRY_DAYS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("JWT_EXPIRATION_SECS", "3600");
         env::set_var("JWT_ACCESS_TOKEN_EXPIRY_MINUTES", "15");
@@ -2739,7 +2767,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_gc = env::var("GC_SCHEDULE").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("GC_SCHEDULE");
 
@@ -2769,7 +2797,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_gc = env::var("GC_SCHEDULE").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("GC_SCHEDULE", "0 30 2 * * *");
 
@@ -2801,7 +2829,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_lc = env::var("LIFECYCLE_CHECK_INTERVAL_SECS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("LIFECYCLE_CHECK_INTERVAL_SECS");
 
@@ -2831,7 +2859,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_lc = env::var("LIFECYCLE_CHECK_INTERVAL_SECS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("LIFECYCLE_CHECK_INTERVAL_SECS", "300");
 
@@ -2865,7 +2893,7 @@ mod tests {
         let saved_region = env::var("S3_REGION").ok();
         let saved_endpoint = env::var("S3_ENDPOINT").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("S3_BUCKET", "my-bucket");
         env::set_var("S3_REGION", "us-east-1");
@@ -2911,7 +2939,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_backup_bucket = env::var("BACKUP_S3_BUCKET").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
 
         // Unset => None (default behavior, backups reuse the primary bucket).
@@ -2949,7 +2977,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_max = env::var("MAX_UPLOAD_SIZE").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("MAX_UPLOAD_SIZE");
 
@@ -2979,7 +3007,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_max = env::var("MAX_UPLOAD_SIZE").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("MAX_UPLOAD_SIZE", "1073741824"); // 1 GB
 
@@ -3011,7 +3039,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_port = env::var("METRICS_PORT").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("METRICS_PORT");
 
@@ -3041,7 +3069,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_port = env::var("METRICS_PORT").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("METRICS_PORT", "9091");
 
@@ -3073,7 +3101,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_port = env::var("METRICS_PORT").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("METRICS_PORT", "not-a-port");
 
@@ -3105,7 +3133,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_max = env::var("MAX_UPLOAD_SIZE").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("MAX_UPLOAD_SIZE", "0");
 
@@ -3237,7 +3265,7 @@ mod tests {
     #[test]
     fn test_proxy_singleflight_advisory_locks_disabled_by_default() {
         let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("PROXY_SINGLEFLIGHT_ADVISORY_LOCKS_ENABLED");
         env::remove_var("PROXY_SINGLEFLIGHT_LOCK_POLL_INTERVAL_MS");
@@ -3251,7 +3279,7 @@ mod tests {
     #[test]
     fn test_proxy_singleflight_advisory_locks_opt_in() {
         let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("PROXY_SINGLEFLIGHT_ADVISORY_LOCKS_ENABLED", "true");
         env::set_var("PROXY_SINGLEFLIGHT_LOCK_POLL_INTERVAL_MS", "125");
@@ -3285,7 +3313,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_rate = env::var("RATE_LIMIT_API_PER_MIN").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::remove_var("RATE_LIMIT_API_PER_MIN");
 
@@ -3319,7 +3347,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_rate = env::var("RATE_LIMIT_API_PER_MIN").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("RATE_LIMIT_API_PER_MIN", "25000");
 
@@ -3354,7 +3382,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_warn = env::var("PASSWORD_EXPIRY_WARNING_DAYS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("PASSWORD_EXPIRY_WARNING_DAYS", "30,14,7,3,1");
 
@@ -3386,7 +3414,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_warn = env::var("PASSWORD_EXPIRY_WARNING_DAYS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("PASSWORD_EXPIRY_WARNING_DAYS", "7,7,3,14,3");
 
@@ -3418,7 +3446,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_warn = env::var("PASSWORD_EXPIRY_WARNING_DAYS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("PASSWORD_EXPIRY_WARNING_DAYS", "0,7,0,1");
 
@@ -3450,7 +3478,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_warn = env::var("PASSWORD_EXPIRY_WARNING_DAYS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("PASSWORD_EXPIRY_WARNING_DAYS", "abc,7,,1,xyz");
 
@@ -3482,7 +3510,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_interval = env::var("PASSWORD_EXPIRY_CHECK_INTERVAL_SECS").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("PASSWORD_EXPIRY_CHECK_INTERVAL_SECS", "1800");
 
@@ -3517,7 +3545,7 @@ mod tests {
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_search = env::var("RATE_LIMIT_SEARCH_PER_MIN").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("RATE_LIMIT_SEARCH_PER_MIN", "500");
 
@@ -3558,7 +3586,7 @@ mod tests {
         let saved_db = env::var("DATABASE_URL").ok();
         let saved_jwt = env::var("JWT_SECRET").ok();
         let saved_dt = env::var("DEPENDENCY_TRACK_ENABLED").ok();
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         match value {
             Some(v) => env::set_var("DEPENDENCY_TRACK_ENABLED", v),
@@ -3664,7 +3692,7 @@ mod tests {
         let saved_dt = env::var("DEPENDENCY_TRACK_ENABLED").ok();
         let saved_url = env::var("DEPENDENCY_TRACK_URL").ok();
 
-        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("DATABASE_URL", "postgresql://127.0.0.1:1/testdb");
         env::set_var("JWT_SECRET", STRONG_SECRET);
         env::set_var("DEPENDENCY_TRACK_URL", "http://dt.example.com:8081");
         env::remove_var("DEPENDENCY_TRACK_ENABLED");

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -711,7 +711,17 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
+    /// The clock starts UNPAUSED here (#2974): under `start_paused = true`
+    /// the very first `advance()` raced the real loopback TCP handshake —
+    /// the handshake progresses in wall-clock time while `connect_timeout`
+    /// is measured in virtual time, so jumping the clock 20s could expire
+    /// the 10s connect timeout before the socket ever became writable
+    /// (deterministic on some platforms). Instead, the connect and the
+    /// response headers complete under real time; only then is the clock
+    /// paused and advanced, so the sole outstanding timers are the server's
+    /// mid-body delay and any total timeout the builder might (wrongly)
+    /// apply — which is exactly what this test exists to detect.
+    #[tokio::test]
     async fn test_large_object_client_builder_does_not_apply_total_timeout() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -751,19 +761,27 @@ mod tests {
                 .build()
                 .expect("build large-object client")
         };
+        let (headers_received_tx, headers_received_rx) = tokio::sync::oneshot::channel::<()>();
         let request = tokio::spawn(async move {
-            client
+            let response = client
                 .post(&url)
                 .body("request body")
                 .send()
                 .await
-                .expect("send request")
-                .bytes()
-                .await
-                .expect("read response")
+                .expect("send request");
+            // Response headers are in: connect (and its timeout timer) are
+            // fully behind us, under real time. Tell the test it is now safe
+            // to pause the clock and jump past the server's mid-body delay.
+            headers_received_tx
+                .send(())
+                .expect("signal headers received");
+            response.bytes().await.expect("read response")
         });
 
-        tokio::task::yield_now().await;
+        headers_received_rx
+            .await
+            .expect("request task reached response headers");
+        tokio::time::pause();
         tokio::time::advance(Duration::from_secs(20)).await;
 
         assert_eq!(request.await.expect("request task").as_ref(), b"OK");

--- a/backend/src/services/smtp_service.rs
+++ b/backend/src/services/smtp_service.rs
@@ -177,7 +177,7 @@ mod tests {
     // drop. Without this, set_var calls in these tests leaked process-wide:
     // env is global and ENV_MUTEX only serializes writers among smtp tests,
     // so parallel tests reading DATABASE_URL via try_pool() saw the bogus
-    // "postgres://test@localhost/test" URL until the next smtp test ran.
+    // "postgres://test@127.0.0.1:1/test" URL until the next smtp test ran.
     struct EnvVarGuard {
         saved: Vec<(&'static str, Option<String>)>,
     }
@@ -216,7 +216,7 @@ mod tests {
     fn test_config_no_smtp() -> Config {
         let _lock = ENV_MUTEX.lock().unwrap();
         let _guard = EnvVarGuard::capture(SMTP_ENV_KEYS);
-        env::set_var("DATABASE_URL", "postgres://test@localhost/test");
+        env::set_var("DATABASE_URL", "postgres://test@127.0.0.1:1/test");
         env::set_var(
             "JWT_SECRET",
             "smtp-suite-passphrase-with-varied-glyphs-2468",
@@ -233,7 +233,7 @@ mod tests {
     fn test_config_with_smtp() -> Config {
         let _lock = ENV_MUTEX.lock().unwrap();
         let _guard = EnvVarGuard::capture(SMTP_ENV_KEYS);
-        env::set_var("DATABASE_URL", "postgres://test@localhost/test");
+        env::set_var("DATABASE_URL", "postgres://test@127.0.0.1:1/test");
         env::set_var(
             "JWT_SECRET",
             "smtp-suite-passphrase-with-varied-glyphs-2468",
@@ -287,7 +287,7 @@ mod tests {
     fn test_invalid_from_address_returns_config_error() {
         let _lock = ENV_MUTEX.lock().unwrap();
         let _guard = EnvVarGuard::capture(SMTP_ENV_KEYS);
-        env::set_var("DATABASE_URL", "postgres://test@localhost/test");
+        env::set_var("DATABASE_URL", "postgres://test@127.0.0.1:1/test");
         env::set_var(
             "JWT_SECRET",
             "smtp-suite-passphrase-with-varied-glyphs-2468",
@@ -326,7 +326,7 @@ mod tests {
     fn test_tls_mode_fallback_on_invalid() {
         let _lock = ENV_MUTEX.lock().unwrap();
         let _guard = EnvVarGuard::capture(SMTP_ENV_KEYS);
-        env::set_var("DATABASE_URL", "postgres://test@localhost/test");
+        env::set_var("DATABASE_URL", "postgres://test@127.0.0.1:1/test");
         env::set_var(
             "JWT_SECRET",
             "smtp-suite-passphrase-with-varied-glyphs-2468",
@@ -340,7 +340,7 @@ mod tests {
     async fn test_dangerous_mode_builds_transport() {
         let _lock = ENV_MUTEX.lock().unwrap();
         let _guard = EnvVarGuard::capture(SMTP_ENV_KEYS);
-        env::set_var("DATABASE_URL", "postgres://test@localhost/test");
+        env::set_var("DATABASE_URL", "postgres://test@127.0.0.1:1/test");
         env::set_var(
             "JWT_SECRET",
             "smtp-suite-passphrase-with-varied-glyphs-2468",

--- a/backend/src/testing.rs
+++ b/backend/src/testing.rs
@@ -102,18 +102,71 @@ pub fn on_connect_result<T>(result: Result<T, sqlx::Error>) -> Option<T> {
 /// the DB is not required; a connect failure under [`REQUIRE_DB_ENV`] panics.
 pub async fn try_pool_with(max_connections: u32) -> Option<PgPool> {
     let url = require_db_url()?;
-    let pool = on_connect_result(
+    // Fail-fast reachability probe (#2986). Two hang shapes hid here:
+    //
+    // * `PgPoolOptions::connect` RETRIES failed connects with backoff until
+    //   `acquire_timeout`, so an unreachable URL burned the full 30s budget
+    //   in every DB-gated test — serialized through the module `*_serial_lock`
+    //   guards, that reads as an indefinite hang of the whole suite.
+    // * A listener that accepts TCP but never completes the Postgres
+    //   handshake (e.g. a dead container's still-forwarded port) is not
+    //   bounded by `acquire_timeout` at all and parked the await forever.
+    //
+    // A single raw connect attempt fails in microseconds on refusal and is
+    // hard-bounded against stalled handshakes; only when it succeeds do we
+    // pay for building the real pool.
+    match bounded_connect(&url).await {
+        Ok(conn) => {
+            use sqlx::Connection;
+            let _ = conn.close().await;
+        }
+        Err(err) => return on_connect_result(Err(err)),
+    }
+    // The outer timeout keeps the pool build itself hang-proof even if the
+    // database degrades between the probe and this connect.
+    let connect = tokio::time::timeout(
+        std::time::Duration::from_secs(35),
         sqlx::postgres::PgPoolOptions::new()
             .max_connections(max_connections)
             // llvm-cov + nextest run DB-backed lib tests in parallel processes.
             // Keep each per-test pool small, but give Postgres pressure a chance
             // to clear instead of turning transient contention into PoolTimedOut.
             .acquire_timeout(std::time::Duration::from_secs(30))
-            .connect(&url)
-            .await,
-    )?;
+            .connect(&url),
+    )
+    .await
+    .unwrap_or(Err(sqlx::Error::PoolTimedOut));
+    let pool = on_connect_result(connect)?;
     ensure_download_event_dispatch(&url).await;
     Some(pool)
+}
+
+/// Bound for any single raw connect attempt. Generous for a healthy (even
+/// heavily loaded) local/CI Postgres answering a TCP + auth handshake, while
+/// keeping an unreachable database from stalling a test for long.
+const CONNECT_ATTEMPT_BOUND: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// `PgConnection::connect` with a hard client-side deadline (#2986).
+///
+/// Unlike the pool path this makes exactly ONE attempt, so refusal fails in
+/// microseconds, and the deadline covers the case `acquire_timeout` cannot:
+/// a listener that accepts TCP but never speaks the Postgres protocol. An
+/// expired deadline surfaces as [`sqlx::Error::PoolTimedOut`] so callers
+/// route it through the same skip-or-fail decision as any connect error.
+pub async fn bounded_connect(url: &str) -> Result<sqlx::PgConnection, sqlx::Error> {
+    bounded_connect_with(url, CONNECT_ATTEMPT_BOUND).await
+}
+
+/// [`bounded_connect`] with an explicit deadline, factored out so the
+/// regression test can exercise the bound without waiting out the real one.
+async fn bounded_connect_with(
+    url: &str,
+    bound: std::time::Duration,
+) -> Result<sqlx::PgConnection, sqlx::Error> {
+    use sqlx::Connection;
+    tokio::time::timeout(bound, sqlx::PgConnection::connect(url))
+        .await
+        .unwrap_or(Err(sqlx::Error::PoolTimedOut))
 }
 
 /// Start (once per test process) the bounded download-event dispatcher that
@@ -194,5 +247,41 @@ mod tests {
         assert!(!must_fail_loud(false, false));
         // Database absent AND required -> the fiction-green case we must block.
         assert!(must_fail_loud(false, true));
+    }
+
+    /// Regression test for the #2986 hang: a listener that ACCEPTS the TCP
+    /// connection but never speaks the Postgres protocol must yield a bounded
+    /// connect error, not park the caller forever. Before the fix, the
+    /// `*_serial_lock` guards issued a raw un-timed `PgConnection::connect`,
+    /// so this exact shape (a dead container's still-forwarded port, a
+    /// wedged proxy) hung the storage-GC / scanner test modules — and every
+    /// test queued behind their module serial locks — indefinitely.
+    #[tokio::test]
+    async fn bounded_connect_fails_instead_of_hanging_on_silent_listener() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind silent listener");
+        let addr = listener.local_addr().expect("local addr");
+        // Accept and HOLD sockets without ever responding, so the client is
+        // neither refused nor answered — the pre-fix forever-park shape.
+        let _server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            loop {
+                if let Ok((socket, _)) = listener.accept().await {
+                    held.push(socket);
+                }
+            }
+        });
+        let url = format!("postgres://u:p@{addr}/db");
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            bounded_connect_with(&url, std::time::Duration::from_millis(500)),
+        )
+        .await
+        .expect("bounded_connect must return well before the outer 10s budget");
+        assert!(
+            result.is_err(),
+            "a silent listener must surface a connect error, not a connection"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Makes `cargo test --workspace --lib` trustworthy again on `main`, closing two independent breakages.

**#2974 — deterministic red test.** `services::http_client::tests::test_large_object_client_builder_does_not_apply_total_timeout` ran a real loopback TCP round-trip under `#[tokio::test(start_paused = true)]`. Virtual time and a real socket handshake do not compose: the handshake progresses in wall-clock time while `connect_timeout` (10s) is measured in virtual time, so the test's `advance(20s)` could expire the connect timeout before the socket became writable — deterministic on platforms where the loopback connect does not complete synchronously (macOS/arm64 per the issue; on Linux it happens to pass). The test now starts with the clock **unpaused**: the connect and the response headers complete under real time (signalled back via a oneshot), and only then is the clock paused and advanced past the server's 20s mid-body delay. The guard is intact — verified by temporarily adding `.timeout(15s)` to `large_object_client_builder` and observing the reworked test fail: a total request timeout wrongly added to the builder still trips the 20s jump.

**#2986 — the full-suite hang without `DATABASE_URL`.** Three interacting defects, all fixed:

1. *Process-wide env leak (why it is emergent):* three `config.rs` tests (`test_config_rate_limit_enabled_by_default`, `test_config_rate_limit_disabled_via_env`, `test_config_login_rate_limit_env_override`) set `DATABASE_URL` (and `JWT_SECRET`) and never restored them, so once they had run, every later DB-gated test in the process saw a bogus URL and switched from "skip cleanly" to "connect". They now save/restore via the module's existing `restore_env` helper. Additionally, the sentinel URL used by all config/smtp env tests now points at `127.0.0.1:1` (instantly refused) instead of `localhost:5432`, so even the unavoidable transient windows while an env test is running (std::env is process-global; the module mutexes are module-local) cannot route concurrent tests at whatever squats on the real Postgres port.
2. *Unbounded raw connects (the literal forever-park):* the `*_serial_lock` guards in `test_db_helpers` issued a raw `PgConnection::connect` with no client-side timeout. A listener that accepts TCP but never completes the Postgres handshake (a dead container's still-forwarded :5432, a wedged proxy) parked that await — and every test queued behind the same module serial lock — forever at 0% CPU. Exactly the modules named in #2986 sit behind such serialization. All raw connects now go through one shared `testing::bounded_connect` (single attempt, hard 10s deadline; expiry routed through the existing skip-or-fail decision).
3. *Pool connect retry loop (the 30s-per-test stall):* `PgPoolOptions::connect` retries failed connects with backoff until `acquire_timeout`, so even an instantly-refused URL burned the full 30s budget per test — serialized behind the module locks, a slice of ~20 such tests reads as an indefinite hang. `testing::try_pool_with` now runs a fail-fast `bounded_connect` probe first (refusal fails in microseconds) and only builds the pool when the probe succeeds, with the pool build itself also hang-bounded.

Reproduced before the fix on a clean `main` checkout: with a silent listener on 127.0.0.1:5432, `cargo test --workspace --lib -- config:: storage_gc scan_dedup` (no `DATABASE_URL`) parks indefinitely — the remaining test threads sit in `epoll`, and `ss` shows dozens of established connections to :5432 each stalled after the 8-byte Postgres `SSLRequest`; gdb backtraces show the storage-GC tests queued on their serial guard. After the fix the same command completes in ~2s with the listener still running, and the full no-`DATABASE_URL` suite completes in ~2 minutes.

CI behavior is unchanged: the DB jobs set `AK_TESTS_REQUIRE_DB=1`, so an unreachable database still fails loudly (now bounded instead of hanging the job), and a reachable one passes the probe and connects exactly as before.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

For #2974 the reworked test is the regression test (it failed deterministically on `main` on macOS/arm64 per the issue, and still fails if a total timeout is added to the builder). For #2986, `testing::tests::bounded_connect_fails_instead_of_hanging_on_silent_listener` reproduces the exact park shape — a listener that accepts and never speaks the Postgres protocol — and asserts a bounded connect error instead of a hang.

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation performed:

- `cargo test --workspace --lib` with `DATABASE_URL` unset: completes green (14469 passed / 0 failed, ~132s), including with a hostile silent listener bound to 127.0.0.1:5432; repeated runs. Previously this command was unusable per #2986.
- `cargo nextest run --workspace --lib` against a migrated throwaway Postgres 16 with `AK_TESTS_REQUIRE_DB=1` (the CI shape): full suite green, including the previously-red `test_large_object_client_builder_does_not_apply_total_timeout`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- jscpd on the touched files: 1.03% duplication (< 3%).

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2974
Closes #2986
