### PR TITLE
ci(release): drop the mesh E2E gate from the release path on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
   # longer part of the backend release's version set (issue #2708).
   #
   # Ordering (A5): preflight -> resolve (blocks <=35 min on the publish) ->
-  # release-gate/mesh -> build-binaries -> verify-images-published -> release.
+  # release-gate -> build-binaries -> verify-images-published -> release.
   # The GitHub Release object still publishes strictly last; this job only
   # moves the gate's START to after the candidate bytes exist.
   # ════════════════════════════════════════════════════════════════════════════
@@ -213,15 +213,18 @@ jobs:
       include_stress: false
       include_failure: false
 
-  mesh-e2e-gate:
-    name: Mesh Replication E2E (optional)
-    # Advisory, but it was the last `dev` literal on the release path; run it
-    # against the published candidate tag like everything else.
-    needs: [release-preflight, resolve-candidate-digest]
-    uses: ./.github/workflows/mesh-e2e.yml
-    with:
-      image_tag: ${{ needs.resolve-candidate-digest.outputs.version }}
-    secrets: inherit
+  # NOTE: `mesh-e2e-gate` was removed from the release path (first on 1.6.x,
+  # commit 919439bb; cherry-picked to main for #2980). It called
+  # ./.github/workflows/mesh-e2e.yml, which patches the ArgoCD Applications
+  # ak-mesh-main / ak-mesh-peer-{1,2,3}. Those Applications are not present on
+  # the cluster (the artifact-keeper-mesh-test ApplicationSet is not applied),
+  # so the job failed with `applications.argoproj.io "ak-mesh-main" not found`
+  # on every recent run on main and every 1.6.x tag (v1.6.0, v1.6.2, v1.6.3),
+  # marking each release run
+  # red. It never blocked publication -- the `release` job below deliberately
+  # did not require it -- so the only effect was a permanently failing advisory
+  # gate on the release path. mesh-e2e.yml is retained and still runnable via
+  # workflow_dispatch once the mesh ApplicationSet is restored.
 
   release-gate:
     name: Release Gate (Full Suite)
@@ -592,10 +595,10 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-binaries, release-gate, mesh-e2e-gate, verify-images-published]
-    # `mesh-e2e-gate` is advisory, so this cannot fall back to the default
-    # `success()` -- it has to name the gates it requires. `!cancelled()` rather
-    # than `always()`: with `always()`, cancelling the run does not stop the
+    needs: [build-binaries, release-gate, verify-images-published]
+    # Every named gate is now required, but the condition stays explicit rather
+    # than falling back to the default `success()`. `!cancelled()` rather than
+    # `always()`: with `always()`, cancelling the run does not stop the
     # publication, because the gates it names have already reported success.
     if: |
       !cancelled() &&


### PR DESCRIPTION
## Summary

Removes the `mesh-e2e-gate` job from the release path in `.github/workflows/release.yml` on main, cherry-picking `919439bb` from `release/1.6.x` (hand-adjusted comment wording for main).

The gate calls `mesh-e2e.yml`, which patches the ArgoCD Applications `ak-mesh-main` / `ak-mesh-peer-{1,2,3}`. Those Applications are not present on the test cluster (the `artifact-keeper-mesh-test` ApplicationSet is not applied), so the job fails structurally with `applications.argoproj.io "ak-mesh-main" not found`. It failed or cascaded in 12 of the last 13 release runs, never blocked publication (the `release` job's `if:` deliberately did not require it), and made red the normal terminal state of a successful release.

Changes (same three hunks as `919439bb`):
- release-path ordering comment updated (`preflight -> resolve -> release-gate -> build-binaries -> verify-images-published -> release`)
- `mesh-e2e-gate` job removed, replaced by an explanatory comment; `mesh-e2e.yml` itself is retained and remains runnable via `workflow_dispatch` once the mesh ApplicationSet is restored
- `release` job: `mesh-e2e-gate` dropped from `needs`; every gate now named in `needs` is required by the `if:` predicate (`build-binaries`, `release-gate`, `verify-images-published`), which stays explicit with `!cancelled()`

The separate `Release Gate (Full Suite) / mesh-tests` job in artifact-keeper-test's `release-gate.yml` is not touched (pinned `@main`, has its own `continue-on-error` rationale, #1936).

Verified: workflow YAML parses (`yaml.safe_load`), and no remaining `needs:`/expression references to `mesh-e2e-gate` anywhere in `.github/workflows/` (only the explanatory comment).

Closes #2980

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (`ci:` workflow-only change; no code paths to test)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (YAML parse + grep for dangling job references)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
