### PR TITLE
ci: make smoke e2e gate reflect every test suite's exit code

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -147,9 +147,40 @@ jobs:
           echo "Running native client tests with profile: $PROFILE"
 
           if [ "$PROFILE" = "smoke" ] || [ -z "$PROFILE" ]; then
-            # Default smoke tests run without a profile flag
-            docker compose -f docker-compose.test.yml --profile smoke up \
-              --abort-on-container-exit
+            # Start the smoke stack detached and wait for every test suite to
+            # run to completion, then inspect each suite's exit code. Do NOT
+            # use `--abort-on-container-exit` here: it stops all remaining
+            # containers as soon as the first one exits and returns only that
+            # container's exit code, so the fastest suite (or a support
+            # container) decides the verdict and failures in the slower
+            # suites go green. Mirrors the smoke-e2e job in ci.yml.
+            docker compose -f docker-compose.test.yml --profile smoke up -d
+
+            echo "Waiting for test containers to finish..."
+            timeout 1500 docker wait e2e-test-pypi e2e-test-npm e2e-test-cargo e2e-test-proxy-virtual || {
+              echo "ERROR: Tests timed out. Container statuses:"
+              docker ps -a --filter "name=e2e-test" --format "table {{.Names}}\t{{.Status}}"
+              echo ""
+              echo "Backend logs (last 50 lines):"
+              docker logs e2e-test-backend --tail 50 2>&1 || true
+              exit 1
+            }
+
+            failed=false
+            for test in pypi npm cargo proxy-virtual; do
+              container="e2e-test-${test}"
+              exit_code=$(docker inspect --format='{{.State.ExitCode}}' "$container" 2>/dev/null || echo "N/A")
+              echo ""
+              echo "═══════════════════════════════════════════"
+              echo "  ${test} — Exit Code: $exit_code"
+              echo "═══════════════════════════════════════════"
+              docker logs "$container" 2>&1 || true
+              if [ "$exit_code" != "0" ]; then failed=true; fi
+            done
+            if [ "$failed" = "true" ]; then
+              echo "One or more smoke test suites failed."
+              exit 1
+            fi
           else
             docker compose -f docker-compose.test.yml --profile "$PROFILE" up \
               --abort-on-container-exit


### PR DESCRIPTION
## Summary

Fixes the smoke E2E gate so its verdict reflects every test suite's real result instead of whichever container exits first.

The smoke branch of `native-client-tests` in `.github/workflows/e2e.yml` ran `docker compose --profile smoke up --abort-on-container-exit` with no per-suite exit-code handling. With that flag, compose SIGTERMs all remaining containers as soon as the first one exits and `up` returns that first container's exit code — so the fastest suite decided the gate, and the slower suites (in practice pypi and npm) were killed mid-run with any failures invisible. This gate sits on the release path (`release.yml` `e2e-gate` → `build-binaries`).

`--exit-code-from <svc>` alone is not sufficient here: it implies `--abort-on-container-exit`, reports only the named service's code, and still kills the sibling suites early. The smoke profile runs four independent test containers, so all four exit codes matter.

## Change

`.github/workflows/e2e.yml` (smoke branch of the "Run native client tests" step only):

- `docker compose --profile smoke up -d` (detached; no `--abort-on-container-exit`)
- `timeout 1500 docker wait e2e-test-pypi e2e-test-npm e2e-test-cargo e2e-test-proxy-virtual` — every suite runs to completion; a hang fails the step with container statuses + backend logs
- Inspect each test container's exit code, print per-suite logs, and `exit 1` if any suite is nonzero

This mirrors the pattern the `smoke-e2e` job in `ci.yml` already uses correctly. The four waited containers are exactly the test services carrying the `smoke` profile in `docker-compose.test.yml` (`pypi-test`, `npm-test`, `cargo-test`, proxy-virtual); support containers (`setup`, `pki`, db, backend, trivy) are not waited on and can no longer decide the verdict. The `always()` cleanup step (`down -v --remove-orphans`) is unchanged, so teardown still happens on every path including timeout.

The non-smoke `else` branch (arbitrary `profile` inputs) still uses `--abort-on-container-exit`; per-profile container sets differ, so that is left for a follow-up rather than widening this change.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"` — parses clean.
- Local two-container repro of the compose semantics (fast helper exits 0 after 1s, slow test exits 1 after 8s):
  - old pattern: `up --abort-on-container-exit` returned **0** (helper's code) and killed the failing test — false green
  - new pattern: `up -d` + `docker wait` + inspect saw `exit=1` and failed — real red
- A support container exiting 0 first no longer greens the gate; a nonzero exit from any of the four suites fails the job.

Closes #2985
