### PR TITLE
chore(release): bump version set to 1.7.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.6.0"
+version = "1.7.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0-rc.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.6.0",
+        version = "1.7.0-rc.1",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Bumps the version set to `1.7.0-rc.1` for the first 1.7.0 release candidate, cut off `main`.

Changed (RELEASING.md step 2, this repo's spots):
- `Cargo.toml` workspace `version` `1.6.0` → `1.7.0-rc.1`
- `Cargo.lock` (`artifact-keeper-backend` entry)
- `backend/src/api/openapi.rs` OpenAPI info `version`

Prerelease cut to exercise the full release pipeline and the newly-blocking gates (E2E + Release Gate Full Suite, incl. the DTF deployment-test gate) end-to-end before stable 1.7.0. Prerelease `-rc.1` tags are exempt from the CHANGELOG-entry requirement and do not move `:latest` (release.yml/docker-publish.yml gate `:latest` on `!contains(ref,'-')`). Web/chart parity bumps are out of scope for a standalone backend RC.

Closes #3036