### PR TITLE
security(images): forward-port trivy-CLI CVE suppressions to main + bump 1.7.0-rc.2

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -85,6 +85,36 @@ CVE-2026-50162
 GHSA-vh4v-2xq2-g5cg
 
 # ---------------------------------------------------------------------------
+# trivy 0.72.0 binary (scanner-adapter image): golang.org/x/text @ v0.38.0
+# Fixed in x/text 0.39.0. trivy 0.72.0 is the latest upstream release and has
+# not been rebuilt against it, so there is no tool version to bump to. Drops
+# off when Aqua ships a trivy release built on x/text >= 0.39.0.
+#
+# Scope verified on 2026-07-29 (v1.6.4 scan): this CVE is present ONLY in the
+# vendored trivy CLI. The scanner-adapter's own binary cannot carry it, since
+# docker/scanner-adapter/go.mod declares no dependencies at all (stdlib only).
+# The backend and openscap images scan clean at 0 findings and do not bundle
+# trivy (#1544), so nothing in the network-reachable service surface is
+# affected. No reachability argument is claimed for the x/text code path
+# itself; the justification here is vendored-binary scope plus the absence of
+# any fixed tool release.
+CVE-2026-56852
+
+# ---------------------------------------------------------------------------
+# trivy 0.72.0 binary (scanner-adapter image): golang.org/x/net @ v0.55.0
+# Same vendored-binary scope as the x/text entry above: present only in the
+# bundled trivy CLI, not in the adapter's own binary (no dependencies) and not
+# in the backend or openscap images (0 findings, no bundled trivy, #1544).
+#
+# Note on severity, learned the hard way on the v1.6.4 cut: this CVE exports
+# to SARIF as UNKNOWN/note, so it looks non-gating in the code-scanning UI.
+# It DOES gate. Trivy filters on the vendor severity, not the NVD one, and
+# logs "Using severities from other vendors for some vulnerabilities"; under
+# `severity: CRITICAL,HIGH` this entry still failed the scan. Do not assume an
+# UNKNOWN/note alert is harmless: check whether the scan step actually failed.
+CVE-2026-46600
+
+# ---------------------------------------------------------------------------
 # trivy 0.72.0 binary (scanner-adapter image) — sigstore verification stack
 # github.com/sigstore/sigstore-go @ v1.1.4 (fixed 1.2.0) and
 # github.com/sigstore/timestamp-authority/v2 @ v2.0.6 (fixed 2.1.0); trivy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.7.0-rc.1"
+version = "1.7.0-rc.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.7.0-rc.1"
+version = "1.7.0-rc.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.7.0-rc.1",
+        version = "1.7.0-rc.2",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Unblocks the 1.7.0 release candidate and bumps to `1.7.0-rc.2`.

**Why:** `v1.7.0-rc.1` stalled at docker-publish's **Security Scan** gate. The scanner-adapter image vendors the trivy 0.72.0 CLI, which carries `CVE-2026-46600` (golang.org/x/net) and `CVE-2026-56852` (golang.org/x/text). Both were suppressed on `release/1.6.x` for v1.6.4 (#2997) but never forward-ported to `main`. Security Scan is a hard gate the multi-arch manifest jobs `needs`, so its failure skips the manifest → `resolve-candidate-digest` has no digest → the release gate chain (E2E, DTF, verify-images) never starts.

**Change:**
- `.trivyignore`: add `CVE-2026-56852` + `CVE-2026-46600` **verbatim** from `release/1.6.x`, including #2997's vendored-binary-scope justification comments. (main's `.trivyignore` becomes identical to `release/1.6.x`'s — the delta was pure-addition.)
- Version set `1.7.0-rc.1` → `1.7.0-rc.2` (`Cargo.toml`, `Cargo.lock`, `backend/src/api/openapi.rs`).

**Scope note:** these are an already-reviewed accepted exception — present only in the vendored trivy CLI (the adapter's own binary has no deps; backend/openscap images scan clean and bundle no trivy, #1544); no fixed trivy release exists to bump to. This is a faithful forward-port, not a new exception.

Closes #3039