### PR TITLE
chore(release): bump version set to 1.7.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.7.0-rc.2"
+version = "1.7.0-rc.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.7.0-rc.2"
+version = "1.7.0-rc.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.7.0-rc.2",
+        version = "1.7.0-rc.3",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Bumps `1.7.0-rc.2` → `1.7.0-rc.3` (Cargo.toml, Cargo.lock, openapi.rs) to cut the next RC off main.

rc.2 verified the product is clean — all release-gate reds were harness bugs, now fixed: digest-assert multi-arch (#322), 3 recalibrated tiers + INFRA-vs-regression labeling (#323), probe glibc build (#325). rc.3 is the first RC on the recalibrated gate. Prerelease `-rc.3` is CHANGELOG-exempt and does not move `:latest`.

Closes #3048