### PR TITLE
fix(oci): require colon-form artifact scopes on OCI write/delete paths

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -4650,8 +4650,8 @@ async fn handle_start_upload(
         };
     // GHSA-vvc3-h39c-mrq5: a read-scoped API token must not be accepted
     // for an OCI blob upload (`docker push`). Enforce the write scope.
-    if !oci_scopes_grant(&token_scopes, "write") {
-        return oci_forbidden_scope("write");
+    if !oci_scopes_grant(&token_scopes, "write:artifacts") {
+        return oci_forbidden_scope("write:artifacts");
     }
 
     let repo = match resolve_repo(&state.db, image_name).await {
@@ -4975,8 +4975,8 @@ async fn handle_patch_upload(
             Err(_) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
         };
     // GHSA-vvc3-h39c-mrq5: PATCH on an upload session is a write operation.
-    if !oci_scopes_grant(&token_scopes, "write") {
-        return oci_forbidden_scope("write");
+    if !oci_scopes_grant(&token_scopes, "write:artifacts") {
+        return oci_forbidden_scope("write:artifacts");
     }
 
     let session_id: Uuid = match uuid_str.parse() {
@@ -5224,8 +5224,8 @@ async fn handle_cancel_upload(
             Ok(c) => c,
             Err(_) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
         };
-    if !oci_scopes_grant(&token_scopes, "write") {
-        return oci_forbidden_scope("write");
+    if !oci_scopes_grant(&token_scopes, "write:artifacts") {
+        return oci_forbidden_scope("write:artifacts");
     }
 
     let session_id: Uuid = match uuid_str.parse() {
@@ -5444,8 +5444,8 @@ async fn handle_complete_upload(
             Err(_) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
         };
     // GHSA-vvc3-h39c-mrq5: completing an upload session writes the blob.
-    if !oci_scopes_grant(&token_scopes, "write") {
-        return oci_forbidden_scope("write");
+    if !oci_scopes_grant(&token_scopes, "write:artifacts") {
+        return oci_forbidden_scope("write:artifacts");
     }
 
     let requested_digest = match digest_query {
@@ -7842,8 +7842,8 @@ async fn handle_put_manifest(
             Err(_) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
         };
     // GHSA-vvc3-h39c-mrq5: PUT manifest is the final step of `docker push`.
-    if !oci_scopes_grant(&token_scopes, "write") {
-        return oci_forbidden_scope("write");
+    if !oci_scopes_grant(&token_scopes, "write:artifacts") {
+        return oci_forbidden_scope("write:artifacts");
     }
 
     let repo = match resolve_repo(&state.db, image_name).await {
@@ -8863,8 +8863,8 @@ async fn handle_delete_manifest(
         };
     // GHSA-vvc3-h39c-mrq5: deleting a manifest is destructive. Require the
     // delete scope on API tokens. JWT/password callers pass through.
-    if !oci_scopes_grant(&token_scopes, "delete") {
-        return oci_forbidden_scope("delete");
+    if !oci_scopes_grant(&token_scopes, "delete:artifacts") {
+        return oci_forbidden_scope("delete:artifacts");
     }
 
     let repo = match resolve_repo(&state.db, image_name).await {
@@ -9858,6 +9858,47 @@ mod tests {
     fn test_oci_scopes_grant_empty_scopes_rejected() {
         let scopes = Some(vec![]);
         assert!(!oci_scopes_grant(&scopes, "write"));
+    }
+
+    // #3053: the OCI write/delete gates require the colon-form artifact
+    // scopes (`write:artifacts` / `delete:artifacts`), aligned with the #2993
+    // migration of the format handlers. A least-privilege granular token —
+    // the only kind of write token mintable since #2996 — must pass, and a
+    // read-only granular token must still be denied.
+    #[test]
+    fn test_oci_write_gate_accepts_granular_write_artifacts_token() {
+        let scopes = Some(vec![
+            "read:artifacts".to_string(),
+            "write:artifacts".to_string(),
+        ]);
+        assert!(oci_scopes_grant(&scopes, "write:artifacts"));
+        // Write does not imply delete.
+        assert!(!oci_scopes_grant(&scopes, "delete:artifacts"));
+    }
+
+    #[test]
+    fn test_oci_write_gate_rejects_read_only_granular_token() {
+        let scopes = Some(vec!["read:artifacts".to_string()]);
+        assert!(!oci_scopes_grant(&scopes, "write:artifacts"));
+        assert!(!oci_scopes_grant(&scopes, "delete:artifacts"));
+    }
+
+    #[test]
+    fn test_oci_write_gate_broad_parent_still_covers_colon_form() {
+        // #2989 parent rule: a broad bare-action scope covers its colon-form
+        // children, so legacy `write`/`delete` tokens keep working.
+        let scopes = Some(vec!["write".to_string(), "delete".to_string()]);
+        assert!(oci_scopes_grant(&scopes, "write:artifacts"));
+        assert!(oci_scopes_grant(&scopes, "delete:artifacts"));
+    }
+
+    #[test]
+    fn test_oci_write_gate_wildcard_and_admin_cover_colon_form() {
+        for wildcard in ["*", "admin"] {
+            let scopes = Some(vec![wildcard.to_string()]);
+            assert!(oci_scopes_grant(&scopes, "write:artifacts"));
+            assert!(oci_scopes_grant(&scopes, "delete:artifacts"));
+        }
     }
 
     // #1316: `oci_scopes_grant` now delegates the wildcard decision to the


### PR DESCRIPTION
## Summary

The #2993/#2989 granular-scope migration moved the ~48 format publish sites to
require the colon-form `write:artifacts` scope, but the OCI blob/manifest write
gates (and the manifest delete gate) in `backend/src/api/handlers/oci_v2.rs`
were left on the bare `"write"` / `"delete"` vocabulary. Under the #2989
parent rule (broad-covers-specific only), a held `write:artifacts` does not
satisfy a bare `write` requirement — and since #2996 made the bare parents
un-mintable, every least-privilege token (`["read:artifacts","write:artifacts"]`)
gets `403 Token does not have required scope: write` on every OCI push path.
Only `*`/`admin` wildcard tokens could push, which breaks a standard CI push
flow (`docker login -u <svc> -p <api-token>` + `docker push`).

This aligns the six OCI scope gates with the rest of the artifact surfaces:

- 5 write gates (`handle_start_upload`, `handle_patch_upload`,
  `handle_cancel_upload`, `handle_complete_upload`, `handle_put_manifest`):
  `oci_scopes_grant(&token_scopes, "write")` → `"write:artifacts"`
- 1 delete gate (manifest delete): `"delete"` → `"delete:artifacts"`

The #2989 parent rule means legacy broad `write`/`delete` tokens and
`*`/`admin` tokens continue to pass; the change is deliberately scoped to the
required-scope strings — the parent rule itself is untouched, so
`write:artifacts` still does not leak into any non-artifact bare-`write` gate.
The repo-ACL layer (`require_oci_repo_write_access`, permission-service action
vocabulary) is unrelated and unchanged.

Closes #3053

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests on the gate predicate (`oci_v2.rs` test module):
- `test_oci_write_gate_accepts_granular_write_artifacts_token` — a
  `["read:artifacts","write:artifacts"]` token passes the write gate (fails on
  `main`) and still does not imply delete
- `test_oci_write_gate_rejects_read_only_granular_token` — a
  `["read:artifacts"]`-only token is still denied on write/delete
- `test_oci_write_gate_broad_parent_still_covers_colon_form` — legacy bare
  `write`/`delete` tokens keep working via the #2989 parent rule
- `test_oci_write_gate_wildcard_and_admin_cover_colon_form` — `*`/`admin`
  unchanged

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance of this build:
- Mint `["read:artifacts","write:artifacts"]` token + repo write grant → OCI
  blob upload init `POST /v2/{repo}/{img}/blobs/uploads/` **202** (was 403 on
  the unpatched build) and full blob PUT + manifest PUT **201**
- `["read:artifacts"]`-only token → same write path still **403**
  `Token does not have required scope: write:artifacts`
- `*` wildcard token → push still works; anonymous/manifest pull unaffected

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
