### PR TITLE
chore(release): bump version set to 1.7.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.7.0-rc.3"
+version = "1.7.0-rc.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.7.0-rc.3"
+version = "1.7.0-rc.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.7.0-rc.3",
+        version = "1.7.0-rc.4",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Bumps `1.7.0-rc.3` → `1.7.0-rc.4` (Cargo.toml, Cargo.lock, openapi.rs) to cut the next RC off main.

rc.4 includes the **OCI granular-scope fix (#3054, closes #3053)** — the HIGH `docker push` regression the rc.3 gate caught (least-privilege tokens 403'd on OCI write). It runs against the recalibrated gate now carrying the digest-pinned **`oci-push-scope` DTF tier (#327/#328)**, which will go GREEN against rc.4 (the image has the fix), and with **mesh soft-waivered** out of the blocking path (deferred to its own release). Prerelease `-rc.4` is CHANGELOG-exempt and does not move `:latest`.

Closes #3055