### PR TITLE
fix(maven): make the flat-key metadata-files owner lookup indexable on 1.6.x (no migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The Maven flat-key metadata-files owner lookup is now indexable** (#2942, #3046): the layer that derives ownership from a parent artifact's `files[]` array matched with a per-row `EXISTS` over `jsonb_array_elements`, which no index can serve. Every flat-key read that reached that layer therefore scanned all of `artifact_metadata`. #2946 removed the scan for keys the claims ledger already knows, but a key the ledger has *never* seen still falls through -- and on a virtual-repository read that is every cloud-backed local-member probe for an artifact that actually lives upstream, i.e. every cache-missing public dependency of a build. Measured on a deployment with ~1.9M `artifact_metadata` rows (91% carrying a `files[]` array), one such lookup costs ~2.8s of pure buffer churn with all pages already cached, and concurrent dependency resolution then queues on the connection pool.
+
+  The lookup is rewritten to jsonb containment (`@>`), preserving both accepted key spellings (#2706) as a two-branch predicate. **No migration is added on the 1.6.x line**: the GIN index that makes the rewrite pay off is left to the operator, precisely so a patch release never performs a write-blocking in-transaction index build (the reason the rewrite was held back from 1.6.4 in the first place). Operators who need the speedup create it with no downtime:
+
+  ```sql
+  CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artifact_metadata_files_gin
+    ON artifact_metadata USING gin ((metadata->'files') jsonb_path_ops);
+  ```
+
+  Deployments that skip it are unaffected -- without an index the containment form performs the same class of sequential scan as the predicate it replaces. The index name and definition match migration 179 on `main`, and that migration is `IF NOT EXISTS`, so a later move to the 1.7 line adopts a hand-built index as a no-op. Adding the migration to this branch was rejected on purpose: `main` has already consumed versions 176-178, so a branch-local number would collide on checksum for any deployment upgrading from 1.6.x to 1.7.x.
+
 ## [1.6.4] - 2026-07-28
 
 A security patch for the 1.6.0 line, hardening Maven flat-key tenant isolation on cloud storage backends. In-place upgrade from any 1.6.x is a drop-in image swap with no database migration.

--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -63,20 +63,44 @@ const OWNER_BY_ARTIFACT_ROW_SQL: &str = "SELECT DISTINCT a.repository_id FROM ar
 /// for the same ambiguity test.
 ///
 /// The GAV-grouped upload handler has always serialized `files[]` entries with
-/// camelCase keys (`"storageKey"`, since #418) -- matching on snake_case
-/// `storage_key` alone never hits real data, which silently disabled this
-/// whole layer (and migration 163's `metadata_files` backfill). COALESCE
-/// accepts both spellings so any hand-repaired snake_case rows keep working.
+/// camelCase keys (`"storageKey"`, since #418); snake_case `storage_key` is
+/// accepted as a fallback spelling so hand-repaired rows keep working (#2706).
+///
+/// Both spellings are matched with jsonb containment (`@>`) rather than a
+/// per-row `EXISTS` over `jsonb_array_elements`, because containment is the
+/// only form a GIN index can serve (#2942). The previous `EXISTS` predicate
+/// was evaluated per row with no index path available, so every flat-key read
+/// that reached this layer scanned all of `artifact_metadata` -- unavoidable
+/// for keys the ledger has never seen, which on a virtual-repository read is
+/// every local-member probe for an artifact that actually lives upstream.
+///
+/// **No migration ships with this change on the 1.6.x line.** The index that
+/// makes the rewrite pay off is deliberately left to the operator, so a patch
+/// release never performs a write-blocking in-transaction index build:
+///
+/// ```sql
+/// CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artifact_metadata_files_gin
+///   ON artifact_metadata USING gin ((metadata->'files') jsonb_path_ops);
+/// ```
+///
+/// Deployments that skip it are unaffected -- without an index this query
+/// performs the same class of sequential scan as the `EXISTS` form it
+/// replaces. Deployments that create it get the indexed plan (a BitmapOr of
+/// two index probes, one per spelling) with no downtime and no upgrade
+/// coupling. The index name and definition match migration 179 on `main`, and
+/// that migration is `IF NOT EXISTS`, so a later move to the 1.7 line adopts
+/// the hand-built index as a no-op.
+///
+/// Containment against an array operand is false for non-array values, so the
+/// explicit `jsonb_typeof` guard the `EXISTS` form needed is implicit here.
 const OWNER_BY_METADATA_FILES_SQL: &str = "SELECT DISTINCT a.repository_id \
      FROM artifact_metadata am \
      JOIN artifacts a ON a.id = am.artifact_id \
      JOIN repositories r ON r.id = a.repository_id \
      WHERE a.is_deleted = false \
        AND r.storage_backend = $2 \
-       AND jsonb_typeof(am.metadata->'files') = 'array' \
-       AND EXISTS ( \
-         SELECT 1 FROM jsonb_array_elements(am.metadata->'files') f \
-         WHERE COALESCE(f->>'storageKey', f->>'storage_key') = $1) \
+       AND (am.metadata->'files' @> jsonb_build_array(jsonb_build_object('storageKey', $1::text)) \
+         OR am.metadata->'files' @> jsonb_build_array(jsonb_build_object('storage_key', $1::text))) \
      LIMIT 2";
 
 /// The attribution table (backfilled legacy keys + write-time claims). The


### PR DESCRIPTION
Closes #3046. Completes the backport of #2943 to the 1.6.x line, as invited by the maintainer in that issue.
Targets `release/1.6.x`.

## What's still broken after #2946

#2946 gave 1.6.4 the ledger-first ordering, which removes the unindexed scan for any key the claims ledger already knows — a real improvement. But a key the ledger has **never** seen still falls through to the metadata-files derivation, and that predicate (a per-row `EXISTS` over `jsonb_array_elements`) cannot be served by any index, so it still scans all of `artifact_metadata`.

That residual case is not a tail: on a **virtual-repository** read, each cloud-backed local member is probed for the requested key. When the artifact actually lives upstream — every cache-missing public dependency of a build — those probes are for keys that legitimately do not exist locally, so they miss the live-row layer, miss the ledger, and each one pays a full scan.

Measured on a deployment with ~1.9M `artifact_metadata` rows, 91% of them carrying a `files[]` array:

```
Seq Scan on artifact_metadata am  (actual time=2770.780..2770.781 rows=0)
  Filter: ((jsonb_typeof((metadata -> 'files')) = 'array') AND (SubPlan 1))
  Rows Removed by Filter: 1904924
  SubPlan 1 -> Function Scan on jsonb_array_elements f  (loops=1743301)
  Buffers: shared hit=181692
Execution Time: 2770.883 ms
```

~2.8 s with every page already cached and no concurrency. The ledger probe that #2946 puts ahead of it, for the same key, is 1.0 ms. Under concurrent resolution these queries queue on the connection pool.

## The change

One predicate, rewritten to jsonb containment, keeping both accepted key spellings (#2706) as a two-branch `OR` that a GIN index serves as a `BitmapOr` of two probes. Verified with `enable_seqscan = off` to force any available index path — the shipped form never produces an `Index Cond`, the containment form does:

```
Bitmap Heap Scan on artifact_metadata am  (cost=17.08..21.11)
  ->  BitmapOr
        ->  Bitmap Index Scan on idx_artifact_metadata_files_gin
              Index Cond: ((metadata -> 'files') @> jsonb_build_array(jsonb_build_object('storageKey', $1)))
        ->  Bitmap Index Scan on idx_artifact_metadata_files_gin
              Index Cond: ((metadata -> 'files') @> jsonb_build_array(jsonb_build_object('storage_key', $1)))
```

Containment against an array operand is false for non-array values, so the explicit `jsonb_typeof` guard the `EXISTS` form needed is implicit and drops out.

## No migration — on purpose

The 1.6.4 notes give the reason the rewrite was held back: *"a write-blocking in-transaction index build is heavier than a patch release should carry."* That objection is about the index build, not the SQL form, so this PR ships **only the query change** and leaves the index to the operator:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artifact_metadata_files_gin
  ON artifact_metadata USING gin ((metadata->'files') jsonb_path_ops);
```

* Deployments that skip it are unaffected — without an index the containment form performs the same class of sequential scan as the predicate it replaces.
* Deployments that create it get the indexed plan with zero downtime and no upgrade coupling.
* The index name and definition match migration 179 on `main`, and that migration is `IF NOT EXISTS`, so a later move to the 1.7 line adopts a hand-built index as a no-op.

There is also a hard reason **not** to add the migration to this branch: `main` has already consumed versions 176, 177 and 178. A branch-local number would be applied with this file's checksum, and a deployment later upgrading 1.6.x -> 1.7.x would find version 176 already applied with a different checksum and refuse to start. Leaving the branch's migration head at 175 keeps the two lines mergeable.

## Tests

No new tests. `release/1.6.x` already carries the three attribution tests that cover this predicate from both directions — `test_attributed_owner_from_metadata_files_camelcase`, `..._snake_case` (both spellings must keep resolving through the rewritten SQL) and `test_attribution_table_claim_outranks_metadata_derivation` (layer precedence unchanged).

## Release-process note (for the trace-back gate)

This commit cannot patch-id-match `main`: #2943 landed there as a single squash (reorder + containment rewrite + migration 179 + tests), and `release/1.6.x` already carries the reorder half via #2946 — so the remaining containment-only delta has no identical counterpart commit on `main` by construction. The SQL constant itself is byte-identical to `main`'s (verified by diffing the extracted constant between this branch and `main`).

#2946 — the other half of the same split — passed this gate via the `release-process: approved` label; requesting the same treatment here. Rationale per the gate's own policy text: this is the completion of an already-approved partial cherry-pick, not a change bypassing `main`.
