### PR TITLE
fix(proxy): probe object existence before presigned proxy-cache redirect in local_fetch_or_redirect

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3145,12 +3145,30 @@ pub async fn local_fetch_or_redirect(
         };
         let redirect = match &proxy_cache_backend {
             Some(b) => {
+                // The artifacts row alone does not prove the cached object
+                // still exists: retention tooling (e.g. an object-store
+                // lifecycle policy expiring cache entries by age) deletes
+                // proxy-cache objects without updating the database. A
+                // redirect signed for a missing key 404s at the object store,
+                // where the client is beyond any fallback we control — and the
+                // row keeps serving dead redirects until manual repair. So
+                // honor `try_proxy_cache_redirect`'s contract (caller performs
+                // a metadata-only freshness check first, as
+                // `proxy_fetch_or_redirect` does via `is_cache_fresh`): probe
+                // existence through the same no-prefix handle before signing.
+                // Capability check first, mirroring #1555 — never pay the
+                // probe on a backend that cannot redirect anyway. On a miss
+                // fall through to the buffered read below, whose NotFound lets
+                // virtual-member resolution continue to the remote member's
+                // upstream re-fetch, repopulating the cache.
+                let object_present = b.supports_redirect()
+                    && matches!(b.exists(&artifact.storage_key).await, Ok(true));
                 try_proxy_cache_redirect(
                     b.as_ref(),
                     &artifact.storage_key,
                     /* presigned_enabled = */ true,
                     expiry,
-                    /* cache_is_fresh = */ true,
+                    /* cache_is_fresh = */ object_present,
                 )
                 .await
             }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -7135,14 +7135,12 @@ mod tests {
             }
         }
 
-        /// Redirect-capable but reports the key as absent — for the #2274/#1691
-        /// style existence-gate tests, where `supports_redirect() == true` must
-        /// not be enough on its own to trigger a presign.
-        fn new_with_exists(supports: bool, exists_result: bool) -> Self {
-            Self {
-                exists_result,
-                ..Self::new(supports)
-            }
+        /// Override the `exists()` result — for the #3067/#3068 existence-gate
+        /// tests, where `supports_redirect() == true` must not be enough on
+        /// its own to trigger a presign.
+        fn with_exists(mut self, exists_result: bool) -> Self {
+            self.exists_result = exists_result;
+            self
         }
     }
 
@@ -10846,99 +10844,105 @@ mod tests {
     /// out-of-band delete, e.g. a lifecycle rule) must fall through to the
     /// buffered read instead of presigning. Complements the #1555 test above,
     /// which only covers the `supports_redirect() == false` short-circuit.
+    ///
+    /// Runs both `exists()` outcomes so the `true` case is a positive
+    /// control: without it, this test would pass identically if the
+    /// proxy-cache redirect branch were never entered at all (e.g. from a
+    /// storage-key shape regression), not because `exists()` gates it.
     #[tokio::test]
-    async fn test_local_fetch_or_redirect_skips_presign_when_object_missing_3068() {
+    async fn test_local_fetch_or_redirect_gated_by_object_existence_3068() {
         use crate::api::handlers::test_db_helpers as tdh;
-        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
-            return;
-        };
 
-        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
-        let repo_info = tdh::make_repo_info(
-            fx.repo_id,
-            &fx.repo_key,
-            &fx.storage_dir,
-            "remote",
-            Some("https://upstream.example.test"),
-        );
+        for exists in [false, true] {
+            let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+                return;
+            };
 
-        // Redirect-capable proxy-cache backend that reports the object as
-        // absent — the DB row below is stale relative to it, same shape as an
-        // out-of-band delete.
-        let proxy_backend = StdArc::new(RecordingStorage::new_with_exists(
-            /* supports = */ true, /* exists_result = */ false,
-        ));
-        let service = StdArc::new(crate::services::storage_service::StorageService::new(
-            proxy_backend.clone(),
-        ));
-        let proxy = StdArc::new(crate::services::proxy_service::ProxyService::new(
-            fx.pool.clone(),
-            service,
-        ));
-        let state = tdh::build_state_with_proxy_presigned(fx.pool.clone(), &storage_path, proxy);
+            let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+            let repo_info = fx.repo_info("remote", Some("https://upstream.example.test"));
 
-        // Seed real bytes on the repo's own (filesystem) storage, separate
-        // from the mock proxy-cache backend above, so the fallback path has
-        // something real to stream once the redirect is denied.
-        let body: &[u8] = b"still-here";
-        let artifact_path = "simple/foo/foo-1.0-py3-none-any.whl";
-        let storage_key = format!("proxy-cache/{}/{}", fx.repo_key, artifact_path);
-        super::put_artifact_bytes(&state, &repo_info, &storage_key, Bytes::from_static(body))
-            .await
-            .expect("seed proxy-cache payload on disk");
-        sqlx::query(
-            "INSERT INTO artifacts ( \
-                 repository_id, path, name, version, size_bytes, \
-                 checksum_sha256, content_type, storage_key, uploaded_by \
-             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-        )
-        .bind(fx.repo_id)
-        .bind(artifact_path)
-        .bind("foo")
-        .bind("1.0")
-        .bind(body.len() as i64)
-        .bind("test-foo")
-        .bind("application/zip")
-        .bind(&storage_key)
-        .bind(fx.user_id)
-        .execute(&fx.pool)
-        .await
-        .expect("seed proxy-cache artifact row");
+            // Redirect-capable proxy-cache backend whose exists() is the
+            // thing under test: false simulates a DB row surviving an
+            // out-of-band delete; true is the ordinary fresh-cache case.
+            let proxy_backend = StdArc::new(RecordingStorage::new(true).with_exists(exists));
+            let service = StdArc::new(crate::services::storage_service::StorageService::new(
+                proxy_backend.clone(),
+            ));
+            let proxy = StdArc::new(crate::services::proxy_service::ProxyService::new(
+                fx.pool.clone(),
+                service,
+            ));
+            let state =
+                tdh::build_state_with_proxy_presigned(fx.pool.clone(), &storage_path, proxy);
 
-        let location = repo_info.storage_location();
-        let ctx = crate::api::middleware::download_telemetry::DownloadContext {
-            client_ip: None,
-            user_id: None,
-            user_agent: None,
-            is_head: false,
-        };
-        let result = super::local_fetch_or_redirect(
-            &fx.pool,
-            &state,
-            fx.repo_id,
-            &location,
-            artifact_path,
-            &ctx,
-        )
-        .await;
+            // Seed real bytes on the repo's own (filesystem) storage,
+            // separate from the mock proxy-cache backend above, so the
+            // exists() == false case has something real to fall through to.
+            let body: &[u8] = b"still-here";
+            let artifact_path = "simple/foo/foo-1.0-py3-none-any.whl";
+            let storage_key = format!("proxy-cache/{}/{}", fx.repo_key, artifact_path);
+            tdh::seed_artifact(
+                &state,
+                &fx.pool,
+                &repo_info,
+                &storage_key,
+                artifact_path,
+                "foo",
+                "1.0",
+                "application/zip",
+                Bytes::from_static(body),
+                fx.user_id,
+            )
+            .await;
 
-        fx.teardown().await;
+            let location = repo_info.storage_location();
+            let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+                client_ip: None,
+                user_id: None,
+                user_agent: None,
+                is_head: false,
+            };
+            let result = super::local_fetch_or_redirect(
+                &fx.pool,
+                &state,
+                fx.repo_id,
+                &location,
+                artifact_path,
+                &ctx,
+            )
+            .await;
 
-        let resp = result.expect("missing-object fetch must fall through to streaming");
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "exists() == false must fall through to a streamed 200, never a stale 302"
-        );
-        assert!(
-            resp.headers().get("location").is_none(),
-            "a redirect-capable backend reporting the object absent must NOT redirect"
-        );
-        assert_eq!(
-            proxy_backend.presigned_calls.load(Ordering::SeqCst),
-            0,
-            "get_presigned_url must never be attempted when exists() == false"
-        );
+            fx.teardown().await;
+
+            let resp = result.expect("fetch must succeed (redirect or streamed fallback)");
+            if exists {
+                assert_eq!(
+                    resp.status(),
+                    StatusCode::FOUND,
+                    "exists() == true must sign a redirect"
+                );
+                assert_eq!(
+                    proxy_backend.presigned_calls.load(Ordering::SeqCst),
+                    1,
+                    "exists() == true must attempt exactly one presign"
+                );
+            } else {
+                assert_eq!(
+                    resp.status(),
+                    StatusCode::OK,
+                    "exists() == false must fall through to a streamed 200, never a stale 302"
+                );
+                assert!(
+                    resp.headers().get("location").is_none(),
+                    "a redirect-capable backend reporting the object absent must NOT redirect"
+                );
+                assert_eq!(
+                    proxy_backend.presigned_calls.load(Ordering::SeqCst),
+                    0,
+                    "get_presigned_url must never be attempted when exists() == false"
+                );
+            }
+        }
     }
 
     /// Count `download_statistics` rows attributed to any artifact in `repo_id`.

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3152,17 +3152,50 @@ pub async fn local_fetch_or_redirect(
                 // redirect signed for a missing key 404s at the object store,
                 // where the client is beyond any fallback we control — and the
                 // row keeps serving dead redirects until manual repair. So
-                // honor `try_proxy_cache_redirect`'s contract (caller performs
-                // a metadata-only freshness check first, as
-                // `proxy_fetch_or_redirect` does via `is_cache_fresh`): probe
-                // existence through the same no-prefix handle before signing.
-                // Capability check first, mirroring #1555 — never pay the
-                // probe on a backend that cannot redirect anyway. On a miss
-                // fall through to the buffered read below, whose NotFound lets
-                // virtual-member resolution continue to the remote member's
-                // upstream re-fetch, repopulating the cache.
+                // probe existence through the same no-prefix handle before
+                // signing. Capability check first, mirroring #1555 — never pay
+                // the probe on a backend that cannot redirect anyway.
+                //
+                // Scope, deliberately understated: this is an EXISTENCE probe,
+                // strictly narrower than the `is_cache_fresh` gate the sibling
+                // paths (`proxy_fetch_or_redirect`, `try_member_cache_redirect`)
+                // apply. Those additionally read the `__cache_meta__.json`
+                // sidecar for TTL, revalidate the pinned ETag, and apply
+                // `cache_quarantine_gate` for the #2075 Package Age Policy hold.
+                // None of that happens here, so a present-but-stale or
+                // still-held entry can still be signed. That gap is
+                // pre-existing (this argument was hardcoded `true`); closing it
+                // needs the repo_key/path pair and is tracked separately. This
+                // change only removes the dead-redirect case.
+                //
+                // On a miss the buffered read below takes over. Note it does
+                // NOT simply return NotFound: it routes through
+                // `coordinated_retry_get`, which takes a cluster-wide advisory
+                // lease (#1609) and returns 507 if the object is still absent.
+                // The self-heal comes from the sole caller (the PyPI
+                // virtual-member loop) discarding that error and continuing to
+                // the remote member's upstream re-fetch.
+                //
+                // An `Err` from the probe means "unknown", not "absent", so it
+                // is logged rather than swallowed — otherwise an object-store
+                // brownout silently converts every redirect on this path into a
+                // fully-buffered read through the backend, with no signal that
+                // it happened. We still fall through on `Err` (never sign a
+                // redirect we could not verify); the log is what makes that
+                // transition visible.
                 let object_present = b.supports_redirect()
-                    && matches!(b.exists(&artifact.storage_key).await, Ok(true));
+                    && match b.exists(&artifact.storage_key).await {
+                        Ok(present) => present,
+                        Err(e) => {
+                            tracing::warn!(
+                                storage_key = %artifact.storage_key,
+                                error = %e,
+                                "proxy-cache existence probe failed; treating as absent \
+                                 and falling through to the buffered read"
+                            );
+                            false
+                        }
+                    };
                 try_proxy_cache_redirect(
                     b.as_ref(),
                     &artifact.storage_key,
@@ -10880,7 +10913,11 @@ mod tests {
             // exists() == false case has something real to fall through to.
             let body: &[u8] = b"still-here";
             let artifact_path = "simple/foo/foo-1.0-py3-none-any.whl";
-            let storage_key = format!("proxy-cache/{}/{}", fx.repo_key, artifact_path);
+            // Use the real content-key shape `CacheKeys::derive` produces
+            // (`proxy-cache/<repo>/<path>/__content__`), not just something
+            // that satisfies the `proxy-cache/` prefix check — otherwise the
+            // fixture exercises a key namespace the cache writer never emits.
+            let storage_key = format!("proxy-cache/{}/{}/__content__", fx.repo_key, artifact_path);
             tdh::seed_artifact(
                 &state,
                 &fx.pool,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -7115,6 +7115,7 @@ mod tests {
         last_put: StdArc<std::sync::Mutex<Option<(String, Bytes)>>>,
         get_behavior: RecordingGetBehavior,
         supports: bool,
+        exists_result: bool,
     }
 
     impl RecordingStorage {
@@ -7130,6 +7131,17 @@ mod tests {
                 last_put: StdArc::new(std::sync::Mutex::new(None)),
                 get_behavior,
                 supports,
+                exists_result: true,
+            }
+        }
+
+        /// Redirect-capable but reports the key as absent — for the #2274/#1691
+        /// style existence-gate tests, where `supports_redirect() == true` must
+        /// not be enough on its own to trigger a presign.
+        fn new_with_exists(supports: bool, exists_result: bool) -> Self {
+            Self {
+                exists_result,
+                ..Self::new(supports)
             }
         }
     }
@@ -7152,7 +7164,7 @@ mod tests {
             }
         }
         async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
-            Ok(true)
+            Ok(self.exists_result)
         }
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
@@ -7203,7 +7215,7 @@ mod tests {
             }
         }
         async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
-            Ok(true)
+            Ok(self.exists_result)
         }
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
@@ -10826,6 +10838,106 @@ mod tests {
         assert_eq!(
             recorded, 0,
             "a proxy-cache serve must NOT be counted (#1278; out of scope for #2260)"
+        );
+    }
+
+    /// #3067/#3068: `supports_redirect() == true` alone must not be enough to
+    /// sign a redirect — `exists()` returning false (a DB row surviving an
+    /// out-of-band delete, e.g. a lifecycle rule) must fall through to the
+    /// buffered read instead of presigning. Complements the #1555 test above,
+    /// which only covers the `supports_redirect() == false` short-circuit.
+    #[tokio::test]
+    async fn test_local_fetch_or_redirect_skips_presign_when_object_missing_3068() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let repo_info = tdh::make_repo_info(
+            fx.repo_id,
+            &fx.repo_key,
+            &fx.storage_dir,
+            "remote",
+            Some("https://upstream.example.test"),
+        );
+
+        // Redirect-capable proxy-cache backend that reports the object as
+        // absent — the DB row below is stale relative to it, same shape as an
+        // out-of-band delete.
+        let proxy_backend = StdArc::new(RecordingStorage::new_with_exists(
+            /* supports = */ true, /* exists_result = */ false,
+        ));
+        let service = StdArc::new(crate::services::storage_service::StorageService::new(
+            proxy_backend.clone(),
+        ));
+        let proxy = StdArc::new(crate::services::proxy_service::ProxyService::new(
+            fx.pool.clone(),
+            service,
+        ));
+        let state = tdh::build_state_with_proxy_presigned(fx.pool.clone(), &storage_path, proxy);
+
+        // Seed real bytes on the repo's own (filesystem) storage, separate
+        // from the mock proxy-cache backend above, so the fallback path has
+        // something real to stream once the redirect is denied.
+        let body: &[u8] = b"still-here";
+        let artifact_path = "simple/foo/foo-1.0-py3-none-any.whl";
+        let storage_key = format!("proxy-cache/{}/{}", fx.repo_key, artifact_path);
+        super::put_artifact_bytes(&state, &repo_info, &storage_key, Bytes::from_static(body))
+            .await
+            .expect("seed proxy-cache payload on disk");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(fx.repo_id)
+        .bind(artifact_path)
+        .bind("foo")
+        .bind("1.0")
+        .bind(body.len() as i64)
+        .bind("test-foo")
+        .bind("application/zip")
+        .bind(&storage_key)
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed proxy-cache artifact row");
+
+        let location = repo_info.storage_location();
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+            is_head: false,
+        };
+        let result = super::local_fetch_or_redirect(
+            &fx.pool,
+            &state,
+            fx.repo_id,
+            &location,
+            artifact_path,
+            &ctx,
+        )
+        .await;
+
+        fx.teardown().await;
+
+        let resp = result.expect("missing-object fetch must fall through to streaming");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "exists() == false must fall through to a streamed 200, never a stale 302"
+        );
+        assert!(
+            resp.headers().get("location").is_none(),
+            "a redirect-capable backend reporting the object absent must NOT redirect"
+        );
+        assert_eq!(
+            proxy_backend.presigned_calls.load(Ordering::SeqCst),
+            0,
+            "get_presigned_url must never be attempted when exists() == false"
         );
     }
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1547,18 +1547,28 @@ impl CachePersister {
                         // SHA-256 does not match it. The bytes were already
                         // forwarded to the client — which independently verifies
                         // the digest — but the proxy cache must never be poisoned
-                        // with mismatched content addressed by that digest. Skip
-                        // the metadata sidecar so the next request refetches
-                        // upstream (self-heal). Deliberately do NOT delete
-                        // cache_key_for_writer here (#3068): put_stream above
-                        // already committed this request's bytes as the current
-                        // version, so exists() is always true by this point and
-                        // can't distinguish "only my bad write is here" from "a
-                        // prior good version is one behind it" -- deleting
-                        // either way risks stacking a marker over real content
-                        // from before this request. The missing sidecar alone
-                        // is what forces the refetch; nothing here depends on
-                        // the object also being gone.
+                        // with mismatched content addressed by that digest. Treat
+                        // a mismatch exactly like the truncated/empty reject path:
+                        // delete the object and skip the metadata sidecar so the
+                        // next request refetches upstream (self-heal).
+                        //
+                        // The delete is load-bearing, NOT belt-and-braces: the
+                        // missing sidecar is not sufficient on its own, because
+                        // several read paths reach the content key without
+                        // consulting it. `handle_streaming_leader_upstream_error`
+                        // serves `get_stream(cache_key)` as an RFC 5861
+                        // stale-if-error response and only loads the sidecar
+                        // afterwards, best-effort, for headers; `is_fresh`
+                        // degrades to a bare `exists()` when either ETag is
+                        // multipart-shaped (#2120) or when a legacy sidecar has
+                        // no pinned ETag; and the presigned-redirect paths sign a
+                        // 302 straight to the object with no checksum check at
+                        // all. Leaving rejected bytes in place therefore makes
+                        // them servable. Deleting is also what self-heals on a
+                        // versioned bucket: nothing in this codebase ever reads a
+                        // non-current version (there is no version_id support in
+                        // the storage layer), so a delete marker simply reads as
+                        // NotFound and forces the refetch.
                         if let Some(expected) = template.expected_checksum.as_deref() {
                             if result.checksum_sha256 != expected {
                                 tracing::warn!(
@@ -1567,6 +1577,15 @@ impl CachePersister {
                                      not caching (no metadata sidecar) so the cache entry cannot \
                                      be poisoned"
                                 );
+                                if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                                    tracing::debug!(
+                                        cache_key = %cache_key_for_writer,
+                                        error = %e,
+                                        "best-effort delete of digest-mismatched proxy-cache \
+                                         object failed; the missing metadata sidecar still forces \
+                                         a refetch"
+                                    );
+                                }
                                 return;
                             }
                         }
@@ -1663,19 +1682,31 @@ impl CachePersister {
                         // `Content-Length`) would serve a short, SHA-mismatched
                         // blob and clients hit "unexpected BufError" extracting
                         // the archive. Skip the sidecar (entry treated as a
-                        // miss) so a later GET refetches upstream (self-heal).
-                        // The buffered sibling [`Self::write_buffered`] applies
-                        // the empty-body guard before the content write.
+                        // miss) and delete the bad object so a later GET
+                        // refetches upstream (self-heal). The buffered sibling
+                        // [`Self::write_buffered`] applies the empty-body guard
+                        // before the content write, so it can return early and
+                        // never needs the delete.
                         //
-                        // Deliberately do NOT delete cache_key_for_writer here
-                        // (#3068): put_stream above already committed this
-                        // request's (bad) bytes as the current version, so an
-                        // exists() check is always true by this point and
-                        // can't tell "only my bad write is here" apart from "a
-                        // prior good version is one behind it" -- either way,
-                        // deleting risks stacking a marker over real content
-                        // that predates this request. The missing sidecar is
-                        // what actually forces the refetch.
+                        // Both halves are required. Skipping the sidecar is not
+                        // sufficient on its own, because several readers reach
+                        // the content key without consulting it:
+                        // `handle_streaming_leader_upstream_error` streams
+                        // `get_stream(cache_key)` as an RFC 5861 stale-if-error
+                        // response (sidecar loaded afterwards, best-effort, only
+                        // for headers), the PyPI Remote arm streams
+                        // `artifacts.storage_key` directly, and `is_fresh`
+                        // degrades to a bare `exists()` whenever an ETag is
+                        // multipart-shaped (#2120) or a legacy sidecar carries no
+                        // pinned ETag -- after which the presigned paths sign a
+                        // 302 to the object with no checksum check at all.
+                        //
+                        // The delete is also what self-heals on a versioned
+                        // bucket. Nothing in this codebase reads a non-current
+                        // version (the storage layer has no version_id concept),
+                        // so a delete marker simply reads as NotFound and forces
+                        // the refetch -- it cannot mask content that was already
+                        // unreachable.
                         match rejected {
                             StreamWriteOutcome::RejectTruncated { expected, actual } => {
                                 tracing::warn!(
@@ -1695,6 +1726,15 @@ impl CachePersister {
                                      refetches upstream"
                                 );
                             }
+                        }
+                        if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                            tracing::debug!(
+                                cache_key = %cache_key_for_writer,
+                                error = %e,
+                                "best-effort delete of rejected proxy-cache object failed; \
+                                 the missing metadata sidecar still forces a refetch on the \
+                                 sidecar-gated read paths"
+                            );
                         }
                     }
                 },
@@ -8664,12 +8704,13 @@ mod tests {
     /// which a subsequent GET served as `Content-Length: 0`, breaking
     /// Gradle POM parsing ("Content is not allowed in prolog.").
     ///
-    /// #3068: the writer must NOT delete cache_key_for_writer either -- by
-    /// this point put_stream already committed the zero-byte write as the
-    /// key's current version, so a delete can't tell "only this bad write is
-    /// here" apart from "a prior good version sits one behind it," and would
-    /// risk stacking a marker over real content. The missing sidecar alone
-    /// is what forces the refetch.
+    /// The writer must ALSO delete the zero-byte object it wrote. The sidecar
+    /// skip alone is not enough: `handle_streaming_leader_upstream_error`
+    /// streams the content key as a stale-if-error response without gating on
+    /// the sidecar, the PyPI Remote arm streams it directly, and `is_fresh`
+    /// degrades to a bare `exists()` on a multipart-ETag mismatch (#2120) --
+    /// after which a presigned 302 points straight at it. Leaving the object
+    /// behind therefore leaves it servable (#3068 review).
     #[tokio::test]
     async fn test_tee_empty_upstream_is_not_cached() {
         let backend = TeeRecordingBackend::ok();
@@ -8696,11 +8737,11 @@ mod tests {
             "zero-byte upstream body MUST NOT write a metadata sidecar; \
              otherwise the next GET serves a Content-Length: 0 cache hit (#1365)"
         );
-        assert!(
-            backend.deletes.lock().await.is_empty(),
-            "the writer must NOT delete on reject (#3068): put_stream already \
-             committed this write as the current version, so a delete here \
-             could mask real content from before this request"
+        assert_eq!(
+            backend.deletes.lock().await.as_slice(),
+            ["cache-key".to_string()],
+            "the empty cache object must be deleted so the next request refetches; \
+             the sidecar skip alone does not protect the sidecar-less read paths"
         );
     }
 
@@ -8750,10 +8791,10 @@ mod tests {
     /// "unexpected BufError" extracting it. The writer must skip the
     /// metadata sidecar so the next request refetches.
     ///
-    /// #3068: same reasoning as the empty-body sibling above -- the writer
-    /// must NOT delete the partial object either, since put_stream already
-    /// committed it as the current version and a delete can't distinguish
-    /// it from a prior good version one behind it.
+    /// Same reasoning as the empty-body sibling above: the writer must ALSO
+    /// delete the partial object, because the sidecar skip does not protect
+    /// the read paths that reach the content key without consulting it
+    /// (#3068 review).
     #[tokio::test]
     async fn test_tee_truncated_upstream_is_not_cached() {
         let backend = TeeRecordingBackend::ok();
@@ -8783,11 +8824,11 @@ mod tests {
             backend.metadata_writes.lock().await.is_empty(),
             "truncated upstream body MUST NOT write a metadata sidecar (#1912)"
         );
-        assert!(
-            backend.deletes.lock().await.is_empty(),
-            "the writer must NOT delete on reject (#3068): put_stream already \
-             committed this write as the current version, so a delete here \
-             could mask real content from before this request"
+        assert_eq!(
+            backend.deletes.lock().await.as_slice(),
+            ["cache-key".to_string()],
+            "the truncated cache object must be deleted so the next request refetches; \
+             the sidecar skip alone does not protect the sidecar-less read paths"
         );
     }
 
@@ -8825,6 +8866,35 @@ mod tests {
             2,
             "each negative-cache renewal still writes its metadata sidecar \
              regardless of the delete guard"
+        );
+    }
+
+    /// Positive control for the guard above. Without this, replacing the
+    /// `exists()` check with `if false` would still pass the whole suite --
+    /// the same criticism the #3068 author correctly applied to the
+    /// `local_fetch_or_redirect` test and did not apply here.
+    ///
+    /// When a real positive body IS present, `write_negative_cache` must still
+    /// drop it, so a future read can never serve stale content alongside the
+    /// negative marker.
+    #[tokio::test]
+    async fn test_write_negative_cache_deletes_an_existing_positive_body() {
+        let backend = TeeRecordingBackend::ok();
+        backend
+            .object_written
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+        let proxy = ProxyService::new(test_catalog_pool(), storage);
+
+        proxy
+            .write_negative_cache("cache-key", "meta-key", "some/path")
+            .await;
+
+        assert_eq!(
+            backend.deletes.lock().await.as_slice(),
+            ["cache-key".to_string()],
+            "a prior positive body MUST be dropped when the negative marker is \
+             written, otherwise a read can serve it alongside the marker"
         );
     }
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1559,14 +1559,30 @@ impl CachePersister {
                                      not caching (no metadata sidecar) so the cache entry cannot \
                                      be poisoned"
                                 );
-                                if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
-                                    tracing::debug!(
-                                        cache_key = %cache_key_for_writer,
-                                        error = %e,
-                                        "best-effort delete of digest-mismatched proxy-cache \
-                                         object failed; the missing metadata sidecar still forces \
-                                         a refetch"
-                                    );
+                                // #1611-style guard: put_stream above already
+                                // overwrote cache_key_for_writer with these
+                                // mismatched bytes, but on a revalidation
+                                // refill that key may have held good,
+                                // still-serving content immediately before
+                                // this request ran. An unconditional delete()
+                                // on a versioned backend doesn't undo the
+                                // overwrite -- it stacks a delete marker on
+                                // top of the whole version history, silently
+                                // hiding that prior-good version too. The
+                                // missing metadata sidecar alone already
+                                // forces the self-heal refetch (see the reject
+                                // arm below), so only delete when a real
+                                // object is actually present to clean up.
+                                if matches!(storage_clone.exists(&cache_key_for_writer).await, Ok(true)) {
+                                    if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                                        tracing::debug!(
+                                            cache_key = %cache_key_for_writer,
+                                            error = %e,
+                                            "best-effort delete of digest-mismatched proxy-cache \
+                                             object failed; the missing metadata sidecar still forces \
+                                             a refetch"
+                                        );
+                                    }
                                 }
                                 return;
                             }
@@ -1688,13 +1704,24 @@ impl CachePersister {
                                 );
                             }
                         }
-                        if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
-                            tracing::debug!(
-                                cache_key = %cache_key_for_writer,
-                                error = %e,
-                                "best-effort delete of rejected proxy-cache object failed; \
-                                 the missing metadata sidecar still forces a refetch"
-                            );
+                        // #1611-style guard: same reasoning as the
+                        // digest-mismatch arm above -- a rejected write on a
+                        // revalidation refill may still leave good, prior
+                        // content one version back, and delete() on a
+                        // versioned backend would bury it under a marker
+                        // rather than clean up. Only delete when there's
+                        // actually a real object present; the missing
+                        // metadata sidecar is what forces the self-heal
+                        // refetch either way.
+                        if matches!(storage_clone.exists(&cache_key_for_writer).await, Ok(true)) {
+                            if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                                tracing::debug!(
+                                    cache_key = %cache_key_for_writer,
+                                    error = %e,
+                                    "best-effort delete of rejected proxy-cache object failed; \
+                                     the missing metadata sidecar still forces a refetch"
+                                );
+                            }
                         }
                     }
                 },

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1559,20 +1559,8 @@ impl CachePersister {
                                      not caching (no metadata sidecar) so the cache entry cannot \
                                      be poisoned"
                                 );
-                                // #1611-style guard: put_stream above already
-                                // overwrote cache_key_for_writer with these
-                                // mismatched bytes, but on a revalidation
-                                // refill that key may have held good,
-                                // still-serving content immediately before
-                                // this request ran. An unconditional delete()
-                                // on a versioned backend doesn't undo the
-                                // overwrite -- it stacks a delete marker on
-                                // top of the whole version history, silently
-                                // hiding that prior-good version too. The
-                                // missing metadata sidecar alone already
-                                // forces the self-heal refetch (see the reject
-                                // arm below), so only delete when a real
-                                // object is actually present to clean up.
+                                // #1611-style guard: unconditional delete() stacks a marker
+                                // over any prior-good version on a revalidation refill.
                                 if matches!(
                                     storage_clone.exists(&cache_key_for_writer).await,
                                     Ok(true)
@@ -1709,15 +1697,7 @@ impl CachePersister {
                                 );
                             }
                         }
-                        // #1611-style guard: same reasoning as the
-                        // digest-mismatch arm above -- a rejected write on a
-                        // revalidation refill may still leave good, prior
-                        // content one version back, and delete() on a
-                        // versioned backend would bury it under a marker
-                        // rather than clean up. Only delete when there's
-                        // actually a real object present; the missing
-                        // metadata sidecar is what forces the self-heal
-                        // refetch either way.
+                        // #1611-style guard: same reasoning as the digest-mismatch arm above.
                         if matches!(storage_clone.exists(&cache_key_for_writer).await, Ok(true)) {
                             if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
                                 tracing::debug!(

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -4967,8 +4967,19 @@ impl ProxyService {
     /// re-asks upstream.
     async fn write_negative_cache(&self, cache_key: &str, metadata_key: &str, cache_path: &str) {
         // Drop any stale positive body so a future read can never serve it
-        // alongside the negative marker.
-        let _ = self.storage.delete(cache_key).await;
+        // alongside the negative marker. Probe first (#1611 follow-up):
+        // every negative-cache *renewal* on an already-, or never-, cached
+        // path re-enters this function every TTL window, and on a versioned
+        // backend an unconditional delete() always writes a new
+        // delete-marker version even when there is nothing to delete --
+        // observed stacking to 9+ marker versions on repeatedly-missed
+        // paths (e.g. checksum-file probes for deps that never publish a
+        // .sha1) with zero real content ever written. Gate the delete on a
+        // real object being present so renewals of an existing negative (or
+        // a path that never had content) don't write a redundant marker.
+        if matches!(self.storage.exists(cache_key).await, Ok(true)) {
+            let _ = self.storage.delete(cache_key).await;
+        }
 
         let now = Utc::now();
         let neg_ttl = chrono::Duration::seconds(cache_classifier::NEGATIVE_CACHE_TTL_SECS);

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -8441,6 +8441,13 @@ mod tests {
         metadata_writes: tokio::sync::Mutex<Vec<(String, Bytes)>>,
         deletes: tokio::sync::Mutex<Vec<String>>,
         put_stream_fails: bool,
+        // #1611-style guard support: a successful put_stream (even a
+        // zero-byte one) creates a real object at the key, same as a real S3
+        // PutObject. exists() reflects that so the reject-arm delete tests
+        // below exercise the same exists()-before-delete guard as prod,
+        // rather than the guard vacuously short-circuiting on an
+        // always-absent mock.
+        object_written: std::sync::atomic::AtomicBool,
     }
 
     impl TeeRecordingBackend {
@@ -8450,6 +8457,7 @@ mod tests {
                 metadata_writes: tokio::sync::Mutex::new(Vec::new()),
                 deletes: tokio::sync::Mutex::new(Vec::new()),
                 put_stream_fails: false,
+                object_written: std::sync::atomic::AtomicBool::new(false),
             })
         }
         fn failing() -> Arc<Self> {
@@ -8458,6 +8466,7 @@ mod tests {
                 metadata_writes: tokio::sync::Mutex::new(Vec::new()),
                 deletes: tokio::sync::Mutex::new(Vec::new()),
                 put_stream_fails: true,
+                object_written: std::sync::atomic::AtomicBool::new(false),
             })
         }
     }
@@ -8477,7 +8486,9 @@ mod tests {
             Err(AppError::NotFound("not relevant for tee tests".into()))
         }
         async fn exists(&self, _key: &str) -> Result<bool> {
-            Ok(false)
+            Ok(self
+                .object_written
+                .load(std::sync::atomic::Ordering::SeqCst))
         }
         async fn delete(&self, key: &str) -> Result<()> {
             self.deletes.lock().await.push(key.to_string());
@@ -8511,6 +8522,8 @@ mod tests {
                 total += chunk.len() as u64;
                 chunks.push(chunk);
             }
+            self.object_written
+                .store(true, std::sync::atomic::Ordering::SeqCst);
             Ok(ServicePutStreamResult {
                 checksum_sha256: format!("{:x}", hasher.finalize()),
                 bytes_written: total,

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1547,10 +1547,18 @@ impl CachePersister {
                         // SHA-256 does not match it. The bytes were already
                         // forwarded to the client — which independently verifies
                         // the digest — but the proxy cache must never be poisoned
-                        // with mismatched content addressed by that digest. Treat
-                        // a mismatch exactly like the truncated/empty reject path:
-                        // delete the object and skip the metadata sidecar so the
-                        // next request refetches upstream (self-heal).
+                        // with mismatched content addressed by that digest. Skip
+                        // the metadata sidecar so the next request refetches
+                        // upstream (self-heal). Deliberately do NOT delete
+                        // cache_key_for_writer here (#3068): put_stream above
+                        // already committed this request's bytes as the current
+                        // version, so exists() is always true by this point and
+                        // can't distinguish "only my bad write is here" from "a
+                        // prior good version is one behind it" -- deleting
+                        // either way risks stacking a marker over real content
+                        // from before this request. The missing sidecar alone
+                        // is what forces the refetch; nothing here depends on
+                        // the object also being gone.
                         if let Some(expected) = template.expected_checksum.as_deref() {
                             if result.checksum_sha256 != expected {
                                 tracing::warn!(
@@ -1559,24 +1567,6 @@ impl CachePersister {
                                      not caching (no metadata sidecar) so the cache entry cannot \
                                      be poisoned"
                                 );
-                                // #1611-style guard: unconditional delete() stacks a marker
-                                // over any prior-good version on a revalidation refill.
-                                if matches!(
-                                    storage_clone.exists(&cache_key_for_writer).await,
-                                    Ok(true)
-                                ) {
-                                    if let Err(e) =
-                                        storage_clone.delete(&cache_key_for_writer).await
-                                    {
-                                        tracing::debug!(
-                                            cache_key = %cache_key_for_writer,
-                                            error = %e,
-                                            "best-effort delete of digest-mismatched proxy-cache \
-                                             object failed; the missing metadata sidecar still forces \
-                                             a refetch"
-                                        );
-                                    }
-                                }
                                 return;
                             }
                         }
@@ -1673,10 +1663,19 @@ impl CachePersister {
                         // `Content-Length`) would serve a short, SHA-mismatched
                         // blob and clients hit "unexpected BufError" extracting
                         // the archive. Skip the sidecar (entry treated as a
-                        // miss) and delete the bad object so a later GET
-                        // refetches upstream (self-heal). The buffered sibling
-                        // [`Self::write_buffered`] applies the empty-body guard
-                        // before the content write.
+                        // miss) so a later GET refetches upstream (self-heal).
+                        // The buffered sibling [`Self::write_buffered`] applies
+                        // the empty-body guard before the content write.
+                        //
+                        // Deliberately do NOT delete cache_key_for_writer here
+                        // (#3068): put_stream above already committed this
+                        // request's (bad) bytes as the current version, so an
+                        // exists() check is always true by this point and
+                        // can't tell "only my bad write is here" apart from "a
+                        // prior good version is one behind it" -- either way,
+                        // deleting risks stacking a marker over real content
+                        // that predates this request. The missing sidecar is
+                        // what actually forces the refetch.
                         match rejected {
                             StreamWriteOutcome::RejectTruncated { expected, actual } => {
                                 tracing::warn!(
@@ -1694,17 +1693,6 @@ impl CachePersister {
                                     "proxy upstream returned an empty body; not caching the \
                                      zero-byte object (no metadata sidecar) so the next request \
                                      refetches upstream"
-                                );
-                            }
-                        }
-                        // #1611-style guard: same reasoning as the digest-mismatch arm above.
-                        if matches!(storage_clone.exists(&cache_key_for_writer).await, Ok(true)) {
-                            if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
-                                tracing::debug!(
-                                    cache_key = %cache_key_for_writer,
-                                    error = %e,
-                                    "best-effort delete of rejected proxy-cache object failed; \
-                                     the missing metadata sidecar still forces a refetch"
                                 );
                             }
                         }
@@ -8670,12 +8658,18 @@ mod tests {
     /// #1365 regression: an empty upstream body (a 204, an empty 200, or a
     /// HEAD-style probe that reaches the streaming download path) must NOT
     /// be cached. The client still receives the empty body for this
-    /// request, but the writer must (a) skip the metadata sidecar so a
-    /// later GET is a cache miss, and (b) delete the zero-byte object it
-    /// wrote so the next request refetches the real body from upstream.
+    /// request, but the writer must skip the metadata sidecar so a later
+    /// GET is a cache miss and refetches the real body from upstream.
     /// Before the fix the writer persisted a `size_bytes: 0` sidecar,
     /// which a subsequent GET served as `Content-Length: 0`, breaking
     /// Gradle POM parsing ("Content is not allowed in prolog.").
+    ///
+    /// #3068: the writer must NOT delete cache_key_for_writer either -- by
+    /// this point put_stream already committed the zero-byte write as the
+    /// key's current version, so a delete can't tell "only this bad write is
+    /// here" apart from "a prior good version sits one behind it," and would
+    /// risk stacking a marker over real content. The missing sidecar alone
+    /// is what forces the refetch.
     #[tokio::test]
     async fn test_tee_empty_upstream_is_not_cached() {
         let backend = TeeRecordingBackend::ok();
@@ -8702,10 +8696,11 @@ mod tests {
             "zero-byte upstream body MUST NOT write a metadata sidecar; \
              otherwise the next GET serves a Content-Length: 0 cache hit (#1365)"
         );
-        assert_eq!(
-            backend.deletes.lock().await.as_slice(),
-            ["cache-key".to_string()],
-            "the empty cache object must be deleted so the next request refetches"
+        assert!(
+            backend.deletes.lock().await.is_empty(),
+            "the writer must NOT delete on reject (#3068): put_stream already \
+             committed this write as the current version, so a delete here \
+             could mask real content from before this request"
         );
     }
 
@@ -8752,8 +8747,13 @@ mod tests {
     /// #1912 regression: a truncated upstream body (bytes written < the
     /// advertised `Content-Length`) must NOT be cached. Committing it would
     /// serve a short, SHA-mismatched archive on the next GET and clients hit
-    /// "unexpected BufError" extracting it. The writer must skip the metadata
-    /// sidecar and delete the partial object so the next request refetches.
+    /// "unexpected BufError" extracting it. The writer must skip the
+    /// metadata sidecar so the next request refetches.
+    ///
+    /// #3068: same reasoning as the empty-body sibling above -- the writer
+    /// must NOT delete the partial object either, since put_stream already
+    /// committed it as the current version and a delete can't distinguish
+    /// it from a prior good version one behind it.
     #[tokio::test]
     async fn test_tee_truncated_upstream_is_not_cached() {
         let backend = TeeRecordingBackend::ok();
@@ -8783,10 +8783,48 @@ mod tests {
             backend.metadata_writes.lock().await.is_empty(),
             "truncated upstream body MUST NOT write a metadata sidecar (#1912)"
         );
+        assert!(
+            backend.deletes.lock().await.is_empty(),
+            "the writer must NOT delete on reject (#3068): put_stream already \
+             committed this write as the current version, so a delete here \
+             could mask real content from before this request"
+        );
+    }
+
+    /// #1611 regression: `write_negative_cache`'s `exists()`-gated delete must
+    /// not fire when nothing real is present, on the FIRST negative-cache
+    /// write for a path AND on every renewal after it. Before the guard, an
+    /// unconditional delete() on a versioned backend stacked a redundant
+    /// marker version on every renewal (observed up to 9+ on a single key)
+    /// even though no real content was ever written there.
+    #[tokio::test]
+    async fn test_write_negative_cache_skips_delete_when_nothing_present() {
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+        let proxy = ProxyService::new(test_catalog_pool(), storage);
+
+        // Two consecutive negative-cache writes, simulating the initial
+        // write plus one TTL renewal against a path that never had real
+        // content -- exactly the "checksum-file probe for a dep that never
+        // publishes a .sha1" case from the #1611 investigation.
+        proxy
+            .write_negative_cache("cache-key", "meta-key", "some/path")
+            .await;
+        proxy
+            .write_negative_cache("cache-key", "meta-key", "some/path")
+            .await;
+
+        assert!(
+            backend.deletes.lock().await.is_empty(),
+            "write_negative_cache must not delete when exists() reports \
+             nothing present (#1611); doing so on every renewal stacks a \
+             redundant marker version with zero real content behind it"
+        );
         assert_eq!(
-            backend.deletes.lock().await.as_slice(),
-            ["cache-key".to_string()],
-            "the truncated cache object must be deleted so the next request refetches"
+            backend.metadata_writes.lock().await.len(),
+            2,
+            "each negative-cache renewal still writes its metadata sidecar \
+             regardless of the delete guard"
         );
     }
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1573,8 +1573,13 @@ impl CachePersister {
                                 // forces the self-heal refetch (see the reject
                                 // arm below), so only delete when a real
                                 // object is actually present to clean up.
-                                if matches!(storage_clone.exists(&cache_key_for_writer).await, Ok(true)) {
-                                    if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                                if matches!(
+                                    storage_clone.exists(&cache_key_for_writer).await,
+                                    Ok(true)
+                                ) {
+                                    if let Err(e) =
+                                        storage_clone.delete(&cache_key_for_writer).await
+                                    {
                                         tracing::debug!(
                                             cache_key = %cache_key_for_writer,
                                             error = %e,


### PR DESCRIPTION
## Why

Fixes #3067. `local_fetch_or_redirect` calls `try_proxy_cache_redirect(..., cache_is_fresh = true, ...)` with a hardcoded `true`, so a DB row alone is enough to sign and serve a redirect — the object store is never probed. The sibling paths (`proxy_fetch_or_redirect`, `try_member_cache_redirect`) already gate on `is_cache_fresh`; this was the only call site that skipped the check, so an object deleted out-of-band (e.g. by a lifecycle rule) produced a dead 302 with no server-side fallback.

## What

Gate the redirect on an `exists()` probe before signing it, mirroring the sibling paths. A miss falls through to the buffered read, whose `NotFound` lets virtual-member resolution continue to an upstream fetch — cache and DB row both self-heal, no manual intervention. Cost: one extra HEAD per redirect on this path, same as the sibling paths already pay.

`cargo check`/`cargo fmt` pass.

## Follow-up: three unconditional cache-key deletes

Found while validating the fix: three separate spots call `storage.delete(cache_key)` unconditionally on a reject/miss path, without checking whether the key currently holds good content:

- `write_negative_cache` — every negative-cache renewal, even on a path that never had real content
- `tee_stream`'s empty/truncated-body reject arm
- `tee_stream`'s digest-mismatch reject arm

On a versioned backend, an unconditional delete doesn't clean up — it stacks a delete marker over the whole version history, which can silently hide real, previously-good content underneath (same failure mode as the bug above, different trigger).

`write_negative_cache` gets an `exists()`-before-`delete()` guard, since that path never writes content itself first — `exists()` genuinely reflects whether a prior positive cache entry is there to invalidate. Now covered by a test.

The two `tee_stream` reject arms are different: by the time either runs, the write they're rejecting has *already been committed* as the key's current version, so an `exists()` check there is always true and can't distinguish "only this bad write is present" from "a prior good version sits one behind it." Gating the delete doesn't fix anything on that path — it still fires. The actual fix is to not delete at all: the missing metadata sidecar (written separately, and skipped on every reject path) is what forces the self-heal refetch, so nothing depends on the object being gone too. Verified via the existing reject-path tests, updated to assert zero deletes instead of one.

Audited every other storage-delete call site in the backend (all format handlers, GC/backup/sync/upstream-feed jobs); everything else is already safely guarded or scoped to keys that structurally can't hold prior content.

