### PR TITLE
feat(storage): per-repo storage-gc endpoint for reclaim estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,36 +1421,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd990d8a6304475bbad64534a0d418f5572f44d5f011437e6b9f1ee7d5c2570"
+checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6"
+checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7ed173c870c0aea202a9830880156905a028a88df076e35ce383a8acbf90a7"
+checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31"
+checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae93f863f9094ae34d2567f9edb0ae2c41d35228b286598354dd78b198868ebd"
+checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae"
+checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1498,24 +1498,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b786958bcb79bdb5fbae095af58f0c2da7d7895c475c991f6a6bb5a9c7e6d9"
+checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5"
+checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017271194ba5e101d626560d0d6767efd341468d1ba0f4d015f19fe64020b65b"
+checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8"
+checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1536,15 +1536,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75904abbc0e7b46d20f7a49c8042c8a4481c0db4253b99889c723c566295d506"
+checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a"
+checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1553,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.12"
+version = "0.123.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b"
+checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
 
 [[package]]
 name = "crc"
@@ -2705,17 +2705,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -3539,15 +3536,13 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3593,20 +3588,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3959,7 +3940,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -4257,12 +4238,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -4868,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558181096e0df4984f45cfc3a7087052df4a61c36089b135a08ceca9cbd352fb"
+checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4880,9 +4855,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d52e2f14e168d75cdabe9bd5fb1ff18a1b119dc6699684aee895dbc3524da9"
+checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5592,7 +5567,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -6119,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -7622,9 +7597,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4442dc12aa2473def8334f0e0f2b489be52c52507c938bbdc8be69ded4ded6"
+checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -7677,9 +7652,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d881c3d6205898a226cc487b117f23b9ed1c7da39952d65bd5eeb6745b3789c"
+checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7704,18 +7679,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab1876bcfa51d6a05dea1c13933f53cbc1e316c783fddebc859f56a736eae07"
+checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195a1521a5214a71b67ca2ba2d9317ae15917288ea9d8e5836142b921c9d155"
+checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
 dependencies = [
  "anyhow",
  "base64",
@@ -7733,9 +7708,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae1407944a0b13a8a77930b5b951aa7134beccecad7efac1ef9f03adb7d1a0f"
+checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7748,15 +7723,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646a53678ce6aaf6f097e18ca51f650f2841aea6d2bcd7b61931397b8b8f30db"
+checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371"
+checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7781,9 +7756,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5e4023a6b167da157338f5f0f505945eb45e78f1cac2d4dcce0922457d7d4"
+checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
 dependencies = [
  "anyhow",
  "cc",
@@ -7797,9 +7772,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da71e2d573e3cc6f753a3b7bff98f425ca060c0e8071cc55c3d867a9edf3ecc"
+checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
 dependencies = [
  "cc",
  "object",
@@ -7809,9 +7784,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627d8f57909a4f9bb1dbe57a96229a54b89d5995353d0b321f3cb9a1a118977a"
+checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7821,24 +7796,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b99315585a8a27125dd9b0150edb115d6f6ff0baae453c21d30822aab77f00"
+checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaee97281dd3fe47ec3d46c16fb9fe2dd32f37d0523c2d5c484f11b348734e4"
+checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c005f82c48492b6b44fa19ee5205bd933c4f8baca41e314eca8331dd3c4fd9"
+checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7849,9 +7824,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b73639a9c0c0e33a2ef942ca99b6772b48393be92bebbd0767c607e5b0a68e0"
+checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7860,9 +7835,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392ca021d084c7426616ef77e1284315555f11bcbb34f416d74b0732db622811"
+checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7877,9 +7852,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd4703351476262d715b72431e80d10289908e3494050071d6521267f522d97"
+checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -7890,9 +7865,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21921b6e8e8ed876a288cb3b0b3aee68809fed8182ce26c9977ffc4af4cb77f6"
+checksum = "82e4772f39340104c70837d421c71c50364c185936f07eaee19e46cb0754c9e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7921,9 +7896,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cceb2d110d8de61e7b0e8c501b838d3c6403a14cdca8cb612ff1228db537c6d"
+checksum = "b1267c55a52d9ce27da6ff522ddb5b847e811cf477b0ef4c7c1155dd544c25ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8028,9 +8003,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a0751406b641ff50ef42d4a1ca843a03040c488c0c27f92093633447464013"
+checksum = "3185c97adf4d5f4c0d2abfea7f0bdeb21b486970acd2cf19c7a7fd95308f1764"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8043,9 +8018,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab62083fdcecdd0cac61b8c46e7de4f2629ebe8699fd9ce790d922cc89d50f5f"
+checksum = "13a019367ecff91d714d8f6cba589c36d7b16195eff0598236f9ce5aaf8b811d"
 dependencies = [
  "anyhow",
  "heck",
@@ -8057,9 +8032,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756b7a4a7f57ee2f53e9ef3501ed0faacda4b8dcb169a921cddc8bc09ebd199e"
+checksum = "5e2f5a33059321aee91888c331b45de1d6e9f9d0f89ab88398ef1fda2d3ee1fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8100,9 +8075,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ec880b20caaa72245944b54cfb22aca111f8c805e12a7542b40d66921e5323"
+checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,11 @@ bytes = "1.5"
 clap = { version = "4.5", features = ["derive", "env"] }
 
 # WASM runtime
-wasmtime = { version = "36.0.12", features = ["component-model", "async"] }
-wasmtime-wasi = "36.0.12"
+wasmtime = { version = "36.0.13", features = ["component-model", "async"] }
+wasmtime-wasi = "36.0.13"
 
 # Git operations
-git2 = "0.20"
+git2 = "0.21"
 
 # OpenSSL (vendored feature for cross-compilation in release builds)
 openssl = { version = "0.10" }

--- a/backend/src/api/handlers/storage_gc.rs
+++ b/backend/src/api/handlers/storage_gc.rs
@@ -1,6 +1,6 @@
 //! Storage garbage collection API handler.
 
-use axum::extract::{Extension, Query};
+use axum::extract::{Extension, Path, Query};
 use axum::{
     extract::State,
     routing::{get, post},
@@ -12,13 +12,14 @@ use utoipa::{IntoParams, OpenApi, ToSchema};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::services::repository_service::RepositoryService;
 use crate::services::storage_gc_service::{
     OciBlobFootprintReport, OciBlobRepoFootprint, StorageGcResult, StorageGcService,
 };
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(run_storage_gc, oci_blob_report),
+    paths(run_storage_gc, run_repository_storage_gc, oci_blob_report),
     components(schemas(
         StorageGcRequest,
         StorageGcResult,
@@ -32,6 +33,19 @@ pub fn router() -> Router<SharedState> {
     Router::new()
         .route("/", post(run_storage_gc))
         .route("/oci-blob-report", get(oci_blob_report))
+}
+
+/// Per-repository GC route, merged into the repositories router so the web
+/// UI's per-repo storage panel can reach it at
+/// `/api/v1/repositories/{key}/storage-gc` (web #708).
+///
+/// Kept out of [`router()`] because that router is nested under
+/// `/api/v1/admin/storage-gc`; this endpoint lives in the
+/// `/api/v1/repositories` namespace and goes through its
+/// `optional_auth_middleware`, so the handler takes
+/// `Extension<Option<AuthExtension>>` and authenticates explicitly.
+pub fn repo_router() -> Router<SharedState> {
+    Router::new().route("/:key/storage-gc", post(run_repository_storage_gc))
 }
 
 /// Request body for storage GC.
@@ -98,6 +112,81 @@ fn require_admin(is_admin: bool) -> Result<()> {
             "Admin privileges required".to_string(),
         ))
     }
+}
+
+/// Unwrap the optional auth extension produced by the repositories router's
+/// `optional_auth_middleware`, failing closed when no credentials were
+/// presented (mirrors the fail-closed `AuthExtension::default` invariant).
+fn require_auth(auth: Option<AuthExtension>) -> Result<AuthExtension> {
+    auth.ok_or_else(|| AppError::Unauthorized("Authentication required".to_string()))
+}
+
+/// POST /api/v1/repositories/{key}/storage-gc
+///
+/// Repository-scoped storage garbage collection (web #708): the endpoint the
+/// web UI's per-repo storage panel calls with `{dry_run: true}` for its
+/// "reclaimable now" estimate.
+///
+/// Semantics: every candidate sweep of [`StorageGcService::run_gc`] is
+/// restricted to rows owned by this repository (soft-deleted artifacts,
+/// abandoned OCI upload sessions, orphaned upload cleanup keys, and orphaned
+/// Maven flat-object attribution rows), while the orphan *predicates* stay
+/// instance-wide — a storage key is only reclaimed (or counted, on a dry
+/// run) when no live artifact, tag, blob, or manifest reference exists for
+/// it anywhere on the instance. The dry-run estimate is therefore
+/// dedup-aware: bytes still shared with another repository are never
+/// reported as reclaimable. On shared (cloud) backends a live run
+/// hard-deletes every repository's soft-deleted rows for a reclaimed key,
+/// exactly as the instance-wide pass would. Admin-gated like the
+/// instance-wide endpoint.
+#[utoipa::path(
+    post,
+    path = "/{key}/storage-gc",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    operation_id = "run_repository_storage_gc",
+    params(("key" = String, Path, description = "Repository key")),
+    request_body = StorageGcRequest,
+    responses(
+        (status = 200, description = "GC result", body = StorageGcResult),
+        (status = 401, description = "Authentication required, or admin privileges required"),
+        (status = 404, description = "Repository not found"),
+    ),
+    security(("bearer_auth" = [])),
+)]
+pub async fn run_repository_storage_gc(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(key): Path<String>,
+    Json(payload): Json<StorageGcRequest>,
+) -> Result<Json<StorageGcResult>> {
+    let auth = require_auth(auth)?;
+    // Admin gate BEFORE the repository lookup so a non-admin cannot probe
+    // repository existence through the 404-vs-401 distinction.
+    require_admin(auth.is_admin)?;
+
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+
+    let service = StorageGcService::new(state.db.clone(), state.storage_registry.clone());
+    let result = service
+        .run_gc_for_repository(repo.id, payload.dry_run)
+        .await?;
+
+    // Mirror the admin endpoint (#2056/#2601): settle the materialized
+    // storage stats after a live pass instead of leaving them stale until
+    // the next cron tick. Best-effort — the GC already ran.
+    if !payload.dry_run {
+        let stats_service = crate::services::storage_stats_service::StorageStatsService::new(
+            state.db.clone(),
+            &state.config.storage_backend,
+        );
+        if let Err(e) = stats_service.recompute_all().await {
+            tracing::warn!("Post-GC storage-stats refresh failed: {}", e);
+        }
+    }
+
+    Ok(Json(result))
 }
 
 /// Resolve the effective grace-window argument for the blob report from the
@@ -325,8 +414,9 @@ mod tests {
     #[test]
     fn test_openapi_doc_has_post_run_and_get_report() {
         // The merged doc keys paths by their full context path, so match by
-        // suffix: there must be exactly one POST-bearing path (run GC) and
-        // exactly one GET-bearing path ending in /oci-blob-report.
+        // suffix: there must be exactly two POST-bearing paths (instance-wide
+        // run GC + per-repository run GC, #708) and exactly one GET-bearing
+        // path ending in /oci-blob-report.
         let doc = StorageGcApiDoc::openapi();
         let post_paths = doc
             .paths
@@ -340,7 +430,10 @@ mod tests {
             .iter()
             .filter(|(path, item)| path.ends_with("/oci-blob-report") && item.get.is_some())
             .count();
-        assert_eq!(post_paths, 1, "exactly one POST path (run GC) expected");
+        assert_eq!(
+            post_paths, 2,
+            "exactly two POST paths (instance + per-repo run GC) expected"
+        );
         assert_eq!(
             report_get, 1,
             "exactly one GET /oci-blob-report path expected"
@@ -352,6 +445,85 @@ mod tests {
     #[test]
     fn test_router_returns_valid_router() {
         let _router = router();
+    }
+
+    #[test]
+    fn test_repo_router_returns_valid_router() {
+        let _router = repo_router();
+    }
+
+    // -- require_auth (repositories-nest optional auth) --
+
+    #[test]
+    fn test_require_auth_unwraps_present_extension() {
+        let auth = AuthExtension {
+            is_admin: true,
+            ..Default::default()
+        };
+        let unwrapped = require_auth(Some(auth)).expect("present auth must pass");
+        assert!(unwrapped.is_admin);
+    }
+
+    #[test]
+    fn test_require_auth_rejects_absent_extension() {
+        let err = require_auth(None).unwrap_err();
+        match err {
+            AppError::Unauthorized(msg) => {
+                assert!(
+                    msg.contains("Authentication required"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected Unauthorized, got {other:?}"),
+        }
+    }
+
+    // -- Per-repository storage-gc endpoint (web #708) --
+
+    #[test]
+    fn test_openapi_doc_includes_repository_storage_gc_operation() {
+        let doc = StorageGcApiDoc::openapi();
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(
+            json.contains("run_repository_storage_gc"),
+            "OpenAPI doc should contain operation ID 'run_repository_storage_gc'"
+        );
+    }
+
+    #[test]
+    fn test_openapi_doc_repository_storage_gc_path() {
+        // The exact path the web UI has called since the panel shipped —
+        // a rename here silently re-breaks web #708.
+        let doc = StorageGcApiDoc::openapi();
+        let (path, item) = doc
+            .paths
+            .paths
+            .iter()
+            .find(|(path, _)| path.ends_with("/repositories/{key}/storage-gc"))
+            .expect("doc must contain /api/v1/repositories/{key}/storage-gc");
+        assert_eq!(path, "/api/v1/repositories/{key}/storage-gc");
+        assert!(item.post.is_some(), "per-repo storage-gc must be a POST");
+    }
+
+    #[test]
+    fn test_openapi_doc_repository_storage_gc_request_body_and_response() {
+        let doc = StorageGcApiDoc::openapi();
+        let json = serde_json::to_string(&doc).unwrap();
+        // Same request/response contract as the instance-wide endpoint:
+        // StorageGcRequest in, StorageGcResult out — the web client depends
+        // on `bytes_freed` / `storage_keys_deleted` / `dry_run` / `errors`.
+        let op_start = json
+            .find("run_repository_storage_gc")
+            .expect("operation present");
+        let op_region = &json[op_start..];
+        assert!(
+            op_region.contains("StorageGcRequest"),
+            "per-repo endpoint must accept StorageGcRequest"
+        );
+        assert!(
+            op_region.contains("StorageGcResult"),
+            "per-repo endpoint must return StorageGcResult"
+        );
     }
 
     // -- OciBlobReportQuery deserialization (issue #1408) --

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -500,6 +500,10 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
             "/repositories",
             handlers::repositories::router()
                 .merge(handlers::age_gate::repo_config_routes())
+                // Per-repo storage GC (web #708): the UI's per-repo storage
+                // panel calls POST /repositories/{key}/storage-gc. Admin-gated
+                // inside the handler.
+                .merge(handlers::storage_gc::repo_router())
                 .merge(handlers::repositories::download_router().layer(
                     middleware::from_fn_with_state(
                         presign_rate_limit_state,

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -405,7 +405,40 @@ impl StorageGcService {
     /// transaction so the row lock prevents any racing writer from
     /// resurrecting the rows before they are hard-deleted.
     pub async fn run_gc(&self, dry_run: bool) -> Result<StorageGcResult> {
-        let orphans = self.select_orphans().await?;
+        self.run_gc_inner(None, dry_run).await
+    }
+
+    /// Repository-scoped variant of [`Self::run_gc`] (web #708).
+    ///
+    /// Every candidate scan is filtered to rows owned by `repository_id`:
+    /// soft-deleted artifacts in this repository (main sweep), this
+    /// repository's abandoned OCI upload sessions, its orphaned upload
+    /// cleanup keys, and its orphaned Maven flat-object attribution rows.
+    ///
+    /// The orphan *predicates* are deliberately NOT narrowed: a storage key
+    /// is only ever reclaimed when no live artifact, tag, blob, or manifest
+    /// reference exists for it anywhere on the instance. A dry run therefore
+    /// reports "bytes reclaimable now, attributable to this repository" —
+    /// honest under cross-repo dedup because a shared blob still referenced
+    /// by another repository never appears in the candidate set. On a shared
+    /// (cloud) backend a live (non-dry-run) run hard-deletes every
+    /// repository's soft-deleted rows for a reclaimed key — exactly what the
+    /// instance-wide pass would do for the same key — so per-repo scoping
+    /// can never strand or prematurely delete another tenant's data.
+    pub async fn run_gc_for_repository(
+        &self,
+        repository_id: Uuid,
+        dry_run: bool,
+    ) -> Result<StorageGcResult> {
+        self.run_gc_inner(Some(repository_id), dry_run).await
+    }
+
+    async fn run_gc_inner(
+        &self,
+        repo_scope: Option<Uuid>,
+        dry_run: bool,
+    ) -> Result<StorageGcResult> {
+        let orphans = self.select_orphans(repo_scope).await?;
 
         let mut result = empty_gc_result(dry_run);
 
@@ -578,7 +611,7 @@ impl StorageGcService {
         // own setup query (e.g. the candidate SELECT) the same way instead
         // of `?`-propagating out of run_gc and aborting later sweeps.
         if let Err(e) = self
-            .cleanup_abandoned_oci_uploads(dry_run, &mut result)
+            .cleanup_abandoned_oci_uploads(repo_scope, dry_run, &mut result)
             .await
         {
             let msg = format_gc_error(
@@ -590,7 +623,7 @@ impl StorageGcService {
             result.errors.push(msg);
         }
         if let Err(e) = self
-            .cleanup_unreferenced_oci_upload_keys(dry_run, &mut result)
+            .cleanup_unreferenced_oci_upload_keys(repo_scope, dry_run, &mut result)
             .await
         {
             let msg = format_gc_error(
@@ -602,7 +635,7 @@ impl StorageGcService {
             result.errors.push(msg);
         }
         if let Err(e) = self
-            .reap_pending_oci_upload_cleanup_keys(dry_run, &mut result)
+            .reap_pending_oci_upload_cleanup_keys(repo_scope, dry_run, &mut result)
             .await
         {
             let msg = format_gc_error(
@@ -614,7 +647,7 @@ impl StorageGcService {
             result.errors.push(msg);
         }
         if let Err(e) = self
-            .cleanup_orphan_maven_flat_objects(dry_run, &mut result)
+            .cleanup_orphan_maven_flat_objects(repo_scope, dry_run, &mut result)
             .await
         {
             let msg = format_gc_error(
@@ -1158,7 +1191,14 @@ impl StorageGcService {
     /// share the same Postgres database, and a peer test's in-flight
     /// orphan row would inflate that counter. Asserting per-key against
     /// this candidate list keeps each test isolated from its neighbors.
-    pub(crate) async fn select_orphans(&self) -> Result<Vec<sqlx::postgres::PgRow>> {
+    /// `repo_scope` (`Some(id)`) restricts the scan to soft-deleted artifacts
+    /// owned by that repository (web #708); the orphan predicate itself stays
+    /// instance-wide, so a scoped scan can only ever *narrow* the candidate
+    /// set, never admit a key the instance-wide scan would protect.
+    pub(crate) async fn select_orphans(
+        &self,
+        repo_scope: Option<Uuid>,
+    ) -> Result<Vec<sqlx::postgres::PgRow>> {
         let sql = format!(
             r#"
             SELECT a.storage_key, r.storage_backend, r.storage_path,
@@ -1167,11 +1207,17 @@ impl StorageGcService {
             FROM artifacts a
             JOIN repositories r ON r.id = a.repository_id
             WHERE {predicate}
+              {scope}
             GROUP BY a.storage_key, r.storage_backend, r.storage_path
             "#,
             predicate = ORPHAN_PREDICATE_SQL,
+            scope = repo_scope_clause("a.repository_id", 1, repo_scope),
         );
-        sqlx::query(&sql)
+        let mut query = sqlx::query(&sql);
+        if let Some(id) = repo_scope {
+            query = query.bind(id);
+        }
+        query
             .fetch_all(&self.db)
             .await
             .map_err(|e| crate::error::AppError::Database(e.to_string()))
@@ -1304,10 +1350,13 @@ impl StorageGcService {
 
     async fn cleanup_abandoned_oci_uploads(
         &self,
+        repo_scope: Option<Uuid>,
         dry_run: bool,
         result: &mut StorageGcResult,
     ) -> Result<()> {
-        let session_ids = self.select_abandoned_oci_upload_session_ids().await?;
+        let session_ids = self
+            .select_abandoned_oci_upload_session_ids(repo_scope)
+            .await?;
         let mut sessions_removed = 0_i64;
         let mut upload_keys_deleted = 0_i64;
 
@@ -1443,19 +1492,27 @@ impl StorageGcService {
         Ok(())
     }
 
-    async fn select_abandoned_oci_upload_session_ids(&self) -> Result<Vec<Uuid>> {
+    async fn select_abandoned_oci_upload_session_ids(
+        &self,
+        repo_scope: Option<Uuid>,
+    ) -> Result<Vec<Uuid>> {
         let sql = format!(
             r#"
             SELECT id
             FROM oci_upload_sessions
             WHERE updated_at < NOW() - {ttl}
+              {scope}
             ORDER BY updated_at ASC
             LIMIT $1
             "#,
             ttl = ABANDONED_OCI_UPLOAD_TTL_SQL,
+            scope = repo_scope_clause("repository_id", 2, repo_scope),
         );
-        let rows = sqlx::query(&sql)
-            .bind(ABANDONED_OCI_UPLOAD_SCAN_LIMIT)
+        let mut query = sqlx::query(&sql).bind(ABANDONED_OCI_UPLOAD_SCAN_LIMIT);
+        if let Some(id) = repo_scope {
+            query = query.bind(id);
+        }
+        let rows = query
             .fetch_all(&self.db)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -1470,10 +1527,13 @@ impl StorageGcService {
 
     async fn cleanup_unreferenced_oci_upload_keys(
         &self,
+        repo_scope: Option<Uuid>,
         dry_run: bool,
         result: &mut StorageGcResult,
     ) -> Result<()> {
-        let cleanup_keys = self.select_unreferenced_oci_upload_cleanup_keys().await?;
+        let cleanup_keys = self
+            .select_unreferenced_oci_upload_cleanup_keys(repo_scope)
+            .await?;
         let mut cleanup_rows_removed = 0_i64;
 
         for cleanup_key in cleanup_keys {
@@ -1576,6 +1636,7 @@ impl StorageGcService {
 
     async fn select_unreferenced_oci_upload_cleanup_keys(
         &self,
+        repo_scope: Option<Uuid>,
     ) -> Result<Vec<OciUploadCleanupKey>> {
         let sql = format!(
             r#"
@@ -1584,6 +1645,7 @@ impl StorageGcService {
             JOIN repositories r ON r.id = c.repository_id
             WHERE c.storage_write_completed_at IS NOT NULL
               AND c.storage_write_completed_at < NOW() - {ttl}
+              {scope}
               -- See the matching DELETE: a committed key (part/final/completion
               -- temp) is intentionally reapable even while its session lives,
               -- so this is NOT guarded by `s.id = c.upload_session_id`.
@@ -1607,9 +1669,13 @@ impl StorageGcService {
             LIMIT $1
             "#,
             ttl = ABANDONED_OCI_UPLOAD_TTL_SQL,
+            scope = repo_scope_clause("c.repository_id", 2, repo_scope),
         );
-        let rows = sqlx::query(&sql)
-            .bind(OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT)
+        let mut query = sqlx::query(&sql).bind(OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT);
+        if let Some(id) = repo_scope {
+            query = query.bind(id);
+        }
+        let rows = query
             .fetch_all(&self.db)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -1640,10 +1706,13 @@ impl StorageGcService {
     /// that may be marking the row complete concurrently.
     async fn reap_pending_oci_upload_cleanup_keys(
         &self,
+        repo_scope: Option<Uuid>,
         dry_run: bool,
         result: &mut StorageGcResult,
     ) -> Result<()> {
-        let cleanup_keys = self.select_pending_oci_upload_cleanup_keys().await?;
+        let cleanup_keys = self
+            .select_pending_oci_upload_cleanup_keys(repo_scope)
+            .await?;
         let mut cleanup_rows_removed = 0_i64;
 
         for cleanup_key in cleanup_keys {
@@ -1740,7 +1809,10 @@ impl StorageGcService {
         Ok(())
     }
 
-    async fn select_pending_oci_upload_cleanup_keys(&self) -> Result<Vec<OciUploadCleanupKey>> {
+    async fn select_pending_oci_upload_cleanup_keys(
+        &self,
+        repo_scope: Option<Uuid>,
+    ) -> Result<Vec<OciUploadCleanupKey>> {
         let sql = format!(
             r#"
             SELECT c.id, c.storage_key, r.storage_backend, r.storage_path
@@ -1748,6 +1820,7 @@ impl StorageGcService {
             JOIN repositories r ON r.id = c.repository_id
             WHERE c.storage_write_completed_at IS NULL
               AND c.created_at < NOW() - {ttl}
+              {scope}
               AND NOT EXISTS (
                 SELECT 1 FROM oci_upload_sessions s
                 WHERE s.id = c.upload_session_id
@@ -1769,9 +1842,13 @@ impl StorageGcService {
             LIMIT $1
             "#,
             ttl = ABANDONED_OCI_UPLOAD_TTL_SQL,
+            scope = repo_scope_clause("c.repository_id", 2, repo_scope),
         );
-        let rows = sqlx::query(&sql)
-            .bind(OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT)
+        let mut query = sqlx::query(&sql).bind(OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT);
+        if let Some(id) = repo_scope {
+            query = query.bind(id);
+        }
+        let rows = query
             .fetch_all(&self.db)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -1810,10 +1887,11 @@ impl StorageGcService {
     /// repository deletion.
     async fn cleanup_orphan_maven_flat_objects(
         &self,
+        repo_scope: Option<Uuid>,
         dry_run: bool,
         result: &mut StorageGcResult,
     ) -> Result<()> {
-        let candidates = self.select_orphan_maven_flat_objects().await?;
+        let candidates = self.select_orphan_maven_flat_objects(repo_scope).await?;
         let mut objects_removed = 0_i64;
 
         for row in candidates {
@@ -1946,6 +2024,7 @@ impl StorageGcService {
     /// (#1493 pattern).
     pub(crate) async fn select_orphan_maven_flat_objects(
         &self,
+        repo_scope: Option<Uuid>,
     ) -> Result<Vec<sqlx::postgres::PgRow>> {
         let sql = format!(
             r#"
@@ -1953,13 +2032,18 @@ impl StorageGcService {
             FROM maven_flat_object_owner o
             JOIN repositories r ON r.id = o.repository_id
             WHERE {predicate}
+              {scope}
             ORDER BY o.storage_key
             LIMIT $1
             "#,
             predicate = ORPHAN_MAVEN_FLAT_PREDICATE_SQL,
+            scope = repo_scope_clause("o.repository_id", 2, repo_scope),
         );
-        sqlx::query(&sql)
-            .bind(ORPHAN_MAVEN_FLAT_SCAN_LIMIT)
+        let mut query = sqlx::query(&sql).bind(ORPHAN_MAVEN_FLAT_SCAN_LIMIT);
+        if let Some(id) = repo_scope {
+            query = query.bind(id);
+        }
+        query
             .fetch_all(&self.db)
             .await
             .map_err(|e| AppError::Database(e.to_string()))
@@ -2354,6 +2438,21 @@ pub(crate) fn record_gc_success(result: &mut StorageGcResult, bytes: i64, count:
 /// Format a GC error message for a specific operation and storage key.
 pub(crate) fn format_gc_error(operation: &str, storage_key: &str, error: &str) -> String {
     format!("Failed to {} for key {}: {}", operation, storage_key, error)
+}
+
+/// SQL clause restricting a GC candidate scan to one repository (#708).
+///
+/// Returns `AND <column> = $<param>` when `repo_scope` is `Some`, or an empty
+/// string for the instance-wide scan. `param` is the 1-based placeholder
+/// index the clause should use — one past the number of binds the unscoped
+/// query already has — and the caller must bind the scoped id in that
+/// position. Extracted as a pure helper so the clause shape (and its bind
+/// arithmetic) is unit-testable without a database.
+fn repo_scope_clause(column: &str, param: usize, repo_scope: Option<Uuid>) -> String {
+    match repo_scope {
+        Some(_) => format!("AND {column} = ${param}"),
+        None => String::new(),
+    }
 }
 
 /// Decoded global aggregate values for the OCI blob footprint report.
@@ -3023,6 +3122,109 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // repo_scope_clause (web #708)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_repo_scope_clause_unscoped_is_empty() {
+        assert_eq!(repo_scope_clause("a.repository_id", 1, None), "");
+    }
+
+    #[test]
+    fn test_repo_scope_clause_scoped_renders_and_predicate() {
+        assert_eq!(
+            repo_scope_clause("a.repository_id", 1, Some(Uuid::new_v4())),
+            "AND a.repository_id = $1"
+        );
+    }
+
+    #[test]
+    fn test_repo_scope_clause_uses_supplied_param_index() {
+        // Selects that already bind a LIMIT at $1 must place the scope bind
+        // at $2; the index is the caller's, not the helper's.
+        assert_eq!(
+            repo_scope_clause("c.repository_id", 2, Some(Uuid::new_v4())),
+            "AND c.repository_id = $2"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // run_gc_for_repository (web #708)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_run_gc_for_repository_returns_error_when_db_unreachable() {
+        let service = make_service("filesystem");
+        let result = service.run_gc_for_repository(Uuid::new_v4(), false).await;
+        assert!(
+            result.is_err(),
+            "repo-scoped run_gc should fail without a database"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_gc_for_repository_dry_run_returns_error_when_db_unreachable() {
+        let service = make_service("s3");
+        let result = service.run_gc_for_repository(Uuid::new_v4(), true).await;
+        assert!(
+            result.is_err(),
+            "repo-scoped dry run should also fail without a database"
+        );
+    }
+
+    /// A soft-deleted, unreferenced artifact is an orphan candidate for its
+    /// OWN repository's scoped scan, but must never appear in a scan scoped
+    /// to a different repository — per-key assertions keep this isolated
+    /// from concurrent tests sharing the database (#1493 pattern).
+    #[tokio::test]
+    async fn test_select_orphans_repo_scope_filters_to_target_repository() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _gc_guard = storage_gc_test_guard().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        let uid = Uuid::new_v4().simple().to_string();
+        let storage_key = format!("maven/com/acme/{uid}/gc-scope-1.0.jar");
+        insert_maven_artifact_row(
+            &fixture.pool,
+            fixture.repo_id,
+            fixture.user_id,
+            &storage_key,
+            true,
+        )
+        .await;
+
+        let service =
+            StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
+        let own_repo = service.select_orphans(Some(fixture.repo_id)).await;
+        let other_repo = service.select_orphans(Some(Uuid::new_v4())).await;
+
+        let storage_path_str = fixture.storage_dir.to_string_lossy().into_owned();
+        fixture.teardown().await;
+
+        let key_present = |orphans: &[sqlx::postgres::PgRow]| {
+            orphans.iter().any(|row| {
+                let key: String = row.try_get("storage_key").unwrap_or_default();
+                let path: String = row.try_get("storage_path").unwrap_or_default();
+                key == storage_key && path == storage_path_str
+            })
+        };
+
+        let own_repo = own_repo.expect("own-repo scoped scan succeeds");
+        assert!(
+            key_present(&own_repo),
+            "scan scoped to the owning repository must include its orphan key"
+        );
+        let other_repo = other_repo.expect("other-repo scoped scan succeeds");
+        assert!(
+            !key_present(&other_repo),
+            "scan scoped to a different repository must not include the key"
+        );
+    }
+
     /// Reference kind for [`insert_referenced_soft_deleted_artifact`].
     enum RefKind {
         /// Insert an `oci_tags` row pointing at the digest.
@@ -3179,7 +3381,7 @@ mod tests {
 
         let service =
             StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
-        let orphans = service.select_orphans().await;
+        let orphans = service.select_orphans(None).await;
 
         let storage_path_str = fixture.storage_dir.to_string_lossy().into_owned();
         fixture.teardown().await;
@@ -3213,7 +3415,7 @@ mod tests {
 
         let service =
             StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
-        let orphans = service.select_orphans().await;
+        let orphans = service.select_orphans(None).await;
 
         let storage_path_str = fixture.storage_dir.to_string_lossy().into_owned();
         fixture.teardown().await;
@@ -4960,7 +5162,7 @@ mod tests {
 
             // Step 1: call the outer SELECT directly through the same
             // service instance so we can signal afterwards.
-            let orphans = service.select_orphans().await.expect("select orphans");
+            let orphans = service.select_orphans(None).await.expect("select orphans");
             assert!(
                 orphans.iter().any(|r| {
                     let key: String = r.try_get("storage_key").unwrap_or_default();


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/repositories/{key}/storage-gc` — the route the web UI's per-repo storage panel has always called for its "reclaimable now" estimate, which 404'd against every shipped backend (artifact-keeper-web#708).

Semantics (documented on the handler): candidate sweeps are scoped to the requested repository, while the orphan predicates stay **instance-wide** — a storage key is only reported reclaimable when no live artifact, tag, blob, or manifest reference exists for it *anywhere*. So the dry run reports "bytes reclaimable now, attributable to this repo" and can never report still-shared bytes as reclaimable (dedup-safe by construction). Live runs trigger the same best-effort storage-stats refresh as the admin endpoint; hard-deletes intentionally keep instance semantics (a reclaimed key is globally orphaned).

- `StorageGcService::run_gc` now delegates to `run_gc_inner(None, …)`; new `run_gc_for_repository(Uuid, dry_run)`; all candidate selects take `repo_scope: Option<Uuid>` (dynamic `sqlx::query` — no `query!` macros, no `.sqlx` regen needed)
- Admin gate runs before the repo lookup (no existence probing); 404 unknown repo; same `StorageGcRequest`/`StorageGcResult` types as the admin endpoint
- Registered in `StorageGcApiDoc` (already merged in `build_openapi`); route merged into the `/repositories` nest

Web side: artifact-keeper-web#708 is fixed without a UI change — the panel already calls exactly this path/body/response shape (comment updates only in the companion web PR).

Refs artifact-keeper-web#708

## Test plan

- 8 new tests: scope-clause units, no-DB error paths, fixture-based scoping test (own-repo scan includes the orphan key, other-repo scan excludes it), OpenAPI contract tests; POST-path count assertion updated 1→2
- `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- `cargo test --workspace --lib`: 14560 passed, 0 failed
- storage_gc module against a migrated Postgres (:30432, migrations through 184): 136/136 pass incl. the new DB-backed scoping test
- `test_openapi_spec_is_valid` passes
- Not verified: end-to-end call from a live UI (needs this build deployed)

Fixes #3074