### PR TITLE
feat(age-gate): enforce proxy download policy for npm, PyPI, and Go

### DIFF
--- a/backend/migrations/191_age_gate_first_seen.sql
+++ b/backend/migrations/191_age_gate_first_seen.sql
@@ -1,0 +1,73 @@
+-- Migration 191: age-gate age-source modes (#2264 / #1558 follow-up): where the cooldown
+-- clock starts for a repository.
+--
+--   upstream_publish_time: the registry-reported publish timestamp (the
+--     #2066 model; npm packument `time`, PyPI `upload-time`). Trustworthy
+--     only insofar as the upstream registry is.
+--   first_seen: the first time THIS server observed the version for the
+--     repository. An AK-local freshness control that needs no upstream
+--     metadata and cannot be backdated by a publisher.
+--
+-- Default preserves existing behavior for every repository already using the
+-- gate.
+ALTER TABLE repositories
+    ADD COLUMN IF NOT EXISTS age_gate_mode TEXT NOT NULL DEFAULT 'upstream_publish_time'
+        CHECK (age_gate_mode IN ('upstream_publish_time', 'first_seen'));
+
+-- Bind each review's recorded basis to the policy it was measured under.
+--
+-- A review row's `upstream_published_at` is only meaningful relative to the
+-- age source (mode) and upstream registry it was resolved against: a
+-- publish-time basis must not satisfy a `first_seen` gate, and a basis
+-- recorded against one upstream must not survive a repoint to another. These
+-- columns carry that identity; `AgeGateService::check` and the background
+-- sweep refuse to honor a basis (or an automatic approval) whose identity
+-- does not match the repository's current policy.
+--
+-- NULL identity marks pre-upgrade rows, with an explicit disposition:
+--   * manually reviewed rows (reviewed_by IS NOT NULL) keep their effect --
+--     they are administrator decisions made before identities were recorded;
+--   * automatically approved rows (reviewed_by IS NULL) are no longer honored
+--     as sticky allows; the decision is recomputed from the current basis on
+--     every request, so legacy automatic approvals cannot bypass a mode
+--     switch, a raised threshold, or a repointed upstream;
+--   * pending rows are swept only while the repository still runs
+--     `upstream_publish_time` (the only mode that existed before this
+--     migration), and are re-stamped with a full identity on their next
+--     request.
+ALTER TABLE age_gate_reviews
+    ADD COLUMN IF NOT EXISTS basis_mode TEXT
+        CHECK (basis_mode IN ('upstream_publish_time', 'first_seen')),
+    ADD COLUMN IF NOT EXISTS basis_upstream_fingerprint TEXT;
+
+-- First-observation records backing `first_seen` mode.
+--
+-- Insert-once: rows are written with ON CONFLICT DO NOTHING and never
+-- updated, so concurrent requests and replicas race benignly (the earliest
+-- observation wins) and repeated listings can never push a version's clock
+-- forward.
+--
+-- `upstream_fingerprint` (sha256 of the repository's normalized upstream URL)
+-- is part of the identity on purpose. Without it, repointing a remote at a
+-- different registry would let a same-named version inherit the elapsed age
+-- of the version it replaces -- an observation is only meaningful about the
+-- upstream it was made against. Re-pointing therefore starts a fresh clock
+-- rather than requiring every repository-update path to remember to
+-- invalidate (the same "remember to call it" bug class #2264 removes from
+-- the download gate).
+CREATE TABLE IF NOT EXISTS age_gate_version_observations (
+    repository_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    upstream_fingerprint TEXT NOT NULL,
+    package_name TEXT NOT NULL,
+    package_version TEXT NOT NULL,
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (repository_id, upstream_fingerprint, package_name, package_version)
+);
+
+-- Upgrade disposition for repositories whose gate is enabled on a
+-- (format, mode) pair this server cannot enforce: the config PUT endpoint
+-- rejects newly enabling unenforceable (format, mode) pairs. For formats in
+-- the capability matrix (npm and pypi in both modes; go in first_seen mode),
+-- an enabled-but-unenforceable configuration fails closed (503) at the proxy
+-- seam. Formats outside the age-gate capability matrix pass through via the
+-- format capability matrix check.

--- a/backend/src/api/handlers/age_gate.rs
+++ b/backend/src/api/handlers/age_gate.rs
@@ -371,7 +371,11 @@ pub async fn get_repo_age_gate(
     Path(key): Path<String>,
 ) -> Result<Json<AgeGateConfigResponse>> {
     let auth = require_auth(auth)?;
-    auth.require_scope("read")?;
+    // Admin-only, for parity with the PUT below and the /admin review routes:
+    // gate posture (enabled + threshold) is operator configuration, not
+    // package metadata (#2264). Blocked download callers still learn
+    // `min_age_days` from the structured 451 body, which is intended.
+    auth.require_admin()?;
     let service = RepoSvc::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
 
@@ -579,5 +583,96 @@ mod tests {
         assert_eq!(resp.repository_key, "");
         assert_eq!(resp.package_name, "lodash");
         assert_eq!(resp.status, "pending");
+    }
+
+    // -----------------------------------------------------------------------
+    // #2264 low-sev disclosure: GET /repositories/{key}/age-gate is admin-only
+    // (parity with the PUT and the /admin review routes). Previously any
+    // authenticated caller with the "read" scope could read gate posture for
+    // any repository. DB-backed: skips without DATABASE_URL; the CI coverage
+    // job runs these against Postgres. The external-vantage twin lives in
+    // tests/security_regression_tests.rs.
+    // -----------------------------------------------------------------------
+
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    fn config_app(state: SharedState, caller: AuthExtension) -> axum::Router {
+        tdh::router_with_auth(repo_config_routes(), state, caller)
+    }
+
+    /// The exact pre-fix caller: an authenticated API token carrying only the
+    /// "read" scope, which passed the old `require_scope("read")` gate.
+    fn read_scope_token() -> AuthExtension {
+        AuthExtension {
+            is_api_token: true,
+            scopes: Some(vec!["read".to_string()]),
+            ..auth(false)
+        }
+    }
+
+    #[tokio::test]
+    async fn get_repo_age_gate_read_scope_token_forbidden_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "npm").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let caller = read_scope_token();
+        let caller_id = caller.user_id;
+        let (status, body) = tdh::send(
+            config_app(state, caller),
+            tdh::get(format!("/{key}/age-gate")),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::FORBIDDEN);
+        let body = String::from_utf8_lossy(&body).to_string();
+        assert!(
+            !body.contains("min_age_days") && !body.contains("enabled"),
+            "403 body must not leak gate config: {body}"
+        );
+        tdh::cleanup(&pool, repo_id, caller_id).await;
+    }
+
+    #[tokio::test]
+    async fn get_repo_age_gate_non_admin_user_forbidden_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // Non-admin session user with unrestricted repo access: repo-access
+        // bits must not grant config reads either.
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "npm").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let caller = auth(false);
+        let caller_id = caller.user_id;
+        let (status, _body) = tdh::send(
+            config_app(state, caller),
+            tdh::get(format!("/{key}/age-gate")),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::FORBIDDEN);
+        tdh::cleanup(&pool, repo_id, caller_id).await;
+    }
+
+    #[tokio::test]
+    async fn get_repo_age_gate_admin_ok_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "npm").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let caller = auth(true);
+        let caller_id = caller.user_id;
+        let (status, body) = tdh::send(
+            config_app(state, caller),
+            tdh::get(format!("/{key}/age-gate")),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let cfg: AgeGateConfigResponse = serde_json::from_slice(&body).expect("valid config body");
+        assert_eq!(cfg.repository_key, key);
+        // Column defaults from migration 146: disabled, 7-day threshold.
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.min_age_days, 7);
+        tdh::cleanup(&pool, repo_id, caller_id).await;
     }
 }

--- a/backend/src/api/handlers/age_gate.rs
+++ b/backend/src/api/handlers/age_gate.rs
@@ -103,12 +103,18 @@ pub struct AgeGateConfigResponse {
     pub repository_key: String,
     pub enabled: bool,
     pub min_age_days: i32,
+    /// Age-source mode: `upstream_publish_time` or `first_seen` (#2264).
+    pub mode: String,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAgeGateConfigRequest {
     pub enabled: bool,
     pub min_age_days: i32,
+    /// Age-source mode. Omitted = keep the repository's current mode, so
+    /// pre-mode clients that PUT `{enabled, min_age_days}` stay valid.
+    #[serde(default)]
+    pub mode: Option<String>,
 }
 
 fn review_to_response(review: AgeGateReview) -> AgeGateReviewResponse {
@@ -379,10 +385,15 @@ pub async fn get_repo_age_gate(
     let service = RepoSvc::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
 
+    // `age_gate_mode` is deliberately not on the Repository model; read the
+    // full policy from the source of truth.
+    let params = crate::services::age_gate_service::resolve_repo_params(&state.db, repo.id).await?;
+
     Ok(Json(AgeGateConfigResponse {
         repository_key: key,
-        enabled: repo.age_gate_enabled,
-        min_age_days: repo.age_gate_min_age_days,
+        enabled: params.age_gate_enabled,
+        min_age_days: params.age_gate_min_age_days,
+        mode: params.age_gate_mode.as_str().to_string(),
     }))
 }
 
@@ -404,6 +415,8 @@ pub async fn update_repo_age_gate(
     let auth = require_auth(auth)?;
     auth.require_admin()?;
 
+    use crate::services::age_gate_service::{self as ags, AgeGateMode, AgeGateService};
+
     crate::services::age_gate_service::validate_min_age_days(body.min_age_days)?;
 
     let service = RepoSvc::new(state.db.clone());
@@ -411,8 +424,35 @@ pub async fn update_repo_age_gate(
 
     require_remote_repo_for_age_gate(&repo.repo_type)?;
 
+    // Omitted mode keeps the repository's current one (pre-mode client
+    // compatibility); a supplied mode must parse.
+    let mode = match &body.mode {
+        Some(raw) => AgeGateMode::parse(raw)?,
+        None => {
+            ags::resolve_repo_params(&state.db, repo.id)
+                .await?
+                .age_gate_mode
+        }
+    };
+
+    // Reject ENABLING the gate on a (format, mode) pair this server cannot
+    // enforce: a 200 here would record an operator's intent that every
+    // download seam then fails closed on (or silently ignores) — the
+    // false-assurance gap flagged on #2930. Disabling is always allowed.
+    if body.enabled {
+        let format = AgeGateService::normalize_format(repo.format.clone());
+        if !AgeGateService::supports_format_mode(&format, mode) {
+            return Err(AppError::Validation(format!(
+                "The age gate cannot be enforced for format {:?} in '{}' mode; \
+                 supported today: npm and pypi (both modes), go (first_seen)",
+                repo.format,
+                mode.as_str()
+            )));
+        }
+    }
+
     let svc = age_gate_service(&state)?;
-    svc.update_repo_config(repo.id, body.enabled, body.min_age_days)
+    svc.update_repo_config(repo.id, body.enabled, body.min_age_days, mode)
         .await?;
 
     let audit = AuditService::new(state.db.clone());
@@ -433,6 +473,7 @@ pub async fn update_repo_age_gate(
                     visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
                     age_gate_enabled: Some(body.enabled),
                     age_gate_min_age_days: Some(body.min_age_days),
+                    age_gate_mode: Some(mode.as_str().to_string()),
                 }),
         )
         .await;
@@ -441,6 +482,7 @@ pub async fn update_repo_age_gate(
         repository_key: key,
         enabled: body.enabled,
         min_age_days: body.min_age_days,
+        mode: mode.as_str().to_string(),
     }))
 }
 
@@ -555,6 +597,8 @@ mod tests {
             request_count: 1,
             last_requested_at: now,
             repository_key: None,
+            basis_mode: None,
+            basis_upstream_fingerprint: None,
         }
     }
 
@@ -673,6 +717,68 @@ mod tests {
         // Column defaults from migration 146: disabled, 7-day threshold.
         assert!(!cfg.enabled);
         assert_eq!(cfg.min_age_days, 7);
+        tdh::cleanup(&pool, repo_id, caller_id).await;
+    }
+
+    /// Enabling the gate on a (format, mode) pair the server cannot enforce
+    /// is rejected up front — recording an operator's intent every seam then
+    /// fails closed on (or silently ignores) is the #2930 false-assurance
+    /// gap. Go has no trustworthy publish-time resolver, so only `first_seen`
+    /// is accepted; disabling is always allowed.
+    #[tokio::test]
+    async fn put_repo_age_gate_rejects_unenforceable_format_mode_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "go").await;
+        let storage = dir.to_string_lossy().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), &storage);
+        let state = tdh::build_state_with_proxy_and_age_gate(pool.clone(), &storage, proxy);
+        let caller = auth(true);
+        let caller_id = caller.user_id;
+
+        let put = |body: serde_json::Value| {
+            tdh::put_json(
+                format!("/{key}/age-gate"),
+                bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            )
+        };
+
+        let (status, _body) = tdh::send(
+            config_app(state.clone(), caller.clone()),
+            put(serde_json::json!({
+                "enabled": true, "min_age_days": 30, "mode": "upstream_publish_time"
+            })),
+        )
+        .await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "go has no publish-time resolver: enabling that mode must be rejected"
+        );
+
+        let (status, body) = tdh::send(
+            config_app(state.clone(), caller.clone()),
+            put(serde_json::json!({
+                "enabled": true, "min_age_days": 30, "mode": "first_seen"
+            })),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let cfg: AgeGateConfigResponse = serde_json::from_slice(&body).expect("valid config body");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.mode, "first_seen");
+
+        // Disabling is always allowed, whatever mode rides along.
+        let (status, _body) = tdh::send(
+            config_app(state, caller),
+            put(serde_json::json!({
+                "enabled": false, "min_age_days": 30, "mode": "upstream_publish_time"
+            })),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+
         tdh::cleanup(&pool, repo_id, caller_id).await;
     }
 }

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -686,6 +686,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -664,6 +664,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -684,6 +685,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -1206,6 +1206,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -1226,6 +1227,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -2152,6 +2152,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -564,6 +564,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -585,6 +586,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -230,6 +230,7 @@ async fn resolve_lfs_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respo
         format: "generic".to_string(),
         age_gate_enabled: false,
         age_gate_min_age_days: 7,
+        age_gate_mode: "upstream_publish_time".to_string(),
         curation_enabled: false,
         curation_default_action: "allow".to_string(),
     })
@@ -1461,6 +1462,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -162,21 +162,21 @@ fn parse_path(raw_path: &str) -> Result<GoProxyRequest, Response> {
     if let Some(version) = operation.strip_suffix(".info") {
         return Ok(GoProxyRequest::Info {
             module,
-            version: version.to_string(),
+            version: decode_module_path(version),
         });
     }
 
     if let Some(version) = operation.strip_suffix(".mod") {
         return Ok(GoProxyRequest::Mod {
             module,
-            version: version.to_string(),
+            version: decode_module_path(version),
         });
     }
 
     if let Some(version) = operation.strip_suffix(".zip") {
         return Ok(GoProxyRequest::Zip {
             module,
-            version: version.to_string(),
+            version: decode_module_path(version),
         });
     }
 
@@ -422,6 +422,232 @@ async fn try_proxy_go_metadata(
     Err(())
 }
 
+/// Parse a goproxy `@v/list` document into its version lines.
+fn parse_version_list(body: &str) -> Vec<String> {
+    body.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Rebuild a goproxy `@v/list` document without the blocked versions,
+/// preserving the order of the surviving lines.
+fn filter_version_list(body: &str, blocked: &std::collections::HashSet<String>) -> String {
+    body.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !blocked.contains(*line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Fetch a Go metadata document from the repository's upstream — or, for a
+/// virtual repository, from its remote members in priority order — returning
+/// the id of the repository that actually served it alongside the body. The
+/// source id is what the age-gate listing filter resolves policy from: for a
+/// virtual repository each member's own gate configuration governs its
+/// contribution (#2264).
+async fn fetch_go_metadata_with_source(
+    state: &SharedState,
+    repo: &RepoInfo,
+    upstream_path: &str,
+) -> Option<(uuid::Uuid, Bytes)> {
+    let proxy = state.proxy_service.as_ref()?;
+    if repo.repo_type == RepositoryType::Remote {
+        let upstream_url = repo.upstream_url.as_deref()?;
+        let (content, _content_type) = proxy_helpers::proxy_fetch_capped(
+            proxy,
+            repo.id,
+            &repo.key,
+            upstream_url,
+            upstream_path,
+            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await
+        .ok()?;
+        return Some((repo.id, content));
+    }
+    if repo.repo_type == RepositoryType::Virtual {
+        let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id)
+            .await
+            .ok()?;
+        for member in members {
+            if member.repo_type != crate::models::repository::RepositoryType::Remote {
+                continue;
+            }
+            let Some(upstream_url) = member.upstream_url.as_deref() else {
+                continue;
+            };
+            if let Ok((content, _content_type)) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                member.id,
+                &member.key,
+                upstream_url,
+                upstream_path,
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await
+            {
+                return Some((member.id, content));
+            }
+        }
+    }
+    None
+}
+
+/// Filter a `@v/list` document through the serving repository's download age
+/// gate. Parsing and rebuilding are pure; the policy runs through the shared
+/// batch evaluation, so the version list and the `.zip` download gate decide
+/// from the same clock — a version withheld here is refused there, and vice
+/// versa. Ungated repositories pass through with no policy reads.
+async fn filter_go_version_list(
+    state: &SharedState,
+    repository_id: uuid::Uuid,
+    module: &str,
+    body: &str,
+) -> Result<String, Response> {
+    let Some(age_gate) = state.age_gate_service.as_ref() else {
+        return Ok(body.to_string());
+    };
+    let params = crate::services::age_gate_service::resolve_repo_params(&state.db, repository_id)
+        .await
+        .map_err(|e| e.into_response())?;
+    if !crate::services::age_gate_service::AgeGateService::gating_requested(&params) {
+        return Ok(body.to_string());
+    }
+    // `@v/list` lines carry no timestamps; under `first_seen` (the only mode
+    // Go supports) the basis is this server's own observation of each listed
+    // version — the upstream-served document is the existence evidence.
+    let versions: Vec<(String, Option<chrono::DateTime<chrono::Utc>>)> = parse_version_list(body)
+        .into_iter()
+        .map(|version| (version, None))
+        .collect();
+    let blocked = age_gate
+        .evaluate_versions_batch(&params, module, &versions)
+        .await
+        .map_err(|e| e.into_response())?;
+    Ok(filter_version_list(body, &blocked))
+}
+
+/// Whether the age gate withholds `version` from `@latest`-shaped responses
+/// for the serving repository. A blocked latest surfaces as 404 to the `go`
+/// client, which then resolves from the filtered `@v/list` — so "latest"
+/// quietly becomes the newest version old enough to serve.
+async fn go_latest_version_is_blocked(
+    state: &SharedState,
+    repository_id: uuid::Uuid,
+    module: &str,
+    version: &str,
+    time: Option<chrono::DateTime<chrono::Utc>>,
+) -> Result<bool, Response> {
+    let Some(age_gate) = state.age_gate_service.as_ref() else {
+        return Ok(false);
+    };
+    let params = crate::services::age_gate_service::resolve_repo_params(&state.db, repository_id)
+        .await
+        .map_err(|e| e.into_response())?;
+    if !crate::services::age_gate_service::AgeGateService::gating_requested(&params) {
+        return Ok(false);
+    }
+    let blocked = age_gate
+        .evaluate_versions_batch(&params, module, &[(version.to_string(), time)])
+        .await
+        .map_err(|e| e.into_response())?;
+    Ok(blocked.contains(version))
+}
+
+/// Enforce the download age gate for one repository serving `module@version`
+/// as a `.zip` (#2264). Policy is re-resolved from the repositories row; the
+/// caller's struct only pre-screens. Under `first_seen` — the only mode Go
+/// supports — an existing observation is the basis; otherwise a successful
+/// upstream `.info` fetch is the existence evidence that starts the clock. A
+/// version with no basis blocks (451, review row created), so an unpublished
+/// name cannot be pre-aged by requesting it early.
+async fn enforce_go_zip_age_gate(
+    state: &SharedState,
+    repository_id: uuid::Uuid,
+    module: &str,
+    version: &str,
+) -> Result<(), Response> {
+    use crate::services::age_gate_service::{resolve_repo_params, AgeGateService};
+
+    let params = resolve_repo_params(&state.db, repository_id)
+        .await
+        .map_err(|e| e.into_response())?;
+    if !AgeGateService::gating_requested(&params) {
+        return Ok(());
+    }
+    AgeGateService::require_enforceable(&params).map_err(|e| e.into_response())?;
+    let Some(svc) = state.age_gate_service.as_ref() else {
+        return Err(proxy_helpers::age_gate_unavailable_response(
+            &params.key,
+            module,
+        ));
+    };
+    // Lookup-only pass first: the common case (version already observed via a
+    // listing) needs no upstream round-trip.
+    let mut basis = svc
+        .download_basis(&params, module, version, None, false)
+        .await
+        .map_err(|e| e.into_response())?;
+    if basis.is_none() {
+        let exists = go_version_exists_upstream(state, &params, module, version).await;
+        if exists {
+            basis = svc
+                .download_basis(&params, module, version, None, true)
+                .await
+                .map_err(|e| e.into_response())?;
+        }
+    }
+    // Go has no last-known-good substitution: a block is the terminal 451.
+    let lkg_opt = proxy_helpers::enforce_age_gate(
+        state.age_gate_service.as_deref(),
+        &params,
+        module,
+        version,
+        basis,
+    )
+    .await?;
+    if let Some(blocked) = lkg_opt {
+        return Err(proxy_helpers::age_gate_blocked_response(
+            blocked.review_id,
+            module,
+            version,
+            params.age_gate_min_age_days,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Positive existence evidence for `module@version`: the upstream serves its
+/// `.info` document. Failures are treated as "no evidence" — the gate then
+/// blocks without starting a clock, never the reverse.
+async fn go_version_exists_upstream(
+    state: &SharedState,
+    params: &crate::services::age_gate_service::AgeGateRepoParams,
+    module: &str,
+    version: &str,
+) -> bool {
+    let Some(proxy) = state.proxy_service.as_ref() else {
+        return false;
+    };
+    let Some(upstream_url) = params.upstream_url.as_deref() else {
+        return false;
+    };
+    let upstream_path = build_go_upstream_path(module, version, "info");
+    proxy_helpers::proxy_fetch_capped(
+        proxy,
+        params.id,
+        &params.key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    .is_ok()
+}
+
 async fn list_versions(
     state: &SharedState,
     repo: &RepoInfo,
@@ -445,27 +671,33 @@ async fn list_versions(
     .map_err(crate::api::handlers::db_err)?;
 
     let body = build_version_list(&versions);
+    // A remote repository can hold hydrated `artifacts` rows; its local list
+    // is filtered against the same policy as the proxied one (ungated repos
+    // pass straight through).
+    let body = filter_go_version_list(state, repo.id, module, &body).await?;
 
     if body.is_empty() {
         // Virtual repo: the version list also lives in the artifact tables of
         // local (non-Remote) member repos, which `try_proxy_go_metadata` does
-        // not consult. Aggregate distinct versions across all members first so
+        // not consult. Aggregate distinct versions across those members so
         // a module stored only in a Local member is listed (#1782).
         if repo.repo_type == RepositoryType::Virtual {
-            let member_versions: Vec<Option<String>> = sqlx::query_scalar!(
+            let member_versions: Vec<Option<String>> = sqlx::query_scalar(
                 r#"
                 SELECT DISTINCT a.version
                 FROM artifacts a
                 INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id
+                INNER JOIN repositories member ON member.id = vrm.member_repo_id
                 WHERE vrm.virtual_repo_id = $1
+                  AND member.repo_type != 'remote'::repository_type
                   AND a.name = $2
                   AND a.is_deleted = false
                   AND a.version IS NOT NULL
                 ORDER BY a.version
                 "#,
-                repo.id,
-                module
             )
+            .bind(repo.id)
+            .bind(module)
             .fetch_all(&state.db)
             .await
             .map_err(crate::api::handlers::db_err)?;
@@ -482,10 +714,17 @@ async fn list_versions(
         }
 
         let upstream_path = build_go_upstream_list_path(module);
-        if let Ok(resp) =
-            try_proxy_go_metadata(state, repo, &upstream_path, "text/plain; charset=utf-8").await
+        if let Some((source_repo_id, content)) =
+            fetch_go_metadata_with_source(state, repo, &upstream_path).await
         {
-            return Ok(resp);
+            let upstream_body = String::from_utf8_lossy(&content).into_owned();
+            let filtered =
+                filter_go_version_list(state, source_repo_id, module, &upstream_body).await?;
+            return Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+                .body(Body::from(filtered))
+                .unwrap());
         }
 
         return Err((StatusCode::NOT_FOUND, "module not found").into_response());
@@ -736,6 +975,14 @@ async fn download_zip(
     version: &str,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
+    // Age gate (#2264): the `.zip` is the gated artifact. The struct only
+    // pre-screens (ungated repositories skip the policy read); the gate
+    // itself re-resolves policy from the repositories row. Virtual members
+    // are gated per member below, each under its own configuration.
+    if repo.age_gate_enabled {
+        enforce_go_zip_age_gate(state, repo.id, module, version).await?;
+    }
+
     let artifact = sqlx::query!(
         r#"
         SELECT id, storage_key, size_bytes, checksum_sha256
@@ -786,16 +1033,36 @@ async fn download_zip(
                 }
             }
 
-            // Virtual repo: try each member in priority order
+            // Virtual repo: try each member in priority order. Gated remote
+            // members that withhold this version are excluded up front —
+            // another (ungated, or aged-past-threshold) member may still
+            // serve it. If a gated member blocked and nobody else served,
+            // the structured 451 is the answer, not a bare 404.
             if repo.repo_type == RepositoryType::Virtual {
+                let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+                let mut allowed = Vec::with_capacity(members.len());
+                let mut blocked_response = None;
+                for member in members {
+                    if member.repo_type == crate::models::repository::RepositoryType::Remote
+                        && member.age_gate_enabled
+                    {
+                        if let Err(resp) =
+                            enforce_go_zip_age_gate(state, member.id, module, version).await
+                        {
+                            blocked_response = Some(resp);
+                            continue;
+                        }
+                    }
+                    allowed.push(member);
+                }
+
                 let db = state.db.clone();
                 let upstream_path = build_go_upstream_path(module, version, "zip");
                 let module_clone = module.to_string();
                 let version_clone = version.to_string();
-                let result = proxy_helpers::resolve_virtual_download(
-                    &state.db,
+                let result = proxy_helpers::resolve_virtual_download_from_members(
+                    allowed,
                     state.proxy_service.as_deref(),
-                    repo.id,
                     &upstream_path,
                     |member_id, location| {
                         let db = db.clone();
@@ -810,9 +1077,14 @@ async fn download_zip(
                         }
                     },
                 )
-                .await?;
+                .await;
 
-                return proxy_helpers::stream_fetch_result(result, "application/zip", None);
+                return match result {
+                    Ok(fetched) => {
+                        proxy_helpers::stream_fetch_result(fetched, "application/zip", None)
+                    }
+                    Err(err) => Err(blocked_response.unwrap_or(err)),
+                };
             }
 
             return Err(not_found);
@@ -891,10 +1163,41 @@ async fn latest_version(
         Ok(a) => a,
         Err(not_found) => {
             let upstream_path = build_go_upstream_latest_path(module);
-            if let Ok(resp) =
-                try_proxy_go_metadata(state, repo, &upstream_path, "application/json").await
+            if let Some((source_repo_id, content)) =
+                fetch_go_metadata_with_source(state, repo, &upstream_path).await
             {
-                return Ok(resp);
+                // Gate the advertised version: a blocked (or unparseable)
+                // "latest" is withheld as 404 so the client re-resolves from
+                // the filtered version list instead of learning about — and
+                // then failing on — a version this repository will not serve.
+                let json: Option<serde_json::Value> = serde_json::from_slice(&content).ok();
+                let version = json
+                    .as_ref()
+                    .and_then(|j| j.get("Version"))
+                    .and_then(|v| v.as_str());
+                let Some(version) = version else {
+                    return Err(
+                        (StatusCode::NOT_FOUND, "no latest version available").into_response()
+                    );
+                };
+                let time = json
+                    .as_ref()
+                    .and_then(|j| j.get("Time"))
+                    .and_then(|t| t.as_str())
+                    .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+                    .map(|t| t.with_timezone(&chrono::Utc));
+                if go_latest_version_is_blocked(state, source_repo_id, module, version, time)
+                    .await?
+                {
+                    return Err(
+                        (StatusCode::NOT_FOUND, "no latest version available").into_response()
+                    );
+                }
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(content))
+                    .unwrap());
             }
             return Err(not_found);
         }
@@ -902,6 +1205,12 @@ async fn latest_version(
 
     let version = artifact.version.unwrap_or_default();
     let time_str = format_go_timestamp(&artifact.created_at);
+
+    // Same policy for the local-rows arm: a remote repository's hydrated
+    // artifact must not advertise a version its download gate withholds.
+    if go_latest_version_is_blocked(state, repo.id, module, &version, None).await? {
+        return Err((StatusCode::NOT_FOUND, "no latest version available").into_response());
+    }
 
     let info = build_version_info_json(&version, &time_str);
 
@@ -1223,8 +1532,9 @@ fn build_go_zip_content_disposition(module: &str, version: &str) -> String {
 
 /// Build the upstream path for a Go module request (used by remote/virtual repos).
 fn build_go_upstream_path(module: &str, version: &str, ext: &str) -> String {
-    let encoded = encode_module_path(module);
-    format!("{}/@v/{}.{}", encoded, version, ext)
+    let encoded_module = encode_module_path(module);
+    let encoded_version = encode_module_path(version);
+    format!("{}/@v/{}.{}", encoded_module, encoded_version, ext)
 }
 
 /// Build the upstream path for a Go module version-list request.
@@ -1242,6 +1552,196 @@ fn build_go_upstream_latest_path(module: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    #[test]
+    fn parse_version_list_trims_and_drops_blank_lines() {
+        assert_eq!(
+            parse_version_list("v1.0.0\n  v1.1.0 \n\nv2.0.0\n"),
+            vec!["v1.0.0", "v1.1.0", "v2.0.0"]
+        );
+        assert!(parse_version_list("").is_empty());
+    }
+
+    #[test]
+    fn filter_version_list_preserves_order_of_survivors() {
+        let blocked: std::collections::HashSet<String> =
+            ["v1.1.0".to_string()].into_iter().collect();
+        assert_eq!(
+            filter_version_list("v1.0.0\nv1.1.0\nv2.0.0", &blocked),
+            "v1.0.0\nv2.0.0"
+        );
+        assert_eq!(
+            filter_version_list("v1.1.0", &blocked),
+            "",
+            "a fully blocked list is empty, not absent"
+        );
+    }
+
+    /// End-to-end Go age-gate slice (#2264): a gated `first_seen` remote repo
+    /// filters young versions from `@v/list`, withholds a young `@latest` as
+    /// 404 (the client then resolves from the filtered list), and blocks the
+    /// `.zip` download with the structured 451 — then serves all three once
+    /// the observations age past the threshold. `.info` stays readable
+    /// throughout (version-addressed metadata, deliberately ungated).
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: buffering response bodies in test assertions is not an artifact path (#1608)
+    #[tokio::test]
+    async fn go_age_gate_filters_list_latest_and_blocks_zip_db() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "go").await else {
+            return;
+        };
+        let upstream = MockServer::start().await;
+        let module = "example.com/gated";
+        Mock::given(method("GET"))
+            .and(path(format!("/{module}/@v/list")))
+            .respond_with(ResponseTemplate::new(200).set_body_string("v1.0.0\nv1.1.0"))
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{module}/@latest")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Version": "v1.1.0",
+                "Time": "2020-01-01T00:00:00Z",
+            })))
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{module}/@v/v1.1.0.zip")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"zip-bytes".to_vec()))
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{module}/@v/v1.1.0.info")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Version": "v1.1.0",
+                "Time": "2020-01-01T00:00:00Z",
+            })))
+            .mount(&upstream)
+            .await;
+
+        sqlx::query(
+            "UPDATE repositories SET upstream_url = $1, age_gate_enabled = true, \
+             age_gate_min_age_days = 30, age_gate_mode = 'first_seen' WHERE id = $2",
+        )
+        .bind(upstream.uri())
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("configure gated go repo");
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state =
+            tdh::build_state_with_proxy_and_age_gate(fx.pool.clone(), storage_path.as_str(), proxy);
+        let mut repo = fx.repo_info("remote", Some(&upstream.uri()));
+        // The struct pre-screens; the gate re-resolves policy from the row
+        // updated above, so both must agree the gate is on.
+        repo.format = "go".to_string();
+        repo.age_gate_enabled = true;
+        repo.age_gate_min_age_days = 30;
+        repo.age_gate_mode = "first_seen".to_string();
+
+        async fn body_string(response: Response) -> String {
+            let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+                .await
+                .expect("read body");
+            String::from_utf8_lossy(&bytes).into_owned()
+        }
+
+        // First sight: the upstream-served list is the existence evidence,
+        // both versions are observed and withheld.
+        let listed = list_versions(&state, &repo, module)
+            .await
+            .expect("list must succeed");
+        assert_eq!(body_string(listed).await, "", "young versions are withheld");
+        let observations: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM age_gate_version_observations WHERE repository_id = $1",
+        )
+        .bind(fx.repo_id)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("count observations");
+        assert_eq!(observations, 2, "listing observes every advertised version");
+
+        // Young @latest is withheld as 404 (client falls back to the list).
+        let err = latest_version(&state, &repo, module)
+            .await
+            .expect_err("young latest must be withheld");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+
+        // Seed an older cached version so the shared seam returns an LKG
+        // outcome. Go deliberately does not substitute it, but its terminal
+        // 451 must still carry the real review id from that outcome.
+        let lkg_id = tdh::seed_artifact(
+            &state,
+            &fx.pool,
+            &repo,
+            &format!("go/{module}/v0.9.0.zip"),
+            &format!("{module}/v0.9.0/v0.9.0.zip"),
+            module,
+            "v0.9.0",
+            "application/zip",
+            bytes::Bytes::from_static(b"PK\x03\x04 old-lkg"),
+            fx.user_id,
+        )
+        .await;
+
+        // The requested artifact itself blocks with the structured 451.
+        let ctx = Default::default();
+        let err = download_zip(&state, &repo, module, "v1.1.0", &ctx)
+            .await
+            .expect_err("young zip must block");
+        assert_eq!(err.status(), StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
+        let blocked: serde_json::Value =
+            serde_json::from_str(&body_string(err).await).expect("451 JSON body");
+        let review_id = blocked["review_id"]
+            .as_str()
+            .and_then(|value| uuid::Uuid::parse_str(value).ok())
+            .expect("real review id");
+        assert_ne!(review_id, uuid::Uuid::nil());
+        sqlx::query("DELETE FROM artifacts WHERE id = $1")
+            .bind(lkg_id)
+            .execute(&fx.pool)
+            .await
+            .expect("remove temporary LKG fixture");
+
+        // Version-addressed metadata stays readable while the zip is gated.
+        let info = version_info(&state, &repo, module, "v1.1.0")
+            .await
+            .expect(".info is metadata and passes");
+        assert_eq!(info.status(), StatusCode::OK);
+
+        // Age the observations: list, latest, and zip all serve.
+        sqlx::query(
+            "UPDATE age_gate_version_observations SET first_seen_at = NOW() - INTERVAL '90 days' \
+             WHERE repository_id = $1",
+        )
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("backdate observations");
+
+        let listed = list_versions(&state, &repo, module)
+            .await
+            .expect("aged list must succeed");
+        assert_eq!(body_string(listed).await, "v1.0.0\nv1.1.0");
+        let latest = latest_version(&state, &repo, module)
+            .await
+            .expect("aged latest must serve");
+        let latest_body = body_string(latest).await;
+        assert!(latest_body.contains("v1.1.0"), "got {latest_body}");
+        let zip = download_zip(&state, &repo, module, "v1.1.0", &ctx)
+            .await
+            .expect("aged zip must serve");
+        assert_eq!(zip.status(), StatusCode::OK);
+
+        tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;
+        let _ = std::fs::remove_dir_all(&fx.storage_dir);
+    }
 
     #[test]
     fn test_decode_module_path() {
@@ -1742,6 +2242,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_build_go_upstream_path_encodes_version() {
+        assert_eq!(
+            build_go_upstream_path("github.com/Azure/go-sdk", "v2.0.0-RC1", "info"),
+            "github.com/!azure/go-sdk/@v/v2.0.0-!r!c1.info"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // encode_module_path round-trip
     // -----------------------------------------------------------------------
@@ -1925,6 +2433,56 @@ mod tests {
         .await
         .expect("insert virtual member");
 
+        // A hydrated Remote member must not leak its cached rows through the
+        // virtual repo's Local-member aggregation. Its versions are evaluated
+        // only through the source-aware upstream path, under that member's
+        // own gate.
+        let remote_id = Uuid::new_v4();
+        let remote_key = format!("r-go-gated-{}", remote_id.simple());
+        sqlx::query(
+            "INSERT INTO repositories
+             (id, key, name, storage_path, repo_type, format, upstream_url,
+              age_gate_enabled, age_gate_min_age_days, age_gate_mode)
+             VALUES ($1, $2, $2, $3, 'remote'::repository_type,
+                     'go'::repository_format, 'https://proxy.golang.org',
+                     true, 30, 'first_seen')",
+        )
+        .bind(remote_id)
+        .bind(&remote_key)
+        .bind(fx.storage_dir.to_string_lossy().as_ref())
+        .execute(&fx.pool)
+        .await
+        .expect("insert gated remote member");
+        let remote = tdh::make_repo_info(
+            remote_id,
+            &remote_key,
+            &fx.storage_dir,
+            "remote",
+            Some("https://proxy.golang.org"),
+        );
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &remote,
+            &format!("go/{module}/v9.9.9.zip"),
+            &format!("{module}/v9.9.9/v9.9.9.zip"),
+            module,
+            "v9.9.9",
+            "application/zip",
+            Bytes::from_static(b"PK\x03\x04 young-remote-version"),
+            fx.user_id,
+        )
+        .await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 2)",
+        )
+        .bind(virtual_id)
+        .bind(remote_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert gated remote virtual member");
+
         let send = |uri: String| {
             let router = fx.router_with_auth(super::router());
             async move {
@@ -1956,6 +2514,10 @@ mod tests {
             .await;
         let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
             .bind(virtual_id)
+            .execute(&fx.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(remote_id)
             .execute(&fx.pool)
             .await;
         fx.teardown().await;

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -1337,6 +1337,7 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -1357,6 +1358,7 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2435,6 +2437,7 @@ entries:
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2472,6 +2475,7 @@ entries:
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2501,6 +2505,7 @@ entries:
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -2658,6 +2658,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2678,6 +2679,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2728,6 +2730,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2749,6 +2752,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2771,6 +2775,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2792,6 +2797,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -1330,6 +1330,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -1350,6 +1351,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -576,6 +576,7 @@ async fn resolve_incus_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Res
         format: "generic".to_string(),
         age_gate_enabled: false,
         age_gate_min_age_days: 7,
+        age_gate_mode: "upstream_publish_time".to_string(),
         curation_enabled: false,
         curation_default_action: "allow".to_string(),
     })
@@ -2400,6 +2401,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2421,6 +2423,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -3704,6 +3707,7 @@ mod streaming_pipeline_regression_tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -882,6 +882,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -3127,6 +3127,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -3147,6 +3148,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -566,6 +566,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -37,7 +37,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::AppError;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
-use crate::services::age_gate_service::{AgeGateDecision, AgeGateService};
+use crate::services::age_gate_service::AgeGateService;
 use crate::services::npm_packument_cache::{
     self as packument_cache, CachedPackument, NpmPackumentCache,
 };
@@ -2055,10 +2055,14 @@ async fn get_package_metadata(
 
             match result {
                 Ok((content, content_type, _budget_permit)) => {
-                    let params =
-                        crate::services::age_gate_service::AgeGateRepoParams::from_repository(
-                            member,
-                        );
+                    // DB-resolve the member's gate policy: the Repository
+                    // model deliberately carries no `age_gate_mode`, and
+                    // policy inputs are read from the source of truth (#2264).
+                    let params = crate::services::age_gate_service::resolve_repo_params(
+                        &state.db, member.id,
+                    )
+                    .await
+                    .map_err(|e| e.into_response())?;
                     return rewrite_and_respond_with_age_gate_params(
                         state,
                         &params,
@@ -2402,22 +2406,14 @@ fn build_npm_tarball_upstream_path(package_name: &str, filename: &str) -> String
     build_tarball_upstream_path(package_name, filename)
 }
 
-/// Map an age-gate block decision with LKG into upstream path + filename.
-fn npm_lkg_redirect_from_decision(
-    decision: &AgeGateDecision,
+/// Map an age-gate last-known-good version into upstream path + filename.
+fn npm_lkg_redirect(
+    lkg: &crate::services::age_gate_service::LastKnownGood,
     package_name: &str,
-) -> Option<(String, String)> {
-    if let AgeGateDecision::Block {
-        last_known_good: Some(lkg),
-        ..
-    } = decision
-    {
-        let lkg_filename = build_npm_tarball_filename(package_name, &lkg.version);
-        let lkg_path = build_npm_tarball_upstream_path(package_name, &lkg_filename);
-        Some((lkg_path, lkg_filename))
-    } else {
-        None
-    }
+) -> (String, String) {
+    let lkg_filename = build_npm_tarball_filename(package_name, &lkg.version);
+    let lkg_path = build_npm_tarball_upstream_path(package_name, &lkg_filename);
+    (lkg_path, lkg_filename)
 }
 
 async fn npm_publish_time_for_version(
@@ -2456,46 +2452,52 @@ async fn apply_npm_download_age_gate(
     package_name: &str,
     filename: &str,
 ) -> Result<Option<(String, String)>, Response> {
-    let svc = match state.age_gate_service.as_ref() {
-        Some(s) => s,
-        None => return Ok(None),
-    };
-    let params = proxy_helpers::age_gate_params(repo);
-    if !AgeGateService::is_applicable(&params) {
+    // Cheap struct-derived pre-check so an ungated repo skips the filename
+    // parse, the DB policy resolve, and the upstream publish-time fetch. The
+    // authoritative policy (mode + upstream identity) is then re-resolved
+    // from the database by id: struct-derived params can carry a stale or
+    // defaulted mode (e.g. a virtual member's RepoInfo), and gate policy is
+    // enforcement input, so it is read from the source of truth (#2264).
+    if !AgeGateService::is_applicable(&proxy_helpers::age_gate_params(repo)) {
         return Ok(None);
     }
+    let params = crate::services::age_gate_service::resolve_repo_params(&state.db, repo.id)
+        .await
+        .map_err(|e| e.into_response())?;
 
     let short_name = npm_tarball_short_name(package_name);
     let version =
         crate::formats::npm::NpmHandler::extract_version_from_filename(filename, short_name)
             .map_err(|e| AppError::Validation(e.to_string()).into_response())?;
 
+    // Publish-time evidence from the packument; under `first_seen` the time
+    // itself is ignored, but presence in the upstream-served document is the
+    // existence evidence that may start the version's observation clock.
     let published_at = npm_publish_time_for_version(state, repo, package_name, &version).await;
-    let decision = svc
-        .check(&params, package_name, &version, published_at)
-        .await
-        .map_err(|e| e.into_response())?;
-    match decision {
-        AgeGateDecision::Allow => Ok(None),
-        AgeGateDecision::Block {
-            review_id: _,
-            last_known_good: Some(_),
-        } => Ok(npm_lkg_redirect_from_decision(&decision, package_name)),
-        AgeGateDecision::Block {
-            review_id,
-            last_known_good: None,
-        } => {
-            let requested_age_days =
-                published_at.map(|p| AgeGateService::package_age_days(p, Utc::now()));
-            Err(proxy_helpers::age_gate_blocked_response(
-                review_id,
+    let basis = match state.age_gate_service.as_deref() {
+        Some(svc) => svc
+            .download_basis(
+                &params,
                 package_name,
                 &version,
-                repo.age_gate_min_age_days,
-                requested_age_days,
-            ))
-        }
-    }
+                published_at,
+                published_at.is_some(),
+            )
+            .await
+            .map_err(|e| e.into_response())?,
+        None => published_at,
+    };
+    // The shared seam (#2264) owns the decision and the terminal 451; only
+    // the LKG substitution below is npm-specific.
+    let lkg = proxy_helpers::enforce_age_gate(
+        state.age_gate_service.as_deref(),
+        &params,
+        package_name,
+        &version,
+        basis,
+    )
+    .await?;
+    Ok(lkg.map(|blocked| npm_lkg_redirect(&blocked.last_known_good, package_name)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2509,9 +2511,19 @@ async fn rewrite_and_respond_with_age_gate(
     repo_key: &str,
     want_abbreviated: bool,
 ) -> Result<Response, Response> {
+    // Quick struct-derived check, then DB-resolve the authoritative policy
+    // (mode + upstream identity) for the filter (#2264).
+    let quick = proxy_helpers::age_gate_params(repo);
+    let params = if AgeGateService::is_applicable(&quick) {
+        crate::services::age_gate_service::resolve_repo_params(&state.db, repo.id)
+            .await
+            .map_err(|e| e.into_response())?
+    } else {
+        quick
+    };
     rewrite_and_respond_with_age_gate_params(
         state,
-        &proxy_helpers::age_gate_params(repo),
+        &params,
         package_name,
         content,
         content_type,
@@ -5757,6 +5769,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -6350,28 +6363,14 @@ mod tests {
     fn test_npm_lkg_redirect_uses_literal_slash_path() {
         use crate::services::age_gate_service::LastKnownGood;
 
-        let decision = AgeGateDecision::Block {
-            review_id: uuid::Uuid::new_v4(),
-            last_known_good: Some(LastKnownGood {
-                version: "16.0.0".to_string(),
-                artifact_path: "ignored".to_string(),
-            }),
+        let lkg = LastKnownGood {
+            version: "16.0.0".to_string(),
+            artifact_path: "ignored".to_string(),
         };
-        let (path, filename) = npm_lkg_redirect_from_decision(&decision, "@angular/core").unwrap();
+        let (path, filename) = npm_lkg_redirect(&lkg, "@angular/core");
         assert_eq!(filename, "core-16.0.0.tgz");
         assert_eq!(path, "@angular/core/-/core-16.0.0.tgz");
         assert!(!path.contains("%2F"));
-    }
-
-    #[test]
-    fn test_npm_lkg_redirect_none_without_last_known_good() {
-        // Allow and Block-without-LKG decisions produce no redirect target.
-        assert!(npm_lkg_redirect_from_decision(&AgeGateDecision::Allow, "express").is_none());
-        let blocked_no_lkg = AgeGateDecision::Block {
-            review_id: uuid::Uuid::new_v4(),
-            last_known_good: None,
-        };
-        assert!(npm_lkg_redirect_from_decision(&blocked_no_lkg, "express").is_none());
     }
 
     #[test]
@@ -8267,6 +8266,8 @@ mod tests {
                 RepositoryFormat::Npm,
                 enabled,
                 7,
+                Default::default(),
+                None,
             )
         };
 

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -2287,6 +2287,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -441,6 +441,7 @@ async fn resolve_protobuf_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, 
         format: "generic".to_string(),
         age_gate_enabled: false,
         age_gate_min_age_days: 7,
+        age_gate_mode: "upstream_publish_time".to_string(),
         curation_enabled: false,
         curation_default_action: "allow".to_string(),
     })

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4787,7 +4787,8 @@ pub(crate) fn age_gate_repo_type_from_str(
 
 /// Map a `repositories.format` string onto the age-gate format alias space:
 /// npm-family clients (yarn/pnpm) gate as npm, pypi-family (poetry) as pypi,
-/// everything else as `Generic` (not in the enforceable matrix).
+/// Go gates as Go, and everything else as `Generic` (not in the enforceable
+/// matrix).
 pub(crate) fn age_gate_format_from_str(
     format: &str,
 ) -> crate::models::repository::RepositoryFormat {
@@ -4795,6 +4796,7 @@ pub(crate) fn age_gate_format_from_str(
     match format.to_lowercase().as_str() {
         "npm" => RepositoryFormat::Npm,
         "pypi" => RepositoryFormat::Pypi,
+        "go" => RepositoryFormat::Go,
         other if other.starts_with("npm") || other == "yarn" || other == "pnpm" => {
             RepositoryFormat::Npm
         }
@@ -11460,6 +11462,18 @@ mod tests {
         assert!(params.age_gate_enabled);
         assert_eq!(params.age_gate_min_age_days, 14);
         assert_eq!(params.key, "npm-remote");
+    }
+
+    #[test]
+    fn age_gate_format_mapping_includes_go_capability() {
+        use crate::models::repository::RepositoryFormat;
+
+        assert_eq!(age_gate_format_from_str("go"), RepositoryFormat::Go);
+        assert_eq!(age_gate_format_from_str("GO"), RepositoryFormat::Go);
+        assert_eq!(
+            age_gate_format_from_str("unsupported"),
+            RepositoryFormat::Generic
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -158,6 +158,9 @@ pub struct RepoInfo {
     pub promotion_only: bool,
     pub age_gate_enabled: bool,
     pub age_gate_min_age_days: i32,
+    /// Age-source mode wire value (migration 191); parsed by
+    /// [`age_gate_params`]. Defaults to `upstream_publish_time`.
+    pub age_gate_mode: String,
     pub curation_enabled: bool,
     pub curation_default_action: String,
 }
@@ -200,7 +203,7 @@ pub async fn resolve_repo_by_key(
     let repo = sqlx::query(
         "SELECT id, key, storage_backend, storage_path, format::text as format, \
          repo_type::text as repo_type, upstream_url, promotion_only, \
-         age_gate_enabled, age_gate_min_age_days, \
+         age_gate_enabled, age_gate_min_age_days, age_gate_mode, \
          curation_enabled, curation_default_action \
          FROM repositories WHERE key = $1",
     )
@@ -237,6 +240,9 @@ pub async fn resolve_repo_by_key(
         promotion_only: repo.try_get("promotion_only").unwrap_or(false),
         age_gate_enabled: repo.try_get("age_gate_enabled").unwrap_or(false),
         age_gate_min_age_days: repo.try_get("age_gate_min_age_days").unwrap_or(7),
+        age_gate_mode: repo
+            .try_get("age_gate_mode")
+            .unwrap_or_else(|_| "upstream_publish_time".to_string()),
         curation_enabled: repo.try_get("curation_enabled").unwrap_or(false),
         curation_default_action: repo
             .try_get("curation_default_action")
@@ -2525,6 +2531,11 @@ pub fn repo_info_from_member(m: &crate::models::repository::Repository) -> RepoI
         promotion_only: m.promotion_only,
         age_gate_enabled: m.age_gate_enabled,
         age_gate_min_age_days: m.age_gate_min_age_days,
+        // `age_gate_mode` is deliberately NOT on the Repository model; this
+        // default is a placeholder. The age-gate wrappers DB-resolve the
+        // authoritative (mode, upstream) policy by id once the cheap
+        // enabled-check passes, so a member's mode is never read from here.
+        age_gate_mode: "upstream_publish_time".to_string(),
         curation_enabled: m.curation_enabled,
         curation_default_action: m.curation_default_action.clone(),
     }
@@ -4760,18 +4771,28 @@ pub(crate) fn build_download_response(
     builder.body(axum::body::Body::from(content)).unwrap()
 }
 
-/// Build age-gate params from a resolved repository descriptor.
-pub fn age_gate_params(info: &RepoInfo) -> crate::services::age_gate_service::AgeGateRepoParams {
-    use crate::models::repository::{RepositoryFormat, RepositoryType};
-    use crate::services::age_gate_service::AgeGateRepoParams;
-
-    let repo_type = match info.repo_type.as_str() {
+/// Map a `repositories.repo_type` string onto the typed enum for age-gate
+/// params, defaulting unknown values to `Local` (never gated).
+pub(crate) fn age_gate_repo_type_from_str(
+    repo_type: &str,
+) -> crate::models::repository::RepositoryType {
+    use crate::models::repository::RepositoryType;
+    match repo_type {
         "remote" => RepositoryType::Remote,
         "virtual" => RepositoryType::Virtual,
         "staging" => RepositoryType::Staging,
         _ => RepositoryType::Local,
-    };
-    let format = match info.format.to_lowercase().as_str() {
+    }
+}
+
+/// Map a `repositories.format` string onto the age-gate format alias space:
+/// npm-family clients (yarn/pnpm) gate as npm, pypi-family (poetry) as pypi,
+/// everything else as `Generic` (not in the enforceable matrix).
+pub(crate) fn age_gate_format_from_str(
+    format: &str,
+) -> crate::models::repository::RepositoryFormat {
+    use crate::models::repository::RepositoryFormat;
+    match format.to_lowercase().as_str() {
         "npm" => RepositoryFormat::Npm,
         "pypi" => RepositoryFormat::Pypi,
         other if other.starts_with("npm") || other == "yarn" || other == "pnpm" => {
@@ -4779,15 +4800,24 @@ pub fn age_gate_params(info: &RepoInfo) -> crate::services::age_gate_service::Ag
         }
         other if other.starts_with("pypi") || other == "poetry" => RepositoryFormat::Pypi,
         _ => RepositoryFormat::Generic,
-    };
+    }
+}
+
+/// Build age-gate params from a resolved repository descriptor. The mode
+/// wire value is CHECK-constrained by migration 191, so the parse fallback
+/// to the default mode is unreachable in practice.
+pub fn age_gate_params(info: &RepoInfo) -> crate::services::age_gate_service::AgeGateRepoParams {
+    use crate::services::age_gate_service::{AgeGateMode, AgeGateRepoParams};
 
     AgeGateRepoParams::from_parts(
         info.id,
         info.key.clone(),
-        repo_type,
-        format,
+        age_gate_repo_type_from_str(&info.repo_type),
+        age_gate_format_from_str(&info.format),
         info.age_gate_enabled,
         info.age_gate_min_age_days,
+        AgeGateMode::parse(&info.age_gate_mode).unwrap_or_default(),
+        info.upstream_url.clone(),
     )
 }
 
@@ -4987,6 +5017,102 @@ pub async fn enforce_curation_lookup(
         default_action: &default_action,
     };
     enforce_curation(db, target, package, version).await
+}
+
+/// 503 response when a repository's age gate is enabled but cannot be
+/// evaluated (service unwired, config unreadable, or no evidence resolution
+/// at the calling seam). The age gate fails CLOSED (#2264): an evaluation
+/// error must refuse the download rather than impersonate a disabled gate —
+/// the deliberate divergence from the curation seam above, which fails open.
+pub fn age_gate_unavailable_response(repo_key: &str, package: &str) -> Response {
+    let body = serde_json::json!({
+        "error": "age_gate_unavailable",
+        "repository": repo_key,
+        "package": package,
+        "message": "The age gate is enabled for this repository but could not be evaluated; refusing the download (fail closed)"
+    });
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
+/// Enforce a repository's publish-age gate on a supported proxy
+/// pull/download (#2264).
+///
+/// The caller supplies the identity it already parses (the same convention as
+/// the curation seam) plus the upstream publish evidence its format resolves;
+/// this core owns applicability, the decision, review-row recording (via
+/// [`AgeGateService::check`]), and the terminal 451.
+///
+/// Outcome mapping:
+/// * `Ok(None)` — allowed: gate off / repository-format not in the
+///   enforceable matrix / version meets the threshold / sticky approval.
+/// * `Ok(Some(blocked))` — blocked, but a last-known-good version exists; the
+///   caller substitutes its format-specific LKG response (npm rebuilds a
+///   tarball path, pypi a wheel filename) so LKG construction stays with the
+///   format that understands it. The outcome retains the real review id for
+///   protocols such as Go that intentionally do not substitute an LKG.
+/// * `Err(451)` — blocked with no LKG: structured `age_gate_blocked` body,
+///   review row created/bumped.
+/// * `Err(5xx)` — the check itself failed. Unlike the curation seam, the age
+///   gate fails CLOSED; see [`age_gate_unavailable_response`].
+///
+/// [`AgeGateService`]: crate::services::age_gate_service::AgeGateService
+#[derive(Debug)]
+pub struct AgeGateSubstitution {
+    pub review_id: Uuid,
+    pub last_known_good: crate::services::age_gate_service::LastKnownGood,
+}
+
+#[allow(clippy::result_large_err)]
+pub async fn enforce_age_gate(
+    svc: Option<&crate::services::age_gate_service::AgeGateService>,
+    params: &crate::services::age_gate_service::AgeGateRepoParams,
+    package: &str,
+    version: &str,
+    published_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> Result<Option<AgeGateSubstitution>, Response> {
+    use crate::services::age_gate_service::{AgeGateDecision, AgeGateService};
+
+    if !AgeGateService::gating_requested(params) {
+        return Ok(None);
+    }
+    AgeGateService::require_enforceable(params).map_err(|e| e.into_response())?;
+    // Applicability established: from here every non-allow path fails closed.
+    let Some(svc) = svc else {
+        return Err(age_gate_unavailable_response(&params.key, package));
+    };
+    match svc
+        .check(params, package, version, published_at)
+        .await
+        .map_err(|e| e.into_response())?
+    {
+        AgeGateDecision::Allow => Ok(None),
+        AgeGateDecision::Block {
+            review_id,
+            last_known_good: Some(lkg),
+        } => Ok(Some(AgeGateSubstitution {
+            review_id,
+            last_known_good: lkg,
+        })),
+        AgeGateDecision::Block {
+            review_id,
+            last_known_good: None,
+        } => {
+            let requested_age_days =
+                published_at.map(|p| AgeGateService::package_age_days(p, chrono::Utc::now()));
+            Err(age_gate_blocked_response(
+                review_id,
+                package,
+                version,
+                params.age_gate_min_age_days,
+                requested_age_days,
+            ))
+        }
+    }
 }
 
 /// Build a minimal `Repository` model for proxy operations.
@@ -6250,6 +6376,7 @@ mod tests {
             promotion_only,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         }
@@ -6955,6 +7082,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -8924,6 +9052,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9045,6 +9174,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9213,6 +9343,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9263,6 +9394,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9314,6 +9446,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9366,6 +9499,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9432,6 +9566,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -9499,6 +9634,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -11316,6 +11452,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: true,
             age_gate_min_age_days: 14,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -11704,6 +11841,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 0,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled,
             curation_default_action: "allow".to_string(),
         }
@@ -11792,5 +11930,140 @@ mod tests {
         );
 
         curation_cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // enforce_age_gate seam (#2264): the age-gate twin of the curation seam
+    // above, landing at the same call sites. Pins the outcome mapping
+    // (allow / LKG hand-back / terminal 451) and the deliberate divergence
+    // from curation: every non-allow evaluation failure fails CLOSED.
+    // -----------------------------------------------------------------------
+
+    fn age_gate_params_for(
+        id: uuid::Uuid,
+        key: &str,
+        repo_type: &str,
+        format: &str,
+        enabled: bool,
+        min_age_days: i32,
+    ) -> crate::services::age_gate_service::AgeGateRepoParams {
+        crate::services::age_gate_service::AgeGateRepoParams::from_parts(
+            id,
+            key.to_string(),
+            age_gate_repo_type_from_str(repo_type),
+            age_gate_format_from_str(format),
+            enabled,
+            min_age_days,
+            Default::default(),
+            None,
+        )
+    }
+
+    fn age_gate_svc(pool: sqlx::PgPool) -> crate::services::age_gate_service::AgeGateService {
+        use crate::services::event_bus::EventBus;
+        crate::services::age_gate_service::AgeGateService::new(
+            pool,
+            std::sync::Arc::new(EventBus::new(4)),
+        )
+    }
+
+    async fn response_json(resp: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        serde_json::from_slice(&bytes).expect("json body")
+    }
+
+    #[tokio::test]
+    async fn test_enforce_age_gate_not_applicable_allows_without_service() {
+        // Gate disabled / hosted repo: gating not requested -> allowed,
+        // and the absence of a wired service must not matter.
+        for (repo_type, format, enabled) in [
+            ("remote", "npm", false),
+            ("local", "npm", true),
+            ("local", "maven", true),
+        ] {
+            let params = age_gate_params_for(
+                uuid::Uuid::new_v4(),
+                "ag-seam",
+                repo_type,
+                format,
+                enabled,
+                7,
+            );
+            let out = enforce_age_gate(None, &params, "left-pad", "1.0.0", None).await;
+            assert!(
+                matches!(out, Ok(None)),
+                "({repo_type}, {format}, enabled={enabled}) must be allowed"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_enforce_age_gate_applicable_without_service_fails_closed() {
+        // An enabled, applicable gate with no wired service must refuse the
+        // download (503), never impersonate a disabled gate. Divergence from
+        // the curation seam, which fails open — deliberate (#2264).
+        let params = age_gate_params_for(uuid::Uuid::new_v4(), "ag-seam", "remote", "npm", true, 7);
+        let out = enforce_age_gate(None, &params, "left-pad", "1.0.0", None).await;
+        let resp = out.expect_err("must fail closed");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = response_json(resp).await;
+        assert_eq!(body["error"], "age_gate_unavailable");
+    }
+
+    #[tokio::test]
+    async fn test_enforce_age_gate_blocks_young_and_allows_old_db() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, key, _) = db_helpers::create_repo(&pool, "remote", "npm").await;
+        sqlx::query(
+            "UPDATE repositories SET age_gate_enabled = true, age_gate_min_age_days = 30 \
+             WHERE id = $1",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("enable age gate");
+        let svc = age_gate_svc(pool.clone());
+        let params = age_gate_params_for(repo_id, &key, "remote", "npm", true, 30);
+
+        // Young version, no LKG on record: terminal 451 with the structured
+        // body, and a pending review row recorded by the check.
+        let young = chrono::Utc::now() - chrono::Duration::days(1);
+        let out = enforce_age_gate(Some(&svc), &params, "seam-pkg", "2.0.0", Some(young)).await;
+        let resp = out.expect_err("young version must block");
+        assert_eq!(resp.status(), StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
+        let body = response_json(resp).await;
+        assert_eq!(body["error"], "age_gate_blocked");
+        assert_eq!(body["package"], "seam-pkg");
+        assert_eq!(body["min_age_days"], 30);
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM age_gate_reviews \
+             WHERE repository_id = $1 AND package_name = 'seam-pkg' AND status = 'pending'",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count review rows");
+        assert_eq!(count, 1, "the block must record a pending review row");
+
+        // A version past the threshold is allowed.
+        let old = chrono::Utc::now() - chrono::Duration::days(365);
+        let out = enforce_age_gate(Some(&svc), &params, "seam-pkg", "1.0.0", Some(old)).await;
+        assert!(matches!(out, Ok(None)), "old version must be allowed");
+
+        // Missing publish evidence counts as not meeting the threshold (#2066
+        // fail-closed carried through the seam).
+        let out = enforce_age_gate(Some(&svc), &params, "seam-pkg", "3.0.0", None).await;
+        assert!(out.is_err(), "missing publish evidence must block");
+
+        let _ = sqlx::query("DELETE FROM age_gate_reviews WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -38,7 +38,7 @@ use crate::api::SharedState;
 use crate::error::AppError;
 use crate::formats::pypi::PypiHandler;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
-use crate::services::age_gate_service::{AgeGateDecision, AgeGateService};
+use crate::services::age_gate_service::AgeGateService;
 use crate::services::upstream_metadata::metadata_http_client;
 use chrono::Utc;
 
@@ -1594,10 +1594,22 @@ async fn filter_pypi_simple_json_response(
     let Some(svc) = state.age_gate_service.as_ref() else {
         return json;
     };
-    let params = proxy_helpers::age_gate_params(repo);
-    if !AgeGateService::is_applicable(&params) {
+    // Quick struct-derived check, then DB-resolve the authoritative policy
+    // (mode + upstream identity) — a virtual member's RepoInfo carries a
+    // defaulted mode (#2264). A resolve failure serves the unfiltered
+    // listing; the download path re-checks fail-closed.
+    if !AgeGateService::is_applicable(&proxy_helpers::age_gate_params(repo)) {
         return json;
     }
+    let params = match crate::services::age_gate_service::resolve_repo_params(&state.db, repo.id)
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, repo_key = %repo.key, "Failed to resolve age-gate params for PyPI simple JSON response; suppressing listing");
+            return "{\"files\":[]}".to_string();
+        }
+    };
     let Ok(mut index) = serde_json::from_str::<serde_json::Value>(&json) else {
         // `rewrite_upstream_simple_json` only returns JSON it serialized
         // itself, so this branch is unreachable in practice.
@@ -1632,19 +1644,40 @@ async fn filter_pypi_simple_html_response(
     let Some(svc) = state.age_gate_service.as_ref() else {
         return html;
     };
-    let params = proxy_helpers::age_gate_params(repo);
-    if !AgeGateService::is_applicable(&params) {
+    // Quick struct-derived check, then DB-resolve the authoritative policy —
+    // same rationale as the JSON twin above (#2264).
+    if !AgeGateService::is_applicable(&proxy_helpers::age_gate_params(repo)) {
         return html;
     }
-    let Ok(client) = metadata_http_client() else {
-        return html;
-    };
-    let Ok(times) = svc
-        .metadata_cache()
-        .fetch_pypi_publish_times(&client, repo.id, effective_upstream, project)
+    let params = match crate::services::age_gate_service::resolve_repo_params(&state.db, repo.id)
         .await
-    else {
-        return html;
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, repo_key = %repo.key, "Failed to resolve age-gate params for PyPI simple HTML response; suppressing listing");
+            return "<html><body></body></html>".to_string();
+        }
+    };
+    // Publish times are only the basis in `upstream_publish_time` mode;
+    // `first_seen` substitutes this server's own observations inside the
+    // filter, so the fetch is skipped (and a fetch failure must not skip
+    // filtering there).
+    let times = if params.age_gate_mode
+        == crate::services::age_gate_service::AgeGateMode::UpstreamPublishTime
+    {
+        let Ok(client) = metadata_http_client() else {
+            return html;
+        };
+        let Ok(times) = svc
+            .metadata_cache()
+            .fetch_pypi_publish_times(&client, repo.id, effective_upstream, project)
+            .await
+        else {
+            return html;
+        };
+        times
+    } else {
+        std::collections::HashMap::new()
     };
     match svc
         .filter_pypi_simple_index(&params, project, &times, &html)
@@ -1661,14 +1694,16 @@ async fn apply_pypi_download_age_gate(
     project: &str,
     filename: &str,
 ) -> Result<Option<String>, Response> {
-    let svc = match state.age_gate_service.as_ref() {
-        Some(s) => s,
-        None => return Ok(None),
-    };
-    let params = proxy_helpers::age_gate_params(repo);
-    if !AgeGateService::is_applicable(&params) {
+    // Cheap struct-derived pre-check, then DB-resolve the authoritative
+    // policy (mode + upstream identity) by id — struct-derived params can
+    // carry a stale or defaulted mode (e.g. a virtual member's RepoInfo),
+    // and gate policy is enforcement input (#2264).
+    if !AgeGateService::is_applicable(&proxy_helpers::age_gate_params(repo)) {
         return Ok(None);
     }
+    let params = crate::services::age_gate_service::resolve_repo_params(&state.db, repo.id)
+        .await
+        .map_err(|e| e.into_response())?;
 
     let info = PypiHandler::parse_filename(filename)
         .map_err(|e| AppError::Validation(e.to_string()).into_response())?;
@@ -1676,44 +1711,41 @@ async fn apply_pypi_download_age_gate(
         AppError::Validation("Missing version in filename".to_string()).into_response()
     })?;
 
-    let published_at =
-        if let (Some(upstream_url), Ok(client)) = (&repo.upstream_url, metadata_http_client()) {
-            svc.metadata_cache()
-                .fetch_pypi_publish_times(&client, repo.id, upstream_url, project)
-                .await
-                .ok()
-                .and_then(|times| times.get(&version).copied())
-        } else {
-            None
-        };
-
-    match svc
-        .check(&params, project, &version, published_at)
-        .await
-        .map_err(|e| e.into_response())?
+    let svc = state.age_gate_service.as_deref();
+    // Publish-time evidence from the project's upstream JSON metadata; under
+    // `first_seen` the time itself is ignored, but presence in the document
+    // is the existence evidence that may start the observation clock.
+    let published_at = if let (Some(svc), Some(upstream_url), Ok(client)) =
+        (svc, &repo.upstream_url, metadata_http_client())
     {
-        AgeGateDecision::Allow => Ok(None),
-        AgeGateDecision::Block {
-            review_id: _,
-            last_known_good: Some(lkg),
-        } => Ok(Some(pypi_lkg_filename_from_artifact_path(
-            &lkg.artifact_path,
-        ))),
-        AgeGateDecision::Block {
-            review_id,
-            last_known_good: None,
-        } => {
-            let requested_age_days =
-                published_at.map(|p| AgeGateService::package_age_days(p, Utc::now()));
-            Err(proxy_helpers::age_gate_blocked_response(
-                review_id,
+        svc.metadata_cache()
+            .fetch_pypi_publish_times(&client, repo.id, upstream_url, project)
+            .await
+            .ok()
+            .and_then(|times| times.get(&version).copied())
+    } else {
+        None
+    };
+    let basis = match svc {
+        Some(svc) => svc
+            .download_basis(
+                &params,
                 project,
                 &version,
-                repo.age_gate_min_age_days,
-                requested_age_days,
-            ))
-        }
-    }
+                published_at,
+                published_at.is_some(),
+            )
+            .await
+            .map_err(|e| e.into_response())?,
+        None => published_at,
+    };
+
+    // The shared seam (#2264) owns the decision and the terminal 451; only
+    // the LKG wheel-filename substitution below is pypi-specific.
+    let lkg = proxy_helpers::enforce_age_gate(svc, &params, project, &version, basis).await?;
+    Ok(lkg.map(|blocked| {
+        pypi_lkg_filename_from_artifact_path(&blocked.last_known_good.artifact_path)
+    }))
 }
 
 /// Run the remote-PyPI download age gate and, when the requested version is
@@ -6471,7 +6503,17 @@ mod tests {
         let mut repo_info = fx.repo_info("remote", Some(&upstream.uri()));
         repo_info.format = "pypi".to_string();
         repo_info.age_gate_enabled = true;
-        repo_info.age_gate_min_age_days = 36_500; // 100 years
+        repo_info.age_gate_min_age_days = 3650; // 10 years
+                                                // The gate re-resolves policy from the repositories row (the struct
+                                                // only pre-screens), so the DB must agree with the struct above.
+        sqlx::query(
+            "UPDATE repositories SET age_gate_enabled = true, age_gate_min_age_days = 3650 \
+             WHERE id = $1",
+        )
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("enable age gate on repo row");
 
         // Seed the local `artifacts` row + payload that would otherwise be
         // served straight from storage on the cache-hit branch.

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1580,10 +1580,11 @@ fn build_pypi_proxy_cache_path(normalized_project: &str, filename: &str) -> Stri
 /// index (#1944). The JSON and HTML representations of one index must
 /// withhold the same young versions, or a JSON-negotiating client (modern
 /// pip) sees everything the HTML filter hides. Mirrors the HTML hook in
-/// `simple_project`: a filter failure serves the unfiltered listing rather
-/// than failing the request — the download path re-checks every version
-/// independently and fails closed, so enforcement never rests on this
-/// listing-side filter.
+/// `simple_project`: an evaluation/filter failure serves the unfiltered
+/// listing rather than failing the request, while an authoritative policy
+/// resolution failure returns a structurally valid empty listing. The
+/// download path re-checks every version independently and fails closed, so
+/// enforcement never rests on this listing-side filter.
 async fn filter_pypi_simple_json_response(
     state: &SharedState,
     repo: &RepoInfo,
@@ -1596,8 +1597,8 @@ async fn filter_pypi_simple_json_response(
     };
     // Quick struct-derived check, then DB-resolve the authoritative policy
     // (mode + upstream identity) — a virtual member's RepoInfo carries a
-    // defaulted mode (#2264). A resolve failure serves the unfiltered
-    // listing; the download path re-checks fail-closed.
+    // defaulted mode (#2264). A resolve failure suppresses the listing with a
+    // valid PEP 691 empty response; the download path re-checks fail-closed.
     if !AgeGateService::is_applicable(&proxy_helpers::age_gate_params(repo)) {
         return json;
     }
@@ -1607,7 +1608,7 @@ async fn filter_pypi_simple_json_response(
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(error = %e, repo_key = %repo.key, "Failed to resolve age-gate params for PyPI simple JSON response; suppressing listing");
-            return "{\"files\":[]}".to_string();
+            return empty_pep691_listing(project);
         }
     };
     let Ok(mut index) = serde_json::from_str::<serde_json::Value>(&json) else {
@@ -3859,11 +3860,13 @@ fn case_a_filter_remote_body(
     Bytes::from(filtered)
 }
 
-/// An empty PEP 691 simple-index listing for `normalized` — the fail-closed body
-/// for a locally-owned name whose suppressed Remote member returned a body that
-/// could not be ownership-filtered (#2967 R4). Mirrors the PEP 691 shape the
-/// merge path expects (`meta`/`name`/`versions`/`files`) so the local splice
-/// still runs, and guarantees no raw upstream byte is ever surfaced.
+/// A structurally valid empty PEP 691 simple-index listing for `normalized`.
+/// Used whenever a listing must fail closed without breaking JSON-simple
+/// clients: for a locally-owned name whose suppressed Remote member returned a
+/// body that could not be ownership-filtered (#2967 R4), and for an age-gate
+/// policy-resolution failure. Mirrors the shape the merge path expects
+/// (`meta`/`name`/`versions`/`files`) and guarantees no raw upstream byte is
+/// surfaced.
 fn empty_pep691_listing(normalized: &str) -> String {
     serde_json::json!({
         "meta": {"api-version": "1.0"},
@@ -4749,6 +4752,17 @@ mod tests {
     #[test]
     fn test_rewrite_upstream_simple_json_returns_none_for_non_json() {
         assert!(rewrite_upstream_simple_json(b"<!DOCTYPE html><html></html>", "r", "p").is_none());
+    }
+
+    #[test]
+    fn test_empty_pep691_listing_preserves_required_project_shape() {
+        let doc: serde_json::Value =
+            serde_json::from_str(&empty_pep691_listing("my-package")).unwrap();
+
+        assert_eq!(doc["meta"]["api-version"], "1.0");
+        assert_eq!(doc["name"], "my-package");
+        assert_eq!(doc["versions"], serde_json::json!([]));
+        assert_eq!(doc["files"], serde_json::json!([]));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2714,6 +2714,7 @@ pub async fn create_repository(
                 visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
                 age_gate_enabled: None,
                 age_gate_min_age_days: None,
+                age_gate_mode: None,
             }),
     )
     .await;
@@ -3637,6 +3638,7 @@ pub async fn update_repository(
                 visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
                 age_gate_enabled: None,
                 age_gate_min_age_days: None,
+                age_gate_mode: None,
             }),
     )
     .await;
@@ -4175,6 +4177,7 @@ pub async fn delete_repository(
                 visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
                 age_gate_enabled: None,
                 age_gate_min_age_days: None,
+                age_gate_mode: None,
             }),
     )
     .await;

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -1136,6 +1136,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -1186,6 +1186,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -1208,6 +1209,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -2211,6 +2211,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -2236,6 +2237,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1090,6 +1090,7 @@ pub fn make_repo_info(
         promotion_only: false,
         age_gate_enabled: false,
         age_gate_min_age_days: 7,
+        age_gate_mode: "upstream_publish_time".to_string(),
         curation_enabled: false,
         curation_default_action: "allow".to_string(),
     }

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -813,6 +813,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };
@@ -836,6 +837,7 @@ mod tests {
             promotion_only: false,
             age_gate_enabled: false,
             age_gate_min_age_days: 7,
+            age_gate_mode: "upstream_publish_time".to_string(),
             curation_enabled: false,
             curation_default_action: "allow".to_string(),
         };

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -143,6 +143,11 @@ pub enum WebhookEvent {
     AgeGateQueued,
     AgeGateApproved,
     AgeGateRejected,
+    /// A decided review moved back to `pending` (#2968). Emitted on the
+    /// internal bus since reopen shipped; mapped to a webhook so subscribers
+    /// that saw `age_gate_approved` / `age_gate_rejected` also see the
+    /// decision being voided (#2264 rides this along).
+    AgeGateReopened,
 }
 
 impl std::fmt::Display for WebhookEvent {
@@ -160,6 +165,7 @@ impl std::fmt::Display for WebhookEvent {
             WebhookEvent::AgeGateQueued => write!(f, "age_gate_queued"),
             WebhookEvent::AgeGateApproved => write!(f, "age_gate_approved"),
             WebhookEvent::AgeGateRejected => write!(f, "age_gate_rejected"),
+            WebhookEvent::AgeGateReopened => write!(f, "age_gate_reopened"),
         }
     }
 }

--- a/backend/src/formats/mod.rs
+++ b/backend/src/formats/mod.rs
@@ -305,3 +305,81 @@ pub fn list_core_formats() -> Vec<&'static str> {
         "lxc",
     ]
 }
+
+// ---------------------------------------------------------------------------
+// Age-gate capability registry (#2264)
+// ---------------------------------------------------------------------------
+
+/// Per-format age-gate capability spec: the single registry every age-gate
+/// capability decision derives from.
+///
+/// One spec per protocol family owns:
+///   * the canonical format aliases collapse onto (`canonical`);
+///   * the bounded metrics label (`label`);
+///   * whether the upstream treats a published coordinate as immutable
+///     (`immutable_coordinates`) — the trust prerequisite for `first_seen`:
+///     a registry that permits overwrite or delete-and-republish can
+///     substitute new content under an aged coordinate; and
+///   * whether this server can resolve upstream publish times for the format
+///     (`publish_time_resolver`) — the prerequisite for
+///     `upstream_publish_time`.
+///
+/// Mode support follows from capabilities
+/// (`AgeGateService::supports_format_mode`); the config endpoint and the
+/// enforcement seam both read this registry, so there is no second
+/// hand-maintained matrix to drift. Package identity is NOT derived here —
+/// per the #2962 seam convention, each format's download handler passes the
+/// identity it already parses.
+pub struct AgeGateFormatSpec {
+    pub canonical: RepositoryFormat,
+    pub label: &'static str,
+    pub immutable_coordinates: bool,
+    pub publish_time_resolver: bool,
+}
+
+static NPM_AGE_GATE_SPEC: AgeGateFormatSpec = AgeGateFormatSpec {
+    canonical: RepositoryFormat::Npm,
+    label: "npm",
+    // npm forbids republishing a (name, version) once published (even after
+    // unpublish, the version number is burned).
+    immutable_coordinates: true,
+    // Packument `time` map.
+    publish_time_resolver: true,
+};
+
+static PYPI_AGE_GATE_SPEC: AgeGateFormatSpec = AgeGateFormatSpec {
+    canonical: RepositoryFormat::Pypi,
+    label: "pypi",
+    // PyPI forbids re-uploading a distribution filename once uploaded.
+    immutable_coordinates: true,
+    // Warehouse JSON `upload-time`.
+    publish_time_resolver: true,
+};
+
+static GO_AGE_GATE_SPEC: AgeGateFormatSpec = AgeGateFormatSpec {
+    canonical: RepositoryFormat::Go,
+    label: "go",
+    // Module proxies serve immutable, checksum-database-pinned versions: a
+    // published (module, version) cannot be replaced with different content
+    // without breaking go.sum verification.
+    immutable_coordinates: true,
+    // `.info` timestamps are VCS tag times the publisher controls — advisory
+    // at best — so there is no trustworthy publish-time resolver; `first_seen`
+    // is the only supported age source.
+    publish_time_resolver: false,
+};
+
+/// Look up the age-gate capability spec for a repository format, collapsing
+/// protocol aliases (yarn/pnpm speak npm; poetry speaks PyPI) onto the
+/// canonical format that owns their policy. `None` means the format has no
+/// age-gate support; the config endpoint rejects attempts to enable it.
+pub fn age_gate_spec(format: &RepositoryFormat) -> Option<&'static AgeGateFormatSpec> {
+    match format {
+        RepositoryFormat::Npm | RepositoryFormat::Yarn | RepositoryFormat::Pnpm => {
+            Some(&NPM_AGE_GATE_SPEC)
+        }
+        RepositoryFormat::Pypi | RepositoryFormat::Poetry => Some(&PYPI_AGE_GATE_SPEC),
+        RepositoryFormat::Go => Some(&GO_AGE_GATE_SPEC),
+        _ => None,
+    }
+}

--- a/backend/src/services/age_gate_service.rs
+++ b/backend/src/services/age_gate_service.rs
@@ -1,18 +1,16 @@
-//! Age-based quality gate for remote NPM and PyPI proxy registries.
+//! Age-based quality gate for supported remote proxy registries.
 //!
-//! # v1 scope limitation
-//!
-//! The gate applies **only to direct Remote repositories** (npm and PyPI).
-//! Virtual repositories whose members include Remote repositories are not
-//! age-gated on the download path — only the Direct Remote branch is checked.
-//! Consumers fetching through a Virtual repo receive unfiltered pass-through.
-//! This is intentional for v1 and should be addressed before extending the
-//! gate to other repository types.
+//! npm and PyPI support upstream publish time and first-seen policy; Go
+//! supports first-seen policy. Direct Remote repositories are evaluated
+//! directly. Virtual repositories apply the policy of the Remote member that
+//! supplied metadata or content, while Local members remain ungated.
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -29,6 +27,50 @@ pub const AUTO_APPROVE_REASON: &str = "auto-approved: crossed age threshold";
 /// listings of the same package skip the per-version write
 const REQUEST_COUNT_DEBOUNCE_SECS: i64 = 3600;
 
+/// Where a repository's cooldown clock starts (#2264 / #1558 follow-up).
+///
+/// The mode is part of the gate's policy identity: a basis measured under one
+/// mode (or against one upstream) never satisfies a policy configured with the
+/// other — see [`review_identity_match`]. Keeping the two sources distinct
+/// means a repository configured for `first_seen` never quietly reverts to
+/// publish time because an upstream timestamp happens to be available, and a
+/// repository configured for `upstream_publish_time` blocks (rather than
+/// substituting a local observation) when that timestamp is missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AgeGateMode {
+    /// The upstream registry's reported publish timestamp (the #2066 model).
+    /// Only as trustworthy as the registry serving it.
+    #[default]
+    UpstreamPublishTime,
+    /// The first time this server observed the version for this repository.
+    /// Needs no upstream metadata and cannot be backdated by a publisher, at
+    /// the cost of measuring local freshness rather than true package age:
+    /// every version of a package is "new" the first time the repository
+    /// sees it, including versions that are objectively ancient.
+    FirstSeen,
+}
+
+impl AgeGateMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UpstreamPublishTime => "upstream_publish_time",
+            Self::FirstSeen => "first_seen",
+        }
+    }
+
+    /// Parse the DB/API representation. Unknown values are a client error,
+    /// never a silent fall back to the default mode.
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "upstream_publish_time" => Ok(Self::UpstreamPublishTime),
+            "first_seen" => Ok(Self::FirstSeen),
+            other => Err(AppError::Validation(format!(
+                "Unknown age gate mode '{other}': expected 'upstream_publish_time' or 'first_seen'"
+            ))),
+        }
+    }
+}
+
 /// Minimal repository view for age-gate decisions (avoids handler ↔ service coupling).
 #[derive(Debug, Clone)]
 pub struct AgeGateRepoParams {
@@ -39,9 +81,14 @@ pub struct AgeGateRepoParams {
     pub format: RepositoryFormat,
     pub age_gate_enabled: bool,
     pub age_gate_min_age_days: i32,
+    pub age_gate_mode: AgeGateMode,
+    /// The upstream this repository proxies. Identifies which registry a
+    /// `first_seen` observation was made against (see [`upstream_fingerprint`]).
+    pub upstream_url: Option<String>,
 }
 
 impl AgeGateRepoParams {
+    #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
         id: Uuid,
         key: impl Into<String>,
@@ -49,6 +96,8 @@ impl AgeGateRepoParams {
         format: RepositoryFormat,
         age_gate_enabled: bool,
         age_gate_min_age_days: i32,
+        age_gate_mode: AgeGateMode,
+        upstream_url: Option<String>,
     ) -> Self {
         Self {
             id,
@@ -57,18 +106,84 @@ impl AgeGateRepoParams {
             format,
             age_gate_enabled,
             age_gate_min_age_days,
+            age_gate_mode,
+            upstream_url,
         }
     }
+}
 
-    pub fn from_repository(repo: &crate::models::repository::Repository) -> Self {
-        Self::from_parts(
-            repo.id,
-            repo.key.clone(),
-            repo.repo_type.clone(),
-            repo.format.clone(),
-            repo.age_gate_enabled,
-            repo.age_gate_min_age_days,
-        )
+/// Resolve a repository's age-gate policy inputs from the database, by id.
+///
+/// For callers holding a `Repository` model rather than a resolved `RepoInfo`
+/// row (e.g. the npm virtual-member metadata loop): the model deliberately
+/// does NOT carry `age_gate_mode`, so policy inputs are re-read from the
+/// source of truth instead of being derived from whatever struct is in hand.
+/// A missing row or a failed read is an error: a repository whose
+/// configuration cannot be read must fail the request, never impersonate
+/// `enabled = false`.
+pub async fn resolve_repo_params(db: &PgPool, repository_id: Uuid) -> Result<AgeGateRepoParams> {
+    use sqlx::Row as _;
+
+    let row = sqlx::query(
+        "SELECT key, repo_type, format, \
+         age_gate_enabled, age_gate_min_age_days, age_gate_mode, upstream_url \
+         FROM repositories WHERE id = $1",
+    )
+    .bind(repository_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?
+    .ok_or_else(|| {
+        AppError::NotFound(format!(
+            "Repository {repository_id} not found for age-gate resolution"
+        ))
+    })?;
+
+    let column = |e: sqlx::Error| AppError::Database(e.to_string());
+
+    Ok(AgeGateRepoParams::from_parts(
+        repository_id,
+        row.try_get::<String, _>("key").map_err(column)?,
+        row.try_get::<RepositoryType, _>("repo_type")
+            .map_err(column)?,
+        AgeGateService::normalize_format(
+            row.try_get::<RepositoryFormat, _>("format")
+                .map_err(column)?,
+        ),
+        row.try_get::<bool, _>("age_gate_enabled").map_err(column)?,
+        row.try_get::<i32, _>("age_gate_min_age_days")
+            .map_err(column)?,
+        AgeGateMode::parse(&row.try_get::<String, _>("age_gate_mode").map_err(column)?)?,
+        row.try_get::<Option<String>, _>("upstream_url")
+            .map_err(column)?,
+    ))
+}
+
+/// Identify the upstream a `first_seen` observation was made against.
+///
+/// Part of the observation's primary key: an observation says "this server
+/// first saw version V of package P *from this upstream* at time T", and that
+/// statement is void if the repository is later repointed at a different
+/// registry. Binding the identity to the upstream means a repoint starts a
+/// fresh clock by construction, instead of requiring every repository-update
+/// path to remember to invalidate observations.
+pub fn upstream_fingerprint(upstream_url: Option<&str>) -> String {
+    let normalized = normalize_upstream_url(upstream_url.unwrap_or_default());
+    hex::encode(Sha256::digest(normalized.as_bytes()))
+}
+
+/// Normalize an upstream URL so that cosmetically different spellings of the
+/// same registry (trailing slash, upper-case host, explicit default port)
+/// share one fingerprint. Paths keep their case: most registries are
+/// case-sensitive there. An unparseable value is fingerprinted as-is rather
+/// than being coerced into a shared bucket.
+pub(crate) fn normalize_upstream_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    match url::Url::parse(trimmed) {
+        // `Url` lower-cases the scheme and host and drops a default port; its
+        // serialization re-adds the root path, which we trim back off.
+        Ok(parsed) => parsed.to_string().trim_end_matches('/').to_string(),
+        Err(_) => trimmed.to_string(),
     }
 }
 
@@ -90,6 +205,51 @@ impl AgeGateReviewStatus {
     }
 }
 
+/// How an existing review row's recorded basis identity relates to the
+/// repository's current policy (mode + normalized upstream fingerprint).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReviewIdentityMatch {
+    /// Recorded under exactly the current (mode, upstream) identity.
+    Matches,
+    /// Recorded under a different mode or upstream. A basis or decision from
+    /// a different identity must never satisfy the current policy.
+    Differs,
+    /// Pre-identity row (both columns NULL, written before migration 191).
+    /// Manual decisions from that era keep their effect — administrators made
+    /// them and there is no recorded identity to contradict; automatic
+    /// approvals do not, because they are recomputable bookkeeping.
+    Legacy,
+}
+
+/// Policy-relevant view of an existing review row, decoupled from the row
+/// shape so [`decide_age_gate_check`] stays a pure function.
+#[derive(Debug, Clone)]
+pub(crate) struct ReviewPolicyView {
+    pub status: String,
+    /// `reviewed_by IS NULL`: approved by the automatic threshold machinery
+    /// (request path or background sweep), not an administrator. Automatic
+    /// approvals are never sticky — they are re-derived from the current
+    /// basis, threshold, and upstream on every decision.
+    pub is_automatic: bool,
+    pub identity: ReviewIdentityMatch,
+}
+
+/// Compare a review row's recorded basis identity against the current policy.
+pub(crate) fn review_identity_match(
+    basis_mode: Option<&str>,
+    basis_fingerprint: Option<&str>,
+    current_mode: AgeGateMode,
+    current_fingerprint: &str,
+) -> ReviewIdentityMatch {
+    match (basis_mode, basis_fingerprint) {
+        (None, None) => ReviewIdentityMatch::Legacy,
+        (Some(mode), Some(fp)) if mode == current_mode.as_str() && fp == current_fingerprint => {
+            ReviewIdentityMatch::Matches
+        }
+        _ => ReviewIdentityMatch::Differs,
+    }
+}
+
 /// Side-effect-free outcome of evaluating a single-version age gate check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AgeGateCheckAction {
@@ -98,28 +258,59 @@ pub(crate) enum AgeGateCheckAction {
     AllowAndAutoApprovePending,
     AllowAlreadyApproved,
     BlockAndRequestReview,
+    /// The row carries a decision the current policy must not honor (an
+    /// automatic approval, or a manual approval bound to a different
+    /// identity): void it back to pending under the current basis and
+    /// identity, and block.
+    BlockAndResetReview,
 }
 
-/// Pure state machine for [`AgeGateService::check`]: maps existing review status
-/// and whether the version meets the age threshold to the action the impure
-/// wrapper should take (DB writes, metrics, LKG lookup).
+/// Pure state machine for [`AgeGateService::check`]: maps the existing review
+/// row (if any) and whether the version meets the age threshold *on the
+/// current clock* to the action the impure wrapper should take (DB writes,
+/// metrics, LKG lookup).
+///
+/// The rules, in order:
+///
+/// * a rejection blocks coordinate-wide — deliberately conservative: an
+///   administrator said "not this version", and a mode switch or repoint
+///   should not quietly unblock it (since #2968, `reopen` is the sanctioned
+///   unblock path);
+/// * a version that meets the threshold on the current basis is allowed —
+///   the basis passed in was resolved under the current policy, so this is
+///   the authoritative recomputation that makes automatic approvals inert as
+///   status (a pending row is retired to `approved` on the way through);
+/// * below the threshold, only a *manual* approval whose identity matches the
+///   current policy (or a pre-identity legacy manual approval) still allows;
+/// * a manual approval under a different identity, or any automatic
+///   approval that no longer holds (raised threshold, switched mode,
+///   repointed upstream, legacy row), is voided back to pending and blocks;
+/// * anything else blocks and records/bumps the pending review.
 pub(crate) fn decide_age_gate_check(
-    existing_status: Option<&str>,
+    existing: Option<&ReviewPolicyView>,
     meets_threshold: bool,
 ) -> AgeGateCheckAction {
-    if existing_status == Some(AgeGateReviewStatus::Rejected.as_str()) {
-        return AgeGateCheckAction::BlockRejected;
+    if let Some(review) = existing {
+        if review.status == AgeGateReviewStatus::Rejected.as_str() {
+            return AgeGateCheckAction::BlockRejected;
+        }
     }
     if meets_threshold {
-        if existing_status == Some(AgeGateReviewStatus::Pending.as_str()) {
+        if existing.is_some_and(|r| r.status == AgeGateReviewStatus::Pending.as_str()) {
             return AgeGateCheckAction::AllowAndAutoApprovePending;
         }
         return AgeGateCheckAction::Allow;
     }
-    if existing_status == Some(AgeGateReviewStatus::Approved.as_str()) {
-        return AgeGateCheckAction::AllowAlreadyApproved;
+    match existing {
+        Some(review) if review.status == AgeGateReviewStatus::Approved.as_str() => {
+            if !review.is_automatic && review.identity != ReviewIdentityMatch::Differs {
+                AgeGateCheckAction::AllowAlreadyApproved
+            } else {
+                AgeGateCheckAction::BlockAndResetReview
+            }
+        }
+        _ => AgeGateCheckAction::BlockAndRequestReview,
     }
-    AgeGateCheckAction::BlockAndRequestReview
 }
 
 /// Per-version classification output for metadata listing (npm packument / PyPI simple index).
@@ -130,20 +321,39 @@ pub(crate) struct MetadataListingClassification {
     pub request_times: Vec<Option<DateTime<Utc>>>,
 }
 
+/// One existing review row as loaded for a whole-package batch evaluation.
+#[derive(Debug, Clone)]
+pub(crate) struct PackageReviewRow {
+    pub status: String,
+    /// `reviewed_by IS NULL` — see [`ReviewPolicyView::is_automatic`].
+    pub is_automatic: bool,
+    pub basis_mode: Option<String>,
+    pub basis_upstream_fingerprint: Option<String>,
+}
+
 /// Classify every version in a metadata document without I/O. Used by
 /// [`AgeGateService::evaluate_versions_batch`].
+///
+/// Applies the same rules as [`decide_age_gate_check`], so a version withheld
+/// from a listing is refused on direct download and vice versa: rejections
+/// block coordinate-wide; the current-clock threshold decides; below the
+/// threshold only an identity-bound (or legacy) *manual* approval still
+/// lists. A stale approval — automatic, or manual under a different identity
+/// — is withheld and re-requested; the batch upsert voids it back to pending.
 pub(crate) fn classify_versions_for_metadata_listing(
     versions: &[(String, Option<DateTime<Utc>>)],
-    existing_reviews: &std::collections::HashMap<String, (Uuid, String)>,
+    existing_reviews: &std::collections::HashMap<String, PackageReviewRow>,
     min_age_days: i32,
+    current_mode: AgeGateMode,
+    current_fingerprint: &str,
     now: DateTime<Utc>,
 ) -> MetadataListingClassification {
     let mut out = MetadataListingClassification::default();
     for (version, published_at) in versions {
         let existing_review = existing_reviews.get(version);
 
-        if let Some((_, status)) = existing_review {
-            if status == AgeGateReviewStatus::Rejected.as_str() {
+        if let Some(review) = existing_review {
+            if review.status == AgeGateReviewStatus::Rejected.as_str() {
                 out.blocked.insert(version.clone());
                 continue;
             }
@@ -153,8 +363,16 @@ pub(crate) fn classify_versions_for_metadata_listing(
             continue;
         }
 
-        if let Some((_, status)) = existing_review {
-            if status == AgeGateReviewStatus::Approved.as_str() {
+        if let Some(review) = existing_review {
+            if review.status == AgeGateReviewStatus::Approved.as_str()
+                && !review.is_automatic
+                && review_identity_match(
+                    review.basis_mode.as_deref(),
+                    review.basis_upstream_fingerprint.as_deref(),
+                    current_mode,
+                    current_fingerprint,
+                ) != ReviewIdentityMatch::Differs
+            {
                 continue;
             }
         }
@@ -227,6 +445,12 @@ pub struct AgeGateReview {
     pub review_reason: Option<String>,
     pub request_count: i32,
     pub last_requested_at: DateTime<Utc>,
+    /// The (mode, upstream) identity the recorded basis was resolved under
+    /// (migration 191). NULL on pre-identity rows; see [`ReviewIdentityMatch`].
+    #[sqlx(default)]
+    pub basis_mode: Option<String>,
+    #[sqlx(default)]
+    pub basis_upstream_fingerprint: Option<String>,
     #[sqlx(default)]
     pub repository_key: Option<String>,
 }
@@ -250,11 +474,74 @@ impl AgeGateService {
         &self.metadata_cache
     }
 
-    /// Whether the age gate applies to this repository.
+    /// Whether an operator has asked for gating on this repository at
+    /// all: a Remote repository with the gate enabled.
+    ///
+    /// Deliberately separate from [`Self::supports_format_mode`]. Supported
+    /// handlers use [`Self::require_enforceable`] after this check so an
+    /// invalid mode cannot silently bypass policy. Formats outside the
+    /// capability matrix have no age-gate handler hook, and the config
+    /// endpoint rejects attempts to enable them.
+    pub fn gating_requested(repo: &AgeGateRepoParams) -> bool {
+        repo.repo_type == RepositoryType::Remote && repo.age_gate_enabled
+    }
+
+    /// Fail closed when a repository's enabled gate cannot actually be
+    /// enforced for its (format, mode) pair. Callers check
+    /// [`Self::gating_requested`] first; a repository that never asked for
+    /// gating is simply not applicable.
+    pub fn require_enforceable(repo: &AgeGateRepoParams) -> Result<()> {
+        if Self::supports_format_mode(&repo.format, repo.age_gate_mode) {
+            return Ok(());
+        }
+        Err(AppError::Internal(format!(
+            "age gate is enabled for repository '{}' but cannot be enforced for \
+             format {:?} in '{}' mode; failing closed",
+            repo.key,
+            repo.format,
+            repo.age_gate_mode.as_str()
+        )))
+    }
+
+    /// Whether the age gate applies to this repository (requested AND
+    /// enforceable). Read-only helpers use this; enforcement paths must use
+    /// [`Self::gating_requested`] + [`Self::require_enforceable`] so an
+    /// enabled-but-unenforceable configuration errors instead of passing.
     pub fn is_applicable(repo: &AgeGateRepoParams) -> bool {
-        repo.repo_type == RepositoryType::Remote
-            && repo.age_gate_enabled
-            && matches!(repo.format, RepositoryFormat::Npm | RepositoryFormat::Pypi)
+        Self::gating_requested(repo) && Self::supports_format_mode(&repo.format, repo.age_gate_mode)
+    }
+
+    /// The enforceable (format, mode) matrix, derived from the single
+    /// per-format capability registry ([`crate::formats::age_gate_spec`]):
+    ///
+    /// - `first_seen` requires immutable upstream coordinates — an
+    ///   observation binds elapsed time to a (package, version) name, which
+    ///   only means something when the upstream cannot substitute new content
+    ///   under that name;
+    /// - `upstream_publish_time` requires a publish-time resolver for the
+    ///   format.
+    ///
+    /// A format with no registry entry supports nothing. The config endpoint
+    /// and the enforcement seam both derive from this one function, so they
+    /// cannot drift.
+    pub fn supports_format_mode(format: &RepositoryFormat, mode: AgeGateMode) -> bool {
+        match crate::formats::age_gate_spec(format) {
+            Some(spec) => match mode {
+                AgeGateMode::FirstSeen => spec.immutable_coordinates,
+                AgeGateMode::UpstreamPublishTime => spec.publish_time_resolver,
+            },
+            None => false,
+        }
+    }
+
+    /// Collapse protocol aliases onto the format whose age-gate policy
+    /// governs them (Yarn/pnpm speak the npm registry protocol, Poetry the
+    /// PyPI one), via the capability registry.
+    pub fn normalize_format(format: RepositoryFormat) -> RepositoryFormat {
+        match crate::formats::age_gate_spec(&format) {
+            Some(spec) => spec.canonical.clone(),
+            None => format,
+        }
     }
 
     /// Compute package age in whole days from upstream publish time.
@@ -276,6 +563,15 @@ impl AgeGateService {
     }
 
     /// Core decision for a single package version.
+    ///
+    /// `published_at` is the basis resolved under the repository's *current*
+    /// policy (publish time or first-seen observation — see
+    /// [`Self::download_basis`]), so the threshold comparison here is the
+    /// authoritative recomputation: an `approved` row written by the
+    /// automatic machinery grants nothing by status alone. Existing review
+    /// rows are interpreted through their recorded basis identity
+    /// ([`review_identity_match`]); a decision recorded under a different
+    /// mode or upstream is voided back to pending rather than honored.
     pub async fn check(
         &self,
         repo: &AgeGateRepoParams,
@@ -283,58 +579,253 @@ impl AgeGateService {
         version: &str,
         published_at: Option<DateTime<Utc>>,
     ) -> Result<AgeGateDecision> {
-        if !Self::is_applicable(repo) {
+        if !Self::gating_requested(repo) {
             return Ok(AgeGateDecision::Allow);
         }
+        Self::require_enforceable(repo)?;
 
         let now = Utc::now();
+        let current_fingerprint = upstream_fingerprint(repo.upstream_url.as_deref());
         let existing = self.get_review(repo.id, package_name, version).await?;
-        let existing_status = existing.as_ref().map(|r| r.status.as_str());
+        let view = existing.as_ref().map(|r| ReviewPolicyView {
+            status: r.status.clone(),
+            is_automatic: r.reviewed_by.is_none(),
+            identity: review_identity_match(
+                r.basis_mode.as_deref(),
+                r.basis_upstream_fingerprint.as_deref(),
+                repo.age_gate_mode,
+                &current_fingerprint,
+            ),
+        });
         let meets_threshold =
             Self::meets_age_threshold(published_at, repo.age_gate_min_age_days, now);
 
-        match decide_age_gate_check(existing_status, meets_threshold) {
-            AgeGateCheckAction::Allow => return Ok(AgeGateDecision::Allow),
+        let block = |review_id: Uuid, lkg: Option<LastKnownGood>| {
+            metrics_service::record_age_gate_blocked_request(&repo.key, format_label(&repo.format));
+            Ok(AgeGateDecision::Block {
+                review_id,
+                last_known_good: lkg,
+            })
+        };
+
+        match decide_age_gate_check(view.as_ref(), meets_threshold) {
+            AgeGateCheckAction::Allow => Ok(AgeGateDecision::Allow),
+            AgeGateCheckAction::AllowAlreadyApproved => Ok(AgeGateDecision::Allow),
+            AgeGateCheckAction::AllowAndAutoApprovePending => {
+                let review = existing.as_ref().expect("pending implies existing review");
+                self.auto_approve(review.id, repo.id, repo.age_gate_mode, &current_fingerprint)
+                    .await?;
+                Ok(AgeGateDecision::Allow)
+            }
             AgeGateCheckAction::BlockRejected => {
                 let review = existing.as_ref().expect("rejected implies existing review");
                 let lkg = self
                     .find_last_known_good(repo.id, package_name, version)
                     .await?;
-                metrics_service::record_age_gate_blocked_request(
-                    &repo.key,
-                    format_label(&repo.format),
-                );
-                return Ok(AgeGateDecision::Block {
-                    review_id: review.id,
-                    last_known_good: lkg,
-                });
+                block(review.id, lkg)
             }
-            AgeGateCheckAction::AllowAndAutoApprovePending => {
-                let review = existing.as_ref().expect("pending implies existing review");
-                self.auto_approve(review.id, repo.id).await?;
-                return Ok(AgeGateDecision::Allow);
+            AgeGateCheckAction::BlockAndResetReview => {
+                let review = existing.as_ref().expect("reset implies existing review");
+                let review_id = self
+                    .reset_review_to_pending(
+                        review.id,
+                        repo.id,
+                        published_at,
+                        repo.age_gate_mode,
+                        &current_fingerprint,
+                    )
+                    .await?;
+                let lkg = self
+                    .find_last_known_good(repo.id, package_name, version)
+                    .await?;
+                block(review_id, lkg)
             }
-            AgeGateCheckAction::AllowAlreadyApproved => return Ok(AgeGateDecision::Allow),
-            AgeGateCheckAction::BlockAndRequestReview => {}
+            AgeGateCheckAction::BlockAndRequestReview => {
+                let review_id = self
+                    .request_review(
+                        repo,
+                        package_name,
+                        version,
+                        published_at,
+                        existing.is_none(),
+                        &current_fingerprint,
+                    )
+                    .await?;
+                let lkg = self
+                    .find_last_known_good(repo.id, package_name, version)
+                    .await?;
+                block(review_id, lkg)
+            }
         }
+    }
 
-        let review_id = self
-            .request_review(
-                repo.id,
-                package_name,
-                version,
-                published_at,
-                existing.is_none(),
-            )
+    /// Record first-sight observations for a batch of versions and return
+    /// each version's (possibly pre-existing) first-seen time.
+    ///
+    /// Callers own the evidence contract: only versions that verifiably exist
+    /// may be observed (the listing filters observe versions parsed out of an
+    /// upstream-served document; the download path proves existence via the
+    /// same upstream metadata it already fetches — see
+    /// [`Self::download_basis`]). Deciding from an existing observation never
+    /// starts a clock; only positive existence evidence may do that.
+    ///
+    /// Insert-once (`ON CONFLICT DO NOTHING`): concurrent requests and replicas
+    /// race benignly because whoever inserts first fixes the timestamp and
+    /// every later observation reads that same value back. Repeated listings of
+    /// a package can therefore never push a version's clock forward, which is
+    /// what makes the elapsed time a usable age.
+    ///
+    /// Observations are keyed by the repository's *current* upstream
+    /// ([`upstream_fingerprint`]), so a repointed remote starts a fresh clock
+    /// instead of inheriting the previous registry's elapsed age.
+    pub async fn observe_versions_first_seen(
+        &self,
+        repo: &AgeGateRepoParams,
+        package_name: &str,
+        versions: &[String],
+    ) -> Result<std::collections::HashMap<String, DateTime<Utc>>> {
+        if versions.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let fingerprint = upstream_fingerprint(repo.upstream_url.as_deref());
+
+        sqlx::query(
+            "INSERT INTO age_gate_version_observations (
+                 repository_id, upstream_fingerprint, package_name, package_version
+             )
+             SELECT $1, $2, $3, v FROM UNNEST($4::text[]) AS t(v)
+             ON CONFLICT (repository_id, upstream_fingerprint, package_name, package_version)
+             DO NOTHING",
+        )
+        .bind(repo.id)
+        .bind(&fingerprint)
+        .bind(package_name)
+        .bind(versions)
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let rows: Vec<(String, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT package_version, first_seen_at
+             FROM age_gate_version_observations
+             WHERE repository_id = $1 AND upstream_fingerprint = $2 AND package_name = $3
+               AND package_version = ANY($4::text[])",
+        )
+        .bind(repo.id)
+        .bind(&fingerprint)
+        .bind(package_name)
+        .bind(versions)
+        .fetch_all(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(rows.into_iter().collect())
+    }
+
+    /// Read back one version's first-seen time WITHOUT recording anything.
+    pub async fn lookup_first_seen(
+        &self,
+        repo: &AgeGateRepoParams,
+        package_name: &str,
+        version: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        let fingerprint = upstream_fingerprint(repo.upstream_url.as_deref());
+        sqlx::query_scalar(
+            "SELECT first_seen_at FROM age_gate_version_observations
+             WHERE repository_id = $1 AND upstream_fingerprint = $2
+               AND package_name = $3 AND package_version = $4",
+        )
+        .bind(repo.id)
+        .bind(&fingerprint)
+        .bind(package_name)
+        .bind(version)
+        .fetch_optional(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))
+    }
+
+    /// Observe (or read back) one version's first-seen time. Same evidence
+    /// contract as [`Self::observe_versions_first_seen`].
+    pub async fn observe_first_seen(
+        &self,
+        repo: &AgeGateRepoParams,
+        package_name: &str,
+        version: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        let observed = self
+            .observe_versions_first_seen(repo, package_name, &[version.to_string()])
             .await?;
-        let lkg = self
-            .find_last_known_good(repo.id, package_name, version)
-            .await?;
-        metrics_service::record_age_gate_blocked_request(&repo.key, format_label(&repo.format));
-        Ok(AgeGateDecision::Block {
-            review_id,
-            last_known_good: lkg,
-        })
+        Ok(observed.get(version).copied())
+    }
+
+    /// Resolve the download-path age basis for one version under the
+    /// repository's configured mode — the single place the download seam
+    /// consults the mode, so it always agrees with the listing filters
+    /// (which share the same clock via [`Self::observe_versions_first_seen`]).
+    ///
+    /// * `upstream_publish_time`: the caller's resolved publish timestamp,
+    ///   verbatim. A missing timestamp stays missing (blocks; #2066).
+    /// * `first_seen`: an existing observation wins; otherwise a new
+    ///   observation is recorded ONLY when the caller holds positive
+    ///   existence evidence for the version (`version_exists_upstream` —
+    ///   e.g. the version appears in the upstream metadata document the
+    ///   handler already fetched). Without evidence no clock starts and the
+    ///   version blocks, so an attacker cannot pre-age a version name by
+    ///   requesting it before it is published.
+    pub async fn download_basis(
+        &self,
+        repo: &AgeGateRepoParams,
+        package_name: &str,
+        version: &str,
+        upstream_published_at: Option<DateTime<Utc>>,
+        version_exists_upstream: bool,
+    ) -> Result<Option<DateTime<Utc>>> {
+        match repo.age_gate_mode {
+            AgeGateMode::UpstreamPublishTime => Ok(upstream_published_at),
+            AgeGateMode::FirstSeen => {
+                if let Some(seen) = self.lookup_first_seen(repo, package_name, version).await? {
+                    return Ok(Some(seen));
+                }
+                if version_exists_upstream {
+                    self.observe_first_seen(repo, package_name, version).await
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    /// Resolve the age basis of every version in a metadata listing according
+    /// to the repository's configured mode.
+    ///
+    /// Publish-time mode borrows the timestamps the caller already parsed out
+    /// of the document; `first_seen` mode ignores them (they are the
+    /// upstream's claim, which is precisely what this mode declines to trust)
+    /// and substitutes this server's own observations.
+    async fn listing_basis_times<'a>(
+        &self,
+        repo: &AgeGateRepoParams,
+        package_name: &str,
+        versions: &'a [(String, Option<DateTime<Utc>>)],
+    ) -> Result<Cow<'a, [(String, Option<DateTime<Utc>>)]>> {
+        match repo.age_gate_mode {
+            AgeGateMode::UpstreamPublishTime => Ok(Cow::Borrowed(versions)),
+            AgeGateMode::FirstSeen => {
+                let names: Vec<String> = versions.iter().map(|(v, _)| v.clone()).collect();
+                let observed = self
+                    .observe_versions_first_seen(repo, package_name, &names)
+                    .await?;
+                Ok(Cow::Owned(
+                    names
+                        .into_iter()
+                        .map(|v| {
+                            let seen = observed.get(&v).copied();
+                            (v, seen)
+                        })
+                        .collect(),
+                ))
+            }
+        }
     }
 
     /// Filter npm packument JSON, removing versions blocked by the age gate.
@@ -344,9 +835,10 @@ impl AgeGateService {
         package_name: &str,
         packument: &mut serde_json::Value,
     ) -> Result<()> {
-        if !Self::is_applicable(repo) {
+        if !Self::gating_requested(repo) {
             return Ok(());
         }
+        Self::require_enforceable(repo)?;
 
         let publish_times = UpstreamMetadataCache::parse_npm_publish_times(packument);
         let versions = collect_npm_packument_versions(packument, &publish_times);
@@ -379,9 +871,10 @@ impl AgeGateService {
         publish_times: &std::collections::HashMap<String, DateTime<Utc>>,
         html: &str,
     ) -> Result<String> {
-        if !Self::is_applicable(repo) {
+        if !Self::gating_requested(repo) {
             return Ok(html.to_string());
         }
+        Self::require_enforceable(repo)?;
 
         let (spans, mut versions) = parse_pypi_simple_index_anchors(html);
         attach_pypi_publish_times(&mut versions, publish_times);
@@ -421,16 +914,22 @@ impl AgeGateService {
         upstream_url: &str,
         index: &mut serde_json::Value,
     ) -> Result<()> {
-        if !Self::is_applicable(repo) {
+        if !Self::gating_requested(repo) {
             return Ok(());
         }
+        Self::require_enforceable(repo)?;
 
         let mut versions = collect_pypi_simple_json_versions(index);
         if versions.is_empty() {
             return Ok(());
         }
 
-        if versions.iter().any(|(_, ts)| ts.is_none()) {
+        // `first_seen` substitutes this server's own observations for the
+        // document's timestamps in `listing_basis_times`, so the fallback
+        // fetch would be both wasted and contrary to the mode's premise.
+        if repo.age_gate_mode == AgeGateMode::UpstreamPublishTime
+            && versions.iter().any(|(_, ts)| ts.is_none())
+        {
             if let Ok(client) = crate::services::upstream_metadata::metadata_http_client() {
                 if let Ok(times) = self
                     .metadata_cache
@@ -469,33 +968,41 @@ impl AgeGateService {
     /// [`Self::auto_approve_aged_reviews`]. A version that has crossed the
     /// threshold is served immediately (decided from its timestamp here) even
     /// before its review row is flipped to `approved`.
-    async fn evaluate_versions_batch(
+    pub(crate) async fn evaluate_versions_batch(
         &self,
         repo: &AgeGateRepoParams,
         package_name: &str,
         versions: &[(String, Option<DateTime<Utc>>)],
     ) -> Result<std::collections::HashSet<String>> {
         let blocked = std::collections::HashSet::new();
-        if !Self::is_applicable(repo) || versions.is_empty() {
+        if !Self::gating_requested(repo) || versions.is_empty() {
             return Ok(blocked);
         }
+        Self::require_enforceable(repo)?;
 
         let now = Utc::now();
+        let current_fingerprint = upstream_fingerprint(repo.upstream_url.as_deref());
         let existing = self.get_reviews_for_package(repo.id, package_name).await?;
+        let versions = self
+            .listing_basis_times(repo, package_name, versions)
+            .await?;
 
         let classification = classify_versions_for_metadata_listing(
-            versions,
+            &versions,
             &existing,
             repo.age_gate_min_age_days,
+            repo.age_gate_mode,
+            &current_fingerprint,
             now,
         );
 
         if !classification.request_versions.is_empty() {
             self.request_reviews_batch(
-                repo.id,
+                repo,
                 package_name,
                 &classification.request_versions,
                 &classification.request_times,
+                &current_fingerprint,
             )
             .await?;
         }
@@ -526,14 +1033,16 @@ impl AgeGateService {
         .map_err(|e| AppError::Database(e.to_string()))?
         .unwrap_or(0);
 
-        let rows = sqlx::query_as!(
-            AgeGateReview,
+        // Non-macro sqlx (like every query touching the migration-185 columns)
+        // so the change needs no `.sqlx` offline-metadata regeneration.
+        let rows = sqlx::query_as::<_, AgeGateReview>(
             r#"
             SELECT
                 r.id, r.repository_id, r.package_name, r.package_version,
                 r.upstream_published_at, r.status, r.requested_at,
                 r.reviewed_by, r.reviewed_at, r.review_reason,
                 r.request_count, r.last_requested_at,
+                r.basis_mode, r.basis_upstream_fingerprint,
                 repo.key as repository_key
             FROM age_gate_reviews r
             INNER JOIN repositories repo ON repo.id = r.repository_id
@@ -542,11 +1051,11 @@ impl AgeGateService {
             ORDER BY r.last_requested_at DESC
             OFFSET $3 LIMIT $4
             "#,
-            repository_key,
-            statuses,
-            offset,
-            limit
         )
+        .bind(repository_key)
+        .bind(statuses)
+        .bind(offset)
+        .bind(limit)
         .fetch_all(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -555,21 +1064,21 @@ impl AgeGateService {
     }
 
     pub async fn get_review_by_id(&self, id: Uuid) -> Result<AgeGateReview> {
-        sqlx::query_as!(
-            AgeGateReview,
+        sqlx::query_as::<_, AgeGateReview>(
             r#"
             SELECT
                 r.id, r.repository_id, r.package_name, r.package_version,
                 r.upstream_published_at, r.status, r.requested_at,
                 r.reviewed_by, r.reviewed_at, r.review_reason,
                 r.request_count, r.last_requested_at,
+                r.basis_mode, r.basis_upstream_fingerprint,
                 repo.key as repository_key
             FROM age_gate_reviews r
             INNER JOIN repositories repo ON repo.id = r.repository_id
             WHERE r.id = $1
             "#,
-            id
         )
+        .bind(id)
         .fetch_optional(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?
@@ -584,22 +1093,32 @@ impl AgeGateService {
     ) -> Result<AgeGateReview> {
         let review = self.get_review_by_id(id).await?;
         require_distinct_status(&review.status, AgeGateReviewStatus::Approved)?;
+        let expected_status = review.status.clone();
 
-        sqlx::query!(
-            r#"
-            UPDATE age_gate_reviews
-            SET status = 'approved', reviewed_by = $2, reviewed_at = NOW(),
-                review_reason = $3
-            WHERE id = $1
-            "#,
-            id,
-            reviewer_id,
-            reason
+        let params = resolve_repo_params(&self.db, review.repository_id).await?;
+        let fingerprint = upstream_fingerprint(params.upstream_url.as_deref());
+        let res = sqlx::query(
+            "UPDATE age_gate_reviews
+             SET status = 'approved', reviewed_by = $2, reviewed_at = NOW(),
+                 review_reason = $3, basis_mode = $4,
+                 basis_upstream_fingerprint = $5
+             WHERE id = $1 AND status = $6",
         )
+        .bind(id)
+        .bind(reviewer_id)
+        .bind(reason)
+        .bind(params.age_gate_mode.as_str())
+        .bind(&fingerprint)
+        .bind(&expected_status)
         .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
+        if res.rows_affected() != 1 {
+            return Err(AppError::Conflict(
+                "Age gate review changed concurrently; retry".to_string(),
+            ));
+        }
         self.event_bus.emit_for_repo(
             "age_gate.approved",
             id,
@@ -618,22 +1137,32 @@ impl AgeGateService {
     ) -> Result<AgeGateReview> {
         let review = self.get_review_by_id(id).await?;
         require_distinct_status(&review.status, AgeGateReviewStatus::Rejected)?;
+        let expected_status = review.status.clone();
 
-        sqlx::query!(
-            r#"
-            UPDATE age_gate_reviews
-            SET status = 'rejected', reviewed_by = $2, reviewed_at = NOW(),
-                review_reason = $3
-            WHERE id = $1
-            "#,
-            id,
-            reviewer_id,
-            reason
+        let params = resolve_repo_params(&self.db, review.repository_id).await?;
+        let fingerprint = upstream_fingerprint(params.upstream_url.as_deref());
+        let res = sqlx::query(
+            "UPDATE age_gate_reviews
+             SET status = 'rejected', reviewed_by = $2, reviewed_at = NOW(),
+                 review_reason = $3, basis_mode = $4,
+                 basis_upstream_fingerprint = $5
+             WHERE id = $1 AND status = $6",
         )
+        .bind(id)
+        .bind(reviewer_id)
+        .bind(reason)
+        .bind(params.age_gate_mode.as_str())
+        .bind(&fingerprint)
+        .bind(&expected_status)
         .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
+        if res.rows_affected() != 1 {
+            return Err(AppError::Conflict(
+                "Age gate review changed concurrently; retry".to_string(),
+            ));
+        }
         self.event_bus.emit_for_repo(
             "age_gate.rejected",
             id,
@@ -662,21 +1191,25 @@ impl AgeGateService {
         require_distinct_status(&review.status, AgeGateReviewStatus::Pending)?;
         let previous_status = review.status.clone();
 
-        sqlx::query!(
-            r#"
-            UPDATE age_gate_reviews
-            SET status = 'pending', reviewed_by = $2, reviewed_at = NOW(),
-                review_reason = $3
-            WHERE id = $1
-            "#,
-            id,
-            reviewer_id,
-            reason
+        let res = sqlx::query(
+            "UPDATE age_gate_reviews
+             SET status = 'pending', reviewed_by = $2, reviewed_at = NOW(),
+                 review_reason = $3
+             WHERE id = $1 AND status = $4",
         )
+        .bind(id)
+        .bind(reviewer_id)
+        .bind(reason)
+        .bind(&previous_status)
         .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
+        if res.rows_affected() != 1 {
+            return Err(AppError::Conflict(
+                "Age gate review changed concurrently; retry".to_string(),
+            ));
+        }
         self.event_bus.emit_for_repo(
             "age_gate.reopened",
             id,
@@ -693,22 +1226,56 @@ impl AgeGateService {
         repo_id: Uuid,
         enabled: bool,
         min_age_days: i32,
+        mode: AgeGateMode,
     ) -> Result<()> {
         validate_min_age_days(min_age_days)?;
 
-        sqlx::query!(
-            r#"
-            UPDATE repositories
-            SET age_gate_enabled = $2, age_gate_min_age_days = $3, updated_at = NOW()
-            WHERE id = $1
-            "#,
-            repo_id,
-            enabled,
-            min_age_days
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let current: Option<String> =
+            sqlx::query_scalar("SELECT age_gate_mode FROM repositories WHERE id = $1 FOR UPDATE")
+                .bind(repo_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let current =
+            current.ok_or_else(|| AppError::NotFound(format!("Repository {repo_id} not found")))?;
+
+        sqlx::query(
+            "UPDATE repositories
+             SET age_gate_enabled = $2, age_gate_min_age_days = $3,
+                 age_gate_mode = $4, updated_at = NOW()
+             WHERE id = $1",
         )
-        .execute(&self.db)
+        .bind(repo_id)
+        .bind(enabled)
+        .bind(min_age_days)
+        .bind(mode.as_str())
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if current != mode.as_str() {
+            sqlx::query(
+                "UPDATE age_gate_reviews
+                 SET upstream_published_at = NULL, basis_mode = NULL,
+                     basis_upstream_fingerprint = NULL
+                 WHERE repository_id = $1 AND status = 'pending'",
+            )
+            .bind(repo_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(())
     }
@@ -756,83 +1323,173 @@ impl AgeGateService {
         package_name: &str,
         version: &str,
     ) -> Result<Option<AgeGateReview>> {
-        sqlx::query_as!(
-            AgeGateReview,
+        sqlx::query_as::<_, AgeGateReview>(
             r#"
             SELECT
                 id, repository_id, package_name, package_version,
                 upstream_published_at, status, requested_at,
                 reviewed_by, reviewed_at, review_reason,
                 request_count, last_requested_at,
+                basis_mode, basis_upstream_fingerprint,
                 NULL::text as repository_key
             FROM age_gate_reviews
             WHERE repository_id = $1 AND package_name = $2 AND package_version = $3
             "#,
-            repository_id,
-            package_name,
-            version
         )
+        .bind(repository_id)
+        .bind(package_name)
+        .bind(version)
         .fetch_optional(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))
     }
 
+    /// Upsert a pending review for one version, stamped with the current
+    /// policy identity.
+    ///
+    /// When the existing row's identity differs from the current policy, its
+    /// recorded basis answers a different question, so the basis is
+    /// OVERWRITTEN (not COALESCEd) and the identity re-stamped. This also
+    /// bounds the in-flight-write race: a request resolved under the old
+    /// policy that lands after a mode switch re-populates the row *with the
+    /// old identity*, which the background sweep then refuses to honor.
+    /// A stale automatic approval racing in here is likewise demoted back to
+    /// pending rather than left standing.
     async fn request_review(
         &self,
-        repository_id: Uuid,
+        repo: &AgeGateRepoParams,
         package_name: &str,
         version: &str,
         published_at: Option<DateTime<Utc>>,
         is_new: bool,
+        fingerprint: &str,
     ) -> Result<Uuid> {
-        let id = sqlx::query_scalar!(
+        let id: Uuid = sqlx::query_scalar(
             r#"
             INSERT INTO age_gate_reviews (
                 repository_id, package_name, package_version,
-                upstream_published_at, status
+                upstream_published_at, status, basis_mode, basis_upstream_fingerprint
             )
-            VALUES ($1, $2, $3, $4, 'pending')
+            VALUES ($1, $2, $3, $4, 'pending', $5, $6)
             ON CONFLICT (repository_id, package_name, package_version)
             DO UPDATE SET
                 request_count = age_gate_reviews.request_count + 1,
                 last_requested_at = NOW(),
-                upstream_published_at = COALESCE(EXCLUDED.upstream_published_at, age_gate_reviews.upstream_published_at)
+                upstream_published_at = CASE
+                    WHEN age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+                      OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+                    THEN EXCLUDED.upstream_published_at
+                    ELSE COALESCE(EXCLUDED.upstream_published_at, age_gate_reviews.upstream_published_at)
+                END,
+                status = CASE
+                    WHEN age_gate_reviews.status = 'rejected' THEN age_gate_reviews.status
+                    WHEN age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+                      OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+                      OR (age_gate_reviews.reviewed_by IS NULL AND age_gate_reviews.status = 'approved')
+                    THEN 'pending'
+                    ELSE age_gate_reviews.status
+                END,
+                reviewed_by = CASE
+                    WHEN age_gate_reviews.status = 'rejected' THEN age_gate_reviews.reviewed_by
+                    WHEN age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+                      OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+                      OR (age_gate_reviews.reviewed_by IS NULL AND age_gate_reviews.status = 'approved')
+                    THEN NULL
+                    ELSE age_gate_reviews.reviewed_by
+                END,
+                basis_mode = EXCLUDED.basis_mode,
+                basis_upstream_fingerprint = EXCLUDED.basis_upstream_fingerprint
             RETURNING id
             "#,
-            repository_id,
-            package_name,
-            version,
-            published_at
         )
+        .bind(repo.id)
+        .bind(package_name)
+        .bind(version)
+        .bind(published_at)
+        .bind(repo.age_gate_mode.as_str())
+        .bind(fingerprint)
         .fetch_one(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         if is_new {
             self.event_bus
-                .emit_for_repo("age_gate.queued", id, repository_id, None);
+                .emit_for_repo("age_gate.queued", id, repo.id, None);
         }
 
         Ok(id)
     }
 
-    async fn auto_approve(&self, review_id: Uuid, repository_id: Uuid) -> Result<()> {
-        sqlx::query!(
+    /// Void a review decision the current policy must not honor (an automatic
+    /// approval whose eligibility no longer holds, or a manual approval bound
+    /// to a different identity): back to pending under the current basis and
+    /// identity. The old decision is not preserved — it answered a different
+    /// question — and the version re-enters the review queue.
+    async fn reset_review_to_pending(
+        &self,
+        review_id: Uuid,
+        repository_id: Uuid,
+        published_at: Option<DateTime<Utc>>,
+        mode: AgeGateMode,
+        fingerprint: &str,
+    ) -> Result<Uuid> {
+        sqlx::query(
             r#"
             UPDATE age_gate_reviews
-            SET status = 'approved', reviewed_by = NULL, reviewed_at = NOW(),
-                review_reason = $2
-            WHERE id = $1 AND status = 'pending'
+            SET status = 'pending', reviewed_by = NULL, reviewed_at = NULL,
+                review_reason = NULL, upstream_published_at = $2,
+                basis_mode = $3, basis_upstream_fingerprint = $4,
+                request_count = request_count + 1, last_requested_at = NOW()
+            WHERE id = $1
             "#,
-            review_id,
-            AUTO_APPROVE_REASON
         )
+        .bind(review_id)
+        .bind(published_at)
+        .bind(mode.as_str())
+        .bind(fingerprint)
         .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         self.event_bus
-            .emit_for_repo("age_gate.approved", review_id, repository_id, None);
+            .emit_for_repo("age_gate.queued", review_id, repository_id, None);
+
+        Ok(review_id)
+    }
+
+    /// Retire a pending review whose version now meets the threshold on the
+    /// current clock. The row is stamped with the identity the eligibility
+    /// was computed under; the resulting `approved` status is bookkeeping,
+    /// not authority — [`decide_age_gate_check`] recomputes automatic
+    /// eligibility from the live basis on every decision.
+    async fn auto_approve(
+        &self,
+        review_id: Uuid,
+        repository_id: Uuid,
+        mode: AgeGateMode,
+        fingerprint: &str,
+    ) -> Result<()> {
+        let res = sqlx::query(
+            r#"
+            UPDATE age_gate_reviews
+            SET status = 'approved', reviewed_by = NULL, reviewed_at = NOW(),
+                review_reason = $2, basis_mode = $3,
+                basis_upstream_fingerprint = $4
+            WHERE id = $1 AND status = 'pending'
+            "#,
+        )
+        .bind(review_id)
+        .bind(AUTO_APPROVE_REASON)
+        .bind(mode.as_str())
+        .bind(fingerprint)
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if res.rows_affected() == 1 {
+            self.event_bus
+                .emit_for_repo("age_gate.approved", review_id, repository_id, None);
+        }
         Ok(())
     }
 
@@ -842,24 +1499,38 @@ impl AgeGateService {
         &self,
         repository_id: Uuid,
         package_name: &str,
-    ) -> Result<std::collections::HashMap<String, (Uuid, String)>> {
-        let rows = sqlx::query!(
+    ) -> Result<std::collections::HashMap<String, PackageReviewRow>> {
+        use sqlx::Row as _;
+        let rows = sqlx::query(
             r#"
-            SELECT id, package_version, status
+            SELECT package_version, status, (reviewed_by IS NULL) AS is_automatic,
+                   basis_mode, basis_upstream_fingerprint
             FROM age_gate_reviews
             WHERE repository_id = $1 AND package_name = $2
             "#,
-            repository_id,
-            package_name
         )
+        .bind(repository_id)
+        .bind(package_name)
         .fetch_all(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        Ok(rows
-            .into_iter()
-            .map(|r| (r.package_version, (r.id, r.status)))
-            .collect())
+        rows.into_iter()
+            .map(|r| {
+                let column = |e: sqlx::Error| AppError::Database(e.to_string());
+                Ok((
+                    r.try_get::<String, _>("package_version").map_err(column)?,
+                    PackageReviewRow {
+                        status: r.try_get("status").map_err(column)?,
+                        is_automatic: r.try_get("is_automatic").map_err(column)?,
+                        basis_mode: r.try_get("basis_mode").map_err(column)?,
+                        basis_upstream_fingerprint: r
+                            .try_get("basis_upstream_fingerprint")
+                            .map_err(column)?,
+                    },
+                ))
+            })
+            .collect()
     }
 
     /// Upsert pending review requests for many versions in a single statement.
@@ -876,44 +1547,83 @@ impl AgeGateService {
     /// never gated by the debounce `WHERE`, which only applies to the UPDATE
     /// action); a bumped row is >= 2. So `request_count = 1` among the returned
     /// rows reliably marks brand-new reviews for `age_gate.queued` emission.
+    /// The debounce NEVER defers a policy correction: a row whose recorded
+    /// identity differs from the current policy, or a stale automatic
+    /// approval, is rewritten immediately (basis overwritten, status demoted
+    /// back to pending) even inside the debounce window — otherwise a
+    /// recently touched row could carry its old basis through a mode switch
+    /// or repoint and be auto-approved by the sweep under the new policy.
     async fn request_reviews_batch(
         &self,
-        repository_id: Uuid,
+        repo: &AgeGateRepoParams,
         package_name: &str,
         versions: &[String],
         published_ats: &[Option<DateTime<Utc>>],
+        fingerprint: &str,
     ) -> Result<()> {
+        use sqlx::Row as _;
         let stale_before = Utc::now() - chrono::Duration::seconds(REQUEST_COUNT_DEBOUNCE_SECS);
-        let rows = sqlx::query!(
+        let rows = sqlx::query(
             r#"
             INSERT INTO age_gate_reviews (
                 repository_id, package_name, package_version,
-                upstream_published_at, status
+                upstream_published_at, status, basis_mode, basis_upstream_fingerprint
             )
-            SELECT $1, $2, v, p, 'pending'
+            SELECT $1, $2, v, p, 'pending', $6, $7
             FROM UNNEST($3::text[], $4::timestamptz[]) AS t(v, p)
             ON CONFLICT (repository_id, package_name, package_version)
             DO UPDATE SET
                 request_count = age_gate_reviews.request_count + 1,
                 last_requested_at = NOW(),
-                upstream_published_at = COALESCE(EXCLUDED.upstream_published_at, age_gate_reviews.upstream_published_at)
+                upstream_published_at = CASE
+                    WHEN age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+                      OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+                    THEN EXCLUDED.upstream_published_at
+                    ELSE COALESCE(EXCLUDED.upstream_published_at, age_gate_reviews.upstream_published_at)
+                END,
+                status = CASE
+                    WHEN age_gate_reviews.status = 'rejected' THEN age_gate_reviews.status
+                    WHEN age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+                      OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+                      OR (age_gate_reviews.reviewed_by IS NULL AND age_gate_reviews.status = 'approved')
+                    THEN 'pending'
+                    ELSE age_gate_reviews.status
+                END,
+                reviewed_by = CASE
+                    WHEN age_gate_reviews.status = 'rejected' THEN age_gate_reviews.reviewed_by
+                    WHEN age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+                      OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+                      OR (age_gate_reviews.reviewed_by IS NULL AND age_gate_reviews.status = 'approved')
+                    THEN NULL
+                    ELSE age_gate_reviews.reviewed_by
+                END,
+                basis_mode = EXCLUDED.basis_mode,
+                basis_upstream_fingerprint = EXCLUDED.basis_upstream_fingerprint
             WHERE age_gate_reviews.last_requested_at < $5
-            RETURNING id AS "id!", (request_count = 1) AS "is_new!"
+               OR age_gate_reviews.basis_mode IS DISTINCT FROM EXCLUDED.basis_mode
+               OR age_gate_reviews.basis_upstream_fingerprint IS DISTINCT FROM EXCLUDED.basis_upstream_fingerprint
+               OR (age_gate_reviews.reviewed_by IS NULL AND age_gate_reviews.status = 'approved')
+            RETURNING id, (request_count = 1) AS is_new
             "#,
-            repository_id,
-            package_name,
-            versions,
-            published_ats as &[Option<DateTime<Utc>>],
-            stale_before
         )
+        .bind(repo.id)
+        .bind(package_name)
+        .bind(versions)
+        .bind(published_ats)
+        .bind(stale_before)
+        .bind(repo.age_gate_mode.as_str())
+        .bind(fingerprint)
         .fetch_all(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         for row in rows {
-            if row.is_new {
+            let column = |e: sqlx::Error| AppError::Database(e.to_string());
+            let id: Uuid = row.try_get("id").map_err(column)?;
+            let is_new: bool = row.try_get("is_new").map_err(column)?;
+            if is_new {
                 self.event_bus
-                    .emit_for_repo("age_gate.queued", row.id, repository_id, None);
+                    .emit_for_repo("age_gate.queued", id, repo.id, None);
             }
         }
         Ok(())
@@ -934,30 +1644,72 @@ impl AgeGateService {
     /// Concurrency-safe across replicas: `WHERE status = 'pending'` plus row
     /// locking means each row is transitioned (and returned) by exactly one
     /// runner, so no duplicate `age_gate.approved` events are emitted.
+    /// The sweep only honors a basis whose recorded identity matches the
+    /// repository's CURRENT policy (mode + normalized upstream fingerprint).
+    /// That closes both stale-row and in-flight-write races: a basis recorded
+    /// before a mode switch or repoint — or written by a request that
+    /// resolved the old policy and landed after the switch — carries the old
+    /// identity and is never swept. Because the fingerprint normalization is
+    /// Rust-side, each gated repository's policy is resolved here and the
+    /// sweep runs per repository.
+    ///
+    /// Legacy pre-identity rows (both columns NULL, written before migration
+    /// 185) are swept only while the repository still runs
+    /// `upstream_publish_time` — the only mode that existed when they were
+    /// written — preserving their pre-upgrade behavior without reopening the
+    /// race: post-upgrade writes always stamp a full identity, so NULL cannot
+    /// be minted anew.
     pub async fn auto_approve_aged_reviews(&self) -> Result<u64> {
-        let rows = sqlx::query!(
-            r#"
-            UPDATE age_gate_reviews r
-            SET status = 'approved', reviewed_by = NULL, reviewed_at = NOW(),
-                review_reason = $1
-            FROM repositories repo
-            WHERE r.repository_id = repo.id
-              AND r.status = 'pending'
-              AND repo.age_gate_enabled = true
-              AND r.upstream_published_at IS NOT NULL
-              AND NOW() - r.upstream_published_at >= make_interval(days => repo.age_gate_min_age_days)
-            RETURNING r.id AS "id!", r.repository_id AS "repository_id!"
-            "#,
-            AUTO_APPROVE_REASON
+        use sqlx::Row as _;
+        let column = |e: sqlx::Error| AppError::Database(e.to_string());
+
+        let repos = sqlx::query(
+            "SELECT id, age_gate_mode, age_gate_min_age_days, upstream_url
+             FROM repositories WHERE age_gate_enabled = true",
         )
         .fetch_all(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        let approved = rows.len() as u64;
-        for row in rows {
-            self.event_bus
-                .emit_for_repo("age_gate.approved", row.id, row.repository_id, None);
+        let mut approved: u64 = 0;
+        for repo in repos {
+            let repo_id: Uuid = repo.try_get("id").map_err(column)?;
+            let mode =
+                AgeGateMode::parse(&repo.try_get::<String, _>("age_gate_mode").map_err(column)?)?;
+            let min_age_days: i32 = repo.try_get("age_gate_min_age_days").map_err(column)?;
+            let upstream_url: Option<String> = repo.try_get("upstream_url").map_err(column)?;
+            let fingerprint = upstream_fingerprint(upstream_url.as_deref());
+
+            let rows = sqlx::query(
+                r#"
+                UPDATE age_gate_reviews
+                SET status = 'approved', reviewed_by = NULL, reviewed_at = NOW(),
+                    review_reason = $2
+                WHERE repository_id = $1
+                  AND status = 'pending'
+                  AND upstream_published_at IS NOT NULL
+                  AND NOW() - upstream_published_at >= make_interval(days => $3)
+                  AND ((basis_mode = $4 AND basis_upstream_fingerprint = $5)
+                       OR (basis_mode IS NULL AND basis_upstream_fingerprint IS NULL
+                           AND $4 = 'upstream_publish_time'))
+                RETURNING id
+                "#,
+            )
+            .bind(repo_id)
+            .bind(AUTO_APPROVE_REASON)
+            .bind(min_age_days)
+            .bind(mode.as_str())
+            .bind(&fingerprint)
+            .fetch_all(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            approved += rows.len() as u64;
+            for row in rows {
+                let id: Uuid = row.try_get("id").map_err(column)?;
+                self.event_bus
+                    .emit_for_repo("age_gate.approved", id, repo_id, None);
+            }
         }
         Ok(approved)
     }
@@ -1320,7 +2072,6 @@ fn compare_dot_segments(a: &str, b: &str) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::repository::ReplicationPriority;
     use chrono::{Duration, TimeZone};
 
     async fn try_db_pool() -> Option<sqlx::PgPool> {
@@ -1338,44 +2089,27 @@ mod tests {
             .expect("connect_lazy should not contact the database")
     }
 
-    fn test_repo(
-        format: RepositoryFormat,
-        repo_type: RepositoryType,
-    ) -> crate::models::repository::Repository {
-        let now = Utc::now();
-        crate::models::repository::Repository {
-            versioning_enabled: false,
-            id: Uuid::new_v4(),
-            key: "age-gate-test".to_string(),
-            name: "Age Gate Test".to_string(),
-            description: Some("unit test repository".to_string()),
-            format,
-            repo_type,
-            storage_backend: "filesystem".to_string(),
-            storage_path: "/tmp/age-gate-test".to_string(),
-            upstream_url: Some("https://example.invalid".to_string()),
-            is_public: false,
-            quota_bytes: None,
-            promotion_only: false,
-            replication_priority: ReplicationPriority::OnDemand,
-            curation_enabled: false,
-            curation_source_repo_id: None,
-            curation_target_repo_id: None,
-            curation_default_action: "allow".to_string(),
-            curation_sync_interval_secs: 3600,
-            curation_auto_fetch: false,
-            age_gate_enabled: true,
-            age_gate_min_age_days: 14,
-            project_id: None,
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
     async fn create_age_gate_repo(
         pool: &sqlx::PgPool,
         format: RepositoryFormat,
         min_age_days: i32,
+    ) -> (Uuid, String) {
+        create_age_gate_repo_with(
+            pool,
+            format,
+            min_age_days,
+            AgeGateMode::default(),
+            TEST_UPSTREAM,
+        )
+        .await
+    }
+
+    async fn create_age_gate_repo_with(
+        pool: &sqlx::PgPool,
+        format: RepositoryFormat,
+        min_age_days: i32,
+        mode: AgeGateMode,
+        upstream_url: &str,
     ) -> (Uuid, String) {
         let id = Uuid::new_v4();
         let key = format!("age-gate-lib-{}-{}", format_label(&format), id);
@@ -1387,16 +2121,17 @@ mod tests {
         sqlx::query(
             "INSERT INTO repositories (
                 id, key, name, storage_path, repo_type, format, upstream_url,
-                age_gate_enabled, age_gate_min_age_days
+                age_gate_enabled, age_gate_min_age_days, age_gate_mode
              )
-             VALUES ($1, $2, $2, $3, 'remote', $4::repository_format, $5, true, $6)",
+             VALUES ($1, $2, $2, $3, 'remote', $4::repository_format, $5, true, $6, $7)",
         )
         .bind(id)
         .bind(&key)
         .bind(format!("/tmp/age-gate-lib/{id}"))
         .bind(format_sql)
-        .bind("https://upstream.example.test")
+        .bind(upstream_url)
         .bind(min_age_days)
+        .bind(mode.as_str())
         .execute(pool)
         .await
         .expect("create age-gate repo");
@@ -1444,6 +2179,41 @@ mod tests {
         .expect("insert review row")
     }
 
+    /// Insert a review row with an explicit basis identity and reviewer
+    /// (None = automatic), for the F2 state-transition tests.
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_review_row_with_identity(
+        pool: &sqlx::PgPool,
+        repository_id: Uuid,
+        package_name: &str,
+        version: &str,
+        status: &str,
+        published_at: Option<DateTime<Utc>>,
+        reviewed_by: Option<Uuid>,
+        basis_mode: Option<&str>,
+        basis_fingerprint: Option<&str>,
+    ) -> Uuid {
+        sqlx::query_scalar(
+            "INSERT INTO age_gate_reviews (
+                repository_id, package_name, package_version, upstream_published_at,
+                status, reviewed_by, basis_mode, basis_upstream_fingerprint
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             RETURNING id",
+        )
+        .bind(repository_id)
+        .bind(package_name)
+        .bind(version)
+        .bind(published_at)
+        .bind(status)
+        .bind(reviewed_by)
+        .bind(basis_mode)
+        .bind(basis_fingerprint)
+        .fetch_one(pool)
+        .await
+        .expect("insert review row with identity")
+    }
+
     async fn insert_artifact(
         pool: &sqlx::PgPool,
         repository_id: Uuid,
@@ -1468,25 +2238,44 @@ mod tests {
         .expect("insert artifact");
     }
 
+    const TEST_UPSTREAM: &str = "https://upstream.example.test";
+
     fn npm_params(id: Uuid, key: String, min_age_days: i32) -> AgeGateRepoParams {
-        AgeGateRepoParams::from_parts(
+        params_with_mode(
             id,
             key,
-            RepositoryType::Remote,
             RepositoryFormat::Npm,
-            true,
             min_age_days,
+            AgeGateMode::UpstreamPublishTime,
         )
     }
 
     fn pypi_params(id: Uuid, key: String, min_age_days: i32) -> AgeGateRepoParams {
+        params_with_mode(
+            id,
+            key,
+            RepositoryFormat::Pypi,
+            min_age_days,
+            AgeGateMode::UpstreamPublishTime,
+        )
+    }
+
+    fn params_with_mode(
+        id: Uuid,
+        key: String,
+        format: RepositoryFormat,
+        min_age_days: i32,
+        mode: AgeGateMode,
+    ) -> AgeGateRepoParams {
         AgeGateRepoParams::from_parts(
             id,
             key,
             RepositoryType::Remote,
-            RepositoryFormat::Pypi,
+            format,
             true,
             min_age_days,
+            mode,
+            Some(TEST_UPSTREAM.to_string()),
         )
     }
 
@@ -1521,18 +2310,6 @@ mod tests {
         assert_eq!(parsed.len(), 1);
     }
 
-    #[test]
-    fn repo_params_from_repository_copies_age_gate_fields() {
-        let repo = test_repo(RepositoryFormat::Pypi, RepositoryType::Remote);
-        let params = AgeGateRepoParams::from_repository(&repo);
-        assert_eq!(params.id, repo.id);
-        assert_eq!(params.key, repo.key);
-        assert_eq!(params.repo_type, RepositoryType::Remote);
-        assert_eq!(params.format, RepositoryFormat::Pypi);
-        assert!(params.age_gate_enabled);
-        assert_eq!(params.age_gate_min_age_days, 14);
-    }
-
     #[tokio::test]
     async fn disabled_or_unsupported_filters_return_without_db_access() {
         let svc = AgeGateService::new(lazy_pool(), Arc::new(EventBus::new(4)));
@@ -1543,14 +2320,8 @@ mod tests {
             RepositoryFormat::Npm,
             false,
             7,
-        );
-        let cargo = AgeGateRepoParams::from_parts(
-            Uuid::new_v4(),
-            "cargo-remote",
-            RepositoryType::Remote,
-            RepositoryFormat::Cargo,
-            true,
-            7,
+            AgeGateMode::UpstreamPublishTime,
+            Some(TEST_UPSTREAM.to_string()),
         );
 
         assert_eq!(
@@ -1566,13 +2337,6 @@ mod tests {
             .await
             .unwrap();
         assert!(packument["versions"].get("1.0.0").is_some());
-
-        let html = "<a href=\"pkg-1.0.0.tar.gz\">pkg-1.0.0.tar.gz</a>";
-        let unchanged = svc
-            .filter_pypi_simple_index(&cargo, "pkg", &std::collections::HashMap::new(), html)
-            .await
-            .unwrap();
-        assert_eq!(unchanged, html);
     }
 
     #[tokio::test]
@@ -1674,7 +2438,7 @@ mod tests {
             AgeGateDecision::Allow
         ));
 
-        svc.update_repo_config(repo_id, false, 14)
+        svc.update_repo_config(repo_id, false, 14, AgeGateMode::UpstreamPublishTime)
             .await
             .expect("update repo config");
         let min_age_days: i32 =
@@ -1846,11 +2610,30 @@ mod tests {
 
         insert_review_row(&pool, pypi_id, "sweep", "1.0.0", "pending", Some(old_ts)).await;
         insert_review_row(&pool, pypi_id, "sweep", "2.0.0", "pending", Some(young_ts)).await;
-        let approved = svc
-            .auto_approve_aged_reviews()
+        svc.auto_approve_aged_reviews()
             .await
             .expect("sweep aged reviews");
-        assert!(approved >= 1);
+        // Assert on row state, not the returned count: the sweep is global,
+        // so a concurrently running test's sweep may legitimately get to the
+        // aged row first.
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM age_gate_reviews
+             WHERE repository_id = $1 AND package_name = 'sweep' AND package_version = '1.0.0'",
+        )
+        .bind(pypi_id)
+        .fetch_one(&pool)
+        .await
+        .expect("aged sweep row");
+        assert_eq!(status, "approved");
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM age_gate_reviews
+             WHERE repository_id = $1 AND package_name = 'sweep' AND package_version = '2.0.0'",
+        )
+        .bind(pypi_id)
+        .fetch_one(&pool)
+        .await
+        .expect("young sweep row");
+        assert_eq!(status, "pending");
     }
 
     #[test]
@@ -1937,33 +2720,118 @@ mod tests {
         assert!(packument["dist-tags"].as_object().unwrap().is_empty());
     }
 
+    fn view(status: &str, is_automatic: bool, identity: ReviewIdentityMatch) -> ReviewPolicyView {
+        ReviewPolicyView {
+            status: status.to_string(),
+            is_automatic,
+            identity,
+        }
+    }
+
     #[test]
     fn decide_age_gate_check_truth_table() {
+        use ReviewIdentityMatch::{Differs, Legacy, Matches};
+        // Rejections block coordinate-wide, regardless of threshold,
+        // identity, or who recorded them.
+        for identity in [Matches, Differs, Legacy] {
+            for meets in [false, true] {
+                assert_eq!(
+                    decide_age_gate_check(Some(&view("rejected", false, identity)), meets),
+                    AgeGateCheckAction::BlockRejected
+                );
+            }
+        }
+        // The current-clock threshold decides; pending rows are retired on
+        // the way through.
         assert_eq!(
-            decide_age_gate_check(Some("rejected"), false),
-            AgeGateCheckAction::BlockRejected
-        );
-        assert_eq!(
-            decide_age_gate_check(Some("rejected"), true),
-            AgeGateCheckAction::BlockRejected
-        );
-        assert_eq!(
-            decide_age_gate_check(Some("pending"), true),
+            decide_age_gate_check(Some(&view("pending", true, Matches)), true),
             AgeGateCheckAction::AllowAndAutoApprovePending
         );
         assert_eq!(decide_age_gate_check(None, true), AgeGateCheckAction::Allow);
         assert_eq!(
-            decide_age_gate_check(Some("approved"), false),
+            decide_age_gate_check(Some(&view("approved", true, Differs)), true),
+            AgeGateCheckAction::Allow,
+            "meeting the threshold on the current basis allows regardless of row state"
+        );
+        // Below the threshold, only an identity-bound (or legacy) MANUAL
+        // approval still allows.
+        assert_eq!(
+            decide_age_gate_check(Some(&view("approved", false, Matches)), false),
             AgeGateCheckAction::AllowAlreadyApproved
         );
+        assert_eq!(
+            decide_age_gate_check(Some(&view("approved", false, Legacy)), false),
+            AgeGateCheckAction::AllowAlreadyApproved,
+            "pre-identity manual approvals keep their effect"
+        );
+        assert_eq!(
+            decide_age_gate_check(Some(&view("approved", false, Differs)), false),
+            AgeGateCheckAction::BlockAndResetReview,
+            "a manual approval under a different identity is voided"
+        );
+        // Automatic approvals are never sticky.
+        for identity in [Matches, Differs, Legacy] {
+            assert_eq!(
+                decide_age_gate_check(Some(&view("approved", true, identity)), false),
+                AgeGateCheckAction::BlockAndResetReview,
+                "an automatic approval that no longer holds is voided ({identity:?})"
+            );
+        }
         assert_eq!(
             decide_age_gate_check(None, false),
             AgeGateCheckAction::BlockAndRequestReview
         );
         assert_eq!(
-            decide_age_gate_check(Some("pending"), false),
+            decide_age_gate_check(Some(&view("pending", true, Matches)), false),
             AgeGateCheckAction::BlockAndRequestReview
         );
+    }
+
+    #[test]
+    fn review_identity_match_rules() {
+        use ReviewIdentityMatch::{Differs, Legacy, Matches};
+        let fp = "aaaa";
+        assert_eq!(
+            review_identity_match(Some("first_seen"), Some(fp), AgeGateMode::FirstSeen, fp),
+            Matches
+        );
+        assert_eq!(
+            review_identity_match(None, None, AgeGateMode::FirstSeen, fp),
+            Legacy
+        );
+        assert_eq!(
+            review_identity_match(
+                Some("upstream_publish_time"),
+                Some(fp),
+                AgeGateMode::FirstSeen,
+                fp
+            ),
+            Differs,
+            "mode changed"
+        );
+        assert_eq!(
+            review_identity_match(Some("first_seen"), Some("bbbb"), AgeGateMode::FirstSeen, fp),
+            Differs,
+            "upstream changed"
+        );
+        assert_eq!(
+            review_identity_match(Some("first_seen"), None, AgeGateMode::FirstSeen, fp),
+            Differs,
+            "half-recorded identity is not legacy"
+        );
+    }
+
+    fn package_review(
+        status: &str,
+        is_automatic: bool,
+        identity_fp: Option<&str>,
+    ) -> PackageReviewRow {
+        PackageReviewRow {
+            status: status.to_string(),
+            is_automatic,
+            basis_mode: identity_fp.map(|_| "upstream_publish_time".to_string()),
+            basis_upstream_fingerprint: identity_fp.map(str::to_string),
+        }
     }
 
     #[test]
@@ -1971,28 +2839,76 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2024, 7, 1, 0, 0, 0).unwrap();
         let young = now - Duration::days(1);
         let old = now - Duration::days(30);
+        let fp = "current-fp";
         let mut existing = std::collections::HashMap::new();
+        // Rejected: blocked, no re-request.
         existing.insert(
             "1.0.0".to_string(),
-            (Uuid::new_v4(), "rejected".to_string()),
+            package_review("rejected", false, Some(fp)),
         );
+        // Manual approval bound to the current identity: listed while young.
         existing.insert(
             "2.0.0".to_string(),
-            (Uuid::new_v4(), "approved".to_string()),
+            package_review("approved", false, Some(fp)),
         );
+        // Manual approval bound to a DIFFERENT identity: withheld + re-requested.
+        existing.insert(
+            "5.0.0".to_string(),
+            package_review("approved", false, Some("other-fp")),
+        );
+        // AUTOMATIC approval (same identity) whose eligibility no longer
+        // holds on the current clock: withheld + re-requested.
+        existing.insert(
+            "6.0.0".to_string(),
+            package_review("approved", true, Some(fp)),
+        );
+        // Legacy (pre-identity) manual approval: listed.
+        existing.insert("7.0.0".to_string(), package_review("approved", false, None));
 
         let versions = vec![
             ("1.0.0".to_string(), Some(young)),
             ("2.0.0".to_string(), Some(young)),
             ("3.0.0".to_string(), Some(old)),
             ("4.0.0".to_string(), Some(young)),
+            ("5.0.0".to_string(), Some(young)),
+            ("6.0.0".to_string(), Some(young)),
+            ("7.0.0".to_string(), Some(young)),
         ];
-        let out = classify_versions_for_metadata_listing(&versions, &existing, 7, now);
+        let out = classify_versions_for_metadata_listing(
+            &versions,
+            &existing,
+            7,
+            AgeGateMode::UpstreamPublishTime,
+            fp,
+            now,
+        );
         assert!(out.blocked.contains("1.0.0"));
         assert!(!out.blocked.contains("2.0.0"));
         assert!(!out.blocked.contains("3.0.0"));
         assert!(out.blocked.contains("4.0.0"));
-        assert_eq!(out.request_versions, vec!["4.0.0".to_string()]);
+        assert!(
+            out.blocked.contains("5.0.0"),
+            "stale-identity manual approval"
+        );
+        assert!(
+            out.blocked.contains("6.0.0"),
+            "automatic approval recomputed"
+        );
+        assert!(
+            !out.blocked.contains("7.0.0"),
+            "legacy manual approval honored"
+        );
+        let mut requested = out.request_versions.clone();
+        requested.sort();
+        assert_eq!(
+            requested,
+            vec![
+                "4.0.0".to_string(),
+                "5.0.0".to_string(),
+                "6.0.0".to_string()
+            ],
+            "stale approvals re-enter the queue; rejections do not"
+        );
     }
 
     #[test]
@@ -2209,6 +3125,8 @@ mod tests {
             RepositoryFormat::Npm,
             true,
             7,
+            Default::default(),
+            None,
         );
         assert!(AgeGateService::is_applicable(&npm_remote));
 
@@ -2219,6 +3137,8 @@ mod tests {
             RepositoryFormat::Npm,
             false,
             7,
+            Default::default(),
+            None,
         );
         assert!(!AgeGateService::is_applicable(&disabled));
 
@@ -2229,6 +3149,8 @@ mod tests {
             RepositoryFormat::Npm,
             true,
             7,
+            Default::default(),
+            None,
         );
         assert!(!AgeGateService::is_applicable(&local));
     }
@@ -2275,5 +3197,741 @@ mod tests {
         let anchor =
             r#"<a href="/packages/requests/2.31.0/requests-2.31.0-py3-none-any.whl">link</a>"#;
         assert_eq!(pypi_anchor_version(anchor), Some("2.31.0".to_string()));
+    }
+
+    #[test]
+    fn mode_round_trips_through_its_wire_form() {
+        for mode in [AgeGateMode::UpstreamPublishTime, AgeGateMode::FirstSeen] {
+            assert_eq!(AgeGateMode::parse(mode.as_str()).unwrap(), mode);
+        }
+        assert_eq!(AgeGateMode::default(), AgeGateMode::UpstreamPublishTime);
+        // An unknown mode is a client error, never a silent default: a typo
+        // must not quietly downgrade a repository to publish-time trust.
+        assert!(matches!(
+            AgeGateMode::parse("firstseen"),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn upstream_fingerprint_is_stable_across_cosmetic_spellings() {
+        let canonical = upstream_fingerprint(Some("https://registry.npmjs.org"));
+        // Trailing slash, upper-case host and an explicit default port all
+        // name the same registry.
+        assert_eq!(
+            canonical,
+            upstream_fingerprint(Some("https://registry.npmjs.org/"))
+        );
+        assert_eq!(
+            canonical,
+            upstream_fingerprint(Some("https://Registry.NPMJS.org"))
+        );
+        assert_eq!(
+            canonical,
+            upstream_fingerprint(Some("https://registry.npmjs.org:443"))
+        );
+        // A different registry — or none at all — must not share the bucket,
+        // or a repoint would inherit the previous upstream's elapsed age.
+        assert_ne!(
+            canonical,
+            upstream_fingerprint(Some("https://evil.example.test"))
+        );
+        assert_ne!(canonical, upstream_fingerprint(None));
+        // Paths stay case-sensitive: most registries treat them that way.
+        assert_ne!(
+            upstream_fingerprint(Some("https://example.test/Repo")),
+            upstream_fingerprint(Some("https://example.test/repo"))
+        );
+    }
+
+    #[test]
+    fn normalize_format_collapses_registry_protocol_aliases() {
+        use RepositoryFormat as F;
+        assert_eq!(AgeGateService::normalize_format(F::Yarn), F::Npm);
+        assert_eq!(AgeGateService::normalize_format(F::Pnpm), F::Npm);
+        assert_eq!(AgeGateService::normalize_format(F::Poetry), F::Pypi);
+        assert_eq!(AgeGateService::normalize_format(F::Npm), F::Npm);
+        assert_eq!(AgeGateService::normalize_format(F::Pypi), F::Pypi);
+        assert_eq!(AgeGateService::normalize_format(F::Generic), F::Generic);
+    }
+
+    #[test]
+    fn supported_format_mode_matrix() {
+        for mode in [AgeGateMode::UpstreamPublishTime, AgeGateMode::FirstSeen] {
+            assert!(AgeGateService::supports_format_mode(
+                &RepositoryFormat::Npm,
+                mode
+            ));
+            assert!(AgeGateService::supports_format_mode(
+                &RepositoryFormat::Pypi,
+                mode
+            ));
+            // No registry entry -> not gateable in any mode. NuGet stays
+            // here until its enforcement seam lands.
+            assert!(!AgeGateService::supports_format_mode(
+                &RepositoryFormat::Cargo,
+                mode
+            ));
+            assert!(!AgeGateService::supports_format_mode(
+                &RepositoryFormat::Maven,
+                mode
+            ));
+            assert!(!AgeGateService::supports_format_mode(
+                &RepositoryFormat::Nuget,
+                mode
+            ));
+        }
+        // Go: immutable module-proxy coordinates support first_seen, but
+        // .info VCS timestamps are publisher-controlled — no publish-time
+        // resolver, so that mode stays unsupported.
+        assert!(AgeGateService::supports_format_mode(
+            &RepositoryFormat::Go,
+            AgeGateMode::FirstSeen
+        ));
+        assert!(!AgeGateService::supports_format_mode(
+            &RepositoryFormat::Go,
+            AgeGateMode::UpstreamPublishTime
+        ));
+    }
+
+    /// F3: an ENABLED gate on a format/mode pair the server cannot enforce is
+    /// a fail-closed configuration error on every policy path — check and
+    /// listing filters alike — never a silent no-op that reports an enabled
+    /// gate while serving everything. (A DISABLED unsupported repo simply
+    /// isn't gated; see the test above.)
+    #[tokio::test]
+    async fn enabled_unsupported_configuration_fails_closed() {
+        let svc = AgeGateService::new(lazy_pool(), Arc::new(EventBus::new(4)));
+        let cargo = AgeGateRepoParams::from_parts(
+            Uuid::new_v4(),
+            "cargo-remote",
+            RepositoryType::Remote,
+            RepositoryFormat::Cargo,
+            true,
+            7,
+            AgeGateMode::UpstreamPublishTime,
+            Some(TEST_UPSTREAM.to_string()),
+        );
+
+        assert!(matches!(
+            svc.check(&cargo, "pkg", "1.0.0", None).await,
+            Err(AppError::Internal(_))
+        ));
+
+        let html = "<a href=\"pkg-1.0.0.tar.gz\">pkg-1.0.0.tar.gz</a>";
+        assert!(matches!(
+            svc.filter_pypi_simple_index(&cargo, "pkg", &std::collections::HashMap::new(), html)
+                .await,
+            Err(AppError::Internal(_))
+        ));
+
+        let mut packument = serde_json::json!({
+            "versions": { "1.0.0": {} },
+            "time": { "1.0.0": "2024-01-01T00:00:00.000Z" }
+        });
+        assert!(matches!(
+            svc.filter_npm_packument(&cargo, "pkg", &mut packument)
+                .await,
+            Err(AppError::Internal(_))
+        ));
+    }
+
+    /// Gate policy comes from the repository row, on every request.
+    #[tokio::test]
+    async fn db_resolve_repo_params_reads_policy_from_the_row() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key) = create_age_gate_repo_with(
+            &pool,
+            RepositoryFormat::Pypi,
+            21,
+            AgeGateMode::FirstSeen,
+            "https://pypi.example.test/simple",
+        )
+        .await;
+
+        let params = resolve_repo_params(&pool, repo_id).await.expect("resolve");
+        assert_eq!(params.key, repo_key);
+        assert_eq!(params.format, RepositoryFormat::Pypi);
+        assert_eq!(params.repo_type, RepositoryType::Remote);
+        assert!(params.age_gate_enabled);
+        assert_eq!(params.age_gate_min_age_days, 21);
+        assert_eq!(params.age_gate_mode, AgeGateMode::FirstSeen);
+        assert_eq!(
+            params.upstream_url.as_deref(),
+            Some("https://pypi.example.test/simple")
+        );
+        assert!(AgeGateService::is_applicable(&params));
+
+        // A repository that cannot be read fails the request rather than
+        // impersonating a disabled gate.
+        assert!(matches!(
+            resolve_repo_params(&pool, Uuid::new_v4()).await,
+            Err(AppError::NotFound(_))
+        ));
+    }
+
+    /// Observations are insert-once, and they belong to the upstream they were
+    /// made against: repointing a remote at a different registry must not let
+    /// a same-named version inherit the age of the version it replaces.
+    #[tokio::test]
+    async fn db_first_seen_observations_are_insert_once_and_upstream_bound() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, repo_key) = create_age_gate_repo_with(
+            &pool,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+            "https://registry-a.example.test",
+        )
+        .await;
+        let mut params = params_with_mode(
+            repo_id,
+            repo_key,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+        );
+        params.upstream_url = Some("https://registry-a.example.test".to_string());
+
+        let versions = vec!["1.0.0".to_string(), "2.0.0".to_string()];
+        let first = svc
+            .observe_versions_first_seen(&params, "pkg", &versions)
+            .await
+            .expect("first observation");
+        assert_eq!(first.len(), 2);
+
+        // Re-observing reads the original timestamps back rather than moving
+        // the clock forward — otherwise a version would never age while it was
+        // being listed.
+        let again = svc
+            .observe_versions_first_seen(&params, "pkg", &versions)
+            .await
+            .expect("second observation");
+        assert_eq!(first, again);
+
+        // Repointed upstream: same repository, same coordinates, different
+        // registry -> a fresh clock, with the original observation preserved.
+        let mut repointed = params.clone();
+        repointed.upstream_url = Some("https://registry-b.example.test".to_string());
+        let after_repoint = svc
+            .observe_versions_first_seen(&repointed, "pkg", &versions)
+            .await
+            .expect("observation after repoint");
+        assert_ne!(after_repoint["1.0.0"], first["1.0.0"]);
+        assert!(after_repoint["1.0.0"] > first["1.0.0"]);
+
+        let rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM age_gate_version_observations WHERE repository_id = $1",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count observations");
+        assert_eq!(rows, 4, "two versions on each of two upstreams");
+    }
+
+    /// The `first_seen` clock starts at first contact and needs no upstream
+    /// metadata: a version nobody has asked for before is blocked on sight,
+    /// and the same version allowed once its observation has aged past the
+    /// threshold.
+    #[tokio::test]
+    async fn db_first_seen_blocks_on_first_sight_and_allows_once_aged() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, repo_key) = create_age_gate_repo_with(
+            &pool,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+            TEST_UPSTREAM,
+        )
+        .await;
+        let params = params_with_mode(
+            repo_id,
+            repo_key,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+        );
+
+        // No publish time is consulted anywhere in this flow. A lookup
+        // before any evidence records nothing; the observation is created
+        // only once existence is proven.
+        assert!(svc
+            .lookup_first_seen(&params, "pkg", "1.0.0")
+            .await
+            .expect("lookup before evidence")
+            .is_none());
+        let basis = svc
+            .observe_first_seen(&params, "pkg", "1.0.0")
+            .await
+            .expect("observe with evidence");
+        assert!(basis.is_some());
+
+        let decision = svc
+            .check(&params, "pkg", "1.0.0", basis)
+            .await
+            .expect("first sight decides");
+        let review_id = match decision {
+            AgeGateDecision::Block { review_id, .. } => review_id,
+            AgeGateDecision::Allow => panic!("a just-observed version must not pass a 7-day gate"),
+        };
+
+        // The review records the basis the decision was made from.
+        let recorded: Option<DateTime<Utc>> =
+            sqlx::query_scalar("SELECT upstream_published_at FROM age_gate_reviews WHERE id = $1")
+                .bind(review_id)
+                .fetch_one(&pool)
+                .await
+                .expect("review row");
+        assert_eq!(recorded, basis);
+
+        // Age the observation past the threshold; the same request now passes
+        // (and retires the pending review).
+        sqlx::query(
+            "UPDATE age_gate_version_observations SET first_seen_at = NOW() - INTERVAL '30 days'
+             WHERE repository_id = $1 AND package_name = 'pkg'",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("backdate observation");
+
+        let aged = svc
+            .lookup_first_seen(&params, "pkg", "1.0.0")
+            .await
+            .expect("read back aged observation");
+        assert!(matches!(
+            svc.check(&params, "pkg", "1.0.0", aged).await.unwrap(),
+            AgeGateDecision::Allow
+        ));
+    }
+
+    /// In `first_seen` mode the listing filter ignores the upstream's own
+    /// timestamps — that claim is exactly what the mode declines to trust — so
+    /// even objectively ancient versions are withheld until this server has
+    /// watched them for the threshold. Listing and download therefore agree.
+    #[tokio::test]
+    async fn db_first_seen_listing_filter_ignores_upstream_publish_times() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, repo_key) = create_age_gate_repo_with(
+            &pool,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+            TEST_UPSTREAM,
+        )
+        .await;
+        let params = params_with_mode(
+            repo_id,
+            repo_key,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+        );
+
+        let packument = || {
+            serde_json::json!({
+                "versions": { "1.0.0": {}, "2.0.0": {} },
+                "time": {
+                    // The registry says these are years old.
+                    "1.0.0": "2019-01-01T00:00:00.000Z",
+                    "2.0.0": "2020-01-01T00:00:00.000Z"
+                }
+            })
+        };
+
+        let mut doc = packument();
+        svc.filter_npm_packument(&params, "pkg", &mut doc)
+            .await
+            .expect("filter on first sight");
+        assert!(
+            doc["versions"].as_object().unwrap().is_empty(),
+            "first_seen must withhold every unobserved version regardless of \
+             the publish times the upstream reports"
+        );
+
+        // Once the observations themselves have aged, the versions appear.
+        sqlx::query(
+            "UPDATE age_gate_version_observations SET first_seen_at = NOW() - INTERVAL '30 days'
+             WHERE repository_id = $1 AND package_name = 'pkg'",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("backdate observations");
+
+        let mut doc = packument();
+        svc.filter_npm_packument(&params, "pkg", &mut doc)
+            .await
+            .expect("filter once aged");
+        assert_eq!(doc["versions"].as_object().unwrap().len(), 2);
+    }
+
+    /// A pending review's basis timestamp means something different under each
+    /// mode, so switching the mode invalidates it: those versions block until
+    /// re-observed on the new clock. Reviewed rows are not rewritten by the
+    /// switch itself — their staleness is enforced at decision time through
+    /// the basis identity.
+    #[tokio::test]
+    async fn db_mode_switch_invalidates_pending_review_basis() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, _key) = create_age_gate_repo(&pool, RepositoryFormat::Npm, 7).await;
+
+        let published = Utc::now() - Duration::days(1);
+        let pending =
+            insert_review_row(&pool, repo_id, "pkg", "1.0.0", "pending", Some(published)).await;
+        let approved =
+            insert_review_row(&pool, repo_id, "pkg", "0.9.0", "approved", Some(published)).await;
+
+        svc.update_repo_config(repo_id, true, 7, AgeGateMode::FirstSeen)
+            .await
+            .expect("switch to first_seen");
+
+        let pending_basis: Option<DateTime<Utc>> =
+            sqlx::query_scalar("SELECT upstream_published_at FROM age_gate_reviews WHERE id = $1")
+                .bind(pending)
+                .fetch_one(&pool)
+                .await
+                .expect("pending row");
+        assert!(
+            pending_basis.is_none(),
+            "a publish-time basis must not survive a switch to first_seen: the \
+             sweep would auto-approve on a clock the repository no longer runs"
+        );
+
+        let approved_basis: Option<DateTime<Utc>> =
+            sqlx::query_scalar("SELECT upstream_published_at FROM age_gate_reviews WHERE id = $1")
+                .bind(approved)
+                .fetch_one(&pool)
+                .await
+                .expect("approved row");
+        assert!(approved_basis.is_some());
+
+        // The mode is persisted and visible to the next request.
+        let params = resolve_repo_params(&pool, repo_id)
+            .await
+            .expect("resolve after switch");
+        assert_eq!(params.age_gate_mode, AgeGateMode::FirstSeen);
+
+        // Re-applying the same mode is not a switch: it must not wipe a basis
+        // that was just re-observed.
+        sqlx::query("UPDATE age_gate_reviews SET upstream_published_at = $2 WHERE id = $1")
+            .bind(pending)
+            .bind(published)
+            .execute(&pool)
+            .await
+            .expect("restore basis");
+        svc.update_repo_config(repo_id, true, 14, AgeGateMode::FirstSeen)
+            .await
+            .expect("threshold-only change");
+        let untouched: Option<DateTime<Utc>> =
+            sqlx::query_scalar("SELECT upstream_published_at FROM age_gate_reviews WHERE id = $1")
+                .bind(pending)
+                .fetch_one(&pool)
+                .await
+                .expect("pending row");
+        assert!(untouched.is_some());
+    }
+
+    /// F2: an automatic approval is bookkeeping, not authority. Switching the
+    /// age source must not let a publish-time auto-approval keep allowing the
+    /// version under `first_seen`; the row is voided back to pending under
+    /// the new identity and the version blocks until its new clock ages.
+    #[tokio::test]
+    async fn db_auto_approval_does_not_bypass_mode_switch() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, repo_key) = create_age_gate_repo(&pool, RepositoryFormat::Npm, 7).await;
+        let fingerprint = upstream_fingerprint(Some(TEST_UPSTREAM));
+
+        // Publish-time auto-approval: aged basis, correct identity for the
+        // OLD policy.
+        let review_id = insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "1.0.0",
+            "approved",
+            Some(Utc::now() - Duration::days(30)),
+            None,
+            Some("upstream_publish_time"),
+            Some(&fingerprint),
+        )
+        .await;
+
+        svc.update_repo_config(repo_id, true, 7, AgeGateMode::FirstSeen)
+            .await
+            .expect("switch to first_seen");
+        let params = params_with_mode(
+            repo_id,
+            repo_key,
+            RepositoryFormat::Npm,
+            7,
+            AgeGateMode::FirstSeen,
+        );
+
+        // Under first_seen the basis is a fresh observation: below threshold.
+        let basis = svc
+            .observe_first_seen(&params, "pkg", "1.0.0")
+            .await
+            .expect("observe under new mode");
+        assert!(matches!(
+            svc.check(&params, "pkg", "1.0.0", basis)
+                .await
+                .expect("check under new mode"),
+            AgeGateDecision::Block { .. }
+        ));
+
+        let (status, basis_mode): (String, Option<String>) =
+            sqlx::query_as("SELECT status, basis_mode FROM age_gate_reviews WHERE id = $1")
+                .bind(review_id)
+                .fetch_one(&pool)
+                .await
+                .expect("review row");
+        assert_eq!(status, "pending", "stale automatic approval is voided");
+        assert_eq!(basis_mode.as_deref(), Some("first_seen"));
+    }
+
+    /// F2: repointing the upstream voids recorded approvals — manual and
+    /// automatic alike — because they answered a question about a different
+    /// registry. Rejections deliberately stay coordinate-wide.
+    #[tokio::test]
+    async fn db_repointing_upstream_voids_approvals_but_not_rejections() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, repo_key) = create_age_gate_repo(&pool, RepositoryFormat::Npm, 7).await;
+        let reviewer = create_reviewer(&pool).await;
+        let old_fingerprint = upstream_fingerprint(Some(TEST_UPSTREAM));
+        let young = Utc::now() - Duration::days(1);
+
+        let manual = insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "1.0.0",
+            "approved",
+            Some(young),
+            Some(reviewer),
+            Some("upstream_publish_time"),
+            Some(&old_fingerprint),
+        )
+        .await;
+        insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "2.0.0",
+            "rejected",
+            Some(young),
+            Some(reviewer),
+            Some("upstream_publish_time"),
+            Some(&old_fingerprint),
+        )
+        .await;
+
+        // Sanity: under the original upstream the manual approval allows.
+        let params = npm_params(repo_id, repo_key.clone(), 7);
+        assert!(matches!(
+            svc.check(&params, "pkg", "1.0.0", Some(young))
+                .await
+                .unwrap(),
+            AgeGateDecision::Allow
+        ));
+
+        // Repoint: same coordinates, different registry.
+        let mut repointed = npm_params(repo_id, repo_key, 7);
+        repointed.upstream_url = Some("https://registry-b.example.test".to_string());
+        assert!(matches!(
+            svc.check(&repointed, "pkg", "1.0.0", Some(young))
+                .await
+                .unwrap(),
+            AgeGateDecision::Block { .. }
+        ));
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM age_gate_reviews WHERE id = $1")
+                .bind(manual)
+                .fetch_one(&pool)
+                .await
+                .expect("manual row");
+        assert_eq!(
+            status, "pending",
+            "stale manual approval re-enters the queue"
+        );
+
+        // The rejection still blocks under the new upstream.
+        assert!(matches!(
+            svc.check(&repointed, "pkg", "2.0.0", Some(young))
+                .await
+                .unwrap(),
+            AgeGateDecision::Block { .. }
+        ));
+    }
+
+    /// F2: raising the threshold restrains versions carrying an earlier
+    /// automatic approval — eligibility is recomputed against the current
+    /// threshold, never read off the row's status.
+    #[tokio::test]
+    async fn db_raising_threshold_restrains_automatic_approvals() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, repo_key) = create_age_gate_repo(&pool, RepositoryFormat::Npm, 7).await;
+        let fingerprint = upstream_fingerprint(Some(TEST_UPSTREAM));
+        let basis = Utc::now() - Duration::days(10);
+
+        insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "1.0.0",
+            "approved",
+            Some(basis),
+            None,
+            Some("upstream_publish_time"),
+            Some(&fingerprint),
+        )
+        .await;
+
+        // 10 days old, threshold 7: allowed (recomputed, identity matches).
+        let params = npm_params(repo_id, repo_key.clone(), 7);
+        assert!(matches!(
+            svc.check(&params, "pkg", "1.0.0", Some(basis))
+                .await
+                .unwrap(),
+            AgeGateDecision::Allow
+        ));
+
+        // Threshold raised to 30: the same auto-approved row must block.
+        svc.update_repo_config(repo_id, true, 30, AgeGateMode::UpstreamPublishTime)
+            .await
+            .expect("raise threshold");
+        let params = npm_params(repo_id, repo_key, 30);
+        assert!(matches!(
+            svc.check(&params, "pkg", "1.0.0", Some(basis))
+                .await
+                .unwrap(),
+            AgeGateDecision::Block { .. }
+        ));
+    }
+
+    /// F2: the background sweep honors only a basis recorded under the
+    /// repository's CURRENT policy identity. Stale rows and in-flight writes
+    /// carrying the old identity are never swept; pre-identity legacy rows
+    /// are swept only while the repository still runs publish-time mode.
+    #[tokio::test]
+    async fn db_sweep_requires_current_identity() {
+        let Some(pool) = try_db_pool().await else {
+            return;
+        };
+        let svc = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        let (repo_id, _key) = create_age_gate_repo(&pool, RepositoryFormat::Npm, 7).await;
+        let current = upstream_fingerprint(Some(TEST_UPSTREAM));
+        let aged = Some(Utc::now() - Duration::days(30));
+
+        let current_identity = insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "1.0.0",
+            "pending",
+            aged,
+            None,
+            Some("upstream_publish_time"),
+            Some(&current),
+        )
+        .await;
+        let stale_identity = insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "2.0.0",
+            "pending",
+            aged,
+            None,
+            Some("upstream_publish_time"),
+            Some("stale-fingerprint"),
+        )
+        .await;
+        let stale_mode = insert_review_row_with_identity(
+            &pool,
+            repo_id,
+            "pkg",
+            "3.0.0",
+            "pending",
+            aged,
+            None,
+            Some("first_seen"),
+            Some(&current),
+        )
+        .await;
+        let legacy = insert_review_row_with_identity(
+            &pool, repo_id, "pkg", "4.0.0", "pending", aged, None, None, None,
+        )
+        .await;
+
+        svc.auto_approve_aged_reviews().await.expect("sweep");
+
+        let status = |id: Uuid| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query_scalar::<_, String>("SELECT status FROM age_gate_reviews WHERE id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await
+                    .expect("row status")
+            }
+        };
+        assert_eq!(status(current_identity).await, "approved");
+        assert_eq!(
+            status(stale_identity).await,
+            "pending",
+            "a basis recorded against a different upstream is never swept"
+        );
+        assert_eq!(
+            status(stale_mode).await,
+            "pending",
+            "a basis recorded under a different mode is never swept"
+        );
+        assert_eq!(
+            status(legacy).await,
+            "approved",
+            "legacy pre-identity rows keep sweeping while the repo runs publish-time"
+        );
+
+        // Under first_seen the legacy arm closes too: a fresh legacy-shaped
+        // row (as an in-flight pre-upgrade write would leave) is not swept.
+        let svc2 = AgeGateService::new(pool.clone(), Arc::new(EventBus::new(16)));
+        svc2.update_repo_config(repo_id, true, 7, AgeGateMode::FirstSeen)
+            .await
+            .expect("switch to first_seen");
+        let legacy_after_switch = insert_review_row_with_identity(
+            &pool, repo_id, "pkg", "5.0.0", "pending", aged, None, None, None,
+        )
+        .await;
+        svc2.auto_approve_aged_reviews().await.expect("sweep 2");
+        assert_eq!(
+            status(legacy_after_switch).await,
+            "pending",
+            "legacy rows are not swept under first_seen"
+        );
     }
 }

--- a/backend/src/services/age_gate_service.rs
+++ b/backend/src/services/age_gate_service.rs
@@ -1972,16 +1972,13 @@ pub(crate) fn apply_pypi_simple_json_blocks(
     }
 }
 
-/// Map a repository format to the bounded Prometheus label used on age-gate
-/// metrics. [`AgeGateService::is_applicable`] restricts the gate to npm/PyPI, so
-/// other formats are never expected here; they collapse to `"other"` rather than
-/// widening the label set.
+/// Map a repository format to the bounded Prometheus label owned by the
+/// age-gate capability registry. Unsupported formats collapse to `"other"`
+/// rather than widening the label set.
 fn format_label(format: &RepositoryFormat) -> &'static str {
-    match format {
-        RepositoryFormat::Npm => "npm",
-        RepositoryFormat::Pypi => "pypi",
-        _ => "other",
-    }
+    crate::formats::age_gate_spec(format)
+        .map(|spec| spec.label)
+        .unwrap_or("other")
 }
 
 /// Drop any `dist-tags` entry whose target version is no longer present in the
@@ -2647,6 +2644,9 @@ mod tests {
     fn format_label_maps_to_bounded_set() {
         assert_eq!(format_label(&RepositoryFormat::Npm), "npm");
         assert_eq!(format_label(&RepositoryFormat::Pypi), "pypi");
+        assert_eq!(format_label(&RepositoryFormat::Go), "go");
+        assert_eq!(format_label(&RepositoryFormat::Yarn), "npm");
+        assert_eq!(format_label(&RepositoryFormat::Poetry), "pypi");
         // Anything outside the gate's supported formats collapses to "other"
         // so the metric label set stays bounded.
         assert_eq!(format_label(&RepositoryFormat::Generic), "other");

--- a/backend/src/services/audit_export.rs
+++ b/backend/src/services/audit_export.rs
@@ -377,6 +377,11 @@ pub mod details {
         /// Minimum upstream publish age for that policy change.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub age_gate_min_age_days: Option<i32>,
+        /// Age-source mode (`upstream_publish_time` / `first_seen`) for that
+        /// policy change. A mode switch changes which basis existing review
+        /// decisions are honored under, so it is audit-relevant on its own.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub age_gate_mode: Option<String>,
     }
 
     /// `ROLE_ASSIGNED` / `ROLE_REVOKED` / `REPOSITORY_PERMISSION_CHANGED`.
@@ -1096,6 +1101,7 @@ mod tests {
             visibility: None,
             age_gate_enabled: None,
             age_gate_min_age_days: None,
+            age_gate_mode: None,
         };
         let v = serde_json::to_value(&d).unwrap();
         assert_eq!(v["key"], "maven-releases");

--- a/backend/src/services/audit_schema.rs
+++ b/backend/src/services/audit_schema.rs
@@ -278,6 +278,7 @@ mod tests {
                     visibility: Some("private".into()),
                     age_gate_enabled: None,
                     age_gate_min_age_days: None,
+                    age_gate_mode: None,
                 }),
         ];
         for entry in &entries {
@@ -344,6 +345,7 @@ mod tests {
                 visibility: Some("private".into()),
                 age_gate_enabled: Some(true),
                 age_gate_min_age_days: Some(14),
+                age_gate_mode: None,
             })
             .unwrap(),
         );

--- a/backend/src/services/webhook_producer.rs
+++ b/backend/src/services/webhook_producer.rs
@@ -51,6 +51,10 @@ pub fn map_event_type(event_type: &str) -> Option<&'static str> {
         "age_gate.queued" => Some("age_gate_queued"),
         "age_gate.approved" => Some("age_gate_approved"),
         "age_gate.rejected" => Some("age_gate_rejected"),
+        // A decided review voided back to pending (#2968): without this arm
+        // subscribers that saw the approval/rejection never learn it was
+        // reopened — the gap #2264's review-identity work rides along with.
+        "age_gate.reopened" => Some("age_gate_reopened"),
         _ => None,
     }
 }
@@ -417,6 +421,7 @@ mod tests {
                 WebhookEvent::AgeGateQueued => ("age_gate.queued", "age_gate_queued"),
                 WebhookEvent::AgeGateApproved => ("age_gate.approved", "age_gate_approved"),
                 WebhookEvent::AgeGateRejected => ("age_gate.rejected", "age_gate_rejected"),
+                WebhookEvent::AgeGateReopened => ("age_gate.reopened", "age_gate_reopened"),
             }
         }
 

--- a/backend/tests/age_gate_tests.rs
+++ b/backend/tests/age_gate_tests.rs
@@ -52,6 +52,8 @@ fn npm_repo_params(id: Uuid, min_age_days: i32) -> AgeGateRepoParams {
         RepositoryFormat::Npm,
         true,
         min_age_days,
+        Default::default(),
+        None,
     )
 }
 
@@ -374,6 +376,8 @@ fn pypi_repo_params(id: Uuid, min_age_days: i32) -> AgeGateRepoParams {
         RepositoryFormat::Pypi,
         true,
         min_age_days,
+        Default::default(),
+        None,
     )
 }
 
@@ -454,6 +458,86 @@ async fn pypi_simple_index_withholds_young_version_via_real_anchors() {
         review_status(&pool, repo_id, pkg, "9.9.9").await,
         "pending",
         "the withheld young version must be queued for review"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL; run with --ignored"]
+async fn approve_stamps_live_basis_identity() {
+    let pool = connect_db().await;
+    let bus = Arc::new(EventBus::new(16));
+    let svc = AgeGateService::new(pool.clone(), bus);
+    let repo_id = create_remote_npm_repo(&pool, "approve-basis", 7).await;
+    let reviewer = create_reviewer(&pool).await;
+
+    insert_pending_review(&pool, repo_id, "testpkg", "1.0.0", None).await;
+
+    let review_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM age_gate_reviews WHERE repository_id = $1 AND package_name = 'testpkg'",
+    )
+    .bind(repo_id)
+    .fetch_one(&pool)
+    .await
+    .expect("get review id");
+
+    let approved = svc
+        .approve(review_id, reviewer, Some("test approve"))
+        .await
+        .expect("approve review");
+
+    assert_eq!(approved.status, "approved");
+    assert_eq!(
+        approved.basis_mode.as_deref(),
+        Some("upstream_publish_time")
+    );
+    assert!(
+        approved.basis_upstream_fingerprint.is_some(),
+        "approve must stamp the upstream fingerprint"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL; run with --ignored"]
+async fn concurrent_review_transition_has_one_winner() {
+    let pool = connect_db().await;
+    let svc = Arc::new(AgeGateService::new(
+        pool.clone(),
+        Arc::new(EventBus::new(32)),
+    ));
+    let repo_id = create_remote_npm_repo(&pool, "approve-race", 7).await;
+    let reviewer = create_reviewer(&pool).await;
+    insert_pending_review(&pool, repo_id, "racepkg", "1.0.0", None).await;
+    let review_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM age_gate_reviews
+         WHERE repository_id = $1 AND package_name = 'racepkg'",
+    )
+    .bind(repo_id)
+    .fetch_one(&pool)
+    .await
+    .expect("get review id");
+
+    const CONTENDERS: usize = 16;
+    let barrier = Arc::new(tokio::sync::Barrier::new(CONTENDERS));
+    let mut tasks = Vec::with_capacity(CONTENDERS);
+    for _ in 0..CONTENDERS {
+        let svc = Arc::clone(&svc);
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            svc.approve(review_id, reviewer, Some("concurrent approve"))
+                .await
+        }));
+    }
+
+    let mut successes = 0;
+    for task in tasks {
+        if task.await.expect("join approve task").is_ok() {
+            successes += 1;
+        }
+    }
+    assert_eq!(
+        successes, 1,
+        "exactly one compare-and-swap transition may succeed"
     );
 }
 

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -713,6 +713,170 @@ mod qc_metadata_leak_2437 {
 }
 
 // ---------------------------------------------------------------------------
+// #2264 (low-sev) — age-gate config disclosure to read-scope callers.
+// Class:  Missing function-level authorization / configuration disclosure.
+// Seam:   `GET /repositories/{key}/age-gate`, exercised end-to-end over the
+//         real repo-config router against a live DB (the external HTTP
+//         vantage), not a helper.
+// What:   `get_repo_age_gate` checked only `require_scope("read")` — no
+//         per-repo access, no admin — so ANY authenticated read-scope caller
+//         (e.g. a read-only API token) could read gate posture
+//         (`enabled` + `min_age_days`) for every repository. The PUT and all
+//         four /admin review endpoints were already admin-only; the GET now
+//         matches them with `require_admin()`.
+// Asserts: a read-scope API token and a plain non-admin user both get 403
+//         with no config fields in the body; an admin still gets 200 with the
+//         config row (migration-146 defaults for a fresh repo).
+//
+// DB-gated; run with:
+//   DATABASE_URL="postgresql://.../artifact_registry" \
+//     cargo test --test security_regression_tests -- --ignored
+// ---------------------------------------------------------------------------
+mod age_gate_config_2264 {
+    // streaming-invariant: test file exempt — buffering a 403/200 response body
+    // in an assertion is not an artifact path (#1608).
+    #![allow(clippy::disallowed_methods)]
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Extension;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use artifact_keeper_backend::api::handlers::age_gate;
+    use artifact_keeper_backend::api::middleware::auth::AuthExtension;
+    use artifact_keeper_backend::api::{AppState, SharedState};
+    use artifact_keeper_backend::config::Config;
+    use artifact_keeper_backend::models::access_scope::AccessScope;
+
+    fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+        let config = Config {
+            database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
+            storage_path: storage_path.into(),
+            jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+            ..Default::default()
+        };
+        let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = Arc::new(
+            artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(storage_path),
+        );
+        let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+            HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        Arc::new(AppState::new(config, pool, storage, registry))
+    }
+
+    /// A non-admin caller. `scopes` distinguishes the read-only API token
+    /// (the exact pre-fix caller) from a plain session user (scopes = None).
+    fn non_admin(scopes: Option<Vec<String>>) -> AuthExtension {
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "ag2264-caller".to_string(),
+            email: "ag2264@test.local".to_string(),
+            is_admin: false,
+            is_api_token: scopes.is_some(),
+            is_service_account: false,
+            scopes,
+            allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
+        }
+    }
+
+    fn admin() -> AuthExtension {
+        AuthExtension {
+            is_admin: true,
+            ..non_admin(None)
+        }
+    }
+
+    /// Insert a remote npm repo (age-gate columns keep migration-146 defaults).
+    /// Returns (repo id, repo key, storage dir).
+    async fn create_remote_repo(pool: &PgPool) -> (Uuid, String, String) {
+        let id = Uuid::new_v4();
+        let key = format!("ag2264-{}", &id.to_string()[..8]);
+        let dir = std::env::temp_dir().join(&key);
+        std::fs::create_dir_all(&dir).expect("create storage dir");
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, upstream_url) \
+             VALUES ($1, $2, $2, $3, 'remote', 'npm'::repository_format, 'https://registry.npmjs.org')",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(dir.to_string_lossy().as_ref())
+        .execute(pool)
+        .await
+        .expect("insert remote repo");
+        (id, key, dir.to_string_lossy().to_string())
+    }
+
+    /// GET `uri` as `caller` through the real repo-config router. The age-gate
+    /// handlers extract `Extension<Option<AuthExtension>>`, so inject the
+    /// Option form (as the production `auth_middleware` does).
+    async fn get_as(state: SharedState, caller: AuthExtension, uri: &str) -> (StatusCode, String) {
+        let app = age_gate::repo_config_routes()
+            .with_state(state)
+            .layer(Extension(Some(caller)));
+        let resp = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL pointed at a Postgres with migrations applied"]
+    async fn regression_2264_age_gate_config_admin_only() {
+        let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+            .await
+            .unwrap();
+        let (repo_id, key, storage) = create_remote_repo(&pool).await;
+        let state = build_state(pool.clone(), &storage);
+        let uri = format!("/{key}/age-gate");
+
+        // The exact disclosure: a read-only API token (passed the old
+        // `require_scope("read")` gate) must now get 403 with no config leak.
+        let (status, body) = get_as(
+            state.clone(),
+            non_admin(Some(vec!["read".to_string()])),
+            &uri,
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "read-scope token must 403");
+        for needle in ["min_age_days", "enabled"] {
+            assert!(
+                !body.contains(needle),
+                "403 body must not leak `{needle}`: {body}"
+            );
+        }
+
+        // A plain non-admin session user is equally rejected — repo-access
+        // bits do not grant config reads.
+        let (status, _body) = get_as(state.clone(), non_admin(None), &uri).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "non-admin user must 403");
+
+        // Admin parity with the PUT: still 200 with the config row.
+        let (status, body) = get_as(state.clone(), admin(), &uri).await;
+        assert_eq!(status, StatusCode::OK, "admin GET must still succeed");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["repository_key"], key.as_str());
+        assert_eq!(v["enabled"], false);
+        assert_eq!(v["min_age_days"], 7);
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // #2439  Cross-repo authorization: ungated /security scan+finding reads and
 //        /sbom generate/cve-status writes.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This lands age-gate enforcement at the shared handler-layer proxy seam shipped for curation in #2962: `enforce_age_gate` sits adjacent to `enforce_curation` at each supported download path, with per-member checks inside virtual resolution loops so the member repository's own policy always applies.

- Migrates the existing npm and PyPI gates onto the shared seam without changing their structured 451, review-row, last-known-good, or listing-filter behavior.
- Adds an explicit `first_seen` age source backed by insert-once observations keyed by repository, normalized upstream fingerprint, package, and version. Repointing a remote therefore starts a fresh clock instead of inheriting observations from a different registry.
- Records the age-source mode and upstream identity behind review decisions. Automatic approvals are never honored across a basis change; manual approvals are stamped from the live repository configuration; rejections remain sticky until explicitly reopened.
- Adds Go module support in `first_seen` mode: `@v/list` is filtered, young `@latest` responses are withheld so the client re-resolves, and `.zip` downloads return the standard 451 with the real review ID. `.info` and `.mod` remain readable because the Go client needs them during MVS resolution.
- Requires admin access for the age-gate config read endpoint, maps `age_gate.reopened` to webhooks, and makes review state transitions compare-and-swap safe so concurrent updates have one winner.
- Rejects configurations for unsupported format/mode combinations rather than presenting an enabled-but-inert control. This PR supports npm and PyPI in both modes and Go in `first_seen` mode.

NuGet is deliberately deferred to a fast-follow PR. Cargo, Maven, OCI, NuGet, and other formats do not gain placeholder or inert call sites here.

Two differences from the curation seam are intentional:

- Age-gate evaluation fails closed on policy/configuration errors; curation currently fails open.
- A block is a structured 451 with a persistent review row and optional last-known-good result, rather than a stateless 403.

partially fixes #2264.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a feature PR (the included config-read authz hardening has a dedicated security regression test)

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (including 16-contender review-transition coverage)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation at feature tip `85dd5ff0c4d89fe8b300633d779ed02e1bad934f`:

- Migration 191 applied successfully to an empty PostgreSQL database.
- `cargo fmt --check`, workspace/all-target Clippy with `-D warnings`, and all-test-target compilation passed.
- Focused Go wire-format, virtual-member source isolation, first-seen/LKG 451, shared-seam, review-basis, and transition-race regressions passed.
- `age_gate_tests`: 12 passed, 0 failed.
- Full library lane: 14,586 passed, 0 failed; 85.28% overall line coverage and 93% changed-code coverage (2,276/2,431).
- Independent delivery validation passed build, lint, backend smoke, web E2E, coverage, and every integration-matrix leg against the same immutable tip.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations (no new endpoints)
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (the project uses forward-only migrations; 191 is additive and preserves existing behavior by default)
- [ ] N/A - no API changes

Migration 191 adds the `age_gate_mode` repository field, review-basis identity columns, and the insert-once observation table. Existing repositories default to `upstream_publish_time`, preserving the shipped npm/PyPI behavior.
