### PR TITLE
perf(repositories): read usage ledger for listing storage totals instead of live SUM

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2218,35 +2218,28 @@ pub async fn list_repositories(
     let repo_ids: Vec<Uuid> = repos.iter().map(|r| r.id).collect();
     let storage_map: std::collections::HashMap<Uuid, i64> = if !repo_ids.is_empty() {
         sqlx::query_as::<_, (Uuid, i64)>(
-            // #2218: per-repo storage now UNIONs the persisted proxy-cache
-            // catalog so remote (proxy) repos count their cached bytes (was 0 —
-            // proxy objects carry no `artifacts` row since #1280). Legacy
-            // pre-#1280 `proxy-cache/%` leftovers in `artifacts` are excluded so
-            // an object that is also lazily backfilled into the catalog is not
-            // summed twice. Hosted repos have no `proxy-cache/%` keys and an
-            // empty catalog, so their totals are unchanged.
+            // #3078: read the trigger-maintained `repository_usage_ledger`
+            // (migrations 171/182) instead of recomputing the 3-way live SUM
+            // over `artifacts` + `proxy_cache_artifacts` + `oci_blobs` on
+            // every listing request — the live SUM's cost scales with total
+            // artifact count, not page size. The ledger is byte-for-byte
+            // equivalent to that SUM: 182's row-level AFTER triggers charge
+            // `hosted_bytes` under the identical predicate the old query used
+            // (`is_deleted = false AND storage_key NOT LIKE 'proxy-cache/%'`,
+            // the #2218 rules), `proxy_bytes`/`oci_bytes` count their tables
+            // whole, and the `pending_delete_at` mark-and-sweep marker is a
+            // deliberate zero-delta no-op. `RepositoryService::get_storage_usage`
+            // stays the live-SUM oracle (reconciler / quota fallback).
             //
-            // OCI layer/config blobs live in `oci_blobs` (`artifacts` only
-            // holds manifests), so docker repos need the third branch or the
-            // listing shows KiBs for repos holding GiBs of layers. Must stay
-            // in lockstep with `RepositoryService::get_storage_usage`.
+            // A repo with no ledger row (created after 182 with zero writes)
+            // is simply absent from this result set and renders 0 via the
+            // `unwrap_or(0)` below — triggers self-seed a row only on growth,
+            // so "no row" means "no counted bytes"; the reconciler re-seeds
+            // rows lost to manual surgery.
             r#"
-            SELECT repository_id, COALESCE(SUM(bytes), 0)::BIGINT
-            FROM (
-                SELECT repository_id, size_bytes AS bytes
-                  FROM artifacts
-                 WHERE repository_id = ANY($1) AND is_deleted = false
-                   AND storage_key NOT LIKE 'proxy-cache/%'
-                UNION ALL
-                SELECT repository_id, size_bytes AS bytes
-                  FROM proxy_cache_artifacts
-                 WHERE repository_id = ANY($1)
-                UNION ALL
-                SELECT repository_id, size_bytes AS bytes
-                  FROM oci_blobs
-                 WHERE repository_id = ANY($1)
-            ) t
-            GROUP BY repository_id
+            SELECT repository_id, (hosted_bytes + proxy_bytes + oci_bytes)::BIGINT
+              FROM repository_usage_ledger
+             WHERE repository_id = ANY($1)
             "#,
         )
         .bind(&repo_ids)
@@ -2259,17 +2252,31 @@ pub async fn list_repositories(
         std::collections::HashMap::new()
     };
 
-    // #2785: the batched per-repo SUM above keys off `repository_id`, which is
-    // (near) empty for a virtual repo — it owns no artifact rows, only member
-    // links. Overwrite each virtual repo's figure with the union of its
-    // resolvable members so the listing total matches the child repos. Virtual
-    // repos are rare, so this touches at most a handful of rows per page.
+    // #2785: the batched per-repo figure above keys off `repository_id`, which
+    // is (near) empty for a virtual repo — it owns no artifact rows, only
+    // member links. Overwrite each virtual repo's figure with the union of its
+    // resolvable members so the listing total matches the child repos.
+    //
+    // #3078: resolve every virtual on the page in ONE query (the old shape
+    // called `get_virtual_storage_usage` once per virtual — an N+1 that
+    // re-scanned every reachable member's artifact rows per call). Seeding 0
+    // first preserves the old always-overwrite semantics: a virtual with no
+    // resolvable members has no row in the batch result and must render 0.
     let mut storage_map = storage_map;
-    for r in &repos {
-        if r.repo_type == RepositoryType::Virtual {
-            let combined = service.get_virtual_storage_usage(r.id).await?;
-            storage_map.insert(r.id, combined);
+    let virtual_ids: Vec<Uuid> = repos
+        .iter()
+        .filter(|r| r.repo_type == RepositoryType::Virtual)
+        .map(|r| r.id)
+        .collect();
+    if !virtual_ids.is_empty() {
+        for id in &virtual_ids {
+            storage_map.insert(*id, 0);
         }
+        storage_map.extend(
+            service
+                .get_virtual_storage_usage_batch(&virtual_ids)
+                .await?,
+        );
     }
 
     // Batch fetch which repos have a trusted GPG key configured (#2568) so the
@@ -20803,5 +20810,238 @@ mod apt_validation_tests {
         let err = ensure_single_line("line1\rline2", "apt_release_version").unwrap_err();
         assert!(err.to_string().contains("apt_release_version"));
         assert!(err.to_string().contains("single-line"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #3078: GET /api/v1/repositories reads `storage_used_bytes` from the
+    // trigger-maintained `repository_usage_ledger` instead of recomputing the
+    // 3-way live SUM per request. The equivalence matrix below seeds the
+    // SOURCE tables (so migration 182's triggers do the charging) and asserts
+    // the listing's ledger-backed figure equals the live-SUM oracle
+    // (`RepositoryService::get_storage_usage` / `get_virtual_storage_usage`,
+    // both deliberately left live) for every seeded shape.
+    // -----------------------------------------------------------------------
+
+    /// Create a repo via the shared fixture helper, then re-key it under the
+    /// caller's unique run prefix so one `?q=<prefix>` listing call returns
+    /// exactly this test's repositories.
+    async fn seeded_repo_3078(
+        pool: &sqlx::PgPool,
+        prefix: &str,
+        tag: &str,
+        repo_type: &str,
+    ) -> Uuid {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let (id, _key, _dir) = tdh::create_repo(pool, repo_type, "generic").await;
+        let key = format!("{prefix}-{tag}");
+        sqlx::query("UPDATE repositories SET key = $1, name = $1 WHERE id = $2")
+            .bind(&key)
+            .bind(id)
+            .execute(pool)
+            .await
+            .expect("re-key repo under run prefix");
+        id
+    }
+
+    /// End-to-end equivalence matrix for the ledger-backed listing (#3078):
+    /// hosted bytes counted; a soft-deleted artifact excluded (seeded live,
+    /// then flipped, so the trigger's decrement is exercised); a legacy
+    /// `proxy-cache/%`-keyed `artifacts` row excluded; `proxy_cache_artifacts`
+    /// and `oci_blobs` counted, including a `pending_delete_at`-marked blob
+    /// (zero-delta no-op); an empty repo with no ledger row renders 0 without
+    /// vanishing from the response; a virtual renders the union of its
+    /// members; a memberless virtual renders 0.
+    #[tokio::test]
+    async fn test_listing_storage_matches_live_sum_oracle_3078() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let _serial = tdh::usage_ledger_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let prefix = format!("lg3078{}", &Uuid::new_v4().simple().to_string()[..12]);
+
+        let hosted = seeded_repo_3078(&pool, &prefix, "hosted", "local").await;
+        let proxied = seeded_repo_3078(&pool, &prefix, "proxied", "remote").await;
+        let oci = seeded_repo_3078(&pool, &prefix, "oci", "local").await;
+        let empty = seeded_repo_3078(&pool, &prefix, "empty", "local").await;
+        let virt = seeded_repo_3078(&pool, &prefix, "virt", "virtual").await;
+        let hollow = seeded_repo_3078(&pool, &prefix, "hollow", "virtual").await;
+
+        // hosted: one live artifact (counted), one soft-deleted (seeded live
+        // then flipped — trigger must decrement), one legacy proxy-cache-keyed
+        // row (trigger must never charge it).
+        let art = |repo: Uuid, key: String, size: i64, deleted: bool| {
+            let pool = pool.clone();
+            async move {
+                let id = Uuid::new_v4();
+                sqlx::query(
+                    "INSERT INTO artifacts (id, repository_id, path, name, size_bytes, \
+                     checksum_sha256, content_type, storage_key, is_deleted) \
+                     VALUES ($1, $2, $3, $3, $4, repeat('b', 64), 'application/octet-stream', \
+                     $5, $6)",
+                )
+                .bind(id)
+                .bind(repo)
+                .bind(format!("p/{id}"))
+                .bind(size)
+                .bind(key)
+                .bind(deleted)
+                .execute(&pool)
+                .await
+                .expect("insert artifact row");
+                id
+            }
+        };
+        art(hosted, format!("cas/00/{}", Uuid::new_v4()), 1_000, false).await;
+        let doomed = art(hosted, format!("cas/01/{}", Uuid::new_v4()), 4_000, false).await;
+        sqlx::query("UPDATE artifacts SET is_deleted = true WHERE id = $1")
+            .bind(doomed)
+            .execute(&pool)
+            .await
+            .expect("soft-delete artifact");
+        art(
+            hosted,
+            format!("proxy-cache/{hosted}/x/__content__"),
+            9_999,
+            false,
+        )
+        .await;
+
+        // proxied: a proxy-cache catalog row (counted whole-table).
+        sqlx::query(
+            "INSERT INTO proxy_cache_artifacts (id, repository_id, path, storage_key, \
+             metadata_key, size_bytes) VALUES ($1, $2, 'c/pkg.tgz', $3, $4, 2500)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(proxied)
+        .bind(format!("proxy-cache/{proxied}/c/pkg.tgz/__content__"))
+        .bind(format!(
+            "proxy-cache/{proxied}/c/pkg.tgz/__cache_meta__.json"
+        ))
+        .execute(&pool)
+        .await
+        .expect("insert proxy cache row");
+
+        // oci: one plain blob + one later marked pending_delete_at (the
+        // mark-and-sweep marker is a zero-delta no-op: still counted).
+        let blob = |repo: Uuid, size: i64| {
+            let pool = pool.clone();
+            async move {
+                let digest = format!("sha256:{}", Uuid::new_v4().simple());
+                sqlx::query(
+                    "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(Uuid::new_v4())
+                .bind(repo)
+                .bind(&digest)
+                .bind(size)
+                .bind(format!("oci-blobs/{digest}"))
+                .execute(&pool)
+                .await
+                .expect("insert oci blob row");
+                digest
+            }
+        };
+        blob(oci, 500_000).await;
+        let marked = blob(oci, 250_000).await;
+        sqlx::query(
+            "UPDATE oci_blobs SET pending_delete_at = NOW() \
+             WHERE repository_id = $1 AND digest = $2",
+        )
+        .bind(oci)
+        .bind(&marked)
+        .execute(&pool)
+        .await
+        .expect("mark blob pending delete");
+
+        // empty: force the missing-ledger-row shape even if something seeded it.
+        sqlx::query("DELETE FROM repository_usage_ledger WHERE repository_id = $1")
+            .bind(empty)
+            .execute(&pool)
+            .await
+            .expect("drop empty repo ledger row");
+
+        // virt: union of hosted + oci members.
+        for (member, prio) in [(hosted, 1), (oci, 2)] {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virt)
+            .bind(member)
+            .bind(prio)
+            .execute(&pool)
+            .await
+            .expect("add virtual member");
+        }
+
+        // One listing call scoped to this run's repos, as an admin (sees all).
+        let state = tdh::build_state(pool.clone(), "/tmp/lg3078-unused");
+        let auth = tdh::admin_auth(user_id, &username);
+        let router = tdh::router_with_auth(super::router(), state, auth);
+        let (status, body) = tdh::send(router, tdh::get(format!("/?q={prefix}&per_page=50"))).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "listing failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("listing json");
+        let listed: std::collections::HashMap<String, i64> = json["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .map(|item| {
+                (
+                    item["key"].as_str().expect("key").to_string(),
+                    item["storage_used_bytes"].as_i64().expect("storage figure"),
+                )
+            })
+            .collect();
+
+        let service = RepositoryService::new(pool.clone());
+        // (id, tag, live-SUM oracle expectation)
+        let matrix = [
+            (hosted, "hosted", 1_000),
+            (proxied, "proxied", 2_500),
+            (oci, "oci", 750_000),
+            (empty, "empty", 0),
+            (virt, "virt", 751_000),
+            (hollow, "hollow", 0),
+        ];
+        for (id, tag, expected) in matrix {
+            let oracle = if tag == "virt" || tag == "hollow" {
+                service
+                    .get_virtual_storage_usage(id)
+                    .await
+                    .expect("virtual oracle")
+            } else {
+                service
+                    .get_storage_usage(id)
+                    .await
+                    .expect("live-SUM oracle")
+            };
+            assert_eq!(
+                oracle, expected,
+                "live-SUM oracle drifted from the seeded expectation for {tag}"
+            );
+            assert_eq!(
+                listed.get(&format!("{prefix}-{tag}")).copied(),
+                Some(expected),
+                "ledger-backed listing figure must equal the live-SUM oracle for {tag}"
+            );
+        }
+
+        for id in [virt, hollow, hosted, proxied, oci, empty] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await;
+        }
+        tdh::cleanup_user(&pool, user_id).await;
     }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -1721,6 +1721,74 @@ impl RepositoryService {
         Ok(usage)
     }
 
+    /// Batched sibling of [`Self::get_virtual_storage_usage`] for the listing
+    /// endpoint (issue #3078): resolve the reachable non-virtual leaves of
+    /// EVERY requested virtual root in ONE query (the listing used to call the
+    /// per-repo method once per virtual on the page — an N+1 whose every call
+    /// also re-scanned every reachable member's artifact rows).
+    ///
+    /// The recursion is the per-repo CTE with the root id threaded through it,
+    /// so roots stay independent: two virtuals sharing a leaf each count it,
+    /// under their own root. `UNION` (not `UNION ALL`) plus the
+    /// `depth < MAX_VIRTUAL_DEPTH` bound keeps the same cycle/nesting
+    /// termination, and `SELECT DISTINCT root_id, repo_id` keeps the #2785
+    /// union semantics — a leaf reachable through two paths under one root is
+    /// counted once.
+    ///
+    /// Per-leaf bytes come from the trigger-maintained
+    /// `repository_usage_ledger` (migrations 171/182), which is byte-for-byte
+    /// equivalent to the live 3-way SUM the per-repo method computes (same
+    /// `is_deleted` / `proxy-cache/%` predicates in 182's triggers), so the
+    /// aggregation input shrinks from O(artifacts under all members) to
+    /// O(member repositories). `LEFT JOIN` + `COALESCE` make a leaf with no
+    /// ledger row contribute 0 rather than poisoning the SUM with NULL. A root
+    /// with no resolvable members has no row in the returned map — the caller
+    /// renders 0 for it.
+    pub async fn get_virtual_storage_usage_batch(
+        &self,
+        virtual_ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, i64>> {
+        if virtual_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let rows: Vec<(Uuid, i64)> = sqlx::query_as(
+            r#"
+            WITH RECURSIVE reachable(root_id, repo_id, depth) AS (
+                SELECT vrm.virtual_repo_id, vrm.member_repo_id, 1
+                  FROM virtual_repo_members vrm
+                 WHERE vrm.virtual_repo_id = ANY($1)
+              UNION
+                SELECT reachable.root_id, vrm.member_repo_id, reachable.depth + 1
+                  FROM reachable
+                  JOIN repositories parent
+                    ON parent.id = reachable.repo_id
+                   AND parent.repo_type = 'virtual'
+                  JOIN virtual_repo_members vrm
+                    ON vrm.virtual_repo_id = reachable.repo_id
+                 WHERE reachable.depth < $2
+            ),
+            leaves AS (
+                SELECT DISTINCT reachable.root_id AS root_id, reachable.repo_id AS id
+                  FROM reachable
+                  JOIN repositories leaf ON leaf.id = reachable.repo_id
+                 WHERE leaf.repo_type <> 'virtual'
+            )
+            SELECT leaves.root_id,
+                   COALESCE(SUM(l.hosted_bytes + l.proxy_bytes + l.oci_bytes), 0)::BIGINT
+              FROM leaves
+              LEFT JOIN repository_usage_ledger l ON l.repository_id = leaves.id
+             GROUP BY leaves.root_id
+            "#,
+        )
+        .bind(virtual_ids)
+        .bind(MAX_VIRTUAL_DEPTH as i32)
+        .fetch_all(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(rows.into_iter().collect())
+    }
+
     /// Reconcile the FULL member set of a virtual repository to exactly
     /// `desired` (issue #2785 defect B).
     ///
@@ -4859,6 +4927,234 @@ mod tests {
             cleanup_repo(&pool, v.id).await;
             cleanup_repo(&pool, a.id).await;
             cleanup_repo(&pool, leaf.id).await;
+        }
+
+        /// #3078: the batched ledger-backed virtual read
+        /// (`get_virtual_storage_usage_batch`) must agree exactly with the
+        /// per-repo live-SUM walk (`get_virtual_storage_usage`, the oracle)
+        /// for every root: a diamond overlap is counted once, a nested virtual
+        /// (depth 2) contributes its leaves, and two independent roots sharing
+        /// a leaf each count it under their own root. The leaves are seeded by
+        /// real source-table INSERTs so migration 182's triggers populate the
+        /// ledger — the test exercises trigger↔read equivalence end-to-end.
+        #[tokio::test]
+        async fn test_virtual_storage_batch_matches_live_oracle_3078() {
+            let _serial = tdh::usage_ledger_serial_lock().await;
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+
+            // leaf1: 1_000 hosted + 2_500 proxy-cached. leaf2: 500_000 OCI.
+            let leaf1 = service
+                .create(make_create_req(
+                    &format!("{suffix}l1"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create leaf1");
+            let leaf2 = service
+                .create(make_create_req(
+                    &format!("{suffix}l2"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create leaf2");
+            insert_artifact(
+                &pool,
+                leaf1.id,
+                "p/1",
+                &format!("cas/aa/{}", Uuid::new_v4()),
+                1_000,
+            )
+            .await;
+            insert_proxy_cache(&pool, leaf1.id, "cached/x.tgz", 2_500).await;
+            insert_oci_blob(
+                &pool,
+                leaf2.id,
+                &format!("sha256:{}", Uuid::new_v4().simple()),
+                500_000,
+            )
+            .await;
+
+            // Diamond: v -> a -> leaf1 and v -> leaf1 (leaf1 reachable twice
+            // under v, and a is a nested virtual member at depth 2).
+            let a = service
+                .create(make_virtual_req(
+                    &format!("{suffix}a"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create a");
+            let v = service
+                .create(make_virtual_req(
+                    &format!("{suffix}v"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create v");
+            // Independent root sharing leaf1 with the diamond, plus leaf2.
+            let w = service
+                .create(make_virtual_req(
+                    &format!("{suffix}w"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create w");
+            // No resolvable members: must be ABSENT from the batch result.
+            let hollow = service
+                .create(make_virtual_req(
+                    &format!("{suffix}h"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create hollow");
+            service
+                .add_virtual_member(a.id, leaf1.id, Some(1))
+                .await
+                .expect("a->leaf1");
+            service
+                .add_virtual_member(v.id, a.id, Some(1))
+                .await
+                .expect("v->a");
+            service
+                .add_virtual_member(v.id, leaf1.id, Some(2))
+                .await
+                .expect("v->leaf1");
+            service
+                .add_virtual_member(w.id, leaf1.id, Some(1))
+                .await
+                .expect("w->leaf1");
+            service
+                .add_virtual_member(w.id, leaf2.id, Some(2))
+                .await
+                .expect("w->leaf2");
+
+            let roots = [v.id, a.id, w.id, hollow.id];
+            let batch = service
+                .get_virtual_storage_usage_batch(&roots)
+                .await
+                .expect("batch read");
+            for (label, root) in [("v", v.id), ("a", a.id), ("w", w.id)] {
+                let oracle = service
+                    .get_virtual_storage_usage(root)
+                    .await
+                    .expect("per-repo oracle");
+                assert_eq!(
+                    batch.get(&root).copied(),
+                    Some(oracle),
+                    "batched ledger read must equal the live-SUM oracle for {label}"
+                );
+            }
+            assert_eq!(
+                batch[&v.id], 3_500,
+                "diamond: leaf1 reachable via two paths counts ONCE under v"
+            );
+            assert_eq!(
+                batch[&w.id], 503_500,
+                "independent roots each count a shared leaf under their own root"
+            );
+            assert!(
+                !batch.contains_key(&hollow.id),
+                "root with no resolvable members is absent (caller renders 0)"
+            );
+            assert!(
+                service
+                    .get_virtual_storage_usage_batch(&[])
+                    .await
+                    .expect("empty batch")
+                    .is_empty(),
+                "empty input short-circuits to an empty map"
+            );
+
+            for repo in [v, a, w, hollow, leaf1, leaf2] {
+                cleanup_repo(&pool, repo.id).await;
+            }
+        }
+
+        /// #3078: an A→B→A membership cycle (forced via direct INSERTs — the
+        /// API's cycle guard refuses to create one) must terminate under the
+        /// depth-bounded `UNION` recursion and count each reachable leaf once,
+        /// with the batched ledger read agreeing with the per-repo live-SUM
+        /// oracle for both roots.
+        #[tokio::test]
+        async fn test_virtual_storage_batch_cycle_terminates_3078() {
+            let _serial = tdh::usage_ledger_serial_lock().await;
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+
+            let leaf = service
+                .create(make_create_req(
+                    &format!("{suffix}cl"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create leaf");
+            insert_artifact(
+                &pool,
+                leaf.id,
+                "c/1",
+                &format!("cas/cc/{}", Uuid::new_v4()),
+                1_000,
+            )
+            .await;
+            let a = service
+                .create(make_virtual_req(
+                    &format!("{suffix}ca"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create a");
+            let b = service
+                .create(make_virtual_req(
+                    &format!("{suffix}cb"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create b");
+            service
+                .add_virtual_member(a.id, b.id, Some(1))
+                .await
+                .expect("a->b");
+            service
+                .add_virtual_member(b.id, leaf.id, Some(1))
+                .await
+                .expect("b->leaf");
+            // Close the cycle behind the API's guard.
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, 9)",
+            )
+            .bind(b.id)
+            .bind(a.id)
+            .execute(&pool)
+            .await
+            .expect("force b->a cycle edge");
+
+            let batch = service
+                .get_virtual_storage_usage_batch(&[a.id, b.id])
+                .await
+                .expect("batch read under cycle");
+            for (label, root) in [("a", a.id), ("b", b.id)] {
+                let oracle = service
+                    .get_virtual_storage_usage(root)
+                    .await
+                    .expect("per-repo oracle under cycle");
+                assert_eq!(oracle, 1_000, "cycle walk reaches the leaf once ({label})");
+                assert_eq!(
+                    batch.get(&root).copied(),
+                    Some(oracle),
+                    "batched read equals the oracle under a cycle ({label})"
+                );
+            }
+
+            for repo in [a, b, leaf] {
+                cleanup_repo(&pool, repo.id).await;
+            }
         }
 
         /// #2785 defect B: a virtual repository's member list is editable after


### PR DESCRIPTION
## Summary

`GET /api/v1/repositories` recomputed every repository's `storage_used_bytes` from the live
source tables on each request: a grouped `UNION ALL` SUM over `artifacts` +
`proxy_cache_artifacts` + `oci_blobs` for the page, plus one `get_virtual_storage_usage`
call **per virtual repo** on the page (an N+1 whose recursive walk re-scanned every
reachable member's rows). Cost scaled with total artifact count, not page size.

The product already maintains the O(1) answer: `repository_usage_ledger` (migration 171),
made authoritative by migration 182's row-level AFTER triggers, which charge
`hosted_bytes` under the identical predicate the listing used
(`is_deleted = false AND storage_key NOT LIKE 'proxy-cache/%'`), count
`proxy_cache_artifacts` / `oci_blobs` whole-table, and treat the `pending_delete_at`
mark-and-sweep marker as a zero-delta no-op. Reading it is exact, not approximate.

This PR repoints the **listing reads only** at the ledger:

- **Non-virtual batch** (`backend/src/api/handlers/repositories.rs`): the 3-way
  `UNION ALL` SUM becomes a PK probe —
  `SELECT repository_id, (hosted_bytes + proxy_bytes + oci_bytes) FROM
  repository_usage_ledger WHERE repository_id = ANY($1)`. A repo with no ledger row
  (no writes since 182) renders 0 via the existing `unwrap_or(0)` map default.
- **Virtuals** (`backend/src/services/repository_service.rs`): new
  `get_virtual_storage_usage_batch` resolves every virtual on the page in ONE recursive
  CTE — the existing #2785 walk with the root id threaded through the recursion
  (same `UNION` dedup, same `depth < MAX_VIRTUAL_DEPTH` bound, same
  `DISTINCT root_id, repo_id` count-each-leaf-once union semantics) — LEFT JOINed to the
  ledger instead of re-summing the source tables. The per-repo
  `get_virtual_storage_usage` keeps its live SUM for its other callers and as the test
  oracle.
- **Deliberately untouched:** `RepositoryService::get_storage_usage` stays the live 3-way
  SUM — it is the reconciler's semantic and the `get_ledger_usage` fallback; repointing it
  at the ledger would be circular. No quota/trigger/reconciler changes, no migration, no
  new index, dynamic sqlx only (no offline metadata change).

### Equivalence matrix (DB-backed tests, seeds go through the real tables so 182's triggers do the charging)

All assert the new ledger-backed figure == the live-SUM oracle for the same data:

| case | result |
|---|---|
| hosted artifact | counted (1000 == oracle) |
| soft-deleted artifact (seeded live, then flipped) | excluded (trigger decrement) |
| legacy `proxy-cache/%`-keyed `artifacts` row | excluded |
| `proxy_cache_artifacts` row | counted |
| `oci_blobs` row | counted |
| `oci_blobs` with `pending_delete_at` set | still counted (zero-delta) |
| empty repo, ledger row deleted | renders 0, still present in response |
| virtual with overlapping members (diamond) | leaf counted ONCE |
| nested virtual (depth 2) | inner leaves contribute |
| A→B→A membership cycle (forced via SQL) | terminates; equals oracle for both roots |
| virtual with no resolvable members | renders 0 |
| batch vs per-repo virtual read | equal for every root |

### Perf (seeded 180k artifacts + 20k proxy rows + 20k oci blobs across 8 repos + 2 virtuals, `EXPLAIN (ANALYZE, BUFFERS)`)

| query | before | after |
|---|---|---|
| non-virtual page batch | 56.1 ms, Seq Scan on `artifacts` (176k rows) + `oci_blobs` | 0.91 ms, ledger PK probe only |
| virtual totals (2 virtuals) | ~49 ms **per virtual** (N+1), Seq Scans on all three tables | 0.49 ms for both in one query |

The new plans contain **no scan of `artifacts`, `proxy_cache_artifacts`, or `oci_blobs`**
— only `repository_usage_ledger` PK probes plus the small
`virtual_repo_members`/`repositories` membership walk — so listing cost is decoupled from
catalog size. End-to-end `GET /api/v1/repositories` on the seeded instance returns the
exact same totals as the live SUM and completes in ~10 ms.

Closes #3078

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (full `cargo nextest run --workspace --lib`: 14593 passed / 0 failed)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
