### PR TITLE
feat(stats): report proxy-cache storage and artifact count in system stats

### DIFF
--- a/backend/.sqlx/query-2b47a8130e7d52549c75c6692fb03ef094dd204f44c19be4c86ad3d8ead44d59.json
+++ b/backend/.sqlx/query-2b47a8130e7d52549c75c6692fb03ef094dd204f44c19be4c86ad3d8ead44d59.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            COUNT(*) as \"count!\",\n            COALESCE(SUM(size_bytes), 0)::BIGINT as \"size!\"\n        FROM proxy_cache_artifacts\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "size!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "2b47a8130e7d52549c75c6692fb03ef094dd204f44c19be4c86ad3d8ead44d59"
+}

--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -789,8 +789,8 @@ pub struct SystemStats {
     pub total_users: i64,
     pub active_peers: i64,
     pub pending_sync_tasks: i64,
-    /// Proxy-cached (pull-through) objects. They have no `artifacts` row, so
-    /// they're excluded from the totals above and reported separately here.
+    /// Proxy-cached (pull-through) objects, tracked in `proxy_cache_artifacts`
+    /// rather than `artifacts`, so they are reported separately here.
     pub proxy_artifact_count: i64,
     pub proxy_storage_bytes: i64,
 }
@@ -1751,6 +1751,119 @@ mod tests {
         assert_eq!(json["total_users"], 25);
         assert_eq!(json["proxy_artifact_count"], 12);
         assert_eq!(json["proxy_storage_bytes"], 2_000_000i64);
+    }
+
+    /// DB-backed (skips without `DATABASE_URL`): `get_system_stats` must
+    /// surface `proxy_cache_artifacts` rows through `proxy_artifact_count` /
+    /// `proxy_storage_bytes`.
+    ///
+    /// The endpoint aggregates the WHOLE table and the test database is
+    /// shared across concurrently running test processes, so assert on the
+    /// exact DELTA produced by this test's rows rather than on absolute
+    /// totals. A bounded retry absorbs the rare interleaving where another
+    /// test mutates the table between the two handler calls; a real wiring
+    /// bug fails every attempt.
+    #[tokio::test]
+    async fn test_get_system_stats_reports_proxy_cache_totals_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _repo_key, _dir) = tdh::create_repo(&pool, "remote", "pypi").await;
+        let state = tdh::build_state(pool.clone(), "/tmp/admin-proxy-stats");
+
+        let sizes: [i64; 2] = [1_234, 8_766];
+        let mut matched = false;
+        for _attempt in 0..3 {
+            let Json(before) = get_system_stats(State(state.clone())).await.unwrap();
+
+            for (i, size) in sizes.iter().enumerate() {
+                sqlx::query(
+                    "INSERT INTO proxy_cache_artifacts \
+                     (repository_id, path, storage_key, metadata_key, size_bytes) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(repo_id)
+                .bind(format!("stats/pkg-{i}.whl"))
+                .bind(format!(
+                    "proxy-cache/{repo_id}/stats/pkg-{i}.whl/__content__"
+                ))
+                .bind(format!(
+                    "proxy-cache/{repo_id}/stats/pkg-{i}.whl/__cache_meta__.json"
+                ))
+                .bind(size)
+                .execute(&pool)
+                .await
+                .expect("seed proxy cache row");
+            }
+
+            let Json(after) = get_system_stats(State(state.clone())).await.unwrap();
+
+            // Remove this attempt's rows before deciding, so a retry
+            // re-seeds from a clean slate (`(repository_id, path)` is
+            // unique).
+            sqlx::query("DELETE FROM proxy_cache_artifacts WHERE repository_id = $1")
+                .bind(repo_id)
+                .execute(&pool)
+                .await
+                .expect("cleanup proxy cache rows");
+
+            if after.proxy_artifact_count == before.proxy_artifact_count + sizes.len() as i64
+                && after.proxy_storage_bytes
+                    == before.proxy_storage_bytes + sizes.iter().sum::<i64>()
+            {
+                matched = true;
+                break;
+            }
+        }
+        assert!(
+            matched,
+            "get_system_stats never reflected the seeded proxy_cache_artifacts \
+             rows (+{} rows / +{} bytes)",
+            sizes.len(),
+            sizes.iter().sum::<i64>()
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup repo");
+    }
+
+    /// DB-backed (skips without `DATABASE_URL`): the proxy-cache aggregate
+    /// must COALESCE `SUM(size_bytes)` to 0 — not NULL — over an empty table,
+    /// since the handler decodes the column as a non-nullable BIGINT
+    /// (`"size!"`). The shared test database can hold rows from concurrent
+    /// tests, so the empty-table shape is forced inside a transaction: the
+    /// DELETE is rolled back and never observed by other tests.
+    #[tokio::test]
+    async fn test_proxy_cache_stats_query_empty_table_coalesces_to_zero_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let mut tx = pool.begin().await.expect("begin transaction");
+        sqlx::query("DELETE FROM proxy_cache_artifacts")
+            .execute(&mut *tx)
+            .await
+            .expect("clear proxy cache rows inside transaction");
+        let (count, size): (i64, i64) = sqlx::query_as(
+            "SELECT COUNT(*), COALESCE(SUM(size_bytes), 0)::BIGINT FROM proxy_cache_artifacts",
+        )
+        .fetch_one(&mut *tx)
+        .await
+        .expect("aggregate over empty proxy cache table");
+        tx.rollback().await.expect("rollback");
+
+        assert_eq!(count, 0);
+        assert_eq!(
+            size, 0,
+            "COALESCE must map SUM's NULL to 0 on an empty table"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -789,6 +789,10 @@ pub struct SystemStats {
     pub total_users: i64,
     pub active_peers: i64,
     pub pending_sync_tasks: i64,
+    /// Proxy-cached (pull-through) objects. They have no `artifacts` row, so
+    /// they're excluded from the totals above and reported separately here.
+    pub proxy_artifact_count: i64,
+    pub proxy_storage_bytes: i64,
 }
 
 /// Get system statistics
@@ -816,6 +820,18 @@ pub async fn get_system_stats(State(state): State<SharedState>) -> Result<Json<S
             COALESCE(SUM(size_bytes), 0)::BIGINT as "size!"
         FROM artifacts
         WHERE is_deleted = false
+        "#
+    )
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let proxy_stats = sqlx::query!(
+        r#"
+        SELECT
+            COUNT(*) as "count!",
+            COALESCE(SUM(size_bytes), 0)::BIGINT as "size!"
+        FROM proxy_cache_artifacts
         "#
     )
     .fetch_one(&state.db)
@@ -855,6 +871,8 @@ pub async fn get_system_stats(State(state): State<SharedState>) -> Result<Json<S
         total_users: user_count,
         active_peers: active_edge_count,
         pending_sync_tasks: pending_sync_count,
+        proxy_artifact_count: proxy_stats.count,
+        proxy_storage_bytes: proxy_stats.size,
     }))
 }
 
@@ -1722,6 +1740,8 @@ mod tests {
             total_users: 25,
             active_peers: 3,
             pending_sync_tasks: 0,
+            proxy_artifact_count: 12,
+            proxy_storage_bytes: 2_000_000,
         };
         let json = serde_json::to_value(&stats).unwrap();
         assert_eq!(json["total_repositories"], 10);
@@ -1729,6 +1749,8 @@ mod tests {
         assert_eq!(json["total_storage_bytes"], 1_000_000_000i64);
         assert_eq!(json["total_downloads"], 5000);
         assert_eq!(json["total_users"], 25);
+        assert_eq!(json["proxy_artifact_count"], 12);
+        assert_eq!(json["proxy_storage_bytes"], 2_000_000i64);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds `proxy_artifact_count` and `proxy_storage_bytes` to `SystemStats`, summed from `proxy_cache_artifacts`. The existing totals stay hosted-only, so the two fields are purely additive. Lets the dashboard show a local + remote breakdown.

Fixes #3087

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A - this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes