### PR TITLE
chore(labels): update automation references for type:* label rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug or unexpected behavior in Artifact Keeper
-labels: ["bug", "needs-triage"]
+labels: ["type:bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for Artifact Keeper
-labels: ["enhancement", "needs-triage"]
+labels: ["type:enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/format_request.yml
+++ b/.github/ISSUE_TEMPLATE/format_request.yml
@@ -1,6 +1,6 @@
 name: Package Format Request
 description: Request support for a new package format
-labels: ["enhancement", "new-format", "needs-triage"]
+labels: ["type:enhancement", "new-format", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       - "artifact-keeper/maintainers"
     labels:
       - "dependencies"
-      - "docker"
+      - "registry/docker"
     commit-message:
       prefix: "chore"
 
@@ -30,7 +30,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "cargo"
+      - "registry/cargo"
     commit-message:
       prefix: "chore"
     # The RustCrypto digest 0.10 -> 0.11 ecosystem migration is mid-flight.

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -133,7 +133,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'open',
-                labels: 'security',
+                labels: 'type:security',
                 per_page: 100
               });
 
@@ -157,7 +157,7 @@ jobs:
                     '',
                     'SARIF reports have been uploaded to the Security tab and as workflow artifacts.',
                   ].join('\n'),
-                  labels: ['security']
+                  labels: ['type:security']
                 });
               }
             }

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
               [View the failed run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
               `,
-              labels: ['bug', 'automated']
+              labels: ['type:bug', 'automated']
             });
         continue-on-error: true
 


### PR DESCRIPTION
Part of #3089 (label taxonomy reorganization, phase 1).

Updates every file that hard-codes the label names being renamed as part of the taxonomy reorg, so the automation keeps working the moment the GitHub labels are renamed:

- **Issue templates** — `bug_report.yml`, `feature_request.yml`, `format_request.yml`: pre-applied labels moved to the `type:*` namespace (`bug` → `type:bug`, `enhancement` → `type:enhancement`). Without this, new issues filed via templates lose their labels once the old names are gone.
- **`scheduled-tests.yml`** — nightly-failure issue creation: `['bug', 'automated']` → `['type:bug', 'automated']`. Without this, `issues.create` throws on the missing label and nightly failures are silently not filed (`continue-on-error` masks it).
- **`scheduled-container-scan.yml`** — Trivy findings dedup query and issue creation: `security` → `type:security`. Without this, the dedup query matches nothing (duplicate scan issues weekly) and findings-issue creation throws.
- **`dependabot.yml`** — ecosystem labels aligned to the new `registry/*` namespace (`docker` → `registry/docker`, `cargo` → `registry/cargo`). Dependabot auto-creates missing labels, so no breakage risk either way.

**Merge coordination:** this PR must merge immediately before/with the `gh` label renames — merging it while the old labels still exist is a no-op functionally (labels are applied by name at issue-creation time), and the renames must not land before this is merged. No runtime code changes; label-string swaps only.