### PR TITLE
fix(docker): add xz binary to hardened backend image for incus .tar.xz extraction

### DIFF
--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -418,7 +418,10 @@ impl IncusScanner {
         // (`--compression=zstd`) ship .tar.zst, so zstd must be handled
         // explicitly — `tar -xzf` (gzip) on a zstd archive
         // fails extraction. zstd support requires the `zstd` binary in the
-        // runtime image (installed in Dockerfile.backend).
+        // runtime image (installed in Dockerfile.backend). The xz path
+        // (`-xJf`) likewise forks the `xz` binary from the runtime image —
+        // `xz-libs` (liblzma, for the in-process xz2 crate) alone is not
+        // sufficient there.
         let is_xz = content.len() >= 5 && content[..5] == [0xFD, 0x37, 0x7A, 0x58, 0x5A];
         let is_zstd = content.len() >= 4 && content[..4] == [0x28, 0xB5, 0x2F, 0xFD];
 

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -68,7 +68,7 @@ FROM registry.access.redhat.com/ubi9/ubi:9.8 AS rootfs-builder
 # Install only essential runtime libraries into a clean rootfs.
 # --refresh forces fresh repo metadata and the follow-up `upgrade -y` pulls
 # the latest RHEL 9 z-stream security errata for every installed package
-# (curl-minimal/libcurl, glibc*, tar, openssl-libs, xz-libs,
+# (curl-minimal/libcurl, glibc*, tar, openssl-libs, xz, xz-libs,
 # zlib, zstd) that the install step alone may miss when the metadata cache is
 # stale. This guarantees the rootfs is rebuilt against current errata on every
 # image build. The reposdir override is required on the upgrade step because
@@ -91,6 +91,7 @@ RUN mkdir -p /mnt/rootfs && \
         openssl-libs \
         zlib \
         xz-libs \
+        xz \
         curl-minimal \
         tar \
         gzip \

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -84,7 +84,7 @@ FROM alpine:3.24 AS runtime
 # current errata on every image build; the targeted `add` keeps the install
 # set explicit.
 RUN apk upgrade --no-cache && \
-    apk add --no-cache --upgrade ca-certificates libgcc libstdc++ zlib xz-libs curl
+    apk add --no-cache --upgrade ca-certificates libgcc libstdc++ zlib xz-libs xz curl
 
 # --- CIS hardening (adapted from CIS Alpine Linux Benchmark) ---
 


### PR DESCRIPTION
## Summary

Closes #2390.

The hardened backend image installed `xz-libs` (liblzma, used by the
in-process `xz2` crate) but not the `xz` package itself. The incus
filesystem scanner shells out to `tar -xJf` for xz-magic archives
(`backend/src/services/incus_scanner.rs`), and GNU tar's `-J` flag forks
the `xz` binary — so exporting/scanning an incus `.tar.xz` rootfs archive
failed on the hardened image with `tar (child): xz: Cannot exec`. The
gzip and zstd binaries were already present; `xz` was simply missed.

Changes:

- `docker/Dockerfile.backend` — add `xz` to the rootfs-builder dnf install
  list (next to `xz-libs`) and to the package-enumeration comment above it.
- `docker/Dockerfile.backend.alpine` — add `xz` to the runtime `apk add`
  line.
- `backend/src/services/incus_scanner.rs` — extend the extraction comment:
  the xz path (`-xJf`) forks the `xz` binary from the runtime image, so
  `xz-libs` alone is not sufficient (same constraint already documented
  for `zstd`). No logic changes.

Purely additive (~0.5 MB in the runtime rootfs); no Rust code paths
change.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Neither box is checked: this is a bug fix, but the defect is a missing OS
package in the runtime image, not a code path, and there is currently no
CI harness that asserts on image contents. Verified instead by building
the image and probing it directly (see below). A possible follow-up is a
small CI image-content assertion (e.g. `docker run --rm --entrypoint
/usr/bin/xz <image> --version` plus a `tar -xJf` smoke archive), left out
of scope here to keep the diff minimal.

## Test Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verification performed against the built image:

- `docker run --rm --entrypoint /usr/bin/xz <image> --version` → exit 0
  (binary present in the hardened rootfs).
- `docker run --rm --entrypoint /usr/bin/tar -v ...:/w <image> -xJf
  /w/test.tar.xz -C /tmp` → exit 0 (pre-fix behavior on the dev image:
  `tar (child): xz: Cannot exec`, exit 2).
- Deployed the image on an isolated stack; `/health` healthy and
  in-container `tar -xJf` / `tar -xzf` / `tar --zstd -xf` probes of test
  archives all succeed.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --
  -D warnings`, and `cargo test --workspace --lib` all pass (comment-only
  Rust change).

## API Changes

- [x] N/A - no API changes
