### PR TITLE
fix(maven): derive catalog package version from GAV path on generic and chunked upload paths

### DIFF
--- a/backend/migrations/192_maven_package_versions_version_backfill.sql
+++ b/backend/migrations/192_maven_package_versions_version_backfill.sql
@@ -1,0 +1,104 @@
+-- #3064: Backfill `package_versions.version` for Maven/Gradle catalog rows
+-- written by the generic/chunked upload paths before the write-path fix.
+--
+-- Context. #2723 normalized `packages.name` to `groupId:artifactId` on the
+-- generic/chunked write paths but left `package_versions.version` holding a
+-- naive path segment (e.g. the first groupId component, `com`), so hosted
+-- Maven grouped listings -- which join `packages` to `package_versions` --
+-- reported components with zero matching versions. The write paths now derive
+-- both name and version from the artifact's GAV path; this backfill repairs
+-- the rows written in between.
+--
+-- Derivation. A Maven artifact is stored at the GAV layout
+--   <groupId-as-path>/<artifactId>/<version>/<file>
+-- (the `artifacts.path` column). For a grouped catalog row
+-- `name = groupId:artifactId` the on-disk version directories are the path
+-- segments directly under `<groupId-as-path>/<artifactId>/` (the "prefix").
+-- A `package_versions` row is broken when NO artifact exists under
+-- `prefix || version || '/'` while the package DOES have candidate version
+-- directories:
+--   * exactly one candidate -> rewrite `version` to it; when a row with that
+--     version already exists for the package (UNIQUE(package_id, version)),
+--     delete the broken row instead;
+--   * multiple candidates  -> the broken row cannot be attributed to a single
+--     version, so it is deleted. The catalog is derived data; the row is
+--     recreated correctly on the next push.
+--
+-- Scope + safety.
+--   * Restricted to Maven/Gradle repositories and to `packages.name` rows in
+--     the grouped `groupId:artifactId` shape (a `:` strictly inside the
+--     name). Bare-name legacy rows are migration 177's concern.
+--   * Proxy repositories store no hosted `artifacts` rows, so their catalog
+--     rows never produce candidates and are left untouched.
+--   * `artifacts.version` carries the same naive-segment residue but is
+--     cosmetic there and is out of scope.
+--   * Forward-only and idempotent: a repaired row matches an existing version
+--     directory and is never selected again, so re-running is a no-op.
+
+WITH maven_packages AS (
+    SELECT
+        p.id,
+        p.repository_id,
+        REPLACE(split_part(p.name, ':', 1), '.', '/')
+            || '/' || split_part(p.name, ':', 2) || '/' AS prefix
+    FROM packages p
+    JOIN repositories r
+      ON r.id = p.repository_id
+     AND r.format IN ('maven', 'gradle')
+    WHERE POSITION(':' IN p.name) > 1
+      AND POSITION(':' IN p.name) < CHAR_LENGTH(p.name)
+),
+candidates AS (
+    SELECT DISTINCT
+        mp.id AS package_id,
+        split_part(SUBSTRING(a.path FROM CHAR_LENGTH(mp.prefix) + 1), '/', 1) AS version
+    FROM maven_packages mp
+    JOIN artifacts a
+      ON a.repository_id = mp.repository_id
+     AND LEFT(a.path, CHAR_LENGTH(mp.prefix)) = mp.prefix
+     AND POSITION('/' IN SUBSTRING(a.path FROM CHAR_LENGTH(mp.prefix) + 1)) > 0
+),
+broken AS (
+    SELECT pv.id AS pv_id, pv.package_id
+    FROM package_versions pv
+    JOIN maven_packages mp
+      ON mp.id = pv.package_id
+    WHERE EXISTS (
+        SELECT 1 FROM candidates c WHERE c.package_id = pv.package_id
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM artifacts a
+        WHERE a.repository_id = mp.repository_id
+          AND LEFT(a.path, CHAR_LENGTH(mp.prefix) + CHAR_LENGTH(pv.version) + 1)
+              = mp.prefix || pv.version || '/'
+    )
+),
+resolved AS (
+    SELECT
+        b.pv_id,
+        b.package_id,
+        ARRAY(
+            SELECT c.version FROM candidates c WHERE c.package_id = b.package_id
+        ) AS versions
+    FROM broken b
+),
+rewritten AS (
+    UPDATE package_versions pv
+    SET version = r.versions[1]
+    FROM resolved r
+    WHERE pv.id = r.pv_id
+      AND ARRAY_LENGTH(r.versions, 1) = 1
+      AND NOT EXISTS (
+          SELECT 1
+          FROM package_versions existing
+          WHERE existing.package_id = r.package_id
+            AND existing.version = r.versions[1]
+            AND existing.id <> r.pv_id
+      )
+    RETURNING pv.id
+)
+DELETE FROM package_versions pv
+USING resolved r
+WHERE pv.id = r.pv_id
+  AND NOT EXISTS (SELECT 1 FROM rewritten w WHERE w.id = r.pv_id);

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -780,7 +780,7 @@ async fn complete(
             .try_create_or_update_from_artifact(
                 session.repository_id,
                 &package_name,
-                package_version,
+                &package_version,
                 session.total_size,
                 &session.checksum_sha256,
                 completed_package_description(&session),
@@ -1143,17 +1143,40 @@ fn maven_package_metadata_from_artifact_metadata(
     Some(catalog)
 }
 
-fn completed_package_catalog_entry<'a>(
-    session: &'a upload_service::UploadSession,
+fn completed_package_catalog_entry(
+    session: &upload_service::UploadSession,
     format: &crate::models::repository::RepositoryFormat,
-) -> Option<(String, &'a str)> {
-    let version = completed_artifact_version(session)?;
+) -> Option<(String, String)> {
+    use crate::models::repository::RepositoryFormat;
     // #2723: Maven/Gradle grouped listings key the catalog `packages` row on
     // `groupId:artifactId`. Prefer the replicated POM metadata's coordinates;
     // otherwise, for a Maven/Gradle repo, derive the grouped name from the
     // artifact path so a generically-pushed asset joins the same component
     // instead of landing under a bare artifactId/filename.
-    let name = replicated_maven_artifact_metadata(session)
+    //
+    // #3064: for Maven/Gradle repos the catalog `package_versions.version`
+    // must come from the same GAV coordinates as the name — the replicated POM
+    // metadata's version when present, else the version segment of the
+    // artifact path. Requiring an explicit create-session version dropped
+    // chunked Maven uploads that carry their coordinates only in the path.
+    let metadata = replicated_maven_artifact_metadata(session);
+    let maven_layout = matches!(format, RepositoryFormat::Maven | RepositoryFormat::Gradle);
+    let version = if maven_layout {
+        metadata
+            .and_then(|m| m.get("version"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                crate::formats::maven::MavenHandler::parse_coordinates(&session.artifact_path)
+                    .ok()
+                    .map(|coords| coords.version)
+            })
+            .or_else(|| completed_artifact_version(session).map(str::to_string))
+    } else {
+        completed_artifact_version(session).map(str::to_string)
+    }?;
+    let name = metadata
         .and_then(maven_package_name_from_metadata)
         .or_else(|| maven_grouped_name_for_format(session, format))
         .unwrap_or_else(|| completed_artifact_name(session).to_string());
@@ -1660,7 +1683,7 @@ mod tests {
 
         assert_eq!(
             completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
-            Some(("large-check".to_string(), "20260603T082854Z"))
+            Some(("large-check".to_string(), "20260603T082854Z".to_string()))
         );
     }
 
@@ -1677,12 +1700,56 @@ mod tests {
 
         assert_eq!(
             completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
-            Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
+            Some((
+                "org.example.ak.maven:ak-core".to_string(),
+                "1.0.0".to_string()
+            ))
         );
         // A non-Maven repo keeps the bare artifact name.
         assert_eq!(
             completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
-            Some(("ak-core-1.0.0.jar".to_string(), "1.0.0"))
+            Some(("ak-core-1.0.0.jar".to_string(), "1.0.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_completed_package_catalog_entry_derives_version_from_gav_path() {
+        // #3064: a chunked Maven upload without an explicit create-session
+        // version must still produce a catalog row — name AND version come
+        // from the GAV path.
+        let session = test_upload_session("com/example/demo/app/1.2.3/app-1.2.3.jar", None, None);
+
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
+            Some(("com.example.demo:app".to_string(), "1.2.3".to_string()))
+        );
+        // A Generic repo keeps the legacy behaviour: no explicit version, no
+        // catalog row.
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
+            None
+        );
+    }
+
+    #[test]
+    fn test_completed_package_catalog_entry_path_version_beats_explicit_for_maven() {
+        // #3064: for Maven/Gradle repos the GAV path is the authoritative
+        // coordinate; an explicit create-session version that disagrees with
+        // the path must not split the component across two version rows.
+        let session = test_upload_session(
+            "com/example/demo/app/1.2.3/app-1.2.3.jar",
+            Some("app"),
+            Some("example"),
+        );
+
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
+            Some(("com.example.demo:app".to_string(), "1.2.3".to_string()))
+        );
+        // Non-Maven formats keep the explicit version as-is.
+        assert_eq!(
+            completed_package_catalog_entry(&session, &RepositoryFormat::Generic),
+            Some(("app".to_string(), "example".to_string()))
         );
     }
 
@@ -1708,7 +1775,10 @@ mod tests {
 
         assert_eq!(
             completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
-            Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
+            Some((
+                "org.example.ak.maven:ak-core".to_string(),
+                "1.0.0".to_string()
+            ))
         );
         assert_eq!(
             completed_package_description(&session),
@@ -1740,7 +1810,10 @@ mod tests {
 
         assert_eq!(
             completed_package_catalog_entry(&session, &RepositoryFormat::Maven),
-            Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
+            Some((
+                "org.example.ak.maven:ak-core".to_string(),
+                "1.0.0".to_string()
+            ))
         );
         assert_eq!(completed_package_description(&session), None);
         assert_eq!(completed_package_metadata(&session), None);

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -922,26 +922,36 @@ impl ArtifactService {
             // (replication / migration / generic push) to match instead of
             // persisting the bare artifactId or filename, which would split a
             // single component across multiple grouped rows.
-            let package_name = match self.repo_service.get_by_id(artifact.repository_id).await {
-                Ok(repo)
-                    if matches!(
-                        repo.format,
-                        RepositoryFormat::Maven | RepositoryFormat::Gradle
-                    ) =>
-                {
-                    crate::formats::maven::MavenHandler::grouped_package_name(
-                        &artifact.path,
-                        &artifact.name,
-                    )
-                }
-                _ => artifact.name.clone(),
-            };
+            //
+            // #3064: the catalog `package_versions.version` must come from the
+            // same GAV coordinates as the name. `artifact.version` on this path
+            // is a naive path segment (e.g. the first groupId component), which
+            // no grouped listing row ever matches.
+            let (package_name, package_version) =
+                match self.repo_service.get_by_id(artifact.repository_id).await {
+                    Ok(repo)
+                        if matches!(
+                            repo.format,
+                            RepositoryFormat::Maven | RepositoryFormat::Gradle
+                        ) =>
+                    {
+                        match crate::formats::maven::MavenHandler::parse_coordinates(&artifact.path)
+                        {
+                            Ok(coords) => (
+                                format!("{}:{}", coords.group_id, coords.artifact_id),
+                                coords.version,
+                            ),
+                            Err(_) => (artifact.name.clone(), ver.clone()),
+                        }
+                    }
+                    _ => (artifact.name.clone(), ver.clone()),
+                };
             let pkg_svc = crate::services::package_service::PackageService::new(self.db.clone());
             pkg_svc
                 .try_create_or_update_from_artifact(
                     artifact.repository_id,
                     &package_name,
-                    ver,
+                    &package_version,
                     artifact.size_bytes,
                     &artifact.checksum_sha256,
                     None,
@@ -3617,6 +3627,88 @@ mod tests {
             .bind(artifact.id)
             .execute(&pool)
             .await;
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    // ---- #3064 catalog coordinates on the generic finalize path -----------
+
+    /// #3064: a generic push into a Maven-format repo must key the catalog
+    /// `packages`/`package_versions` rows on the GAV coordinates derived from
+    /// the artifact path (`com.example.demo:app` / `1.2.3`), not on the naive
+    /// path-segment name/version the generic handler computes. An unparseable
+    /// path keeps the bare-name fallback. Skips without `DATABASE_URL`.
+    #[tokio::test]
+    async fn test_generic_push_into_maven_repo_records_gav_catalog_entry() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, _username) = tdh::create_user(&pool).await;
+        let (repo_id, _repo_key, storage_dir) = tdh::create_repo(&pool, "local", "maven").await;
+
+        let storage: Arc<dyn StorageBackend> = Arc::new(
+            crate::storage::filesystem::FilesystemStorage::new(storage_dir.clone()),
+        );
+        let svc = ArtifactService::new(pool.clone(), storage);
+
+        // The generic PUT handler derives name/version as naive path segments
+        // (segments[0]/segments[1]); mirror that call shape here.
+        svc.upload(
+            repo_id,
+            "com/example/demo/app/1.2.3/app-1.2.3.jar",
+            "com",
+            Some("example"),
+            "application/java-archive",
+            Bytes::from_static(b"gav-jar"),
+            Some(user_id),
+        )
+        .await
+        .expect("gav upload succeeds");
+
+        let (name,): (String,) =
+            sqlx::query_as("SELECT name FROM packages WHERE repository_id = $1")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .expect("packages row");
+        assert_eq!(name, "com.example.demo:app");
+
+        let (version,): (String,) = sqlx::query_as(
+            "SELECT pv.version FROM package_versions pv \
+             JOIN packages p ON p.id = pv.package_id \
+             WHERE p.repository_id = $1",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .expect("package_versions row");
+        assert_eq!(version, "1.2.3");
+
+        // Unparseable Maven path (< 4 segments): bare name/version fallback.
+        svc.upload(
+            repo_id,
+            "misc/tools/tool.bin",
+            "misc",
+            Some("tools"),
+            "application/octet-stream",
+            Bytes::from_static(b"fallback-bin"),
+            Some(user_id),
+        )
+        .await
+        .expect("fallback upload succeeds");
+
+        let (fallback_version,): (String,) = sqlx::query_as(
+            "SELECT pv.version FROM package_versions pv \
+             JOIN packages p ON p.id = pv.package_id \
+             WHERE p.repository_id = $1 AND p.name = 'misc'",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .expect("fallback package_versions row");
+        assert_eq!(fallback_version, "tools");
+
         tdh::cleanup(&pool, repo_id, user_id).await;
         let _ = std::fs::remove_dir_all(&storage_dir);
     }


### PR DESCRIPTION
## Summary

Hosted Maven repositories returned **0 components** in the grouped view
(`GET /api/v1/repositories/{key}/artifacts?group_by=maven_component`) for
artifacts pushed through the generic PUT or chunked-upload paths.

Closes #3064.

Root cause: #2723 normalized `packages.name` to `groupId:artifactId` on those
two write paths but left `package_versions.version` holding a naive path
segment (`segments[1]`, e.g. the first groupId component `com`). The grouped
listing joins `packages` to `package_versions`, so the component's version
never matched any real GAV directory and the component collapsed out of the
view. A chunked Maven upload without an explicit create-session version got no
catalog row at all.

Changes:

- `backend/src/services/artifact_service.rs` — generic finalize path: for
  Maven/Gradle repos, derive both the catalog name **and version** from
  `MavenHandler::parse_coordinates(&artifact.path)`; unparseable paths keep
  the previous `(artifact.name, artifact.version)` fallback. Non-Maven
  formats unchanged.
- `backend/src/api/handlers/upload.rs` — chunked-upload completion
  (`completed_package_catalog_entry`): for Maven/Gradle repos, take the
  catalog version from the replicated POM metadata's `version` when present,
  otherwise from the GAV path, instead of requiring an explicit
  create-session version. Non-Maven formats and the bare-name fallback keep
  their current behavior.
- `backend/migrations/192_maven_package_versions_version_backfill.sql` —
  repairs existing catalog rows in Maven/Gradle repos whose
  `package_versions.version` matches no on-disk version directory: rewrites
  the version when the package has exactly one candidate directory (deleting
  the broken row instead if that version row already exists), and deletes
  unattributable rows when there are multiple candidates (derived catalog
  data, recreated on next push). Forward-only and idempotent; proxy
  repositories have no hosted `artifacts` rows and are untouched.

The native Maven PUT handler and the proxy cache index already record
consistent coordinates and are unchanged.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`upload.rs`: a chunked Maven session with no explicit version and a GAV path
now yields `("com.example.demo:app", "1.2.3")` (was `None`), and an explicit
version that disagrees with the path no longer wins. `artifact_service.rs`: a
DB-backed test pushes `com/example/demo/app/1.2.3/app-1.2.3.jar` through the
generic finalize path and asserts the catalog rows read
`com.example.demo:app` / `1.2.3` (was `com.example.demo:app` / `example`).

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
