### PR TITLE
docs(quota): correct stale migration-182 claim about check_quota_locked admission source

### DIFF
--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -1977,6 +1977,14 @@ impl RepositoryService {
     /// GC. The background reconciler ([`Self::reconcile_usage_ledger`])
     /// remains as a drift safety net only.
     ///
+    /// NOTE on migration 182's header comment (#3080): it claims
+    /// "`check_quota_locked` still reads the authoritative live sum". That
+    /// was true when 182 shipped but is stale — quota admission has read the
+    /// `repository_usage_ledger` row under `FOR UPDATE` (the query below)
+    /// since #2516/#2992. The migration file cannot be corrected because
+    /// sqlx validates checksums of applied migrations, so THIS comment is
+    /// the authoritative statement of how admission reads usage.
+    ///
     /// Usage at the target `path` is netted out (unique-index lookup on
     /// `(repository_id, path)`), so an in-place overwrite is charged only its
     /// size delta rather than double-counting the bytes it replaces.


### PR DESCRIPTION
## Summary
Migration 182's header comment claims "`check_quota_locked` still reads the authoritative live sum", but that statement is stale: quota admission has been ledger-backed since #2516/#2992 — `check_quota_locked` reads the `repository_usage_ledger` row under `SELECT ... FOR UPDATE`. The migration file itself cannot be corrected because sqlx validates checksums of applied migrations and editing it would break existing deployments.

This PR adds a doc-comment paragraph on `check_quota_locked` in `backend/src/services/repository_service.rs` explicitly stating that admission reads the ledger under `FOR UPDATE`, that migration 182's header predates this and is wrong, and that the Rust doc comment is the authoritative statement.

Comment-only change; no runtime behavior is affected.

Fixes #3080

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (documentation-only change; no code behavior to test)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` pass)
- [x] No regressions in existing tests (comment-only change)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes