### PR TITLE
ci(docker-publish): scheduled main publish to keep amd64 buildcache warm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,18 @@ on:
       - '.beads/**'
       - 'LICENSE'
       - 'CLAUDE.md'
+  # Keep the registry layer cache warm (#3044). The amd64 backend build takes
+  # ~60-90 min when the :buildcache-amd64 registry cache is cold or stale
+  # (arm64 stays ~9 min), so a release tag cut after a quiet spell on main
+  # pays that full cost. A scheduled main build re-runs the normal publish
+  # pipeline, refreshing the buildcache-* cache tags (cache-to mode=max) so a
+  # subsequent tag cut hits warm cache. On a schedule event github.ref is
+  # refs/heads/main, so docker/metadata-action produces exactly the main-push
+  # tag set (main, dev, sha-<sha>) — the release-facing tags (semver, latest)
+  # are gated on refs/tags/v* and cannot fire, and the tag-push/dispatch
+  # guards in publish-preflight are skipped for schedule events.
+  schedule:
+    - cron: '23 5 * * 1,4'  # Mon/Thu 05:23 UTC
   workflow_dispatch:
     inputs:
       tag:
@@ -55,6 +67,12 @@ jobs:
   publish-preflight:
     name: Publish identity preflight
     runs-on: ubuntu-latest
+    # Scheduled cache-warm runs (#3044) only make sense in the canonical repo:
+    # forks have no business refreshing our ghcr buildcache and would just
+    # burn runner minutes. Every other job needs this one (directly or
+    # transitively) without a status-check override, so skipping it skips the
+    # whole run; the always()-gated summary job carries the same guard.
+    if: ${{ github.event_name != 'schedule' || github.repository == 'artifact-keeper/artifact-keeper' }}
     permissions:
       contents: read
     outputs:
@@ -1912,7 +1930,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [merge-backend, merge-openscap, merge-scanner-adapter]
-    if: always()
+    # always() would otherwise run this even when the fork guard on
+    # publish-preflight skipped everything else; mirror that guard here.
+    if: ${{ always() && (github.event_name != 'schedule' || github.repository == 'artifact-keeper/artifact-keeper') }}
     steps:
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Fixes #3044.

On a release tag cut, the amd64 backend image build takes ~60-90 min when the `:buildcache-amd64` registry layer cache is cold or stale (arm64 stays ~9 min on hosted runners). The cache is only refreshed by main-branch pushes, so a tag cut after a quiet spell on main pays the full cold-build cost.

This adds a `schedule:` trigger (Mon/Thu 05:23 UTC) to `docker-publish.yml` so the normal publish pipeline runs from main twice a week, refreshing the `buildcache-amd64`/`buildcache-arm64` registry cache tags (`cache-to ... mode=max`) for all three images. A subsequent tag cut then hits warm cache.

Why this is safe / publishes nothing misleading:
- On a `schedule` event `github.ref` is `refs/heads/main`, so `docker/metadata-action` produces exactly the main-push tag set: `main` (`type=ref,event=branch` keys off the ref), `sha-<sha>` (`type=sha`), and `dev` (its `enable` checks `github.ref == refs/heads/main`). Release-facing tags (`semver`, `latest`, `1.1-dev`) are gated on refs that cannot occur on a schedule.
- The tag-push and workflow_dispatch guard steps in `publish-preflight` are gated on `refs/tags/v*` / `workflow_dispatch` and skip cleanly; `promote_version`/`dispatch_tag` outputs stay empty, so the build jobs run and PROMOTE mode stays off.
- The scanner-adapter's stable-tag logic sets `stable_requested=false` for non-tag refs, so scheduled runs publish only its `dev` + `sha` tags, same as a main push.
- Concurrency group is keyed by `event_name` + `ref`, so a scheduled run never cancels (or is cancelled by) a push or dispatch run; `cancel-in-progress` evaluates false for schedule events.
- Fork guard: `publish-preflight` (which every other job needs, directly or transitively) gets `if: github.event_name != 'schedule' || github.repository == 'artifact-keeper/artifact-keeper'`; the `always()`-gated `summary` job mirrors the same guard so fork schedule runs are fully inert.

Orthogonal to #2121 / #2897 (moving amd64 builds to GitHub-hosted runners): this is only a trigger + guard, no runner changes.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — YAML syntax check passes; `actionlint` produces no new findings versus main (all remaining findings are pre-existing: `ak-ci-runners` self-hosted label, suspended-alpine `if: false` constants, shellcheck info notes)
- [x] No regressions in existing tests — workflow-only change, no Rust code touched

## API Changes
- [x] N/A - no API changes