### PR TITLE
fix(auth): cap OIDC outbound response sizes (userinfo/token/discovery/jwks)

### DIFF
--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -28,6 +28,7 @@ use crate::services::audit_service::{
 use crate::services::auth_config_service::AuthConfigService;
 use crate::services::auth_config_service::SsoProviderInfo;
 use crate::services::auth_service::{AuthService, FederatedCredentials};
+use crate::services::http_client::{read_json_capped, MAX_OIDC_RESPONSE_BYTES};
 use crate::services::ldap_service::LdapService;
 use crate::services::saml_service::SamlService;
 
@@ -167,14 +168,15 @@ pub async fn oidc_login(
     // SSO trust class: connect-time SSRF check honors SSO_ALLOW_PRIVATE_IPS
     // / AK_SSRF_ALLOW_PRIVATE_CIDRS for the configured IdP (issue #2380).
     let http_client = crate::services::http_client::sso_client();
-    let discovery: serde_json::Value = http_client
+    let discovery_response = http_client
         .get(&discovery_url)
         .send()
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to fetch OIDC discovery: {e}")))?
-        .json()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse OIDC discovery: {e}")))?;
+        .map_err(|e| AppError::Internal(format!("Failed to fetch OIDC discovery: {e}")))?;
+    let discovery: serde_json::Value =
+        read_json_capped(discovery_response, MAX_OIDC_RESPONSE_BYTES)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to parse OIDC discovery: {e}")))?;
 
     let authorization_endpoint = discovery["authorization_endpoint"]
         .as_str()
@@ -415,14 +417,15 @@ async fn oidc_callback_inner(
     // SSO trust class: connect-time SSRF check honors SSO_ALLOW_PRIVATE_IPS
     // / AK_SSRF_ALLOW_PRIVATE_CIDRS for the configured IdP (issue #2380).
     let http_client = crate::services::http_client::sso_client();
-    let discovery: serde_json::Value = http_client
+    let discovery_response = http_client
         .get(&discovery_url)
         .send()
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to fetch OIDC discovery: {e}")))?
-        .json()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse OIDC discovery: {e}")))?;
+        .map_err(|e| AppError::Internal(format!("Failed to fetch OIDC discovery: {e}")))?;
+    let discovery: serde_json::Value =
+        read_json_capped(discovery_response, MAX_OIDC_RESPONSE_BYTES)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to parse OIDC discovery: {e}")))?;
 
     let token_endpoint = discovery["token_endpoint"]
         .as_str()
@@ -444,15 +447,16 @@ async fn oidc_callback_inner(
     if let Some(verifier) = pkce_code_verifier.as_deref() {
         form.push(("code_verifier", verifier));
     }
-    let token_response: serde_json::Value = http_client
+    let token_exchange_response = http_client
         .post(token_endpoint)
         .form(&form)
         .send()
         .await
-        .map_err(|e| AppError::Internal(format!("Token exchange failed: {e}")))?
-        .json()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse token response: {e}")))?;
+        .map_err(|e| AppError::Internal(format!("Token exchange failed: {e}")))?;
+    let token_response: serde_json::Value =
+        read_json_capped(token_exchange_response, MAX_OIDC_RESPONSE_BYTES)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to parse token response: {e}")))?;
 
     let id_token = token_response["id_token"]
         .as_str()
@@ -1387,7 +1391,7 @@ async fn fetch_userinfo_groups(
         tracing::warn!(status = %resp.status(), "OIDC userinfo non-200; using id_token groups only");
         return Vec::new();
     }
-    let body: serde_json::Value = match resp.json().await {
+    let body: serde_json::Value = match read_json_capped(resp, MAX_OIDC_RESPONSE_BYTES).await {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(error = %e, "OIDC userinfo not JSON; using id_token groups only");
@@ -1802,12 +1806,12 @@ async fn validate_id_token(
         .ok_or_else(|| AppError::Internal("OIDC discovery missing jwks_uri".into()))?;
     validate_oidc_fetch_url(jwks_uri, "OIDC JWKS URI")?;
 
-    let jwks: serde_json::Value = http_client
+    let jwks_response = http_client
         .get(jwks_uri)
         .send()
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to fetch JWKS: {e}")))?
-        .json()
+        .map_err(|e| AppError::Internal(format!("Failed to fetch JWKS: {e}")))?;
+    let jwks: serde_json::Value = read_json_capped(jwks_response, MAX_OIDC_RESPONSE_BYTES)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to parse JWKS: {e}")))?;
 

--- a/backend/src/services/ci_oidc_service.rs
+++ b/backend/src/services/ci_oidc_service.rs
@@ -714,16 +714,19 @@ impl CiOidcService {
             "{}/.well-known/openid-configuration",
             issuer_url.trim_end_matches('/')
         );
-        let discovery: serde_json::Value = self
+        let response = self
             .http
             .get(&url)
             .timeout(OIDC_HTTP_TIMEOUT)
             .send()
             .await
-            .map_err(|e| AppError::Internal(format!("CI OIDC discovery fetch failed: {e}")))?
-            .json()
-            .await
-            .map_err(|e| AppError::Internal(format!("CI OIDC discovery parse failed: {e}")))?;
+            .map_err(|e| AppError::Internal(format!("CI OIDC discovery fetch failed: {e}")))?;
+        let discovery: serde_json::Value = crate::services::http_client::read_json_capped(
+            response,
+            crate::services::http_client::MAX_OIDC_RESPONSE_BYTES,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("CI OIDC discovery parse failed: {e}")))?;
         Ok(discovery)
     }
 
@@ -737,16 +740,19 @@ impl CiOidcService {
             }
         }
 
-        let jwks: serde_json::Value = self
+        let response = self
             .http
             .get(jwks_uri)
             .timeout(OIDC_HTTP_TIMEOUT)
             .send()
             .await
-            .map_err(|e| AppError::Internal(format!("CI JWKS fetch failed: {e}")))?
-            .json()
-            .await
-            .map_err(|e| AppError::Internal(format!("CI JWKS parse failed: {e}")))?;
+            .map_err(|e| AppError::Internal(format!("CI JWKS fetch failed: {e}")))?;
+        let jwks: serde_json::Value = crate::services::http_client::read_json_capped(
+            response,
+            crate::services::http_client::MAX_OIDC_RESPONSE_BYTES,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("CI JWKS parse failed: {e}")))?;
 
         let mut cache = jwks_cache().write().await;
         cache.insert(

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -205,6 +205,54 @@ pub fn sso_client() -> reqwest::Client {
         .expect("failed to build SSO HTTP client")
 }
 
+/// Maximum bytes accepted from an OIDC/SSO identity-provider JSON response
+/// (discovery document, token exchange, JWKS, userinfo). Real-world documents
+/// are a few KB; the cap stops a malicious or compromised IdP from returning
+/// a multi-hundred-MB body that a plain `reqwest .json()` would buffer
+/// entirely into memory (memory-DoS, issue #2834).
+pub const MAX_OIDC_RESPONSE_BYTES: usize = 512 * 1024;
+
+/// Deserialize a JSON response body while enforcing a hard byte cap.
+///
+/// Unlike `reqwest::Response::json()`, which buffers however many bytes the
+/// server chooses to send, this short-circuits on a `Content-Length` header
+/// above `max_bytes` (without reading any of the body), and otherwise streams
+/// the body chunk by chunk, erroring as soon as the accumulated size would
+/// exceed the cap. Only the bounded bytes are then deserialized.
+///
+/// Returns the error as a `String` so each call site can wrap it in its own
+/// error variant (`AppError::Internal`, `AppError::Authentication`, ...)
+/// while keeping its existing message prefix.
+pub async fn read_json_capped<T: serde::de::DeserializeOwned>(
+    mut response: reqwest::Response,
+    max_bytes: usize,
+) -> std::result::Result<T, String> {
+    if let Some(declared) = response.content_length() {
+        if declared > max_bytes as u64 {
+            return Err(format!(
+                "response body of {declared} bytes exceeds the {max_bytes}-byte limit"
+            ));
+        }
+    }
+
+    let mut body: Vec<u8> = Vec::with_capacity(std::cmp::min(
+        response.content_length().unwrap_or(8 * 1024) as usize,
+        max_bytes,
+    ));
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| format!("failed to read response body: {e}"))?
+    {
+        if body.len() + chunk.len() > max_bytes {
+            return Err(format!("response body exceeds the {max_bytes}-byte limit"));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    serde_json::from_slice(&body).map_err(|e| format!("invalid JSON in response body: {e}"))
+}
+
 /// Load operator-provided custom CA certificate(s) (`CUSTOM_CA_CERT_PATH`)
 /// into the builder when configured. Shared by every client builder so the
 /// private-CA handling is identical and lives in one place.
@@ -902,6 +950,180 @@ mod tests {
             send_errored,
             "the request through an unexempted loopback proxy must fail at the \
              resolver instead of connecting"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // read_json_capped (#2834): OIDC outbound response-size cap
+    // -------------------------------------------------------------------
+
+    use super::read_json_capped;
+
+    /// A small, well-formed JSON body under the cap deserializes normally.
+    #[tokio::test]
+    async fn test_read_json_capped_small_body_ok() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"issuer": "https://idp.example.com"})),
+            )
+            .mount(&server)
+            .await;
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .unwrap();
+        let value: serde_json::Value = read_json_capped(resp, 1024).await.unwrap();
+        assert_eq!(value["issuer"], "https://idp.example.com");
+    }
+
+    /// A valid JSON body exactly at the cap is still accepted (the limit is
+    /// inclusive; only EXCEEDING it errors).
+    #[tokio::test]
+    async fn test_read_json_capped_body_exactly_at_cap_ok() {
+        // 64-byte JSON document, read with a 64-byte cap.
+        let body = format!("{{\"pad\":\"{}\"}}", "x".repeat(64 - 10));
+        assert_eq!(body.len(), 64);
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_raw(body, "application/json"),
+            )
+            .mount(&server)
+            .await;
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .unwrap();
+        let value: serde_json::Value = read_json_capped(resp, 64).await.unwrap();
+        assert!(value["pad"].is_string());
+    }
+
+    /// A chunked body (no Content-Length, so the header short-circuit cannot
+    /// fire) that grows past the cap must be aborted mid-stream with a clear
+    /// error, not buffered to completion.
+    #[tokio::test]
+    async fn test_read_json_capped_streamed_body_over_cap_errors() {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let payload = vec![b'a'; 256];
+                let _ = sock
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\n\
+                          Content-Type: application/json\r\n\
+                          Transfer-Encoding: chunked\r\n\
+                          Connection: close\r\n\r\n",
+                    )
+                    .await;
+                let _ = sock.write_all(b"100\r\n").await;
+                let _ = sock.write_all(&payload).await;
+                let _ = sock.write_all(b"\r\n0\r\n\r\n").await;
+            }
+        });
+
+        let resp = reqwest::Client::new()
+            .get(format!("http://127.0.0.1:{}/", addr.port()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.content_length(),
+            None,
+            "chunked response must not carry a Content-Length, or this test \
+             would exercise the header short-circuit instead of the stream cap"
+        );
+        let err = read_json_capped::<serde_json::Value>(resp, 64)
+            .await
+            .expect_err("a 256-byte chunked body must exceed the 64-byte cap");
+        let _ = server.await;
+        assert!(
+            err.contains("exceeds the 64-byte limit"),
+            "expected size-cap error, got: {err}"
+        );
+    }
+
+    /// A Content-Length header above the cap must be refused WITHOUT reading
+    /// the body: the server here never sends a single body byte and holds the
+    /// socket open, so anything that tried to read would hang until the outer
+    /// timeout instead of returning immediately.
+    #[tokio::test]
+    async fn test_read_json_capped_content_length_over_cap_errors_without_reading_body() {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let _ = sock
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\n\
+                          Content-Type: application/json\r\n\
+                          Content-Length: 10485760\r\n\r\n",
+                    )
+                    .await;
+                // Hold the connection open, never sending the body.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            }
+        });
+
+        let resp = reqwest::Client::new()
+            .get(format!("http://127.0.0.1:{}/", addr.port()))
+            .send()
+            .await
+            .unwrap();
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            read_json_capped::<serde_json::Value>(resp, 512 * 1024),
+        )
+        .await
+        .expect("oversized Content-Length must be refused immediately, not by reading the body");
+        server.abort();
+
+        let err = result.expect_err("10 MiB declared body must exceed the 512 KiB cap");
+        assert!(
+            err.contains("10485760") && err.contains("exceeds"),
+            "expected declared-length cap error, got: {err}"
+        );
+    }
+
+    /// A body under the cap that is not valid JSON surfaces a parse error
+    /// (the cap must not mask deserialization failures).
+    #[tokio::test]
+    async fn test_read_json_capped_invalid_json_errors() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_raw("not json at all", "application/json"),
+            )
+            .mount(&server)
+            .await;
+
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .unwrap();
+        let err = read_json_capped::<serde_json::Value>(resp, 1024)
+            .await
+            .expect_err("non-JSON body must fail deserialization");
+        assert!(
+            err.contains("invalid JSON"),
+            "expected JSON parse error, got: {err}"
         );
     }
 }

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::config::Config;
 use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
+use crate::services::http_client::{read_json_capped, MAX_OIDC_RESPONSE_BYTES};
 
 /// OIDC provider configuration
 #[derive(Debug, Clone)]
@@ -223,9 +224,11 @@ impl OidcService {
                 )));
             }
 
-            let discovery: OidcDiscovery = response.json().await.map_err(|e| {
-                AppError::Internal(format!("Failed to parse OIDC discovery: {}", e))
-            })?;
+            let discovery: OidcDiscovery = read_json_capped(response, MAX_OIDC_RESPONSE_BYTES)
+                .await
+                .map_err(|e| {
+                    AppError::Internal(format!("Failed to parse OIDC discovery: {}", e))
+                })?;
 
             self.discovery = Some(discovery);
         }
@@ -320,8 +323,7 @@ impl OidcService {
             )));
         }
 
-        response
-            .json()
+        read_json_capped(response, MAX_OIDC_RESPONSE_BYTES)
             .await
             .map_err(|e| AppError::Authentication(format!("Failed to parse token response: {}", e)))
     }
@@ -436,10 +438,12 @@ impl OidcService {
             return Err(AppError::Authentication("Userinfo request failed".into()));
         }
 
-        let claims: HashMap<String, serde_json::Value> = response
-            .json()
-            .await
-            .map_err(|e| AppError::Authentication(format!("Failed to parse userinfo: {}", e)))?;
+        let claims: HashMap<String, serde_json::Value> =
+            read_json_capped(response, MAX_OIDC_RESPONSE_BYTES)
+                .await
+                .map_err(|e| {
+                    AppError::Authentication(format!("Failed to parse userinfo: {}", e))
+                })?;
 
         let sub = claims
             .get("sub")


### PR DESCRIPTION
## Summary

Every OIDC outbound fetch buffered the identity provider's response through reqwest's `.json()`, which reads however many bytes the server chooses to send. A malicious or compromised IdP could return a multi-hundred-MB body well inside the request timeout and balloon backend memory (~618MB resident for a 500MB body) — on an unauthenticated login path.

This adds `read_json_capped()` to `services::http_client`, shared by every OIDC call site:

- Short-circuits on a `Content-Length` above the cap **without reading any of the body**.
- Otherwise streams the body via `Response::chunk()` and errors as soon as the accumulated size would exceed the cap (covers chunked/`Transfer-Encoding` responses that declare no length).
- Deserializes only the bounded bytes.

The cap is `MAX_OIDC_RESPONSE_BYTES = 512 * 1024` (512 KiB); real discovery/JWKS/userinfo/token documents are a few KB. Errors are returned as `String` so each call site keeps its existing message prefix and `AppError` variant, and the non-fatal userinfo-groups path keeps degrading to a `warn!` + empty group set rather than failing login.

Capped call sites (all nine, one shared helper — no copy-paste):

| File | Fetch |
| --- | --- |
| `backend/src/services/oidc_service.rs` | discovery, token exchange, userinfo |
| `backend/src/api/handlers/sso.rs` | discovery (login), discovery (callback), token exchange, JWKS, userinfo groups (#2831) |
| `backend/src/services/ci_oidc_service.rs` | discovery, JWKS |

No behavior change for well-behaved providers.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Five unit tests in `services::http_client::tests` cover the helper directly:
- `test_read_json_capped_small_body_ok` — small valid JSON deserializes normally.
- `test_read_json_capped_body_exactly_at_cap_ok` — a body exactly at the cap is accepted (limit is inclusive).
- `test_read_json_capped_streamed_body_over_cap_errors` — a chunked 256-byte body with **no** `Content-Length` is aborted mid-stream against a 64-byte cap; asserts `content_length() == None` first so the test cannot silently pass via the header short-circuit.
- `test_read_json_capped_content_length_over_cap_errors_without_reading_body` — a server declaring `Content-Length: 10485760` and then never sending a body byte (holding the socket open 30s) must be refused immediately; wrapped in a 2s `tokio::time::timeout` so any implementation that reads the body fails the test rather than passing slowly.
- `test_read_json_capped_invalid_json_errors` — the cap does not mask a genuine deserialization failure.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` (exit 0, zero warnings) and `cargo test --workspace --lib` (14653 passed, 0 failed) all pass locally on this branch rebased onto current `main`. Not manually exercised against a live IdP — the mock-server tests cover the capped paths.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Fixes #2834