### PR TITLE
docs(api): ratify full-set replace semantics for PUT virtual/members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING API SEMANTICS: `PUT /api/v1/repositories/{key}/members` (virtual repository members) is a full-set replace** (#2795, ratified in #2899): as of #2795 the request body is the *complete* desired member list, not a partial update. Any existing member whose key is absent from the body is **removed**; members present in the body are inserted if missing, or have their priority updated if already present; an empty `members` array removes every member. Previously the endpoint only reordered members that already existed and returned 404 for a member that was not already present, which made it impossible to add or remove a member when editing a virtual repository after creation. **API clients that send a partial member list in order to reorder priorities will now delete the members they omit** and must be updated to always send the complete member list. The web UI (`virtual-members-panel.tsx` move-up/move-down) and the CLI (`members reorder`, documented as a bulk full-set operation) already send the full list and are unaffected. The behavior is now stated in the OpenAPI operation description and pinned by a regression test.
+
 ### Fixed
 
 - **Scheduled backups claim one durable run per due occurrence** (#2219): multi-replica schedulers no longer create duplicate archives for the same schedule tick. Long runs renew their token-fenced claim, and run finalization plus advancement of the unchanged schedule occurrence is transactional. A schedule whose cron expression has no further occurrence is now disabled with a warning instead of being left permanently due, where it consumed a due-schedule slot and could starve other schedules.

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -8199,14 +8199,27 @@ pub struct AddVirtualMemberRequest {
     pub priority: Option<i32>,
 }
 
+/// Full-set replace of a virtual repository's members (PR #2795, issue #2785;
+/// ratified in issue #2899).
+///
+/// This body is the COMPLETE desired member list, not a partial patch. Any
+/// current member whose key is absent from `members` is removed; keys present
+/// are inserted or have their priority updated. An empty `members` array
+/// removes every member.
+///
+/// WARNING: sending a partial list to reorder priorities deletes the omitted
+/// members. Clients must always send the full member list.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateVirtualMembersRequest {
+    /// The complete desired member set. Members not listed here are removed.
     pub members: Vec<VirtualMemberPriority>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct VirtualMemberPriority {
+    /// Key of the member repository. Inserted if it is not already a member.
     pub member_key: String,
+    /// Resolution priority. Lower values are searched first.
     pub priority: i32,
 }
 
@@ -8454,17 +8467,38 @@ pub async fn remove_virtual_member(
 
 /// Replace the full member set of a virtual repository (add / remove / reorder).
 ///
-/// #2785: this is the "edit the members after creation" operation. The body is
-/// the complete desired member list; members not listed are removed, listed
-/// members that are not yet present are added, and priorities are refreshed.
-/// The prior implementation only reordered members that already existed and
-/// returned 404 for any member not already present, so adding a member through
-/// an edit form failed.
+/// This is a FULL-SET REPLACE, not a partial update. The request body is the
+/// complete desired member list:
+///
+///   * any existing member NOT present in the body is REMOVED;
+///   * a member present in the body that is not yet a member is INSERTED;
+///   * a member present in the body that already exists has its priority
+///     UPDATED to the supplied value;
+///   * an empty `members` array removes every member.
+///
+/// WARNING: sending a partial list to reorder priorities will DELETE the
+/// members you omitted. Always send the complete member list, including the
+/// members whose priority is unchanged.
+///
+/// PR #2795 (issue #2785) introduced these semantics so that the members of a
+/// virtual repository are editable after creation: the prior implementation only
+/// reordered members that already existed and returned 404 for any member not
+/// already present, so adding a member through an edit form failed. The change
+/// in request semantics was ratified in #2899.
 #[utoipa::path(
     put,
     path = "/{key}/members",
     context_path = "/api/v1/repositories",
     tag = "repositories",
+    description = "Replace the full member set of a virtual repository. \
+        This is a full-set replace, not a partial update: the request body is the \
+        complete desired member list. Any existing member that is not present in the \
+        body is removed. Members present in the body are inserted if missing, or have \
+        their priority updated if already present. An empty `members` array removes \
+        every member. Warning: sending a partial list in order to reorder priorities \
+        will delete the members omitted from that list, so clients must always send \
+        the complete member list. These semantics were introduced in PR #2795 \
+        (issue #2785) and ratified in issue #2899.",
     params(
         ("key" = String, Path, description = "Repository key"),
     ),

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -1792,21 +1792,38 @@ impl RepositoryService {
     /// Reconcile the FULL member set of a virtual repository to exactly
     /// `desired` (issue #2785 defect B).
     ///
-    /// Editing a virtual repository after creation must be able to add and
-    /// remove members, not merely reorder the ones added at create time. This
-    /// replaces the membership with exactly the `(member_repo_id, priority)`
-    /// pairs in `desired`, in a single transaction guarded by the same
-    /// process-wide member-graph advisory lock that `add_virtual_member` and
+    /// # Contract: full-set replace, not a partial update
+    ///
+    /// `desired` is the COMPLETE desired membership. This replaces the
+    /// membership with exactly the `(member_repo_id, priority)` pairs it
+    /// contains, in a single transaction guarded by the same process-wide
+    /// member-graph advisory lock that `add_virtual_member` and
     /// `update_virtual_member_priorities` take (so it never contends with a
     /// concurrent membership mutation):
     ///
-    ///   * members not present in `desired` are removed;
-    ///   * members already present have their priority updated;
-    ///   * new members are inserted.
+    ///   * members NOT present in `desired` are REMOVED;
+    ///   * members already present have their priority UPDATED;
+    ///   * members present in `desired` but not yet in the table are INSERTED;
+    ///   * an empty `desired` removes every member.
     ///
-    /// An empty `desired` removes every member. Caller-side authorization
-    /// (repo-admin on the virtual parent + token-scope / cycle / format checks
-    /// per member) is enforced by the handler before this runs.
+    /// This is destructive by design. A caller that passes a partial list in
+    /// order to reorder priorities will DELETE the members it omitted, so
+    /// callers must always assemble the full member list first.
+    ///
+    /// Editing a virtual repository after creation must be able to add and
+    /// remove members, not merely reorder the ones added at create time, which
+    /// is why PR #2795 (issue #2785) changed
+    /// `PUT /api/v1/repositories/{key}/members` from a priorities-only
+    /// update to this replace. Issue #2899 reviewed the
+    /// resulting breaking API-semantics change and RATIFIED it: replace
+    /// semantics are the intended, supported contract of this function and of
+    /// that endpoint. Do not narrow it back to a priorities-only update; the
+    /// removal arm is covered by
+    /// `test_set_virtual_members_edits_after_create_2785`.
+    ///
+    /// Caller-side authorization (repo-admin on the virtual parent +
+    /// token-scope / cycle / format checks per member) is enforced by the
+    /// handler before this runs.
     pub async fn set_virtual_members(
         &self,
         virtual_repo_id: Uuid,
@@ -5169,6 +5186,16 @@ mod tests {
         /// creation — `set_virtual_members` adds, removes, and reorders members
         /// to match exactly the supplied set (the pre-fix PUT endpoint only
         /// reordered members that already existed).
+        ///
+        /// #2899 ratified the resulting full-set REPLACE semantics as the
+        /// intended contract of `PUT /api/v1/repositories/{key}/members`.
+        /// This test pins that contract: a call whose `desired` list omits a
+        /// current member REMOVES that member. That is destructive on purpose,
+        /// so the removal arm is asserted explicitly here (members A, B, C then
+        /// a reconcile with only [A, B] must leave exactly A and B). If a
+        /// future change reverts to a priorities-only update, or makes the
+        /// reconcile merge rather than replace, this test must fail rather than
+        /// be relaxed.
         #[tokio::test]
         async fn test_set_virtual_members_edits_after_create_2785() {
             let Some(pool) = tdh::try_pool().await else {
@@ -5223,6 +5250,36 @@ mod tests {
                 ids(&service.get_virtual_members(virt.id).await.expect("list")),
                 vec![b.id, a.id],
                 "B (prio 2) then A (prio 5) after add + reprioritise"
+            );
+
+            // #2899 replace semantics, the destructive arm. Bring the set to
+            // exactly {A, B, C}, then reconcile with a PARTIAL list [A, B].
+            // C is absent from the request, so C must be removed: a caller
+            // that sends a subset to reorder loses the members it omitted.
+            service
+                .set_virtual_members(virt.id, &[(a.id, 1), (b.id, 2), (c.id, 3)])
+                .await
+                .expect("reconcile to A, B, C");
+            assert_eq!(
+                ids(&service.get_virtual_members(virt.id).await.expect("list")),
+                vec![a.id, b.id, c.id],
+                "precondition: membership is exactly {{A, B, C}}"
+            );
+
+            service
+                .set_virtual_members(virt.id, &[(a.id, 1), (b.id, 2)])
+                .await
+                .expect("reconcile to the partial list A, B");
+            let after_partial = service.get_virtual_members(virt.id).await.expect("list");
+            assert_eq!(
+                ids(&after_partial),
+                vec![a.id, b.id],
+                "PUT with only [A, B] leaves exactly A and B: C, omitted from the \
+                 request, is REMOVED (full-set replace, #2795/#2899)"
+            );
+            assert!(
+                !ids(&after_partial).contains(&c.id),
+                "C is gone, not merely reordered behind A and B"
             );
 
             // Edit: replace the whole set with C only (removes A and B).


### PR DESCRIPTION
## Summary

Implements the decision on #2899: **ratify** the destructive full-set replace semantics that #2795 introduced for `PUT /api/v1/repositories/{key}/members` (the virtual-repository member endpoint). **No behavior changes** — this PR documents the contract and pins it in code.

#2795 (fixing #2785) changed the endpoint from a priorities-only update to a full-set replace. `RepositoryService::set_virtual_members` does a remove-absent `DELETE` plus an upsert `INSERT` in a single transaction under `pg_advisory_xact_lock`. That was necessary to make a virtual repository's members editable after creation (the old code returned 404 for any member not already present, so an edit form could not add one), but it is a breaking change in *request* semantics that was never documented: a client sending a partial list to reorder priorities now **deletes** the members it omitted.

### Client audit (already performed; no client changes needed)

- **artifact-keeper-web**: `virtual-members-panel.tsx` `handleMoveUp`/`handleMoveDown` map over the entire `sortedMembers` array, so the web UI always sends the full member list. Safe under replace semantics.
- **artifact-keeper-cli**: the `MembersCommand::Reorder` subcommand is documented as "Reorder all members by priority (bulk). Each entry is `member_key=priority`." — explicitly a full-set operation. Safe.

Neither shipped client sends a partial list, which is what makes ratifying rather than reverting viable.

### What changed

| File | Change |
| --- | --- |
| `backend/src/api/handlers/repositories.rs` | Explicit `description` on the `update_virtual_members` `#[utoipa::path]` stating the body is the complete desired member list, that absent members are removed, and warning that a partial list deletes the omitted members. The same contract added as rustdoc on the handler, on `UpdateVirtualMembersRequest`, and on its fields so it surfaces on the generated request-body schema. |
| `backend/src/services/repository_service.rs` | Extended the `set_virtual_members` rustdoc with a "Contract: full-set replace, not a partial update" section, the single-transaction-under-advisory-lock guarantee, why #2795 introduced it, that #2899 ratified it, and an explicit "do not narrow this back to a priorities-only update" note pointing at the covering test. |
| `CHANGELOG.md` | New `### Changed` entry under `## [Unreleased]` calling out the breaking API-semantics change and telling API clients they must send the complete member list. Sponsors/Thank You are intentionally omitted; the release process adds those at cut time. |
| `backend/src/services/repository_service.rs` (tests) | Strengthened the existing regression test rather than duplicating it. |

Note on the path: #2899's title says "PUT virtual-members" and its text uses `/{key}/virtual/members`, but the mounted route is `/:key/members` under the `/api/v1/repositories` context path. All prose added here uses the real path.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is a `docs/` PR that ratifies existing behavior, so the regression-test requirement does not apply. A test was strengthened anyway (below).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`test_set_virtual_members_edits_after_create_2785` (in the DB-gated `mod db`, matching the convention of its neighbours) already covered add/reorder/replace-all/clear. It did **not** assert the specific case the #2899 decision turns on: a request that omits a current member. Added that arm explicitly — bring the membership to exactly `{A, B, C}`, assert the precondition, then reconcile with only `[A, B]` and assert the result is exactly `[A, B]`, with a second assertion that C is *gone* rather than merely reordered behind them. The test doc comment now states that a future change reverting to priorities-only, or making the reconcile merge rather than replace, must fail this test rather than have it relaxed.

E2E is unchecked because the DTF side is already covered separately: artifact-keeper-test#330 rewrote the concurrent-PUT test for replace semantics and #331 corrected a stale header, both merged.

Gate results, all run locally on the rebased branch:

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass, exit 0, zero warnings
- `cargo test --workspace --lib` — pass, **14656 passed, 0 failed, 6 ignored**. No pre-existing failures observed.
- `cargo test --lib test_openapi_spec_is_valid` — pass

The modified test was also run against a live Postgres (`DATABASE_URL=postgresql://registry:registry@localhost:30432/artifact_registry`) so it was not silently skipped by the `try_pool()` gate: it passes. The new assertion was confirmed load-bearing by temporarily mutating the call to pass `[A, B, C]` instead of `[A, B]`, observing the test fail on exactly that assertion, then reverting.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

There **is** an API change here, but it is documentation-only in this PR: the wire behavior of `PUT /api/v1/repositories/{key}/members` is unchanged from what shipped in #2795. What changes is the published OpenAPI operation description and request-body schema documentation, which now state unambiguously that the endpoint is a full-set replace, that any existing member absent from the body is removed, that an empty `members` array removes every member, and that sending a partial list to reorder will delete the omitted members. No migration is involved.

Fixes #2899
