### PR TITLE
fix(maven): stop migration 192 aborting startup on a UNIQUE violation

### DIFF
--- a/backend/migrations/192_maven_package_versions_version_backfill.sql
+++ b/backend/migrations/192_maven_package_versions_version_backfill.sql
@@ -3,31 +3,51 @@
 --
 -- Context. #2723 normalized `packages.name` to `groupId:artifactId` on the
 -- generic/chunked write paths but left `package_versions.version` holding a
--- naive path segment (e.g. the first groupId component, `com`), so hosted
--- Maven grouped listings -- which join `packages` to `package_versions` --
--- reported components with zero matching versions. The write paths now derive
--- both name and version from the artifact's GAV path; this backfill repairs
--- the rows written in between.
+-- naive path segment, so hosted Maven grouped listings -- which join
+-- `packages` to `package_versions` -- reported components with zero matching
+-- versions. The write paths now derive both name and version from the
+-- artifact's GAV path; this backfill repairs the rows written in between.
 --
 -- Derivation. A Maven artifact is stored at the GAV layout
 --   <groupId-as-path>/<artifactId>/<version>/<file>
 -- (the `artifacts.path` column). For a grouped catalog row
 -- `name = groupId:artifactId` the on-disk version directories are the path
 -- segments directly under `<groupId-as-path>/<artifactId>/` (the "prefix").
--- A `package_versions` row is broken when NO artifact exists under
--- `prefix || version || '/'` while the package DOES have candidate version
--- directories:
---   * exactly one candidate -> rewrite `version` to it; when a row with that
---     version already exists for the package (UNIQUE(package_id, version)),
---     delete the broken row instead;
---   * multiple candidates  -> the broken row cannot be attributed to a single
---     version, so it is deleted. The catalog is derived data; the row is
---     recreated correctly on the next push.
+-- A `package_versions` row is broken when its version is not one of those
+-- directories while the package DOES have candidate version directories.
+--
+-- Repair rule (see the UNIQUE(package_id, version) note below):
+--   * exactly one candidate AND exactly one broken row -> rewrite that row;
+--   * anything else (several broken rows, or several candidates) -> delete
+--     the broken rows. The catalog is derived data and is recreated
+--     correctly on the next push, so deleting is safe and is the only
+--     option that cannot violate the unique constraint.
+--
+-- WHY NOT "rewrite every broken row when there is one candidate":
+--   `package_versions` carries UNIQUE(package_id, version)
+--   (019_builds_packages.sql:52). The UPDATE's guard subquery sees the
+--   pre-statement snapshot, so with TWO broken rows and ONE candidate both
+--   rows pass the guard and both are rewritten to the same version, raising
+--   23505. Migrations run at boot, so that aborts startup and the deployment
+--   crash-loops until someone does DB surgery. That shape is organically
+--   reachable (a generic-push naive version plus a chunked explicit version
+--   on the same GAV), so the rule above rewrites AT MOST ONE row per package
+--   and deletes the remainder. Covered by
+--   `migration_192_multiple_broken_rows_single_candidate_does_not_violate_unique`.
 --
 -- Scope + safety.
 --   * Restricted to Maven/Gradle repositories and to `packages.name` rows in
 --     the grouped `groupId:artifactId` shape (a `:` strictly inside the
 --     name). Bare-name legacy rows are migration 177's concern.
+--   * Artifacts are attributed to the LONGEST matching package prefix, so a
+--     nested coordinate (`com.example:app` vs `com.example.app:foo`) does not
+--     harvest the nested package's directories as its own candidate versions
+--     and then "repair" a healthy row into a wrong one.
+--   * Prefix matching uses LIKE against a literal-escaped prefix so it can be
+--     served by the text_pattern_ops index on artifacts(path) (migration 110);
+--     `LEFT(path, N) = prefix` is not sargable and degraded to a full scan per
+--     broken row on large catalogs, risking the 30-minute startup
+--     statement_timeout.
 --   * Proxy repositories store no hosted `artifacts` rows, so their catalog
 --     rows never produce candidates and are left untouched.
 --   * `artifacts.version` carries the same naive-segment residue but is
@@ -47,17 +67,47 @@ WITH maven_packages AS (
      AND r.format IN ('maven', 'gradle')
     WHERE POSITION(':' IN p.name) > 1
       AND POSITION(':' IN p.name) < CHAR_LENGTH(p.name)
+      -- Exactly one colon. `split_part(name, ':', 2)` would silently truncate a
+      -- multi-colon name ('a:b:c' -> 'b') while the read path splits on the
+      -- FIRST colon only (repositories.rs `maven_component_path_prefix`), so the
+      -- two would disagree about the artifactId. Such names are not produced by
+      -- the Maven write paths; skip rather than guess.
+      AND CHAR_LENGTH(p.name) - CHAR_LENGTH(REPLACE(p.name, ':', '')) = 1
 ),
+-- Escape LIKE metacharacters so a prefix containing % or _ stays literal.
+maven_prefixes AS (
+    SELECT
+        mp.id,
+        mp.repository_id,
+        mp.prefix,
+        REPLACE(REPLACE(REPLACE(mp.prefix, '\', '\\'), '%', '\%'), '_', '\_')
+            AS prefix_like
+    FROM maven_packages mp
+),
+-- Version directories that actually exist under each package prefix.
+-- An artifact is attributed to the LONGEST matching prefix only.
 candidates AS (
     SELECT DISTINCT
         mp.id AS package_id,
         split_part(SUBSTRING(a.path FROM CHAR_LENGTH(mp.prefix) + 1), '/', 1) AS version
-    FROM maven_packages mp
+    FROM maven_prefixes mp
     JOIN artifacts a
       ON a.repository_id = mp.repository_id
-     AND LEFT(a.path, CHAR_LENGTH(mp.prefix)) = mp.prefix
+     AND a.path LIKE mp.prefix_like || '%'
      AND POSITION('/' IN SUBSTRING(a.path FROM CHAR_LENGTH(mp.prefix) + 1)) > 0
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM maven_prefixes longer
+        WHERE longer.repository_id = mp.repository_id
+          AND CHAR_LENGTH(longer.prefix) > CHAR_LENGTH(mp.prefix)
+          AND a.path LIKE longer.prefix_like || '%'
+    )
+      AND split_part(SUBSTRING(a.path FROM CHAR_LENGTH(mp.prefix) + 1), '/', 1) <> ''
 ),
+-- A row is broken iff its version is not one of the package's candidate
+-- directories, and the package has at least one candidate. Expressed as an
+-- anti-join against `candidates` so `artifacts` is scanned once overall
+-- rather than once per broken row.
 broken AS (
     SELECT pv.id AS pv_id, pv.package_id
     FROM package_versions pv
@@ -68,37 +118,47 @@ broken AS (
     )
     AND NOT EXISTS (
         SELECT 1
-        FROM artifacts a
-        WHERE a.repository_id = mp.repository_id
-          AND LEFT(a.path, CHAR_LENGTH(mp.prefix) + CHAR_LENGTH(pv.version) + 1)
-              = mp.prefix || pv.version || '/'
+        FROM candidates c
+        WHERE c.package_id = pv.package_id
+          AND c.version = pv.version
     )
 ),
-resolved AS (
+counts AS (
     SELECT
-        b.pv_id,
         b.package_id,
-        ARRAY(
-            SELECT c.version FROM candidates c WHERE c.package_id = b.package_id
-        ) AS versions
+        COUNT(*) AS broken_count,
+        (SELECT COUNT(*) FROM candidates c WHERE c.package_id = b.package_id)
+            AS candidate_count,
+        MIN(b.pv_id::text) AS keep_pv_id
     FROM broken b
+    GROUP BY b.package_id
 ),
+-- Rewrite only when the mapping is unambiguous AND collision-free: exactly
+-- one broken row and exactly one candidate for that package.
+-- `candidates` is JOINed rather than read through a scalar subquery: the
+-- ct.candidate_count = 1 predicate guarantees exactly one matching row, and a
+-- scalar subquery here would be evaluated for multi-candidate packages too
+-- (Postgres does not promise it is filtered first), raising "more than one row
+-- returned by a subquery used as an expression".
 rewritten AS (
     UPDATE package_versions pv
-    SET version = r.versions[1]
-    FROM resolved r
-    WHERE pv.id = r.pv_id
-      AND ARRAY_LENGTH(r.versions, 1) = 1
+    SET version = c.version
+    FROM broken b
+    JOIN counts ct ON ct.package_id = b.package_id
+    JOIN candidates c ON c.package_id = b.package_id
+    WHERE pv.id = b.pv_id
+      AND ct.broken_count = 1
+      AND ct.candidate_count = 1
       AND NOT EXISTS (
           SELECT 1
           FROM package_versions existing
-          WHERE existing.package_id = r.package_id
-            AND existing.version = r.versions[1]
-            AND existing.id <> r.pv_id
+          WHERE existing.package_id = b.package_id
+            AND existing.id <> b.pv_id
+            AND existing.version = c.version
       )
     RETURNING pv.id
 )
 DELETE FROM package_versions pv
-USING resolved r
-WHERE pv.id = r.pv_id
-  AND NOT EXISTS (SELECT 1 FROM rewritten w WHERE w.id = r.pv_id);
+USING broken b
+WHERE pv.id = b.pv_id
+  AND NOT EXISTS (SELECT 1 FROM rewritten w WHERE w.id = b.pv_id);

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -4362,4 +4362,183 @@ mod tests {
         .expect("ledger row after re-delete");
         assert_eq!(hosted_after, 0, "re-delete must not decrement again");
     }
+
+    // ---- #3064 migration 192: seeded backfill behaviour ------------------
+
+    /// Migration 192 rewrites `package_versions.version` for Maven catalog
+    /// rows whose version does not match any on-disk version directory. It is
+    /// data-dependent, and CI only ever applies migrations to an EMPTY
+    /// database, so the risky arms are exercised here against seeded rows.
+    ///
+    /// The regression this pins: `package_versions` carries
+    /// UNIQUE(package_id, version). An earlier revision rewrote EVERY broken
+    /// row whose package had exactly one candidate version directory. With two
+    /// broken rows and one candidate, both were updated to the same version and
+    /// the statement raised 23505, aborting the migration transaction. Because
+    /// migrations run at boot, that turned into a startup crash loop that only
+    /// manual DB surgery could clear. The fix rewrites at most one row per
+    /// package and deletes the rest, so this shape must now resolve cleanly.
+    ///
+    /// Uses TEMP tables (ON COMMIT DROP) inside a rolled-back transaction so
+    /// the real catalog is never touched, mirroring
+    /// `test_repository_owner_migration_backfills_without_flag_day`.
+    /// Skips without `DATABASE_URL`.
+    #[tokio::test]
+    async fn migration_192_repairs_maven_catalog_versions_without_unique_violation() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let mut tx = pool.begin().await.expect("begin migration fixture");
+
+        sqlx::raw_sql(
+            r#"
+            CREATE TEMP TABLE repositories (
+                id UUID PRIMARY KEY,
+                format TEXT NOT NULL
+            ) ON COMMIT DROP;
+            CREATE TEMP TABLE packages (
+                id UUID PRIMARY KEY,
+                repository_id UUID NOT NULL,
+                name TEXT NOT NULL
+            ) ON COMMIT DROP;
+            CREATE TEMP TABLE package_versions (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                package_id UUID NOT NULL,
+                version VARCHAR(100) NOT NULL,
+                UNIQUE (package_id, version)
+            ) ON COMMIT DROP;
+            CREATE TEMP TABLE artifacts (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                repository_id UUID NOT NULL,
+                path TEXT NOT NULL
+            ) ON COMMIT DROP;
+            "#,
+        )
+        .execute(&mut *tx)
+        .await
+        .expect("create isolated migration tables");
+
+        let repo = Uuid::new_v4();
+        // p_two: TWO broken rows, ONE candidate -> the 23505 shape.
+        let p_two = Uuid::new_v4();
+        // p_one: ONE broken row, ONE candidate -> unambiguous rewrite.
+        let p_one = Uuid::new_v4();
+        // p_healthy: already correct -> must be left alone.
+        let p_healthy = Uuid::new_v4();
+        // p_multi: ONE broken row, TWO candidates -> ambiguous, delete.
+        let p_multi = Uuid::new_v4();
+
+        sqlx::query("INSERT INTO repositories (id, format) VALUES ($1, 'maven')")
+            .bind(repo)
+            .execute(&mut *tx)
+            .await
+            .expect("seed repository");
+
+        sqlx::query(
+            "INSERT INTO packages (id, repository_id, name) VALUES \
+             ($1, $5, 'com.example.two:app'), \
+             ($2, $5, 'com.example.one:app'), \
+             ($3, $5, 'com.example.ok:app'), \
+             ($4, $5, 'com.example.multi:app')",
+        )
+        .bind(p_two)
+        .bind(p_one)
+        .bind(p_healthy)
+        .bind(p_multi)
+        .bind(repo)
+        .execute(&mut *tx)
+        .await
+        .expect("seed packages");
+
+        sqlx::query(
+            "INSERT INTO artifacts (repository_id, path) VALUES \
+             ($1, 'com/example/two/app/2.0.0/app-2.0.0.jar'), \
+             ($1, 'com/example/one/app/3.0.0/app-3.0.0.jar'), \
+             ($1, 'com/example/ok/app/4.0.0/app-4.0.0.jar'), \
+             ($1, 'com/example/multi/app/5.0.0/app-5.0.0.jar'), \
+             ($1, 'com/example/multi/app/6.0.0/app-6.0.0.jar')",
+        )
+        .bind(repo)
+        .execute(&mut *tx)
+        .await
+        .expect("seed artifacts");
+
+        sqlx::query(
+            "INSERT INTO package_versions (package_id, version) VALUES \
+             ($1, 'example'), ($1, '1.0.0-STALE'), \
+             ($2, 'example'), \
+             ($3, '4.0.0'), \
+             ($4, 'multi')",
+        )
+        .bind(p_two)
+        .bind(p_one)
+        .bind(p_healthy)
+        .bind(p_multi)
+        .execute(&mut *tx)
+        .await
+        .expect("seed catalog rows");
+
+        // Must not raise 23505. Before the fix this errored and aborted.
+        sqlx::raw_sql(include_str!(
+            "../../migrations/192_maven_package_versions_version_backfill.sql"
+        ))
+        .execute(&mut *tx)
+        .await
+        .expect("migration 192 must survive two broken rows sharing one candidate");
+
+        // Replay must be a no-op: the migration is forward-only and idempotent.
+        sqlx::raw_sql(include_str!(
+            "../../migrations/192_maven_package_versions_version_backfill.sql"
+        ))
+        .execute(&mut *tx)
+        .await
+        .expect("migration 192 replays cleanly");
+
+        async fn versions_for(
+            tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+            pkg: Uuid,
+        ) -> Vec<String> {
+            sqlx::query_scalar::<_, String>(
+                "SELECT version FROM package_versions WHERE package_id = $1 ORDER BY version",
+            )
+            .bind(pkg)
+            .fetch_all(&mut **tx)
+            .await
+            .expect("read catalog rows")
+        }
+
+        // The 23505 shape: ambiguous, so both rows are dropped rather than
+        // collapsed onto the same (package_id, version).
+        let two = versions_for(&mut tx, p_two).await;
+        assert!(
+            two.is_empty(),
+            "two broken rows sharing one candidate are deleted, not merged; got {two:?}"
+        );
+
+        // Unambiguous: repaired to the real on-disk version directory.
+        let one = versions_for(&mut tx, p_one).await;
+        assert_eq!(
+            one,
+            vec!["3.0.0".to_string()],
+            "single broken row with a single candidate is rewritten from the GAV path"
+        );
+
+        // Healthy rows are never touched.
+        let healthy = versions_for(&mut tx, p_healthy).await;
+        assert_eq!(
+            healthy,
+            vec!["4.0.0".to_string()],
+            "a row that already matches a version directory must be left alone"
+        );
+
+        // Ambiguous by candidate count: cannot attribute, so drop.
+        let multi = versions_for(&mut tx, p_multi).await;
+        assert!(
+            multi.is_empty(),
+            "a broken row with several candidate versions is deleted; got {multi:?}"
+        );
+
+        tx.rollback().await.expect("rollback migration fixture");
+    }
 }


### PR DESCRIPTION
## Summary

**Boot-crash blocker in migration 192, shipped by #3093.** Found by post-merge review, then reproduced.

Migration 192 rewrote *every* broken `package_versions` row whose package had exactly one candidate version directory. The UPDATE's collision guard evaluates against the pre-statement snapshot, so with **two broken rows and one candidate** both rows pass the guard and both are rewritten to the same version, violating `UNIQUE(package_id, version)` (`019_builds_packages.sql:52`).

Migrations run at boot, so this aborts the migration transaction and the deployment **crash-loops** until someone does DB surgery. The shape is organically reachable: a generic-push naive version plus a chunked explicit version on the same GAV.

Reproduced against Postgres 16 with the shipped migration:

```
ERROR:  duplicate key value violates unique constraint "package_versions_package_id_version_key"
DETAIL:  Key (package_id, version)=(..., 2.0.0) already exists.
```

### Why 192 is edited in place

A follow-up migration cannot rescue a failure *inside* 192 — 192 aborts the boot before anything after it runs. Blast radius of the in-place edit is limited to `:dev` consumers who pulled main in the few hours since #3093 merged, and for them the old file either already crashed or was a no-op.

## Changes

- **Rewrite at most one row per package, delete the remainder.** The unique constraint can no longer be violated. The catalog is derived data, recreated on next push, so deletion is safe.
- **Sargable prefix matching.** `LIKE` against a literal-escaped prefix instead of `LEFT(path, N) = prefix`, which could not use migration 110's `text_pattern_ops` index and degraded to a scan per broken row, risking the 30-minute startup `statement_timeout`. `broken` is now an anti-join over `candidates` instead of a correlated `NOT EXISTS` re-scanning `artifacts` per row.
- **Longest-prefix attribution.** A nested coordinate (`com.example:app` vs `com.example.app:foo`) can no longer harvest the nested package's directories as its own candidates and "repair" a healthy row into a wrong one.
- **Skip multi-colon names.** `split_part(name, ':', 2)` would truncate them while the read path splits on the first colon only.
- **Ignore empty version segments.**

## Test Checklist

- [x] Adds a regression test that would have caught the bug
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean, zero warnings
- [x] `cargo test --workspace --lib` — 14657 passed, 0 failed
- [x] New test run against live Postgres 16 — passes
- [x] **Verified load-bearing**: against the pre-fix migration it fails with the 23505 above

`migration_192_repairs_maven_catalog_versions_without_unique_violation` seeds the four interesting shapes into TEMP tables in a rolled-back transaction (the migration-172 test pattern) and applies the migration twice for idempotency:

| Shape | Expected | Verified |
|---|---|---|
| 2 broken rows, 1 candidate | no 23505; both deleted | pass |
| 1 broken row, 1 candidate | rewritten to on-disk version | pass |
| healthy row | untouched | pass |
| 1 broken row, 2 candidates | deleted (ambiguous) | pass |
| replay | no-op | pass |

CI only ever applies migrations to an empty database, which is why a data-dependent migration bug was invisible to it.

## API Changes

None.

Refs #3064

Fixes #3102
