### PR TITLE
ci: close release-bump gate bypass that skipped all Rust CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,9 +192,38 @@ jobs:
               patch = f.get('patch')
               if not patch:
                   full_ci(f'{name!r} has no inline patch to validate (diff too large)')
-              for line in patch.splitlines():
-                  if line.startswith('+++') or line.startswith('---'):
-                      continue
+              # Split on '\n' ONLY. str.splitlines() also breaks on the
+              # vertical tab, form feed, file/group/record separators, NEL and
+              # the Unicode line/paragraph separators -- none of which git or
+              # the GitHub patch field treat as a line terminator. Every one of
+              # them is also valid Rust/TOML whitespace, so splitlines() turned
+              # a single physical diff line into two Python "lines" and the
+              # trailing fragment -- which does not start with +/- -- was
+              # skipped entirely, letting arbitrary code ride into openapi.rs
+              # on a line whose prefix matched the version regex. The gate then
+              # skipped Check Rust, Backend Unit Tests and Code Coverage while
+              # CI Complete reported success. Belt and braces: reject outright
+              # any patch containing one of those separators.
+              SPLIT_ONLY_IN_PYTHON = (
+                  '\x0b', '\x0c', '\x1c', '\x1d', '\x1e',
+                  '\x85', '\u2028', '\u2029',
+              )
+              if any(sep in patch for sep in SPLIT_ONLY_IN_PYTHON):
+                  full_ci(f'{name!r} patch contains a non-newline line separator')
+              lines = [ln.rstrip('\r') for ln in patch.split('\n')]
+              # Cargo.toml: the regex alone is position-blind. A section table
+              # ([dependencies.foo], [patch.crates-io.foo], ...) also puts
+              # `version = "X.Y.Z"` at column 0, so a dependency edit would
+              # match. Require that the only TOML section the hunk touches is
+              # [workspace.package]; anything else falls back to full CI.
+              if name == 'Cargo.toml':
+                  sections = {
+                      ln[1:].strip() for ln in lines
+                      if ln[1:2] == '[' and ln[:1] in (' ', '+', '-')
+                  }
+                  if sections - {'[workspace.package]'}:
+                      full_ci(f'Cargo.toml hunk touches sections {sorted(sections)}')
+              for line in lines:
                   if line.startswith(('+', '-')) and not line_re.match(line):
                       full_ci(f'{name!r} changes a non-version line: {line!r}')
 


### PR DESCRIPTION
## Summary

**CI-integrity blocker in the release-bump gate from #3097.** Found by post-merge adversarial review, then reproduced.

The gate validated diff lines with `patch.splitlines()`. Python splits on `\x0b \x0c \x1c \x1d \x1e \x85 \u2028 \u2029` in addition to `\n` — git and the GitHub `patch` field treat **none** of those as line terminators. One physical diff line became two Python "lines", and the trailing fragment (not starting with `+`/`-`) was skipped by the validator entirely.

All of those characters are also valid Rust/TOML whitespace, so:

```
+        version = "1.7.1",<FF>fn backdoor() { }
```

is **one line to git**, matches the version regex as far as the validator reads, and compiles. The gate returned `bump_only=true`, skipping 🦀 Check Rust, 🧪 Backend Unit Tests and 📊 Code Coverage while ✅ CI Complete reported success.

The gate's header comment claimed it "fails CLOSED … on any +/- diff line that is not provably a version-string line." That was false.

## Fixes

- Split on `\n` only (stripping trailing `\r`), **and** reject outright any patch containing one of those separators, so the property is enforced rather than merely avoided.
- Drop the `+++`/`---` skip: GitHub's patch field starts at `@@` and never contains file headers, so it matched nothing legitimate while exempting any added line starting `++` or removed line starting `--`.
- `Cargo.toml`: require the hunk to touch no TOML section other than `[workspace.package]`. The regex is position-blind and a section table (`[dependencies.foo]`, `[patch.crates-io.foo]`) also puts `version = "X.Y.Z"` at column 0. Latent today, closed now.

## Test Checklist

- [x] Verified by extracting the gate script from the workflow and running it against synthetic `pulls/files` payloads
- [x] YAML parses; no literal control characters in the workflow file
- [ ] N/A — no Rust changes

| Case | Expected | Result |
|---|---|---|
| real #3056 release-bump shape | fast-path | `true` |
| plain openapi.rs version line | fast-path | `true` |
| **form-feed smuggle (the bypass)** | full CI | `false` |
| U+2028 smuggle | full CI | `false` |
| `[dependencies.openssl]` downgrade | full CI | `false` |
| `+++`-prefixed line | full CI | `false` |
| non-listed code file | full CI | `false` |
| renamed file | full CI | `false` |
| missing patch (huge diff) | full CI | `false` |
| empty listing | full CI | `false` |

Blast radius of the original bug was limited: the gate always returns `false` on `push`, so main CI would have caught an exploited PR after merge, not before.

## API Changes

None.

Refs #3045

Fixes #3103
