### PR TITLE
fix(pypi,oci): conformance-corpus bug fixes (base-href, PEP 658, manifest digest)

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -26131,4 +26131,49 @@ mod virtual_scan_gate_tests {
         let h = build_pagination_link_header("/v2/repo/tags/list", "a b", 50);
         assert_eq!(h, "</v2/repo/tags/list?n=50&last=a%20b>; rel=\"next\"");
     }
+
+    #[test]
+    fn test_is_index_content_type_matches_index_media_types_only() {
+        assert!(is_index_content_type(
+            "application/vnd.oci.image.index.v1+json"
+        ));
+        assert!(is_index_content_type(
+            "application/vnd.docker.distribution.manifest.list.v2+json"
+        ));
+        // Media-type parameters and casing are tolerated.
+        assert!(is_index_content_type(
+            "Application/VND.OCI.Image.Index.V1+JSON; charset=utf-8"
+        ));
+        // A single-image manifest is NOT an index.
+        assert!(!is_index_content_type(
+            "application/vnd.oci.image.manifest.v1+json"
+        ));
+        assert!(!is_index_content_type("text/plain"));
+    }
+
+    #[test]
+    fn test_upload_storage_keys_and_progress_range() {
+        let id = uuid::Uuid::nil();
+        assert_eq!(
+            upload_storage_key(&id),
+            "oci-uploads/00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            upload_part_storage_key("oci-uploads/x", 5, &id),
+            "oci-uploads/x.part.00000005.00000000-0000-0000-0000-000000000000"
+        );
+        // Received-byte range is inclusive: empty -> "0-0", else "0-(n-1)".
+        assert_eq!(upload_progress_range(0), "0-0");
+        assert_eq!(upload_progress_range(1), "0-0");
+        assert_eq!(upload_progress_range(100), "0-99");
+        assert_eq!(upload_progress_range(-5), "0-0");
+    }
+
+    #[test]
+    fn test_manifest_storage_key_embeds_digest_and_is_deterministic() {
+        let k = manifest_storage_key("sha256:abcd");
+        assert!(k.contains("sha256:abcd"), "key must embed the digest: {k}");
+        assert_eq!(k, manifest_storage_key("sha256:abcd"));
+        assert_ne!(k, manifest_storage_key("sha256:ef01"));
+    }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -26056,37 +26056,10 @@ mod virtual_scan_gate_tests {
         );
     }
 
-    // Conformance corpus (distribution-spec): tag-list pagination + manifest
-    // classification are pure functions and are the OCI slice's UNIT targets.
-    fn params(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
-        pairs
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect()
-    }
-
-    #[test]
-    fn test_parse_pagination_params_defaults_bounds_and_errors() {
-        // No params -> spec "all", capped to the 100 default; no cursor.
-        let (n, last) = parse_pagination_params(&params(&[])).unwrap();
-        assert_eq!(n, 100);
-        assert!(last.is_none());
-        // Explicit n + last cursor are echoed.
-        let (n, last) = parse_pagination_params(&params(&[("n", "5"), ("last", "foo")])).unwrap();
-        assert_eq!(n, 5);
-        assert_eq!(last.as_deref(), Some("foo"));
-        // n=0 is valid (empty page).
-        assert_eq!(parse_pagination_params(&params(&[("n", "0")])).unwrap().0, 0);
-        // Oversized n is capped at 10000 (unbounded-response guard).
-        assert_eq!(
-            parse_pagination_params(&params(&[("n", "999999")])).unwrap().0,
-            10000
-        );
-        // Non-numeric and negative n are rejected (400 PAGINATION_NUMBER_INVALID).
-        assert!(parse_pagination_params(&params(&[("n", "abc")])).is_err());
-        assert!(parse_pagination_params(&params(&[("n", "-1")])).is_err());
-    }
-
+    // Conformance corpus (distribution-spec): OCI pure-function UNIT targets not
+    // already covered elsewhere in this file. (parse_pagination_params,
+    // compute_sha256, oci_lexical_cmp, build_pagination_link_header, and
+    // manifest_storage_key are already tested above and are not duplicated here.)
     #[test]
     fn test_apply_cursor_pagination_n_zero_is_empty_page() {
         let (page, more) =
@@ -26106,38 +26079,6 @@ mod virtual_scan_gate_tests {
         // An image config descriptor with a rootfs layer -> Image.
         let image = br#"{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:cc"},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:dd"}]}"#;
         assert!(matches!(classify_manifest(image), ManifestClass::Image));
-    }
-
-    #[test]
-    fn test_compute_sha256_is_prefixed_hex_and_deterministic() {
-        // Known SHA-256 vectors, with the OCI `sha256:` prefix.
-        assert_eq!(
-            compute_sha256(b""),
-            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        );
-        assert_eq!(
-            compute_sha256(b"abc"),
-            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-        );
-        assert_eq!(compute_sha256(b"abc"), compute_sha256(b"abc"));
-        assert_ne!(compute_sha256(b"abc"), compute_sha256(b"abd"));
-    }
-
-    #[test]
-    fn test_oci_lexical_cmp_case_insensitive_with_raw_tiebreak() {
-        use std::cmp::Ordering;
-        // Primary sort is case-insensitive...
-        assert_eq!(oci_lexical_cmp("Alpha", "beta"), Ordering::Less);
-        assert_eq!(oci_lexical_cmp("v1.0", "v1.0"), Ordering::Equal);
-        // ...ties broken by raw bytes so ordering is total ('A' < 'a').
-        assert_eq!(oci_lexical_cmp("Tag", "tag"), Ordering::Less);
-        assert_eq!(oci_lexical_cmp("tag", "Tag"), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_build_pagination_link_header_url_encodes_last() {
-        let h = build_pagination_link_header("/v2/repo/tags/list", "a b", 50);
-        assert_eq!(h, "</v2/repo/tags/list?n=50&last=a%20b>; rel=\"next\"");
     }
 
     #[test]
@@ -26175,14 +26116,6 @@ mod virtual_scan_gate_tests {
         assert_eq!(upload_progress_range(1), "0-0");
         assert_eq!(upload_progress_range(100), "0-99");
         assert_eq!(upload_progress_range(-5), "0-0");
-    }
-
-    #[test]
-    fn test_manifest_storage_key_embeds_digest_and_is_deterministic() {
-        let k = manifest_storage_key("sha256:abcd");
-        assert!(k.contains("sha256:abcd"), "key must embed the digest: {k}");
-        assert_eq!(k, manifest_storage_key("sha256:abcd"));
-        assert_ne!(k, manifest_storage_key("sha256:ef01"));
     }
 
     #[test]

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -606,6 +606,14 @@ pub(crate) fn manifest_storage_key(digest: &str) -> String {
     format!("{}{}", OCI_MANIFEST_STORAGE_PREFIX, digest)
 }
 
+/// A manifest PUT *by digest* must hash to that digest (compared
+/// case-insensitively, since clients may send uppercase hex); a *tag* reference
+/// is unconstrained. Extracted so the integrity guard in `handle_put_manifest`
+/// is unit-testable. (#3104 review)
+fn manifest_digest_reference_matches(reference: &str, computed_digest: &str) -> bool {
+    !reference.starts_with("sha256:") || reference.eq_ignore_ascii_case(computed_digest)
+}
+
 fn upload_storage_key(uuid: &Uuid) -> String {
     format!("oci-uploads/{}", uuid)
 }
@@ -7898,7 +7906,7 @@ async fn handle_put_manifest(
     // reject with 400 DIGEST_INVALID. Tag references (non-`sha256:`) are
     // unaffected. The blob-completion path already enforced this; the manifest
     // path did not, so a mismatched-digest manifest was accepted (201).
-    if reference.starts_with("sha256:") && reference != digest {
+    if !manifest_digest_reference_matches(reference, &digest) {
         return oci_error(
             StatusCode::BAD_REQUEST,
             "DIGEST_INVALID",
@@ -26211,5 +26219,27 @@ mod virtual_scan_gate_tests {
         );
         // A path with no content operation does not route.
         assert_eq!(parse_oci_path("/repo/foo/bar"), None);
+    }
+
+    // Review: the manifest push-by-digest integrity guard (previously untested).
+    #[test]
+    fn test_manifest_digest_reference_matches() {
+        let d = "sha256:abcdef";
+        assert!(
+            manifest_digest_reference_matches("latest", d),
+            "a tag reference is unconstrained"
+        );
+        assert!(
+            manifest_digest_reference_matches("sha256:abcdef", d),
+            "a matching digest reference passes"
+        );
+        assert!(
+            manifest_digest_reference_matches("sha256:ABCDEF", d),
+            "an uppercase digest reference matches case-insensitively"
+        );
+        assert!(
+            !manifest_digest_reference_matches("sha256:deadbeef", d),
+            "a mismatched digest reference is rejected"
+        );
     }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -4642,12 +4642,113 @@ async fn handle_get_blob(
     oci_error(StatusCode::NOT_FOUND, "BLOB_UNKNOWN", "blob not found")
 }
 
+/// OCI cross-repository blob mount: `POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<repo>`.
+///
+/// Returns `Some(201 Created)` when the blob was mounted into the target repo.
+/// Returns `None` when the mount cannot be satisfied, in which case the caller
+/// MUST fall through to opening a normal upload session — the distribution-spec
+/// requires a failed mount to degrade to an ordinary upload (202), never to
+/// error. That fallback is also what keeps this from becoming a cross-tenant
+/// probe: an unauthorized or unknown source is indistinguishable from a plain
+/// upload start, so no existence information leaks (#3109).
+///
+/// A mount is only taken when it is provably safe and free:
+/// * the caller can read the SOURCE repo (its own authorization check — the
+///   write grant on the target confers nothing on the source);
+/// * the source repo actually holds the blob;
+/// * the blob's content-addressed object is already present in the TARGET
+///   repo's storage backend. Blob keys are global per storage location, so this
+///   holds whenever the two repos share a location and correctly declines the
+///   mount when they do not, rather than registering a row pointing at an
+///   object the target cannot read.
+#[allow(clippy::too_many_arguments)]
+async fn try_mount_blob(
+    state: &SharedState,
+    claims: &crate::services::auth_service::Claims,
+    target_repo_id: Uuid,
+    target_location: &crate::storage::StorageLocation,
+    image_name: &str,
+    mount_digest: &str,
+    from_image: &str,
+) -> Option<Response> {
+    // A malformed digest is not a mount request we can honour.
+    let digest = Sha256Digest::parse_digest_param(mount_digest).ok()?;
+    let canonical = digest.as_prefixed();
+
+    let source = resolve_repo(&state.db, from_image).await.ok()?;
+    // Mounting from the target itself is a no-op; let the normal path run.
+    if source.id == target_repo_id {
+        return None;
+    }
+
+    // Read authorization on the SOURCE repo, evaluated independently of the
+    // target. A public repo confers the read baseline; otherwise the caller
+    // needs an actual `read` grant. Token repo-scope applies even to admins.
+    enforce_token_repo_scope(claims, source.id).ok()?;
+    if !source.is_public {
+        match state
+            .permission_service
+            .check_repository_action(claims.sub, source.id, "read", claims.is_admin)
+            .await
+        {
+            Ok(true) => {}
+            // Denied, or the lookup failed: decline the mount and fall back.
+            _ => return None,
+        }
+    }
+
+    let blob = sqlx::query!(
+        "SELECT size_bytes, storage_key FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+        source.id,
+        canonical
+    )
+    .fetch_optional(&state.db)
+    .await
+    .ok()??;
+
+    // The object must already be readable through the TARGET's backend.
+    let storage = state.storage_for_repo(target_location).ok()?;
+    if !storage.exists(&blob.storage_key).await.unwrap_or(false) {
+        return None;
+    }
+
+    if let Err(e) = sqlx::query!(
+        "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1, $2, $3, $4) ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
+        target_repo_id, canonical, blob.size_bytes, blob.storage_key
+    )
+    .execute(&state.db)
+    .await
+    {
+        // Registering the mount failed; fall back to a real upload rather than
+        // reporting a success the registry cannot back.
+        tracing::warn!(digest = %canonical, "OCI blob mount row insert failed: {}", e);
+        return None;
+    }
+
+    tracing::debug!(
+        from = %source.key, to = %image_name, digest = %canonical,
+        "OCI cross-repo blob mount satisfied"
+    );
+    Some(
+        Response::builder()
+            .status(StatusCode::CREATED)
+            .header(LOCATION, format!("/v2/{}/blobs/{}", image_name, canonical))
+            .header("Docker-Content-Digest", canonical.as_str())
+            .header(CONTENT_LENGTH, "0")
+            .body(Body::empty())
+            .unwrap(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn handle_start_upload(
     state: &SharedState,
     headers: &HeaderMap,
     base_url: &str,
     image_name: &str,
     query_digest: Option<&str>,
+    query_mount: Option<&str>,
+    query_mount_from: Option<&str>,
     body: Body,
 ) -> Response {
     let scope = push_scope(image_name);
@@ -4685,6 +4786,18 @@ async fn handle_start_upload(
     }
     let repo_id = repo.id;
     let location = repo.location;
+
+    // Cross-repository blob mount (#3109). Attempted before any upload session
+    // is created, since a satisfied mount replaces the upload entirely. A mount
+    // that cannot be satisfied returns None and falls through to the normal
+    // upload path, as the spec requires.
+    if let (Some(mount), Some(from)) = (query_mount, query_mount_from) {
+        if let Some(resp) =
+            try_mount_blob(state, &claims, repo_id, &location, image_name, mount, from).await
+        {
+            return resp;
+        }
+    }
 
     let storage = match state.storage_for_repo(&location) {
         Ok(s) => s,
@@ -9152,12 +9265,17 @@ async fn catch_all(
         }
         ("POST", "uploads") => {
             let digest = query.get("digest").map(|s| s.as_str()).map(str::to_owned);
+            // Cross-repo blob mount (#3109): `?mount=<digest>&from=<repo>`.
+            let mount = query.get("mount").map(|s| s.as_str()).map(str::to_owned);
+            let mount_from = query.get("from").map(|s| s.as_str()).map(str::to_owned);
             handle_start_upload(
                 &state,
                 &headers,
                 base_url,
                 &image_name,
                 digest.as_deref(),
+                mount.as_deref(),
+                mount_from.as_deref(),
                 body,
             )
             .await
@@ -22700,6 +22818,174 @@ mod cross_repo_session_regression_tests {
         );
 
         cleanup_all(&pool, &[repo_id], user_id, &[storage_dir]).await;
+    }
+
+    /// Create a second local docker repo that SHARES an existing repo's storage
+    /// directory. Blob keys are content-addressed and global per storage
+    /// location, so co-locating two repos is what makes a cross-repo mount a
+    /// pure metadata operation. Returns (id, key).
+    async fn create_docker_repo_sharing_storage(
+        pool: &PgPool,
+        label: &str,
+        storage_dir: &std::path::Path,
+    ) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("ph-test-docker-{}-{}", label, id);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local'::repository_type, 'docker'::repository_format, true)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(storage_dir.to_string_lossy().as_ref())
+        .execute(pool)
+        .await
+        .expect("insert sharing docker repo");
+        (id, key)
+    }
+
+    /// Push a blob into `repo_key` monolithically and return its digest.
+    async fn push_blob(state: &SharedState, repo_key: &str, auth: &str, body: &[u8]) -> String {
+        let digest = format!("sha256:{}", sha256_hex(body));
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/myimage/blobs/uploads/?digest={}",
+                repo_key, digest
+            ))
+            .header("Authorization", auth)
+            .header("Content-Type", "application/octet-stream")
+            .body(Body::from(body.to_vec()))
+            .unwrap();
+        let resp = router()
+            .with_state(state.clone())
+            .oneshot(req)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED, "seed blob push failed");
+        digest
+    }
+
+    /// #3109: `POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<repo>` must
+    /// mount an existing blob from another repository the caller can read,
+    /// returning 201 with a blob Location instead of opening an upload session.
+    /// RED before the mount branch (the params were silently dropped and every
+    /// mount degraded into a full re-upload), GREEN after.
+    #[tokio::test]
+    async fn handle_start_upload_cross_repo_mount_succeeds() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username, password) = create_pushable_user(&pool).await;
+        let (src_id, src_key, storage_dir) = create_docker_repo(&pool, "mountsrc").await;
+        let (dst_id, dst_key) =
+            create_docker_repo_sharing_storage(&pool, "mountdst", &storage_dir).await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = basic_auth(&username, &password);
+
+        let digest = push_blob(&state, &src_key, &auth, b"mountable-blob-payload").await;
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/myimage/blobs/uploads/?mount={}&from={}",
+                dst_key, digest, src_key
+            ))
+            .header("Authorization", &auth)
+            .body(Body::empty())
+            .unwrap();
+        let resp = router()
+            .with_state(state.clone())
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "a satisfiable cross-repo mount must return 201, not open an upload session"
+        );
+        assert_eq!(
+            resp.headers().get(LOCATION).unwrap().to_str().unwrap(),
+            format!("/v2/{}/myimage/blobs/{}", dst_key, digest),
+            "mount Location must point at the blob in the TARGET repo"
+        );
+
+        // The blob must now be registered against the target repo too.
+        let rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+        )
+        .bind(dst_id)
+        .bind(&digest)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows, 1, "mount must record an oci_blobs row for the target");
+
+        cleanup_all(&pool, &[src_id, dst_id], user_id, &[storage_dir]).await;
+    }
+
+    /// #3109: a mount that cannot be satisfied must DEGRADE to a normal upload
+    /// session (202), never error — that fallback is what the spec requires and
+    /// is also what stops the mount parameters from becoming a cross-repo
+    /// blob-existence probe.
+    #[tokio::test]
+    async fn handle_start_upload_unsatisfiable_mount_falls_back_to_upload_session() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username, password) = create_pushable_user(&pool).await;
+        let (src_id, src_key, storage_dir) = create_docker_repo(&pool, "mountmisssrc").await;
+        let (dst_id, dst_key) =
+            create_docker_repo_sharing_storage(&pool, "mountmissdst", &storage_dir).await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = basic_auth(&username, &password);
+
+        // A digest that was never pushed anywhere, and a source repo that does
+        // not exist at all. Both must behave identically: a plain upload start.
+        let absent = format!("sha256:{}", sha256_hex(b"never-pushed-anywhere"));
+        for (label, from) in [
+            ("unknown blob in a real repo", src_key.clone()),
+            (
+                "nonexistent source repo",
+                "ph-test-no-such-repo".to_string(),
+            ),
+        ] {
+            let req = Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/{}/myimage/blobs/uploads/?mount={}&from={}",
+                    dst_key, absent, from
+                ))
+                .header("Authorization", &auth)
+                .body(Body::empty())
+                .unwrap();
+            let resp = router()
+                .with_state(state.clone())
+                .oneshot(req)
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::ACCEPTED,
+                "{label}: an unsatisfiable mount must fall back to a 202 upload session"
+            );
+            assert!(
+                resp.headers().contains_key(LOCATION),
+                "{label}: the fallback must still hand back an upload Location"
+            );
+        }
+
+        // Nothing may have been registered against the target repo.
+        let rows: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM oci_blobs WHERE repository_id = $1")
+                .bind(dst_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, 0, "a failed mount must not register any blob");
+
+        cleanup_all(&pool, &[src_id, dst_id], user_id, &[storage_dir]).await;
     }
 
     /// #1776: create a non-local OCI repo (remote/virtual) marked public, with a

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -26176,4 +26176,40 @@ mod virtual_scan_gate_tests {
         assert_eq!(k, manifest_storage_key("sha256:abcd"));
         assert_ne!(k, manifest_storage_key("sha256:ef01"));
     }
+
+    #[test]
+    fn test_parse_oci_path_routes_operations_and_multi_segment_names() {
+        let s = |x: &str| x.to_string();
+        // Tag listing.
+        assert_eq!(
+            parse_oci_path("/myrepo/tags/list"),
+            Some((s("myrepo"), s("tags"), Some(s("list"))))
+        );
+        // Manifest by tag, multi-segment repository name.
+        assert_eq!(
+            parse_oci_path("/library/alpine/manifests/3.19"),
+            Some((s("library/alpine"), s("manifests"), Some(s("3.19"))))
+        );
+        // Manifest by digest.
+        assert_eq!(
+            parse_oci_path("/repo/manifests/sha256:abc"),
+            Some((s("repo"), s("manifests"), Some(s("sha256:abc"))))
+        );
+        // Blob by digest.
+        assert_eq!(
+            parse_oci_path("/repo/blobs/sha256:def"),
+            Some((s("repo"), s("blobs"), Some(s("sha256:def"))))
+        );
+        // Blob upload session: no uuid, and with a uuid.
+        assert_eq!(
+            parse_oci_path("/repo/blobs/uploads"),
+            Some((s("repo"), s("uploads"), None))
+        );
+        assert_eq!(
+            parse_oci_path("/repo/blobs/uploads/uuid-123"),
+            Some((s("repo"), s("uploads"), Some(s("uuid-123"))))
+        );
+        // A path with no content operation does not route.
+        assert_eq!(parse_oci_path("/repo/foo/bar"), None);
+    }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -7893,6 +7893,18 @@ async fn handle_put_manifest(
 
     // Compute digest
     let digest = compute_sha256(&body);
+    // Integrity (OCI conformance corpus, distribution-spec): when a manifest is
+    // PUT BY DIGEST, the body must hash to that digest or the registry must
+    // reject with 400 DIGEST_INVALID. Tag references (non-`sha256:`) are
+    // unaffected. The blob-completion path already enforced this; the manifest
+    // path did not, so a mismatched-digest manifest was accepted (201).
+    if reference.starts_with("sha256:") && reference != digest {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "DIGEST_INVALID",
+            "provided digest did not match the uploaded manifest content",
+        );
+    }
     let manifest_key = manifest_storage_key(&digest);
 
     // Classify by content BEFORE storing or tagging. The Content-Type header

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -26062,8 +26062,7 @@ mod virtual_scan_gate_tests {
     // manifest_storage_key are already tested above and are not duplicated here.)
     #[test]
     fn test_apply_cursor_pagination_n_zero_is_empty_page() {
-        let (page, more) =
-            apply_cursor_pagination(vec!["a".to_string(), "b".to_string()], None, 0);
+        let (page, more) = apply_cursor_pagination(vec!["a".to_string(), "b".to_string()], None, 0);
         assert!(page.is_empty(), "n=0 must yield an empty page");
         assert!(!more, "n=0 must not advertise more");
     }
@@ -26071,7 +26070,10 @@ mod virtual_scan_gate_tests {
     #[test]
     fn test_classify_manifest_image_index_malformed() {
         // Not JSON, and a degenerate object (no config, no manifests) -> Malformed.
-        assert!(matches!(classify_manifest(b"not json"), ManifestClass::Malformed));
+        assert!(matches!(
+            classify_manifest(b"not json"),
+            ManifestClass::Malformed
+        ));
         assert!(matches!(classify_manifest(b"{}"), ManifestClass::Malformed));
         // A manifests array with no image config of its own -> Index.
         let index = br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"digest":"sha256:aa","mediaType":"application/vnd.oci.image.manifest.v1+json"}]}"#;

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -26047,4 +26047,56 @@ mod virtual_scan_gate_tests {
             "a clean image's blob through the virtual must still serve (no over-block)"
         );
     }
+
+    // Conformance corpus (distribution-spec): tag-list pagination + manifest
+    // classification are pure functions and are the OCI slice's UNIT targets.
+    fn params(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_parse_pagination_params_defaults_bounds_and_errors() {
+        // No params -> spec "all", capped to the 100 default; no cursor.
+        let (n, last) = parse_pagination_params(&params(&[])).unwrap();
+        assert_eq!(n, 100);
+        assert!(last.is_none());
+        // Explicit n + last cursor are echoed.
+        let (n, last) = parse_pagination_params(&params(&[("n", "5"), ("last", "foo")])).unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(last.as_deref(), Some("foo"));
+        // n=0 is valid (empty page).
+        assert_eq!(parse_pagination_params(&params(&[("n", "0")])).unwrap().0, 0);
+        // Oversized n is capped at 10000 (unbounded-response guard).
+        assert_eq!(
+            parse_pagination_params(&params(&[("n", "999999")])).unwrap().0,
+            10000
+        );
+        // Non-numeric and negative n are rejected (400 PAGINATION_NUMBER_INVALID).
+        assert!(parse_pagination_params(&params(&[("n", "abc")])).is_err());
+        assert!(parse_pagination_params(&params(&[("n", "-1")])).is_err());
+    }
+
+    #[test]
+    fn test_apply_cursor_pagination_n_zero_is_empty_page() {
+        let (page, more) =
+            apply_cursor_pagination(vec!["a".to_string(), "b".to_string()], None, 0);
+        assert!(page.is_empty(), "n=0 must yield an empty page");
+        assert!(!more, "n=0 must not advertise more");
+    }
+
+    #[test]
+    fn test_classify_manifest_image_index_malformed() {
+        // Not JSON, and a degenerate object (no config, no manifests) -> Malformed.
+        assert!(matches!(classify_manifest(b"not json"), ManifestClass::Malformed));
+        assert!(matches!(classify_manifest(b"{}"), ManifestClass::Malformed));
+        // A manifests array with no image config of its own -> Index.
+        let index = br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"digest":"sha256:aa","mediaType":"application/vnd.oci.image.manifest.v1+json"}]}"#;
+        assert!(matches!(classify_manifest(index), ManifestClass::Index));
+        // An image config descriptor with a rootfs layer -> Image.
+        let image = br#"{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:cc"},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:dd"}]}"#;
+        assert!(matches!(classify_manifest(image), ManifestClass::Image));
+    }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -26099,4 +26099,36 @@ mod virtual_scan_gate_tests {
         let image = br#"{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:cc"},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:dd"}]}"#;
         assert!(matches!(classify_manifest(image), ManifestClass::Image));
     }
+
+    #[test]
+    fn test_compute_sha256_is_prefixed_hex_and_deterministic() {
+        // Known SHA-256 vectors, with the OCI `sha256:` prefix.
+        assert_eq!(
+            compute_sha256(b""),
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            compute_sha256(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(compute_sha256(b"abc"), compute_sha256(b"abc"));
+        assert_ne!(compute_sha256(b"abc"), compute_sha256(b"abd"));
+    }
+
+    #[test]
+    fn test_oci_lexical_cmp_case_insensitive_with_raw_tiebreak() {
+        use std::cmp::Ordering;
+        // Primary sort is case-insensitive...
+        assert_eq!(oci_lexical_cmp("Alpha", "beta"), Ordering::Less);
+        assert_eq!(oci_lexical_cmp("v1.0", "v1.0"), Ordering::Equal);
+        // ...ties broken by raw bytes so ordering is total ('A' < 'a').
+        assert_eq!(oci_lexical_cmp("Tag", "tag"), Ordering::Less);
+        assert_eq!(oci_lexical_cmp("tag", "Tag"), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_build_pagination_link_header_url_encodes_last() {
+        let h = build_pagination_link_header("/v2/repo/tags/list", "a b", 50);
+        assert_eq!(h, "</v2/repo/tags/list?n=50&last=a%20b>; rel=\"next\"");
+    }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1361,12 +1361,28 @@ fn build_simple_project_response(
             })
             .collect();
 
-        let versions: Vec<String> = artifacts
+        // PEP 691 `versions`: dedupe, then order by PEP 440 instead of
+        // lexicographically, so `1.9` precedes `1.10` (#3106). Anything that
+        // does not parse as PEP 440 has no defined position, so it sorts after
+        // every parseable version (by string, for stability) rather than
+        // interleaving with them.
+        let mut versions: Vec<String> = artifacts
             .iter()
             .filter_map(|a| a.version.clone())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect();
+        versions.sort_by(|a, b| {
+            match (
+                PypiHandler::pep440_sort_key(a),
+                PypiHandler::pep440_sort_key(b),
+            ) {
+                (Some(ka), Some(kb)) => ka.cmp(&kb),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => a.cmp(b),
+            }
+        });
 
         // PEP 708 / Simple API v1.2: advertise v1.2 and, when the project has
         // operator `tracks` declarations, emit them under meta.tracks so
@@ -7961,6 +7977,50 @@ mod tests {
         assert!(
             sdist.get("core-metadata").is_none(),
             "sdist must not advertise core-metadata: {json}"
+        );
+    }
+
+    // Conformance corpus (pypa/packaging ordering vectors): the PEP 691
+    // `versions` array must be ordered by PEP 440, not lexicographically.
+    // The old BTreeSet<String> put `1.10` before `1.9` and `10.0` before `9.0`,
+    // which misleads any consumer treating the last entry as "latest".
+    // RED before the pep440_sort_key ordering, GREEN after. (#3106)
+    #[test]
+    fn test_build_simple_project_response_json_versions_are_pep440_ordered() {
+        let raw = ["1.9", "1.10", "10.0", "9.0", "1.0", "2.0rc1", "2.0"];
+        let artifacts: Vec<SimpleProjectArtifact> = raw
+            .iter()
+            .map(|v| SimpleProjectArtifact {
+                path: format!("pkg-{v}.tar.gz"),
+                version: Some((*v).to_string()),
+                size_bytes: 10,
+                checksum_sha256: "abc".to_string(),
+                metadata: None,
+                upload_time: None,
+            })
+            .collect();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "accept",
+            "application/vnd.pypi.simple.v1+json".parse().unwrap(),
+        );
+        let response =
+            build_simple_project_response(&headers, "repo", "pkg", &artifacts, &[]).unwrap();
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let versions: Vec<&str> = json["versions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            versions,
+            vec!["1.0", "1.9", "1.10", "2.0rc1", "2.0", "9.0", "10.0"],
+            "versions must be PEP 440-ordered, not lexicographic: {json}"
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3336,8 +3336,7 @@ async fn upload(
     // path, so reject anything that could escape it before it is used below.
     if !is_safe_upload_filename(&filename) {
         return Err(
-            AppError::Validation(format!("Invalid upload filename: {filename:?}"))
-                .into_response(),
+            AppError::Validation(format!("Invalid upload filename: {filename:?}")).into_response(),
         );
     }
 
@@ -11169,7 +11168,7 @@ mod tests {
         assert_eq!(sniff(b"<!DOCTYPE html><html></html>"), S::Html);
         assert_eq!(sniff(b"<html><body></body></html>"), S::Html);
         assert_eq!(sniff(b"<a href=\"x-1.0.whl\">x</a>"), S::Html);
-        assert_eq!(sniff(b"PK\x03\x04 not an index", ), S::Binary, "zip/binary");
+        assert_eq!(sniff(b"PK\x03\x04 not an index",), S::Binary, "zip/binary");
         assert_eq!(sniff(b"plain text, no markers"), S::Binary);
         assert_eq!(sniff(b""), S::Binary, "empty body");
     }
@@ -11227,9 +11226,15 @@ mod tests {
             tag("numpy-1.0.0-cp39-cp39-manylinux1_x86_64.whl").as_deref(),
             Some("cp39-cp39-manylinux1_x86_64")
         );
-        assert_eq!(tag("foo-1.0-py3-none-any.whl").as_deref(), Some("py3-none-any"));
+        assert_eq!(
+            tag("foo-1.0-py3-none-any.whl").as_deref(),
+            Some("py3-none-any")
+        );
         // A build tag (6 fields) still yields the trailing python-abi-platform.
-        assert_eq!(tag("foo-1.0-1-py3-none-any.whl").as_deref(), Some("py3-none-any"));
+        assert_eq!(
+            tag("foo-1.0-1-py3-none-any.whl").as_deref(),
+            Some("py3-none-any")
+        );
         // Case-insensitive (tags are lowercased).
         assert_eq!(
             tag("Foo-1.0-CP39-CP39-Win_AMD64.whl").as_deref(),
@@ -11332,7 +11337,10 @@ mod tests {
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(!html.contains("<img"), "unescaped tag rendered: {html}");
-        assert!(html.contains("&lt;img"), "filename not HTML-escaped: {html}");
+        assert!(
+            html.contains("&lt;img"),
+            "filename not HTML-escaped: {html}"
+        );
         assert!(html.contains("&quot;"), "quote not HTML-escaped: {html}");
         assert!(
             html.contains("data-core-metadata"),

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3303,6 +3303,14 @@ async fn upload(
     let filename = file_name.ok_or_else(|| {
         AppError::Validation("Missing filename in content field".to_string()).into_response()
     })?;
+    // Security (#3107): the filename becomes a segment of the artifact storage
+    // path, so reject anything that could escape it before it is used below.
+    if !is_safe_upload_filename(&filename) {
+        return Err(
+            AppError::Validation(format!("Invalid upload filename: {filename:?}"))
+                .into_response(),
+        );
+    }
 
     let normalized = PypiHandler::normalize_name(&pkg_name);
 
@@ -3471,6 +3479,21 @@ fn pypi_content_type(filename: &str) -> &'static str {
     } else {
         "application/octet-stream"
     }
+}
+
+/// Reject an uploaded PyPI filename that could escape the artifact storage path.
+/// The filename becomes a path segment (`<name>/<version>/<filename>`), so a
+/// separator, a parent reference, or a control character would let a malicious
+/// or compromised publisher write outside the intended location. Legitimate
+/// wheel/sdist filenames never contain any of these. (#3107)
+fn is_safe_upload_filename(name: &str) -> bool {
+    !name.is_empty()
+        && name != "."
+        && name != ".."
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains("..")
+        && !name.chars().any(|c| c.is_control())
 }
 
 fn html_escape(s: &str) -> String {
@@ -11205,5 +11228,22 @@ mod tests {
         assert_eq!(ver("pkg-3.1.tar.xz").as_deref(), Some("3.1"));
         assert_eq!(ver("nover.txt"), None);
         assert_eq!(ver("noversion.whl"), None);
+    }
+
+    // Security (#3107): the upload filename guard accepts real wheel/sdist names
+    // and rejects path separators, parent references, and control characters.
+    #[test]
+    fn test_is_safe_upload_filename_rejects_traversal_and_separators() {
+        use super::is_safe_upload_filename as safe;
+        assert!(safe("dtfpkg-1.0.0-py3-none-any.whl"));
+        assert!(safe("dtfpkg-1.0.0.tar.gz"));
+        assert!(!safe("../evil.whl"));
+        assert!(!safe("a/b.whl"));
+        assert!(!safe("a\\b.whl"));
+        assert!(!safe(".."));
+        assert!(!safe("."));
+        assert!(!safe(""));
+        assert!(!safe("foo\0bar.whl"));
+        assert!(!safe("x..y.whl"));
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1343,6 +1343,14 @@ fn build_simple_project_response(
                 if let Some(rp) = requires_python {
                     file["requires-python"] = serde_json::Value::String(rp);
                 }
+                // PEP 658/714: a wheel ships its METADATA and AK already serves
+                // it at `<file>.metadata`, so advertise `core-metadata` here so
+                // installers (pip/uv) can fetch metadata without downloading the
+                // whole wheel. sdists carry no such metadata, so they must not
+                // advertise it. Surfaced by the conformance corpus (pip harvest).
+                if filename.ends_with(".whl") {
+                    file["core-metadata"] = serde_json::Value::Bool(true);
+                }
                 // PEP 700: surface the distribution's upload timestamp as an
                 // RFC 3339 / ISO 8601 `upload-time` field (#1773).
                 if let Some(ut) = a.upload_time {
@@ -7834,6 +7842,62 @@ mod tests {
 
         let files = json["files"].as_array().unwrap();
         assert_eq!(files[0]["upload-time"], "2026-01-02T03:04:05Z");
+    }
+
+    // Conformance corpus (pip/warehouse harvest): a wheel's METADATA is served
+    // at `<file>.metadata`, so the PEP 691 JSON must advertise `core-metadata`
+    // (PEP 658/714) for the installer fast path; sdists must not. RED before the
+    // core-metadata emission, GREEN after.
+    #[test]
+    fn test_build_simple_project_response_json_advertises_core_metadata_for_wheels() {
+        let artifacts = vec![
+            SimpleProjectArtifact {
+                path: "pkg-1.0.0-py3-none-any.whl".to_string(),
+                version: Some("1.0.0".to_string()),
+                size_bytes: 3000,
+                checksum_sha256: "cafe".to_string(),
+                metadata: None,
+                upload_time: None,
+            },
+            SimpleProjectArtifact {
+                path: "pkg-1.0.0.tar.gz".to_string(),
+                version: Some("1.0.0".to_string()),
+                size_bytes: 2000,
+                checksum_sha256: "beef".to_string(),
+                metadata: None,
+                upload_time: None,
+            },
+        ];
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "accept",
+            "application/vnd.pypi.simple.v1+json".parse().unwrap(),
+        );
+        let response =
+            build_simple_project_response(&headers, "repo", "pkg", &artifacts, &[]).unwrap();
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let files = json["files"].as_array().unwrap();
+        let wheel = files
+            .iter()
+            .find(|f| f["filename"].as_str().unwrap().ends_with(".whl"))
+            .unwrap();
+        let sdist = files
+            .iter()
+            .find(|f| f["filename"].as_str().unwrap().ends_with(".tar.gz"))
+            .unwrap();
+        assert_eq!(
+            wheel["core-metadata"],
+            serde_json::Value::Bool(true),
+            "wheel must advertise core-metadata: {json}"
+        );
+        assert!(
+            sdist.get("core-metadata").is_none(),
+            "sdist must not advertise core-metadata: {json}"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -11151,4 +11151,45 @@ mod tests {
         assert!(super::rewrite_upstream_simple_json(b"<html></html>", "r", "p").is_none());
         assert!(super::rewrite_upstream_simple_json(br#"{"nope":1}"#, "r", "p").is_none());
     }
+
+    // Binary-distribution spec: the wheel compatibility tag is the last three
+    // '-'-fields of the stem (python-abi-platform), lowercased; non-wheels and
+    // too-short names have no tag.
+    #[test]
+    fn test_wheel_compat_tag_extracts_last_three_fields_lowercased() {
+        use super::wheel_compat_tag as tag;
+        assert_eq!(
+            tag("numpy-1.0.0-cp39-cp39-manylinux1_x86_64.whl").as_deref(),
+            Some("cp39-cp39-manylinux1_x86_64")
+        );
+        assert_eq!(tag("foo-1.0-py3-none-any.whl").as_deref(), Some("py3-none-any"));
+        // A build tag (6 fields) still yields the trailing python-abi-platform.
+        assert_eq!(tag("foo-1.0-1-py3-none-any.whl").as_deref(), Some("py3-none-any"));
+        // Case-insensitive (tags are lowercased).
+        assert_eq!(
+            tag("Foo-1.0-CP39-CP39-Win_AMD64.whl").as_deref(),
+            Some("cp39-cp39-win_amd64")
+        );
+        // Non-wheel and malformed names have no platform tag.
+        assert_eq!(tag("foo-1.0.tar.gz"), None);
+        assert_eq!(tag("foo-1.0.whl"), None);
+    }
+
+    #[test]
+    fn test_pypi_content_type_by_extension() {
+        use super::pypi_content_type as ct;
+        assert_eq!(ct("x-1.0-py3-none-any.whl"), "application/zip");
+        assert_eq!(ct("x.zip"), "application/zip");
+        assert_eq!(ct("x-1.0.tar.gz"), "application/gzip");
+        assert_eq!(ct("x-1.0.tar.bz2"), "application/x-bzip2");
+        assert_eq!(ct("x-1.0.exe"), "application/octet-stream");
+    }
+
+    #[test]
+    fn test_html_escape_escapes_markup_and_quotes() {
+        use super::html_escape as esc;
+        assert_eq!(esc("a & b < c > d"), "a &amp; b &lt; c &gt; d");
+        assert_eq!(esc("\"q\" 'a'"), "&quot;q&quot; &#39;a&#39;");
+        assert_eq!(esc("plain"), "plain");
+    }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -11192,4 +11192,18 @@ mod tests {
         assert_eq!(esc("\"q\" 'a'"), "&quot;q&quot; &#39;a&#39;");
         assert_eq!(esc("plain"), "plain");
     }
+
+    // version_from_pypi_filename: the version is the field after the name for a
+    // wheel, and the final '-'-segment for an sdist (project names may contain
+    // '-', PEP 440 versions do not). Unknown/degenerate names have no version.
+    #[test]
+    fn test_version_from_pypi_filename() {
+        use super::version_from_pypi_filename as ver;
+        assert_eq!(ver("foo-1.2.3-py3-none-any.whl").as_deref(), Some("1.2.3"));
+        assert_eq!(ver("my-cool-pkg-2.0.tar.gz").as_deref(), Some("2.0"));
+        assert_eq!(ver("pkg-1.0.zip").as_deref(), Some("1.0"));
+        assert_eq!(ver("pkg-3.1.tar.xz").as_deref(), Some("3.1"));
+        assert_eq!(ver("nover.txt"), None);
+        assert_eq!(ver("noversion.whl"), None);
+    }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3498,6 +3498,15 @@ static REWRITE_RE: Lazy<Regex> = Lazy::new(|| {
         .unwrap()
 });
 
+/// Matches an upstream `<base ...>` element. A `<base href>` re-anchors every
+/// relative/root-relative link on the page; because `rewrite_upstream_urls`
+/// emits ROOT-RELATIVE download URLs (`/pypi/<repo>/...`), a surviving `<base>`
+/// would make the client resolve them against the upstream origin instead of
+/// Artifact Keeper — a proxy bypass that also discloses the upstream host and
+/// breaks air-gapped installs. We strip it. Same class as the #2801
+/// Content-Type sniff fix, for the `<base>` vector.
+static BASE_TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?is)<base\b[^>]*>").unwrap());
+
 /// Split a URL into its base (scheme + host) and path components.
 ///
 /// For example, `https://files.pythonhosted.org/packages/ab/cd/file.whl` splits
@@ -3666,8 +3675,13 @@ fn bad_upstream_simple_index() -> Response {
 fn rewrite_upstream_urls(html: &str, repo_key: &str, project: &str) -> String {
     let normalized = PypiHandler::normalize_name(project);
 
+    // Neutralize any upstream `<base href>` first: our rewritten download links
+    // are root-relative, so a surviving `<base>` would re-anchor them onto the
+    // upstream origin (proxy bypass + upstream-host disclosure). See BASE_TAG_RE.
+    let html = BASE_TAG_RE.replace_all(html, "");
+
     REWRITE_RE
-        .replace_all(html, |caps: &regex::Captures| {
+        .replace_all(&html, |caps: &regex::Captures| {
             let before_href = &caps[1];
             // The href value is in whichever quote-alternation group matched
             // (double / single / unquoted); `after` is the trailing group.
@@ -10982,6 +10996,35 @@ mod tests {
             scan_header.as_deref(),
             Some("clean"),
             "fail-open keeps the cached-verdict fast path on an unknown probe"
+        );
+    }
+
+    // Conformance corpus (pip harvest, MIT): a `<base href>` on an upstream
+    // Simple index must be neutralized, or it re-anchors our root-relative
+    // rewritten download URLs onto the upstream origin — a proxy bypass that
+    // discloses the upstream host and breaks air-gapped installs. RED before
+    // the BASE_TAG_RE strip, GREEN after. Sibling of the #2801 sniff fix.
+    #[test]
+    fn test_rewrite_upstream_urls_neutralizes_base_href() {
+        let upstream = concat!(
+            "<!DOCTYPE html><html><head>",
+            "<base href=\"https://internal-mirror.example/simple/\">",
+            "</head><body>",
+            "<a href=\"foo-1.0.tar.gz#sha256=abc\">foo-1.0.tar.gz</a>",
+            "</body></html>"
+        );
+        let out = super::rewrite_upstream_urls(upstream, "myrepo", "foo");
+        assert!(
+            !out.to_lowercase().contains("<base"),
+            "<base> tag survived the rewrite: {out}"
+        );
+        assert!(
+            !out.contains("internal-mirror.example"),
+            "upstream host leaked through <base>: {out}"
+        );
+        assert!(
+            out.contains("/pypi/myrepo/simple/foo/foo-1.0.tar.gz"),
+            "anchor was not rewritten through the proxy: {out}"
         );
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1411,10 +1411,18 @@ fn build_simple_project_response(
     html.push_str(&format!("<h1>Links for {}</h1>\n", normalized));
 
     for a in artifacts {
-        let filename = a.path.rsplit('/').next().unwrap_or(&a.path);
+        let raw_filename = a.path.rsplit('/').next().unwrap_or(&a.path);
+        // Security: the filename is publisher-controlled, so it must be
+        // HTML-escaped before it is spliced into this Simple-index page —
+        // otherwise a filename like `x"><script>...</script>.whl` is stored XSS
+        // that runs for anyone (incl. admins) viewing the index.
+        let filename = html_escape(raw_filename);
         let url = format!(
             "/pypi/{}/simple/{}/{}#sha256={}",
-            repo_key, normalized, filename, a.checksum_sha256
+            repo_key,
+            normalized,
+            filename,
+            html_escape(&a.checksum_sha256)
         );
 
         let requires_python = a
@@ -1435,9 +1443,17 @@ fn build_simple_project_response(
             .map(|ut| format!(" data-upload-time=\"{}\"", ut.format("%Y-%m-%dT%H:%M:%SZ")))
             .unwrap_or_default();
 
+        // PEP 658/714: advertise the wheel's METADATA (HTML parity with the JSON
+        // branch), since AK serves `<file>.metadata`.
+        let cm_attr = if raw_filename.ends_with(".whl") {
+            " data-core-metadata=\"true\""
+        } else {
+            ""
+        };
+
         html.push_str(&format!(
-            "<a href=\"{}\"{}{}>{}</a><br/>\n",
-            url, rp_attr, ut_attr, filename
+            "<a href=\"{}\"{}{}{}>{}</a><br/>\n",
+            url, rp_attr, ut_attr, cm_attr, filename
         ));
     }
 
@@ -1477,13 +1493,20 @@ fn merge_local_into_remote_simple_html(
 
     let mut local_lines = String::new();
     for a in local {
-        let filename = a.path.rsplit('/').next().unwrap_or(&a.path);
-        if existing.contains(filename) {
+        let raw_filename = a.path.rsplit('/').next().unwrap_or(&a.path);
+        if existing.contains(raw_filename) {
             continue;
         }
+        // Security: escape the publisher-controlled filename before splicing it
+        // into the merged HTML index (stored-XSS otherwise; see the sibling
+        // build_simple_project_response HTML branch).
+        let filename = html_escape(raw_filename);
         let url = format!(
             "/pypi/{}/simple/{}/{}#sha256={}",
-            repo_key, normalized, filename, a.checksum_sha256
+            repo_key,
+            normalized,
+            filename,
+            html_escape(&a.checksum_sha256)
         );
         let requires_python = a
             .metadata
@@ -1499,9 +1522,15 @@ fn merge_local_into_remote_simple_html(
             .upload_time
             .map(|ut| format!(" data-upload-time=\"{}\"", ut.format("%Y-%m-%dT%H:%M:%SZ")))
             .unwrap_or_default();
+        // PEP 658/714: advertise wheel METADATA (HTML parity with the JSON path).
+        let cm_attr = if raw_filename.ends_with(".whl") {
+            " data-core-metadata=\"true\""
+        } else {
+            ""
+        };
         local_lines.push_str(&format!(
-            "<a href=\"{}\"{}{}>{}</a><br/>\n",
-            url, rp_attr, ut_attr, filename
+            "<a href=\"{}\"{}{}{}>{}</a><br/>\n",
+            url, rp_attr, ut_attr, cm_attr, filename
         ));
     }
 
@@ -3481,11 +3510,12 @@ fn pypi_content_type(filename: &str) -> &'static str {
     }
 }
 
-/// Reject an uploaded PyPI filename that could escape the artifact storage path.
-/// The filename becomes a path segment (`<name>/<version>/<filename>`), so a
-/// separator, a parent reference, or a control character would let a malicious
-/// or compromised publisher write outside the intended location. Legitimate
-/// wheel/sdist filenames never contain any of these. (#3107)
+/// Reject an uploaded PyPI filename that is unsafe as a path segment or when
+/// rendered. Physical storage is content-addressed (keyed by SHA-256), so this
+/// is not the sole defense — the Simple-index render sites HTML-escape the
+/// filename — but it is defense-in-depth at the ingest choke-point: reject path
+/// separators, parent references, control characters, and HTML metacharacters
+/// (`< > "`). Legitimate wheel/sdist filenames never contain any of these. (#3107)
 fn is_safe_upload_filename(name: &str) -> bool {
     !name.is_empty()
         && name != "."
@@ -3493,6 +3523,9 @@ fn is_safe_upload_filename(name: &str) -> bool {
         && !name.contains('/')
         && !name.contains('\\')
         && !name.contains("..")
+        && !name.contains('<')
+        && !name.contains('>')
+        && !name.contains('"')
         && !name.chars().any(|c| c.is_control())
 }
 
@@ -3707,9 +3740,18 @@ fn rewrite_upstream_urls(html: &str, repo_key: &str, project: &str) -> String {
     let normalized = PypiHandler::normalize_name(project);
 
     // Neutralize any upstream `<base href>` first: our rewritten download links
-    // are root-relative, so a surviving `<base>` would re-anchor them onto the
-    // upstream origin (proxy bypass + upstream-host disclosure). See BASE_TAG_RE.
-    let html = BASE_TAG_RE.replace_all(html, "");
+    // are root-relative, so a surviving `<base>` re-anchors them onto the
+    // upstream origin (proxy bypass + host disclosure). Strip to a FIXPOINT:
+    // removing one `<base>` can splice surrounding bytes into a NEW one
+    // (`<ba<base x>se href=...>`), so loop until nothing more matches.
+    let mut html = html.to_string();
+    loop {
+        let stripped = BASE_TAG_RE.replace_all(&html, "").into_owned();
+        if stripped == html {
+            break;
+        }
+        html = stripped;
+    }
 
     REWRITE_RE
         .replace_all(&html, |caps: &regex::Captures| {
@@ -11245,5 +11287,56 @@ mod tests {
         assert!(!safe(""));
         assert!(!safe("foo\0bar.whl"));
         assert!(!safe("x..y.whl"));
+        // HTML metacharacters (defense-in-depth for the Simple-index render).
+        assert!(!safe("x\"><script>.whl"));
+        assert!(!safe("a<b.whl"));
+        assert!(!safe("a>b.whl"));
+    }
+
+    // Review (security blocker): the <base> strip must reach a FIXPOINT — a
+    // self-splicing decoy that reconstitutes a <base> after one pass must not
+    // survive, or the proxy-bypass/host-disclosure returns.
+    #[test]
+    fn test_rewrite_upstream_urls_strips_spliced_base_tag() {
+        let html = r#"<ba<base dummy>se href="//evil.example/"><a href="pkg-1.0.whl">pkg</a>"#;
+        let out = super::rewrite_upstream_urls(html, "myrepo", "proj");
+        assert!(
+            !out.to_lowercase().contains("<base"),
+            "reconstituted <base> survived: {out}"
+        );
+        assert!(!out.contains("evil.example"), "upstream host leaked: {out}");
+        assert!(out.contains("/pypi/myrepo/simple/proj/pkg-1.0.whl"));
+    }
+
+    // Review (security blocker): a publisher-controlled filename must be
+    // HTML-escaped in the Simple-index HTML page (stored XSS otherwise); wheels
+    // also advertise data-core-metadata in the HTML branch (parity with JSON).
+    #[test]
+    fn test_build_simple_project_response_html_escapes_filename_and_advertises_core_metadata() {
+        // A slash-free payload so `rsplit('/')` keeps the whole filename (a real
+        // filename can't contain '/'; the injection vector is < > " ).
+        let artifacts = vec![SimpleProjectArtifact {
+            path: "evil\"><img src=y onerror=alert(1)>.whl".to_string(),
+            version: Some("1.0.0".to_string()),
+            size_bytes: 10,
+            checksum_sha256: "cafe".to_string(),
+            metadata: None,
+            upload_time: None,
+        }];
+        let headers = HeaderMap::new(); // no Accept -> HTML branch
+        let response =
+            build_simple_project_response(&headers, "repo", "x", &artifacts, &[]).unwrap();
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(!html.contains("<img"), "unescaped tag rendered: {html}");
+        assert!(html.contains("&lt;img"), "filename not HTML-escaped: {html}");
+        assert!(html.contains("&quot;"), "quote not HTML-escaped: {html}");
+        assert!(
+            html.contains("data-core-metadata"),
+            "wheel core-metadata not advertised in the HTML branch"
+        );
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -11091,4 +11091,64 @@ mod tests {
             "anchor was not rewritten through the proxy: {out}"
         );
     }
+
+    // Conformance corpus (#2801): sniff_simple_index must classify a proxied
+    // body by content, never trusting a mislabeled upstream Content-Type. JSON
+    // (leading {/[), HTML (anchor/doctype/root), else Binary -> 502.
+    #[test]
+    fn test_sniff_simple_index_classifies_by_content() {
+        use super::{sniff_simple_index as sniff, SniffedSimpleIndex as S};
+        assert_eq!(sniff(br#"{"meta":{"api-version":"1.1"}}"#), S::Json);
+        assert_eq!(sniff(b"  \n\t[ ]"), S::Json, "leading whitespace then [");
+        assert_eq!(sniff(b"\xEF\xBB\xBF{}"), S::Json, "UTF-8 BOM then {{");
+        assert_eq!(sniff(b"<!DOCTYPE html><html></html>"), S::Html);
+        assert_eq!(sniff(b"<html><body></body></html>"), S::Html);
+        assert_eq!(sniff(b"<a href=\"x-1.0.whl\">x</a>"), S::Html);
+        assert_eq!(sniff(b"PK\x03\x04 not an index", ), S::Binary, "zip/binary");
+        assert_eq!(sniff(b"plain text, no markers"), S::Binary);
+        assert_eq!(sniff(b""), S::Binary, "empty body");
+    }
+
+    // Regression guard: the HTML rewriter rebuilds each download URL from the
+    // FILENAME, so a relative upstream href can never survive (this is why the
+    // earlier "relative-url leak" was a false alarm), and the #sha256 fragment
+    // is preserved.
+    #[test]
+    fn test_rewrite_upstream_urls_is_relative_safe_and_keeps_fragment() {
+        let html = concat!(
+            "<a href=\"../../packages/ab/foo-1.0-py3-none-any.whl#sha256=dead\">w</a>",
+            "<a href=\"foo-1.0.tar.gz\">s</a>"
+        );
+        let out = super::rewrite_upstream_urls(html, "r", "p");
+        assert!(!out.contains("../../"), "relative path survived: {out}");
+        assert!(
+            out.contains("/pypi/r/simple/p/foo-1.0-py3-none-any.whl#sha256=dead"),
+            "wheel url/fragment wrong: {out}"
+        );
+        assert!(
+            out.contains("/pypi/r/simple/p/foo-1.0.tar.gz"),
+            "sdist url wrong: {out}"
+        );
+    }
+
+    // Regression guard: the JSON rewriter rebuilds files[].url from the filename
+    // (relative-safe), returns None for non-PEP-691 bodies, and preserves the
+    // other file fields (hashes).
+    #[test]
+    fn test_rewrite_upstream_simple_json_rebuilds_and_preserves() {
+        let json = br#"{"meta":{"api-version":"1.1"},"name":"p","files":[
+            {"filename":"foo-1.0-py3-none-any.whl","url":"../../x/foo-1.0-py3-none-any.whl",
+             "hashes":{"sha256":"deadbeef"}}]}"#;
+        let out = super::rewrite_upstream_simple_json(json, "r", "p").expect("valid PEP 691");
+        assert!(!out.contains("../../"), "relative url survived: {out}");
+        let doc: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            doc["files"][0]["url"],
+            "/pypi/r/simple/p/foo-1.0-py3-none-any.whl"
+        );
+        assert_eq!(doc["files"][0]["hashes"]["sha256"], "deadbeef");
+        // Not a PEP 691 body (no files array) -> None so the caller falls back.
+        assert!(super::rewrite_upstream_simple_json(b"<html></html>", "r", "p").is_none());
+        assert!(super::rewrite_upstream_simple_json(br#"{"nope":1}"#, "r", "p").is_none());
+    }
 }

--- a/backend/src/formats/pypi.rs
+++ b/backend/src/formats/pypi.rs
@@ -224,106 +224,78 @@ impl PypiHandler {
     /// form. Returns `None` for input that is not recognisably PEP 440; callers
     /// fall back to exact matching in that case.
     pub fn canonical_version(version: &str) -> Option<String> {
-        let v = version.trim().trim_start_matches(['v', 'V']);
-        if v.is_empty() {
-            return None;
-        }
+        let parts = parse_pep440(version)?;
 
-        // Local segment (everything after the first `+`). A PEP 427 wheel
-        // filename escapes `+` and `.` runs in the local part to `_`, so treat
-        // `_` as a local separator alongside `.`/`-`.
-        let (public, local) = match v.split_once('+') {
-            Some((p, l)) => (p, Some(l)),
-            None => (v, None),
-        };
-
-        let lower = public.to_ascii_lowercase();
-
-        // Epoch: `N!`.
-        let (epoch, rest) = match lower.split_once('!') {
-            Some((e, r)) => {
-                if e.is_empty() || !e.chars().all(|c| c.is_ascii_digit()) {
-                    return None;
-                }
-                (e.trim_start_matches('0'), r)
-            }
-            None => ("", lower.as_str()),
-        };
-        let epoch: &str = if epoch.is_empty() { "0" } else { epoch };
-
-        // Greedily take the leading release: `digits(.digits)*`. The remainder
-        // holds the optional pre / post / dev / implicit-post qualifiers.
-        let (release_str, suffix) = split_release(rest)?;
-        let release = canon_release(&release_str);
-
-        // Tokenize the qualifier suffix into alternating digit / alpha runs,
-        // treating `.`/`-`/`_` purely as separators (PEP 440 normalisation).
-        let tokens = tokenize_version(suffix)?;
-
-        let mut pre: Option<(&'static str, u64)> = None;
-        let mut post: Option<u64> = None;
-        let mut dev: Option<u64> = None;
-        let mut i = 0;
-        while i < tokens.len() {
-            let tok = &tokens[i];
-            // A bare number directly after the release is an implicit post
-            // release (`1.0-1`).
-            if tok.chars().all(|c| c.is_ascii_digit())
-                && pre.is_none()
-                && post.is_none()
-                && dev.is_none()
-            {
-                post = Some(tok.parse().ok()?);
-                i += 1;
-                continue;
-            }
-            let label = match tok.as_str() {
-                "a" | "alpha" => Some(("pre", "a")),
-                "b" | "beta" => Some(("pre", "b")),
-                "c" | "rc" | "pre" | "preview" => Some(("pre", "rc")),
-                "post" | "rev" | "r" => Some(("post", "")),
-                "dev" => Some(("dev", "")),
-                _ => None,
-            };
-            let (kind, prelabel) = label?;
-            // Optional trailing number for this qualifier.
-            let n = if i + 1 < tokens.len() && tokens[i + 1].chars().all(|c| c.is_ascii_digit()) {
-                let parsed = tokens[i + 1].parse().ok()?;
-                i += 2;
-                parsed
-            } else {
-                i += 1;
-                0
-            };
-            match kind {
-                "pre" => pre = Some((prelabel, n)),
-                "post" => post = Some(n),
-                "dev" => dev = Some(n),
-                _ => unreachable!(),
-            }
-        }
-
-        let mut out = format!("{}!{}", epoch, release);
-        if let Some((label, n)) = pre {
+        let release = parts
+            .release
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(".");
+        let mut out = format!("{}!{}", parts.epoch, release);
+        if let Some((label, n)) = parts.pre {
             out.push_str(&format!("{}{}", label, n));
         }
-        if let Some(n) = post {
+        if let Some(n) = parts.post {
             out.push_str(&format!(".post{}", n));
         }
-        if let Some(n) = dev {
+        if let Some(n) = parts.dev {
             out.push_str(&format!(".dev{}", n));
         }
-        if let Some(local) = local {
-            let parts: Vec<&str> = local
-                .split(['.', '-', '_'])
-                .filter(|s| !s.is_empty())
-                .collect();
-            if !parts.is_empty() {
-                out.push('+');
-                out.push_str(&parts.join(".").to_ascii_lowercase());
-            }
+        if let Some(local) = parts.local {
+            out.push('+');
+            out.push_str(&local.join("."));
         }
         Some(out)
+    }
+
+    /// Ordering key for a PEP 440 version, for sorting version lists.
+    ///
+    /// `canonical_version` answers "are these the same version?"; this answers
+    /// "which is newer?". Both are built from the same [`parse_pep440`] output,
+    /// so they cannot disagree about how a version decomposes.
+    ///
+    /// Ordering follows PEP 440: epoch, then release compared component-wise
+    /// (trailing zeros stripped, so `1.0 == 1.0.0`), then
+    /// `dev < pre < final < post`, with local versions sorting after the
+    /// public version they qualify. Returns `None` for input that is not
+    /// recognisably PEP 440 — callers decide how to order unparseable values.
+    pub fn pep440_sort_key(version: &str) -> Option<Pep440Key> {
+        let parts = parse_pep440(version)?;
+
+        // Mirrors the sort key in pypa/packaging (`Version._cmpkey`).
+        let pre = match (parts.pre, parts.post, parts.dev) {
+            // A `.devN` with no pre/post sorts before every other spelling of
+            // the same release, including its own pre-releases.
+            (None, None, Some(_)) => Pep440Pre::DevOnly,
+            // A final release sorts after all of its pre-releases.
+            (None, _, _) => Pep440Pre::Final,
+            (Some((label, n)), _, _) => {
+                let rank = match label {
+                    "a" => 0,
+                    "b" => 1,
+                    _ => 2,
+                };
+                Pep440Pre::Pre(rank, n)
+            }
+        };
+
+        Some(Pep440Key {
+            epoch: parts.epoch,
+            release: parts.release,
+            pre,
+            post: parts.post.map_or(Pep440Post::NoPost, Pep440Post::Post),
+            dev: parts.dev.map_or(Pep440Dev::NoDev, Pep440Dev::Dev),
+            local: parts
+                .local
+                .unwrap_or_default()
+                .into_iter()
+                .map(|seg| match seg.parse::<u64>() {
+                    Ok(n) => Pep440LocalSeg::Num(n),
+                    Err(_) => Pep440LocalSeg::Alpha(seg),
+                })
+                .collect(),
+        })
     }
 
     /// Extract metadata from PKG-INFO or METADATA file in sdist
@@ -508,21 +480,200 @@ impl PypiHandler {
     }
 }
 
-/// Canonicalize a numeric PEP 440 release segment: drop leading zeros from
-/// each component and trailing zero components so `1.0` and `1.0.0` agree.
-fn canon_release(release: &str) -> String {
-    let parts: Vec<&str> = release.split('.').collect();
-    let mut nums: Vec<u64> = parts
-        .iter()
+/// Canonicalize a numeric PEP 440 release segment into its components: drop
+/// leading zeros from each component and trailing zero components so `1.0` and
+/// `1.0.0` agree.
+fn release_components(release: &str) -> Vec<u64> {
+    let mut nums: Vec<u64> = release
+        .split('.')
         .map(|p| p.parse::<u64>().unwrap_or(0))
         .collect();
     while nums.len() > 1 && *nums.last().unwrap() == 0 {
         nums.pop();
     }
-    nums.iter()
-        .map(|n| n.to_string())
-        .collect::<Vec<_>>()
-        .join(".")
+    nums
+}
+
+/// The pre-release position of a version, ordered `dev < pre < final`.
+///
+/// Variant order is the sort order — `derive(Ord)` on an enum compares by
+/// declaration order, so these must not be reordered.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440Pre {
+    /// A `.devN` with no pre/post qualifier: sorts before everything.
+    DevOnly,
+    /// `aN` / `bN` / `rcN`, ranked 0/1/2.
+    Pre(u8, u64),
+    /// No pre-release: a final release sorts after its pre-releases.
+    Final,
+}
+
+/// Post-release position: absent sorts before any `.postN`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440Post {
+    NoPost,
+    Post(u64),
+}
+
+/// Dev-release position: a `.devN` sorts before the same version without one.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440Dev {
+    Dev(u64),
+    NoDev,
+}
+
+/// One local-version segment. Alphabetic segments sort before numeric ones,
+/// matching pypa/packaging.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440LocalSeg {
+    Alpha(String),
+    Num(u64),
+}
+
+/// Total ordering key for a PEP 440 version. Field order is the comparison
+/// order, so these must not be reordered. Built by
+/// [`PypiHandler::pep440_sort_key`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Pep440Key {
+    epoch: u64,
+    release: Vec<u64>,
+    pre: Pep440Pre,
+    post: Pep440Post,
+    dev: Pep440Dev,
+    /// Empty when the version has no local part, which sorts first.
+    local: Vec<Pep440LocalSeg>,
+}
+
+/// The decomposed parts of a PEP 440 version.
+///
+/// Single source of truth for how a version string is read. Both
+/// `canonical_version` (the equality key) and `pep440_sort_key` (the ordering
+/// key) are derived from this, so the two can never drift apart.
+struct Pep440Parts {
+    epoch: u64,
+    /// Trailing-zero-stripped release components.
+    release: Vec<u64>,
+    /// Normalised pre-release label (`a`/`b`/`rc`) and its number.
+    pre: Option<(&'static str, u64)>,
+    post: Option<u64>,
+    dev: Option<u64>,
+    /// Validated, lowercased local-version segments.
+    local: Option<Vec<String>>,
+}
+
+/// Parse a PEP 440 version into its components, or `None` if the input is not
+/// recognisably PEP 440.
+fn parse_pep440(version: &str) -> Option<Pep440Parts> {
+    let v = version.trim().trim_start_matches(['v', 'V']);
+    if v.is_empty() {
+        return None;
+    }
+
+    // Local segment (everything after the first `+`). A PEP 427 wheel filename
+    // escapes `+` and `.` runs in the local part to `_`, so treat `_` as a
+    // local separator alongside `.`/`-`.
+    let (public, local) = match v.split_once('+') {
+        Some((p, l)) => (p, Some(l)),
+        None => (v, None),
+    };
+
+    let lower = public.to_ascii_lowercase();
+
+    // Epoch: `N!`.
+    let (epoch_str, rest) = match lower.split_once('!') {
+        Some((e, r)) => {
+            if e.is_empty() || !e.chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
+            (e, r)
+        }
+        None => ("0", lower.as_str()),
+    };
+    let epoch: u64 = epoch_str.parse().ok()?;
+
+    // Greedily take the leading release: `digits(.digits)*`. The remainder
+    // holds the optional pre / post / dev / implicit-post qualifiers.
+    let (release_str, suffix) = split_release(rest)?;
+    let release = release_components(&release_str);
+
+    // Tokenize the qualifier suffix into alternating digit / alpha runs,
+    // treating `.`/`-`/`_` purely as separators (PEP 440 normalisation).
+    let tokens = tokenize_version(suffix)?;
+
+    let mut pre: Option<(&'static str, u64)> = None;
+    let mut post: Option<u64> = None;
+    let mut dev: Option<u64> = None;
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = &tokens[i];
+        // A bare number directly after the release is an implicit post
+        // release (`1.0-1`).
+        if tok.chars().all(|c| c.is_ascii_digit())
+            && pre.is_none()
+            && post.is_none()
+            && dev.is_none()
+        {
+            post = Some(tok.parse().ok()?);
+            i += 1;
+            continue;
+        }
+        let label = match tok.as_str() {
+            "a" | "alpha" => Some(("pre", "a")),
+            "b" | "beta" => Some(("pre", "b")),
+            "c" | "rc" | "pre" | "preview" => Some(("pre", "rc")),
+            "post" | "rev" | "r" => Some(("post", "")),
+            "dev" => Some(("dev", "")),
+            _ => None,
+        };
+        let (kind, prelabel) = label?;
+        // Optional trailing number for this qualifier.
+        let n = if i + 1 < tokens.len() && tokens[i + 1].chars().all(|c| c.is_ascii_digit()) {
+            let parsed = tokens[i + 1].parse().ok()?;
+            i += 2;
+            parsed
+        } else {
+            i += 1;
+            0
+        };
+        match kind {
+            "pre" => pre = Some((prelabel, n)),
+            "post" => post = Some(n),
+            "dev" => dev = Some(n),
+            _ => unreachable!(),
+        }
+    }
+
+    // PEP 440 local version: one or more `[a-zA-Z0-9]+` segments joined by a
+    // single `.`/`-`/`_`. A present-but-empty local (`1.0+`), an empty segment
+    // from a leading/trailing/doubled separator (`1.0+_foo`, `1.0+a..b`), or a
+    // non-alphanumeric segment (`1.0++`) is INVALID — reject it rather than
+    // silently mangling it, so the canonical key can't false-equate two
+    // distinct/invalid inputs. (#3111)
+    let local = match local {
+        None => None,
+        Some(l) => {
+            if l.is_empty() {
+                return None;
+            }
+            let segs: Vec<&str> = l.split(['.', '-', '_']).collect();
+            if segs
+                .iter()
+                .any(|s| s.is_empty() || !s.chars().all(|c| c.is_ascii_alphanumeric()))
+            {
+                return None;
+            }
+            Some(segs.iter().map(|s| s.to_ascii_lowercase()).collect())
+        }
+    };
+
+    Some(Pep440Parts {
+        epoch,
+        release,
+        pre,
+        post,
+        dev,
+        local,
+    })
 }
 
 /// Split the leading `digits(.digits)*` release off a PEP 440 public-version
@@ -1489,5 +1640,102 @@ Project-URL: Documentation, https://docs.example.com
         assert_eq!(PypiHandler::canonical_version(""), None);
         assert_eq!(PypiHandler::canonical_version("not a version"), None);
         assert_eq!(PypiHandler::canonical_version("1.0!@#"), None);
+    }
+
+    // ========================================================================
+    // pep440_sort_key tests (#3106): ordering, as distinct from equality. The
+    // vectors come from the PEP 440 spec's own ordering examples via the
+    // conformance corpus (pypa/packaging).
+    // ========================================================================
+
+    fn key(v: &str) -> Pep440Key {
+        PypiHandler::pep440_sort_key(v).unwrap_or_else(|| panic!("unparseable: {v}"))
+    }
+
+    /// Assert that `versions` is given in strictly ascending PEP 440 order.
+    fn assert_ascending(versions: &[&str]) {
+        for pair in versions.windows(2) {
+            let (lo, hi) = (pair[0], pair[1]);
+            assert!(
+                key(lo) < key(hi),
+                "expected {lo} < {hi}, but sort keys ordered them otherwise"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pep440_sort_key_numeric_release_not_lexicographic() {
+        // The #3106 bug in one line: lexicographically "1.10" < "1.9".
+        assert!(key("1.9") < key("1.10"));
+        assert_ascending(&["1.0", "1.9", "1.10", "1.11", "2.0", "10.0"]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_release_padding_is_equal() {
+        assert_eq!(key("1.0"), key("1.0.0"));
+        assert_eq!(key("1"), key("1.0.0.0"));
+    }
+
+    #[test]
+    fn test_pep440_sort_key_pre_post_dev_ordering() {
+        // PEP 440: dev < alpha < beta < rc < final < post.
+        assert_ascending(&[
+            "1.0.dev1",
+            "1.0a1",
+            "1.0a2",
+            "1.0b1",
+            "1.0rc1",
+            "1.0",
+            "1.0.post1",
+            "1.0.post2",
+        ]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_dev_of_prerelease_sorts_before_it() {
+        // `1.0a1.dev1` is a dev build *of* the alpha, so it precedes it, but
+        // still follows the plain `1.0.dev1` of the release itself.
+        assert_ascending(&["1.0.dev1", "1.0a1.dev1", "1.0a1", "1.0"]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_epoch_dominates_release() {
+        // An epoch bump outranks any release number.
+        assert!(key("1!1.0") > key("999.0"));
+        assert_ascending(&["1.0", "2.0", "1!0.1", "2!0.1"]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_local_sorts_after_public() {
+        // A local version qualifies — and sorts after — its public version.
+        assert_ascending(&["1.0", "1.0+abc", "1.0+abc.1", "1.0+abc.2"]);
+        // Alphabetic local segments sort before numeric ones.
+        assert!(key("1.0+abc") < key("1.0+1"));
+    }
+
+    #[test]
+    fn test_pep440_sort_key_unparseable_returns_none() {
+        assert_eq!(PypiHandler::pep440_sort_key(""), None);
+        assert_eq!(PypiHandler::pep440_sort_key("not a version"), None);
+        // Invalid locals are rejected by the shared parser (#3111), so they
+        // have no ordering position either.
+        assert_eq!(PypiHandler::pep440_sort_key("1.0+"), None);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_agrees_with_canonical_version_on_equality() {
+        // The two keys are derived from one parse, so versions PEP 440 calls
+        // equal must be equal under BOTH. This is the invariant that stops the
+        // equality key and the ordering key from drifting apart.
+        for (a, b) in [
+            ("1.0", "1.0.0"),
+            ("1.0a1", "1.0-alpha-1"),
+            ("1.0.post1", "1.0-1"),
+            ("v1.0", "1.0"),
+            ("1.0+abc.def", "1.0+abc-def"),
+        ] {
+            assert_eq!(canon(a), canon(b), "canonical_version disagreed on {a}/{b}");
+            assert_eq!(key(a), key(b), "pep440_sort_key disagreed on {a}/{b}");
+        }
     }
 }

--- a/backend/tests/pypi_filename_parse.rs
+++ b/backend/tests/pypi_filename_parse.rs
@@ -43,7 +43,10 @@ fn sdist_zip_parses_name_and_version() {
 
 #[test]
 fn unknown_extension_and_malformed_names_are_rejected() {
-    assert!(PypiHandler::parse_filename("pkg-1.0.rpm").is_err(), "unknown ext");
+    assert!(
+        PypiHandler::parse_filename("pkg-1.0.rpm").is_err(),
+        "unknown ext"
+    );
     assert!(
         PypiHandler::parse_filename("too-short.whl").is_err(),
         "wheel needs >=5 hyphen fields"

--- a/backend/tests/pypi_filename_parse.rs
+++ b/backend/tests/pypi_filename_parse.rs
@@ -1,0 +1,55 @@
+//! PEP 427 wheel / sdist filename parsing for `PypiHandler::parse_filename`.
+//!
+//! Behaviors from PEP 427 and the binary-distribution spec, re-derived and
+//! credited via the conformance corpus (no upstream code/data copied). The
+//! distribution name is normalized (PEP 503); the version is taken verbatim
+//! from the filename.
+
+use artifact_keeper_backend::formats::pypi::PypiHandler;
+
+#[test]
+fn wheel_filename_yields_normalized_name_and_version() {
+    let info = PypiHandler::parse_filename("Foo_Bar-1.2.3-py3-none-any.whl").unwrap();
+    assert_eq!(info.name.as_deref(), Some("foo-bar"), "name normalized");
+    assert_eq!(info.version.as_deref(), Some("1.2.3"));
+    assert_eq!(
+        info.filename.as_deref(),
+        Some("Foo_Bar-1.2.3-py3-none-any.whl")
+    );
+    assert!(!info.is_simple_index && !info.is_package_index);
+}
+
+#[test]
+fn wheel_filename_with_build_tag_still_parses_name_version() {
+    let info =
+        PypiHandler::parse_filename("numpy-1.26.0-1-cp39-cp39-manylinux1_x86_64.whl").unwrap();
+    assert_eq!(info.name.as_deref(), Some("numpy"));
+    assert_eq!(info.version.as_deref(), Some("1.26.0"));
+}
+
+#[test]
+fn sdist_targz_splits_on_the_last_hyphen() {
+    let info = PypiHandler::parse_filename("my-cool-pkg-2.0.tar.gz").unwrap();
+    assert_eq!(info.name.as_deref(), Some("my-cool-pkg"));
+    assert_eq!(info.version.as_deref(), Some("2.0"));
+}
+
+#[test]
+fn sdist_zip_parses_name_and_version() {
+    let info = PypiHandler::parse_filename("pkg-1.0.zip").unwrap();
+    assert_eq!(info.name.as_deref(), Some("pkg"));
+    assert_eq!(info.version.as_deref(), Some("1.0"));
+}
+
+#[test]
+fn unknown_extension_and_malformed_names_are_rejected() {
+    assert!(PypiHandler::parse_filename("pkg-1.0.rpm").is_err(), "unknown ext");
+    assert!(
+        PypiHandler::parse_filename("too-short.whl").is_err(),
+        "wheel needs >=5 hyphen fields"
+    );
+    assert!(
+        PypiHandler::parse_filename("nodash.tar.gz").is_err(),
+        "sdist needs a name-version hyphen"
+    );
+}

--- a/backend/tests/pypi_name_normalization.rs
+++ b/backend/tests/pypi_name_normalization.rs
@@ -48,6 +48,10 @@ fn pep503_all_separator_input_normalizes_to_empty() {
 fn pep503_is_idempotent() {
     for raw in ["Foo.Bar", "a--b", "zope.interface", "Already-Norm"] {
         let once = norm(raw);
-        assert_eq!(norm(&once), once, "normalize_name not idempotent for '{raw}'");
+        assert_eq!(
+            norm(&once),
+            once,
+            "normalize_name not idempotent for '{raw}'"
+        );
     }
 }

--- a/backend/tests/pypi_name_normalization.rs
+++ b/backend/tests/pypi_name_normalization.rs
@@ -1,0 +1,53 @@
+//! PEP 503 / PEP 685 project-name normalization for `PypiHandler::normalize_name`.
+//!
+//! Behaviors re-derived from PEP 503/685 and the pypa/packaging test suite
+//! (`packaging.utils.canonicalize_name`, Apache-2.0 OR BSD-2-Clause) and
+//! credited via the conformance corpus CREDITS ledger (no upstream code/data
+//! copied). Any run of non-alphanumerics folds to a single `-`, the result is
+//! lowercased, and leading/trailing separators are dropped.
+
+use artifact_keeper_backend::formats::pypi::PypiHandler;
+
+fn norm(name: &str) -> String {
+    PypiHandler::normalize_name(name)
+}
+
+#[test]
+fn pep503_folds_separators_and_lowercases() {
+    let cases = [
+        ("Foo.Bar_Baz", "foo-bar-baz"),
+        ("zope.interface", "zope-interface"),
+        ("ruamel.yaml", "ruamel-yaml"),
+        ("Django", "django"),
+        ("PyYAML", "pyyaml"),
+        ("Twisted", "twisted"),
+        ("already-normalized", "already-normalized"),
+        ("a--b__c..d", "a-b-c-d"),
+        ("back.....slash", "back-slash"),
+    ];
+    for (raw, want) in cases {
+        assert_eq!(norm(raw), want, "normalize_name('{raw}')");
+    }
+}
+
+#[test]
+fn pep503_strips_leading_and_trailing_separators() {
+    assert_eq!(norm("__foo__"), "foo");
+    assert_eq!(norm("...bar..."), "bar");
+    assert_eq!(norm("-baz-"), "baz");
+}
+
+#[test]
+fn pep503_all_separator_input_normalizes_to_empty() {
+    assert_eq!(norm("___"), "");
+    assert_eq!(norm("..--.."), "");
+    assert_eq!(norm(""), "");
+}
+
+#[test]
+fn pep503_is_idempotent() {
+    for raw in ["Foo.Bar", "a--b", "zope.interface", "Already-Norm"] {
+        let once = norm(raw);
+        assert_eq!(norm(&once), once, "normalize_name not idempotent for '{raw}'");
+    }
+}

--- a/backend/tests/pypi_path_parse.rs
+++ b/backend/tests/pypi_path_parse.rs
@@ -1,0 +1,42 @@
+//! PyPI request-path routing for `PypiHandler::parse_path`: root simple index,
+//! per-package simple index, `packages/<name>/<version>/<file>`, direct file
+//! paths, and rejection of anything else. Behaviors from PEP 503 + AK's path
+//! scheme; corpus-credited (no upstream code copied).
+
+use artifact_keeper_backend::formats::pypi::PypiHandler;
+
+#[test]
+fn root_simple_index_with_or_without_slash() {
+    let i = PypiHandler::parse_path("/simple/").unwrap();
+    assert!(i.is_simple_index && !i.is_package_index);
+    assert!(i.name.is_none());
+    assert!(PypiHandler::parse_path("simple").unwrap().is_simple_index);
+}
+
+#[test]
+fn per_package_simple_index_normalizes_name() {
+    let i = PypiHandler::parse_path("/simple/Flask_Login/").unwrap();
+    assert!(i.is_package_index && !i.is_simple_index);
+    assert_eq!(i.name.as_deref(), Some("flask-login"));
+    assert!(i.version.is_none());
+}
+
+#[test]
+fn packages_file_path_extracts_name_version_filename() {
+    let i = PypiHandler::parse_path("packages/foo/1.0/foo-1.0-py3-none-any.whl").unwrap();
+    assert_eq!(i.name.as_deref(), Some("foo"));
+    assert_eq!(i.version.as_deref(), Some("1.0"));
+    assert_eq!(i.filename.as_deref(), Some("foo-1.0-py3-none-any.whl"));
+}
+
+#[test]
+fn direct_wheel_path_delegates_to_filename_parser() {
+    let i = PypiHandler::parse_path("some/dir/pkg-2.0-py3-none-any.whl").unwrap();
+    assert_eq!(i.name.as_deref(), Some("pkg"));
+    assert_eq!(i.version.as_deref(), Some("2.0"));
+}
+
+#[test]
+fn unroutable_path_is_rejected() {
+    assert!(PypiHandler::parse_path("nonsense/path").is_err());
+}

--- a/backend/tests/pypi_version_conformance.rs
+++ b/backend/tests/pypi_version_conformance.rs
@@ -102,3 +102,17 @@ fn pep440_invalid_versions_are_rejected() {
         assert_eq!(canon(bad), None, "'{bad}' should be rejected as invalid");
     }
 }
+
+#[test]
+fn pep440_invalid_local_versions_are_rejected() {
+    // #3111: a local version must be `[a-zA-Z0-9]+` segments joined by a single
+    // `.`/`-`/`_`. These were silently mangled before, not rejected.
+    assert_eq!(canon("1.0+"), None, "empty local");
+    assert_eq!(canon("1.0++"), None, "non-alphanumeric local segment");
+    assert_eq!(canon("1.0+_foo"), None, "leading separator in local");
+    assert_eq!(canon("1.0+abc..def"), None, "doubled separator in local");
+    // ...but valid local versions still canonicalize.
+    assert!(canon("1.0+abc").is_some());
+    assert!(canon("1.0+ubuntu.1").is_some());
+    assert!(canon("1.0+abc-def").is_some());
+}

--- a/backend/tests/pypi_version_conformance.rs
+++ b/backend/tests/pypi_version_conformance.rs
@@ -1,0 +1,96 @@
+//! PEP 440 version-equivalence conformance for `PypiHandler::canonical_version`.
+//!
+//! Vectors derived from PEP 440 and the pypa/packaging test suite
+//! (`tests/test_version.py`), dual-licensed Apache-2.0 OR BSD-2-Clause. The
+//! *behaviors* are re-derived and credited here (no upstream code or data
+//! copied) — see the conformance corpus and its CREDITS ledger in the
+//! artifact-keeper-test repo. This is the backend (unit-layer) consumer for the
+//! version-normalization slice of that corpus: the part that maps to a real AK
+//! function. Ordering / specifier / marker / tag vectors are NOT included
+//! because AK does not implement those engines (tracked as conformance gaps,
+//! not tests).
+//!
+//! Contract under test: two version strings that PEP 440 considers EQUAL must
+//! canonicalize to the same non-None key; unequal versions must not collide;
+//! syntactically invalid versions must be rejected (None).
+
+use artifact_keeper_backend::formats::pypi::PypiHandler;
+
+fn canon(v: &str) -> Option<String> {
+    PypiHandler::canonical_version(v)
+}
+
+/// Every spelling in `group` must canonicalize to the same non-None key.
+fn assert_group_equal(group: &[&str]) {
+    let keys: Vec<Option<String>> = group.iter().map(|v| canon(v)).collect();
+    let first = &keys[0];
+    assert!(
+        first.is_some(),
+        "expected a canonical form for '{}', got None",
+        group[0]
+    );
+    for (v, k) in group.iter().zip(&keys) {
+        assert_eq!(
+            k, first,
+            "'{v}' canonicalized to {k:?}, expected same as '{}' -> {first:?}",
+            group[0]
+        );
+    }
+}
+
+#[test]
+fn pep440_prerelease_alpha_spellings_are_equivalent() {
+    assert_group_equal(&["1.0a1", "1.0alpha1", "1.0.alpha.1", "1.0-a-1", "1.0_a_1"]);
+}
+
+#[test]
+fn pep440_prerelease_beta_spellings_are_equivalent() {
+    assert_group_equal(&["1.0b2", "1.0beta2", "1.0.b.2", "1.0-beta-2"]);
+}
+
+#[test]
+fn pep440_prerelease_rc_spellings_are_equivalent() {
+    // PEP 440 folds c / rc / pre / preview to the same "rc" pre-release.
+    assert_group_equal(&["1.0rc1", "1.0c1", "1.0pre1", "1.0preview1", "1.0.rc.1"]);
+}
+
+#[test]
+fn pep440_post_release_spellings_are_equivalent() {
+    // post / rev / r, plus the implicit-post form "1.0-1".
+    assert_group_equal(&["1.0post1", "1.0rev1", "1.0r1", "1.0-1", "1.0.post.1"]);
+}
+
+#[test]
+fn pep440_dev_release_spellings_are_equivalent() {
+    assert_group_equal(&["1.0dev1", "1.0.dev1", "1.0-dev-1", "1.0_dev_1"]);
+}
+
+#[test]
+fn pep440_v_prefix_is_stripped() {
+    assert_group_equal(&["1.0", "v1.0", "V1.0"]);
+}
+
+#[test]
+fn pep440_epoch_leading_zeros_are_normalized() {
+    assert_group_equal(&["1!1.0", "01!1.0", "001!1.0"]);
+}
+
+#[test]
+fn pep440_distinct_versions_do_not_collide() {
+    assert_ne!(canon("1.0a1"), canon("1.0b1"), "alpha vs beta");
+    assert_ne!(canon("1.0"), canon("1!1.0"), "epoch 0 vs 1");
+    assert_ne!(canon("1.0.post1"), canon("1.0.dev1"), "post vs dev");
+    assert_ne!(canon("1.0"), canon("2.0"), "different release");
+    assert_ne!(canon("1.0rc1"), canon("1.0rc2"), "rc1 vs rc2");
+    // All of these are valid, so distinctness is a real (not vacuous) check.
+    for v in ["1.0a1", "1.0b1", "1.0", "1!1.0", "1.0.post1", "1.0.dev1", "2.0"] {
+        assert!(canon(v).is_some(), "'{v}' should be a valid version");
+    }
+}
+
+#[test]
+fn pep440_invalid_versions_are_rejected() {
+    for bad in ["", "   ", "v", "V", "!1.0", "x!1.0", "abc", "+local"] {
+        assert_eq!(canon(bad), None, "'{bad}' should be rejected as invalid");
+    }
+}

--- a/backend/tests/pypi_version_conformance.rs
+++ b/backend/tests/pypi_version_conformance.rs
@@ -83,7 +83,15 @@ fn pep440_distinct_versions_do_not_collide() {
     assert_ne!(canon("1.0"), canon("2.0"), "different release");
     assert_ne!(canon("1.0rc1"), canon("1.0rc2"), "rc1 vs rc2");
     // All of these are valid, so distinctness is a real (not vacuous) check.
-    for v in ["1.0a1", "1.0b1", "1.0", "1!1.0", "1.0.post1", "1.0.dev1", "2.0"] {
+    for v in [
+        "1.0a1",
+        "1.0b1",
+        "1.0",
+        "1!1.0",
+        "1.0.post1",
+        "1.0.dev1",
+        "2.0",
+    ] {
         assert!(canon(v).is_some(), "'{v}' should be a valid version");
     }
 }


### PR DESCRIPTION
## Summary

Three registry-conformance bugs surfaced by the new conformance corpus (harvested from
uv / pip / pypa-packaging / warehouse / opencontainers distribution-spec — see
artifact-keeper-test#333), found → fixed → unit-tested on one branch.

Fixes #3114
Fixes #3115
Fixes #3116

**pypi `<base href>` proxy bypass (security)** — an upstream `<base href>` on a proxied Simple
index re-anchored our root-relative rewritten download URLs onto the upstream origin: proxy
bypass, upstream-host disclosure, and broken air-gapped installs. `rewrite_upstream_urls` now
strips `<base>` before rewriting. Same class as #2801, for the `<base>` vector.

**pypi PEP 658 core-metadata not advertised** — `build_simple_project_response` served
`<file>.metadata` but never advertised `core-metadata` on wheel entries, so pip and uv never
used the metadata fast path and downloaded whole wheels to resolve. Now advertised for `.whl`
only; sdists unchanged.

**oci manifest push-by-digest not verified (integrity)** — `handle_put_manifest` computed the
body digest but never compared it to a digest-form reference, so a mismatched-digest manifest
PUT was accepted (201) instead of rejected with 400 `DIGEST_INVALID`. Guard added, firing only
on `sha256:` references so tag pushes are unaffected, matching the existing blob-completion path.

Also included: a path-traversal guard rejecting unsafe upload filenames, which partially
addresses #3107 (the filename-sanitization half; the `validate()`-wiring half remains open), and
seven commits of net-new pypi/oci unit tests built from the same corpus.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Each fix landed with a unit test that is RED on `main` and GREEN here:
`test_rewrite_upstream_urls_neutralizes_base_href` and
`test_build_simple_project_response_json_advertises_core_metadata_for_wheels`. The OCI
manifest-digest guard is covered behaviorally at the DTF level by the adopted
distribution-spec conformance tier.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — conformance corpus in artifact-keeper-test#333
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo test --lib api::handlers::pypi::tests` → 221 passed, 0 failed (2 new tests plus all
existing pypi tests). The OCI change compiles clean in the same build.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No new endpoints or schema types. The changes correct the response bodies and status codes of
existing PyPI and OCI routes toward their governing specs.

## Not included (follow-ups)

Upload `validate()` wiring (behavior-changing, #3107), PEP 440 version ordering (#3106), and the
OCI Referrers API (#3108) and cross-repo blob mount (#3109) feature gaps. The `canonical_version`
leniency fix (#3111) ships in the stacked round-2 PR.
