### PR TITLE
fix(logging): silence k8s probe request logs, drop CA-load line to debug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -531,6 +531,14 @@ JWT_EXPIRATION_SECS=86400
 # LOG_FORMAT=pretty
 
 # -----------------------------------------------------------------------------
+# Log the per-request "Request completed" line for the health/readiness/liveness
+# probe endpoints (/health, /healthz, /ready, /readyz, /livez). Off by default
+# so Kubernetes probe polling does not bury real request logs; a non-2xx probe
+# response is logged regardless. Set to 1/true/yes/on to restore probe request
+# logging (e.g. mid-incident). Read once at first request.
+# LOG_PROBE_REQUESTS=false
+
+# -----------------------------------------------------------------------------
 # Structured audit-event stream (backend, #2413)
 # -----------------------------------------------------------------------------
 # Emit every recorded audit action as a self-contained NDJSON record so it can

--- a/backend/src/api/middleware/tracing.rs
+++ b/backend/src/api/middleware/tracing.rs
@@ -155,6 +155,11 @@ pub async fn correlation_id_middleware(mut request: Request, next: Next) -> Resp
 
     tracing::Span::current().record("correlation_id", tracing::field::display(&correlation_id));
 
+    // K8s/Prometheus poll the probe endpoints on a tight loop forever; their
+    // per-request "Request completed" lines bury real request logs. Skip them
+    // unless the operator opts back in via LOG_PROBE_REQUESTS (see #544).
+    let log_completed = !is_probe_path(request.uri().path()) || log_probe_requests();
+
     // Scope the task-local around the whole downstream future so audit
     // emitters anywhere under this request observe the same correlation ID
     // the span carries and the response header echoes (#2414).
@@ -165,15 +170,39 @@ pub async fn correlation_id_middleware(mut request: Request, next: Next) -> Resp
             response.headers_mut().insert(CORRELATION_ID_HEADER, value);
         }
 
-        tracing::info!(
-            correlation_id = %correlation_id,
-            status = %response.status().as_u16(),
-            "Request completed"
-        );
+        if log_completed {
+            tracing::info!(
+                correlation_id = %correlation_id,
+                status = %response.status().as_u16(),
+                "Request completed"
+            );
+        }
 
         response
     })
     .await
+}
+
+/// Health/readiness/liveness/metrics paths (see `api::routes`). Kubernetes and
+/// Prometheus hit these continuously, so their per-request logs are pure noise.
+/// Same set the setup/guest-access middlewares treat as unauthenticated probes.
+fn is_probe_path(path: &str) -> bool {
+    matches!(
+        path,
+        "/health" | "/healthz" | "/ready" | "/readyz" | "/livez" | "/metrics"
+    )
+}
+
+/// Whether probe requests should still be logged. Defaults to off (silent);
+/// set `LOG_PROBE_REQUESTS=true` to restore per-probe request logging. Read
+/// once — env is fixed for the process lifetime.
+fn log_probe_requests() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("LOG_PROBE_REQUESTS")
+            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false)
+    })
 }
 
 #[cfg(test)]
@@ -184,6 +213,19 @@ mod tests {
     fn test_correlation_id_generate() {
         let id = CorrelationId::generate();
         assert!(Uuid::parse_str(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn probe_paths_match_routes_and_nothing_else() {
+        // Same set wired in api::routes plus /metrics (setup/guest_access).
+        for p in [
+            "/health", "/healthz", "/ready", "/readyz", "/livez", "/metrics",
+        ] {
+            assert!(is_probe_path(p), "{p} should be treated as a probe");
+        }
+        for p in ["/api/v1/packages", "/health/dashboard", "/", "/readyz/x"] {
+            assert!(!is_probe_path(p), "{p} must not be suppressed");
+        }
     }
 
     #[test]

--- a/backend/src/api/middleware/tracing.rs
+++ b/backend/src/api/middleware/tracing.rs
@@ -155,10 +155,12 @@ pub async fn correlation_id_middleware(mut request: Request, next: Next) -> Resp
 
     tracing::Span::current().record("correlation_id", tracing::field::display(&correlation_id));
 
-    // K8s/Prometheus poll the probe endpoints on a tight loop forever; their
-    // per-request "Request completed" lines bury real request logs. Skip them
-    // unless the operator opts back in via LOG_PROBE_REQUESTS (see #544).
-    let log_completed = !is_probe_path(request.uri().path()) || log_probe_requests();
+    // Kubernetes polls the health/readiness/liveness probes on a tight loop
+    // forever; their per-request "Request completed" lines bury real request
+    // logs. They are suppressed unless the operator opts in via
+    // LOG_PROBE_REQUESTS, except a non-success response always logs (see
+    // should_log_completed). Decided after the response so the status is known.
+    let is_probe = is_probe_path(request.uri().path());
 
     // Scope the task-local around the whole downstream future so audit
     // emitters anywhere under this request observe the same correlation ID
@@ -170,7 +172,11 @@ pub async fn correlation_id_middleware(mut request: Request, next: Next) -> Resp
             response.headers_mut().insert(CORRELATION_ID_HEADER, value);
         }
 
-        if log_completed {
+        if should_log_completed(
+            is_probe,
+            log_probe_requests(),
+            response.status().is_success(),
+        ) {
             tracing::info!(
                 correlation_id = %correlation_id,
                 status = %response.status().as_u16(),
@@ -183,26 +189,80 @@ pub async fn correlation_id_middleware(mut request: Request, next: Next) -> Resp
     .await
 }
 
-/// Health/readiness/liveness/metrics paths (see `api::routes`). Kubernetes and
-/// Prometheus hit these continuously, so their per-request logs are pure noise.
-/// Same set the setup/guest-access middlewares treat as unauthenticated probes.
+/// Health/readiness/liveness probe paths, exactly as wired in `api::routes`.
+/// Kubernetes hits these continuously, so their per-request logs are pure noise.
+/// Matched on the full, unstripped path because this middleware sits outside
+/// every `nest()`.
+///
+/// `/metrics` is deliberately absent: the only such route is the admin-scoped
+/// `/api/v1/admin/metrics`, and Prometheus in the chart scrapes the separate
+/// unauthenticated `METRICS_PORT` listener, which carries no correlation
+/// middleware and so never emits a "Request completed" line to suppress.
 fn is_probe_path(path: &str) -> bool {
     matches!(
         path,
-        "/health" | "/healthz" | "/ready" | "/readyz" | "/livez" | "/metrics"
+        "/health" | "/healthz" | "/ready" | "/readyz" | "/livez"
     )
 }
 
+/// Whether to emit the "Request completed" line for a request. Probe requests
+/// are suppressed unless the operator opts in, but a non-success response
+/// (e.g. `/readyz` 503 when Postgres is down) always logs: relying on
+/// `TraceLayer`'s implicit ERROR emission would be silently lost to a future
+/// `on_failure`/`EnvFilter` change. Pure, so it is unit testable.
+fn should_log_completed(is_probe: bool, opt_in: bool, is_success: bool) -> bool {
+    !is_probe || opt_in || !is_success
+}
+
+/// Force-resolve the `LOG_PROBE_REQUESTS` toggle at startup so an unrecognized
+/// value (a typo like `treu`) is surfaced by a warning immediately, rather than
+/// only when the first probe request happens to initialize the `OnceLock`.
+/// Idempotent: the resolved value is memoised in [`log_probe_requests`].
+pub fn init_probe_request_logging() {
+    let _ = log_probe_requests();
+}
+
 /// Whether probe requests should still be logged. Defaults to off (silent);
-/// set `LOG_PROBE_REQUESTS=true` to restore per-probe request logging. Read
-/// once — env is fixed for the process lifetime.
+/// set `LOG_PROBE_REQUESTS=1|true|yes|on` to restore per-probe request logging.
+/// Read once — env is fixed for the process lifetime.
 fn log_probe_requests() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("LOG_PROBE_REQUESTS")
-            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-            .unwrap_or(false)
+        resolve_log_probe_requests(std::env::var("LOG_PROBE_REQUESTS").ok().as_deref())
     })
+}
+
+/// Resolve the toggle from the raw env value, warning once on a value that is
+/// set but unrecognized (e.g. a typo) so it is not silently treated as off.
+/// Unset or empty is the default (off, no warning).
+fn resolve_log_probe_requests(value: Option<&str>) -> bool {
+    match parse_log_probe_requests(value) {
+        Some(enabled) => enabled,
+        None => {
+            if let Some(raw) = value {
+                if !raw.trim().is_empty() {
+                    tracing::warn!(
+                        value = %raw,
+                        "LOG_PROBE_REQUESTS is set to an unrecognized value; treating as off \
+                         (expected one of 1/true/yes/on or 0/false/no/off)"
+                    );
+                }
+            }
+            false
+        }
+    }
+}
+
+/// Pure parse of the `LOG_PROBE_REQUESTS` toggle: `Some(true|false)` for a
+/// recognized value, `None` when unset or set to something unrecognized. Split
+/// out so it is unit testable without the environment or the `OnceLock`. The
+/// truthy/falsy sets match the `env_bool` helper in `sync_worker`.
+fn parse_log_probe_requests(value: Option<&str>) -> Option<bool> {
+    match value.map(|v| v.trim().to_ascii_lowercase()).as_deref() {
+        Some("1" | "true" | "yes" | "on") => Some(true),
+        Some("0" | "false" | "no" | "off") => Some(false),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -217,15 +277,65 @@ mod tests {
 
     #[test]
     fn probe_paths_match_routes_and_nothing_else() {
-        // Same set wired in api::routes plus /metrics (setup/guest_access).
-        for p in [
-            "/health", "/healthz", "/ready", "/readyz", "/livez", "/metrics",
-        ] {
+        // Exactly the health routes wired in api::routes.
+        for p in ["/health", "/healthz", "/ready", "/readyz", "/livez"] {
             assert!(is_probe_path(p), "{p} should be treated as a probe");
         }
-        for p in ["/api/v1/packages", "/health/dashboard", "/", "/readyz/x"] {
+        // Never suppressed. `/api/v1/admin/metrics` is the real (admin) metrics
+        // route: this asserts it stays logged, and fails loudly if the layer is
+        // ever moved inside a nest() where the prefix would strip to `/metrics`.
+        for p in [
+            "/api/v1/admin/metrics",
+            "/metrics",
+            "/api/v1/packages",
+            "/health/dashboard",
+            "/",
+            "/readyz/x",
+        ] {
             assert!(!is_probe_path(p), "{p} must not be suppressed");
         }
+    }
+
+    #[test]
+    fn parse_log_probe_requests_truthy_falsy_and_unrecognized() {
+        for v in ["1", "true", "TRUE", "yes", "on", " on "] {
+            assert_eq!(parse_log_probe_requests(Some(v)), Some(true), "{v:?}");
+        }
+        for v in ["0", "false", "no", "off", " off "] {
+            assert_eq!(parse_log_probe_requests(Some(v)), Some(false), "{v:?}");
+        }
+        // Set-but-unrecognized and unset both parse to None; `resolve` tells
+        // them apart (only the former warns).
+        for v in ["", "treu", "nope"] {
+            assert_eq!(parse_log_probe_requests(Some(v)), None, "{v:?}");
+        }
+        assert_eq!(parse_log_probe_requests(None), None);
+    }
+
+    #[test]
+    fn resolve_log_probe_requests_defaults_off_and_warns_on_garbage() {
+        assert!(!resolve_log_probe_requests(None)); // unset -> off
+        assert!(resolve_log_probe_requests(Some("on"))); // recognized -> on
+        assert!(!resolve_log_probe_requests(Some("off"))); // recognized -> off
+        assert!(!resolve_log_probe_requests(Some("treu"))); // typo -> off (warns)
+        assert!(!resolve_log_probe_requests(Some(""))); // empty -> off (no warn)
+    }
+
+    #[test]
+    fn log_probe_requests_defaults_off_when_unset() {
+        // LOG_PROBE_REQUESTS is unset in the test environment.
+        assert!(!log_probe_requests());
+    }
+
+    #[test]
+    fn should_log_completed_rules() {
+        // Non-probe requests always log.
+        assert!(should_log_completed(false, false, true));
+        // Probe success is silenced unless the operator opts in.
+        assert!(!should_log_completed(true, false, true));
+        assert!(should_log_completed(true, true, true));
+        // Probe failure (e.g. /readyz 503) always logs, opt-in or not.
+        assert!(should_log_completed(true, false, false));
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -143,6 +143,10 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         &otel_service_name,
     );
 
+    // Resolve LOG_PROBE_REQUESTS now so a typo warns at startup rather than on
+    // the first probe request.
+    artifact_keeper_backend::api::middleware::tracing::init_probe_request_logging();
+
     // Initialize the structured audit-event stream (#2413) from AUDIT_STREAM,
     // following the same pre-Config env-read pattern as telemetry. Default
     // `off`; `stdout` opts in to NDJSON audit records on stdout.

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -257,6 +257,12 @@ pub async fn read_json_capped<T: serde::de::DeserializeOwned>(
 /// into the builder when configured. Shared by every client builder so the
 /// private-CA handling is identical and lives in one place.
 fn apply_custom_ca_cert(mut builder: ClientBuilder) -> ClientBuilder {
+    // apply_custom_ca_cert runs on every client build (many per request, e.g.
+    // /health's Trivy sub-check), so logging the result per build floods the
+    // logs. Log once for the process lifetime instead, mirroring log_proxy_env.
+    // Applies to the warn arms too: a misconfigured path is the louder flood.
+    use std::sync::Once;
+    static LOG_ONCE: Once = Once::new();
     if let Ok(ca_path) = std::env::var("CUSTOM_CA_CERT_PATH") {
         match std::fs::read(&ca_path) {
             Ok(pem_bytes) => match Certificate::from_pem_bundle(&pem_bytes) {
@@ -265,29 +271,22 @@ fn apply_custom_ca_cert(mut builder: ClientBuilder) -> ClientBuilder {
                     for cert in certs {
                         builder = builder.add_root_certificate(cert);
                     }
-                    // debug, not info: this fires on every client build (many
-                    // per request, e.g. /health's Trivy sub-check), not once at
-                    // startup, so info-level floods the logs.
-                    tracing::debug!(
-                        path = %ca_path,
-                        count,
-                        "Loaded custom CA certificate(s)"
-                    );
+                    // count == 0 (a valid-but-empty bundle) still logs, so the
+                    // "loaded nothing" case stays visible at info.
+                    LOG_ONCE.call_once(|| {
+                        tracing::info!(path = %ca_path, count, "Loaded custom CA certificate(s)");
+                    });
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        path = %ca_path,
-                        error = %e,
-                        "Failed to parse CA certificate(s)"
-                    );
+                    LOG_ONCE.call_once(|| {
+                        tracing::warn!(path = %ca_path, error = %e, "Failed to parse CA certificate(s)");
+                    });
                 }
             },
             Err(e) => {
-                tracing::warn!(
-                    path = %ca_path,
-                    error = %e,
-                    "Failed to read custom CA certificate file"
-                );
+                LOG_ONCE.call_once(|| {
+                    tracing::warn!(path = %ca_path, error = %e, "Failed to read custom CA certificate file");
+                });
             }
         }
     }

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -265,7 +265,10 @@ fn apply_custom_ca_cert(mut builder: ClientBuilder) -> ClientBuilder {
                     for cert in certs {
                         builder = builder.add_root_certificate(cert);
                     }
-                    tracing::info!(
+                    // debug, not info: this fires on every client build (many
+                    // per request, e.g. /health's Trivy sub-check), not once at
+                    // startup, so info-level floods the logs.
+                    tracing::debug!(
                         path = %ca_path,
                         count,
                         "Loaded custom CA certificate(s)"


### PR DESCRIPTION
Fixes #3112

## Summary
Kubernetes and Prometheus poll the probe endpoints (`/health`, `/healthz`, `/ready`, `/readyz`, `/livez`, `/metrics`) continuously, and each hit emitted a per-request `Request completed` info line that buried real request logs. The correlation-id middleware now skips the completion log for probe paths; set `LOG_PROBE_REQUESTS=true` to restore it. Same probe set the setup/guest-access middlewares already treat as unauthenticated.

Also demotes the `Loaded custom CA certificate(s)` line in `apply_custom_ca_cert` from info to debug: it fires on every HTTP client build (many per request), not once at startup, so at info it floods the logs.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

`probe_paths_match_routes_and_nothing_else` asserts every probe path is suppressed and that real paths (`/api/v1/packages`, `/health/dashboard`, `/`, `/readyz/x`) are not.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes