### PR TITLE
fix(pypi): reject invalid PEP 440 local versions in canonical_version

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -4642,12 +4642,113 @@ async fn handle_get_blob(
     oci_error(StatusCode::NOT_FOUND, "BLOB_UNKNOWN", "blob not found")
 }
 
+/// OCI cross-repository blob mount: `POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<repo>`.
+///
+/// Returns `Some(201 Created)` when the blob was mounted into the target repo.
+/// Returns `None` when the mount cannot be satisfied, in which case the caller
+/// MUST fall through to opening a normal upload session — the distribution-spec
+/// requires a failed mount to degrade to an ordinary upload (202), never to
+/// error. That fallback is also what keeps this from becoming a cross-tenant
+/// probe: an unauthorized or unknown source is indistinguishable from a plain
+/// upload start, so no existence information leaks (#3109).
+///
+/// A mount is only taken when it is provably safe and free:
+/// * the caller can read the SOURCE repo (its own authorization check — the
+///   write grant on the target confers nothing on the source);
+/// * the source repo actually holds the blob;
+/// * the blob's content-addressed object is already present in the TARGET
+///   repo's storage backend. Blob keys are global per storage location, so this
+///   holds whenever the two repos share a location and correctly declines the
+///   mount when they do not, rather than registering a row pointing at an
+///   object the target cannot read.
+#[allow(clippy::too_many_arguments)]
+async fn try_mount_blob(
+    state: &SharedState,
+    claims: &crate::services::auth_service::Claims,
+    target_repo_id: Uuid,
+    target_location: &crate::storage::StorageLocation,
+    image_name: &str,
+    mount_digest: &str,
+    from_image: &str,
+) -> Option<Response> {
+    // A malformed digest is not a mount request we can honour.
+    let digest = Sha256Digest::parse_digest_param(mount_digest).ok()?;
+    let canonical = digest.as_prefixed();
+
+    let source = resolve_repo(&state.db, from_image).await.ok()?;
+    // Mounting from the target itself is a no-op; let the normal path run.
+    if source.id == target_repo_id {
+        return None;
+    }
+
+    // Read authorization on the SOURCE repo, evaluated independently of the
+    // target. A public repo confers the read baseline; otherwise the caller
+    // needs an actual `read` grant. Token repo-scope applies even to admins.
+    enforce_token_repo_scope(claims, source.id).ok()?;
+    if !source.is_public {
+        match state
+            .permission_service
+            .check_repository_action(claims.sub, source.id, "read", claims.is_admin)
+            .await
+        {
+            Ok(true) => {}
+            // Denied, or the lookup failed: decline the mount and fall back.
+            _ => return None,
+        }
+    }
+
+    let blob = sqlx::query!(
+        "SELECT size_bytes, storage_key FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+        source.id,
+        canonical
+    )
+    .fetch_optional(&state.db)
+    .await
+    .ok()??;
+
+    // The object must already be readable through the TARGET's backend.
+    let storage = state.storage_for_repo(target_location).ok()?;
+    if !storage.exists(&blob.storage_key).await.unwrap_or(false) {
+        return None;
+    }
+
+    if let Err(e) = sqlx::query!(
+        "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1, $2, $3, $4) ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
+        target_repo_id, canonical, blob.size_bytes, blob.storage_key
+    )
+    .execute(&state.db)
+    .await
+    {
+        // Registering the mount failed; fall back to a real upload rather than
+        // reporting a success the registry cannot back.
+        tracing::warn!(digest = %canonical, "OCI blob mount row insert failed: {}", e);
+        return None;
+    }
+
+    tracing::debug!(
+        from = %source.key, to = %image_name, digest = %canonical,
+        "OCI cross-repo blob mount satisfied"
+    );
+    Some(
+        Response::builder()
+            .status(StatusCode::CREATED)
+            .header(LOCATION, format!("/v2/{}/blobs/{}", image_name, canonical))
+            .header("Docker-Content-Digest", canonical.as_str())
+            .header(CONTENT_LENGTH, "0")
+            .body(Body::empty())
+            .unwrap(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn handle_start_upload(
     state: &SharedState,
     headers: &HeaderMap,
     base_url: &str,
     image_name: &str,
     query_digest: Option<&str>,
+    query_mount: Option<&str>,
+    query_mount_from: Option<&str>,
     body: Body,
 ) -> Response {
     let scope = push_scope(image_name);
@@ -4685,6 +4786,18 @@ async fn handle_start_upload(
     }
     let repo_id = repo.id;
     let location = repo.location;
+
+    // Cross-repository blob mount (#3109). Attempted before any upload session
+    // is created, since a satisfied mount replaces the upload entirely. A mount
+    // that cannot be satisfied returns None and falls through to the normal
+    // upload path, as the spec requires.
+    if let (Some(mount), Some(from)) = (query_mount, query_mount_from) {
+        if let Some(resp) =
+            try_mount_blob(state, &claims, repo_id, &location, image_name, mount, from).await
+        {
+            return resp;
+        }
+    }
 
     let storage = match state.storage_for_repo(&location) {
         Ok(s) => s,
@@ -9152,12 +9265,17 @@ async fn catch_all(
         }
         ("POST", "uploads") => {
             let digest = query.get("digest").map(|s| s.as_str()).map(str::to_owned);
+            // Cross-repo blob mount (#3109): `?mount=<digest>&from=<repo>`.
+            let mount = query.get("mount").map(|s| s.as_str()).map(str::to_owned);
+            let mount_from = query.get("from").map(|s| s.as_str()).map(str::to_owned);
             handle_start_upload(
                 &state,
                 &headers,
                 base_url,
                 &image_name,
                 digest.as_deref(),
+                mount.as_deref(),
+                mount_from.as_deref(),
                 body,
             )
             .await
@@ -22700,6 +22818,174 @@ mod cross_repo_session_regression_tests {
         );
 
         cleanup_all(&pool, &[repo_id], user_id, &[storage_dir]).await;
+    }
+
+    /// Create a second local docker repo that SHARES an existing repo's storage
+    /// directory. Blob keys are content-addressed and global per storage
+    /// location, so co-locating two repos is what makes a cross-repo mount a
+    /// pure metadata operation. Returns (id, key).
+    async fn create_docker_repo_sharing_storage(
+        pool: &PgPool,
+        label: &str,
+        storage_dir: &std::path::Path,
+    ) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("ph-test-docker-{}-{}", label, id);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local'::repository_type, 'docker'::repository_format, true)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(storage_dir.to_string_lossy().as_ref())
+        .execute(pool)
+        .await
+        .expect("insert sharing docker repo");
+        (id, key)
+    }
+
+    /// Push a blob into `repo_key` monolithically and return its digest.
+    async fn push_blob(state: &SharedState, repo_key: &str, auth: &str, body: &[u8]) -> String {
+        let digest = format!("sha256:{}", sha256_hex(body));
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/myimage/blobs/uploads/?digest={}",
+                repo_key, digest
+            ))
+            .header("Authorization", auth)
+            .header("Content-Type", "application/octet-stream")
+            .body(Body::from(body.to_vec()))
+            .unwrap();
+        let resp = router()
+            .with_state(state.clone())
+            .oneshot(req)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED, "seed blob push failed");
+        digest
+    }
+
+    /// #3109: `POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<repo>` must
+    /// mount an existing blob from another repository the caller can read,
+    /// returning 201 with a blob Location instead of opening an upload session.
+    /// RED before the mount branch (the params were silently dropped and every
+    /// mount degraded into a full re-upload), GREEN after.
+    #[tokio::test]
+    async fn handle_start_upload_cross_repo_mount_succeeds() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username, password) = create_pushable_user(&pool).await;
+        let (src_id, src_key, storage_dir) = create_docker_repo(&pool, "mountsrc").await;
+        let (dst_id, dst_key) =
+            create_docker_repo_sharing_storage(&pool, "mountdst", &storage_dir).await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = basic_auth(&username, &password);
+
+        let digest = push_blob(&state, &src_key, &auth, b"mountable-blob-payload").await;
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/myimage/blobs/uploads/?mount={}&from={}",
+                dst_key, digest, src_key
+            ))
+            .header("Authorization", &auth)
+            .body(Body::empty())
+            .unwrap();
+        let resp = router()
+            .with_state(state.clone())
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "a satisfiable cross-repo mount must return 201, not open an upload session"
+        );
+        assert_eq!(
+            resp.headers().get(LOCATION).unwrap().to_str().unwrap(),
+            format!("/v2/{}/myimage/blobs/{}", dst_key, digest),
+            "mount Location must point at the blob in the TARGET repo"
+        );
+
+        // The blob must now be registered against the target repo too.
+        let rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+        )
+        .bind(dst_id)
+        .bind(&digest)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows, 1, "mount must record an oci_blobs row for the target");
+
+        cleanup_all(&pool, &[src_id, dst_id], user_id, &[storage_dir]).await;
+    }
+
+    /// #3109: a mount that cannot be satisfied must DEGRADE to a normal upload
+    /// session (202), never error — that fallback is what the spec requires and
+    /// is also what stops the mount parameters from becoming a cross-repo
+    /// blob-existence probe.
+    #[tokio::test]
+    async fn handle_start_upload_unsatisfiable_mount_falls_back_to_upload_session() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username, password) = create_pushable_user(&pool).await;
+        let (src_id, src_key, storage_dir) = create_docker_repo(&pool, "mountmisssrc").await;
+        let (dst_id, dst_key) =
+            create_docker_repo_sharing_storage(&pool, "mountmissdst", &storage_dir).await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = basic_auth(&username, &password);
+
+        // A digest that was never pushed anywhere, and a source repo that does
+        // not exist at all. Both must behave identically: a plain upload start.
+        let absent = format!("sha256:{}", sha256_hex(b"never-pushed-anywhere"));
+        for (label, from) in [
+            ("unknown blob in a real repo", src_key.clone()),
+            (
+                "nonexistent source repo",
+                "ph-test-no-such-repo".to_string(),
+            ),
+        ] {
+            let req = Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/{}/myimage/blobs/uploads/?mount={}&from={}",
+                    dst_key, absent, from
+                ))
+                .header("Authorization", &auth)
+                .body(Body::empty())
+                .unwrap();
+            let resp = router()
+                .with_state(state.clone())
+                .oneshot(req)
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::ACCEPTED,
+                "{label}: an unsatisfiable mount must fall back to a 202 upload session"
+            );
+            assert!(
+                resp.headers().contains_key(LOCATION),
+                "{label}: the fallback must still hand back an upload Location"
+            );
+        }
+
+        // Nothing may have been registered against the target repo.
+        let rows: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM oci_blobs WHERE repository_id = $1")
+                .bind(dst_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, 0, "a failed mount must not register any blob");
+
+        cleanup_all(&pool, &[src_id, dst_id], user_id, &[storage_dir]).await;
     }
 
     /// #1776: create a non-local OCI repo (remote/virtual) marked public, with a

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1361,12 +1361,28 @@ fn build_simple_project_response(
             })
             .collect();
 
-        let versions: Vec<String> = artifacts
+        // PEP 691 `versions`: dedupe, then order by PEP 440 instead of
+        // lexicographically, so `1.9` precedes `1.10` (#3106). Anything that
+        // does not parse as PEP 440 has no defined position, so it sorts after
+        // every parseable version (by string, for stability) rather than
+        // interleaving with them.
+        let mut versions: Vec<String> = artifacts
             .iter()
             .filter_map(|a| a.version.clone())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect();
+        versions.sort_by(|a, b| {
+            match (
+                PypiHandler::pep440_sort_key(a),
+                PypiHandler::pep440_sort_key(b),
+            ) {
+                (Some(ka), Some(kb)) => ka.cmp(&kb),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => a.cmp(b),
+            }
+        });
 
         // PEP 708 / Simple API v1.2: advertise v1.2 and, when the project has
         // operator `tracks` declarations, emit them under meta.tracks so
@@ -7961,6 +7977,50 @@ mod tests {
         assert!(
             sdist.get("core-metadata").is_none(),
             "sdist must not advertise core-metadata: {json}"
+        );
+    }
+
+    // Conformance corpus (pypa/packaging ordering vectors): the PEP 691
+    // `versions` array must be ordered by PEP 440, not lexicographically.
+    // The old BTreeSet<String> put `1.10` before `1.9` and `10.0` before `9.0`,
+    // which misleads any consumer treating the last entry as "latest".
+    // RED before the pep440_sort_key ordering, GREEN after. (#3106)
+    #[test]
+    fn test_build_simple_project_response_json_versions_are_pep440_ordered() {
+        let raw = ["1.9", "1.10", "10.0", "9.0", "1.0", "2.0rc1", "2.0"];
+        let artifacts: Vec<SimpleProjectArtifact> = raw
+            .iter()
+            .map(|v| SimpleProjectArtifact {
+                path: format!("pkg-{v}.tar.gz"),
+                version: Some((*v).to_string()),
+                size_bytes: 10,
+                checksum_sha256: "abc".to_string(),
+                metadata: None,
+                upload_time: None,
+            })
+            .collect();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "accept",
+            "application/vnd.pypi.simple.v1+json".parse().unwrap(),
+        );
+        let response =
+            build_simple_project_response(&headers, "repo", "pkg", &artifacts, &[]).unwrap();
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let versions: Vec<&str> = json["versions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            versions,
+            vec!["1.0", "1.9", "1.10", "2.0rc1", "2.0", "9.0", "10.0"],
+            "versions must be PEP 440-ordered, not lexicographic: {json}"
         );
     }
 

--- a/backend/src/formats/pypi.rs
+++ b/backend/src/formats/pypi.rs
@@ -314,14 +314,24 @@ impl PypiHandler {
             out.push_str(&format!(".dev{}", n));
         }
         if let Some(local) = local {
-            let parts: Vec<&str> = local
-                .split(['.', '-', '_'])
-                .filter(|s| !s.is_empty())
-                .collect();
-            if !parts.is_empty() {
-                out.push('+');
-                out.push_str(&parts.join(".").to_ascii_lowercase());
+            // PEP 440 local version: one or more `[a-zA-Z0-9]+` segments joined
+            // by a single `.`/`-`/`_`. A present-but-empty local (`1.0+`), an
+            // empty segment from a leading/trailing/doubled separator
+            // (`1.0+_foo`, `1.0+a..b`), or a non-alphanumeric segment (`1.0++`)
+            // is INVALID — reject it rather than silently mangling it, so the
+            // canonical key can't false-equate two distinct/invalid inputs. (#3111)
+            if local.is_empty() {
+                return None;
             }
+            let parts: Vec<&str> = local.split(['.', '-', '_']).collect();
+            if parts
+                .iter()
+                .any(|s| s.is_empty() || !s.chars().all(|c| c.is_ascii_alphanumeric()))
+            {
+                return None;
+            }
+            out.push('+');
+            out.push_str(&parts.join(".").to_ascii_lowercase());
         }
         Some(out)
     }

--- a/backend/src/formats/pypi.rs
+++ b/backend/src/formats/pypi.rs
@@ -224,116 +224,78 @@ impl PypiHandler {
     /// form. Returns `None` for input that is not recognisably PEP 440; callers
     /// fall back to exact matching in that case.
     pub fn canonical_version(version: &str) -> Option<String> {
-        let v = version.trim().trim_start_matches(['v', 'V']);
-        if v.is_empty() {
-            return None;
-        }
+        let parts = parse_pep440(version)?;
 
-        // Local segment (everything after the first `+`). A PEP 427 wheel
-        // filename escapes `+` and `.` runs in the local part to `_`, so treat
-        // `_` as a local separator alongside `.`/`-`.
-        let (public, local) = match v.split_once('+') {
-            Some((p, l)) => (p, Some(l)),
-            None => (v, None),
-        };
-
-        let lower = public.to_ascii_lowercase();
-
-        // Epoch: `N!`.
-        let (epoch, rest) = match lower.split_once('!') {
-            Some((e, r)) => {
-                if e.is_empty() || !e.chars().all(|c| c.is_ascii_digit()) {
-                    return None;
-                }
-                (e.trim_start_matches('0'), r)
-            }
-            None => ("", lower.as_str()),
-        };
-        let epoch: &str = if epoch.is_empty() { "0" } else { epoch };
-
-        // Greedily take the leading release: `digits(.digits)*`. The remainder
-        // holds the optional pre / post / dev / implicit-post qualifiers.
-        let (release_str, suffix) = split_release(rest)?;
-        let release = canon_release(&release_str);
-
-        // Tokenize the qualifier suffix into alternating digit / alpha runs,
-        // treating `.`/`-`/`_` purely as separators (PEP 440 normalisation).
-        let tokens = tokenize_version(suffix)?;
-
-        let mut pre: Option<(&'static str, u64)> = None;
-        let mut post: Option<u64> = None;
-        let mut dev: Option<u64> = None;
-        let mut i = 0;
-        while i < tokens.len() {
-            let tok = &tokens[i];
-            // A bare number directly after the release is an implicit post
-            // release (`1.0-1`).
-            if tok.chars().all(|c| c.is_ascii_digit())
-                && pre.is_none()
-                && post.is_none()
-                && dev.is_none()
-            {
-                post = Some(tok.parse().ok()?);
-                i += 1;
-                continue;
-            }
-            let label = match tok.as_str() {
-                "a" | "alpha" => Some(("pre", "a")),
-                "b" | "beta" => Some(("pre", "b")),
-                "c" | "rc" | "pre" | "preview" => Some(("pre", "rc")),
-                "post" | "rev" | "r" => Some(("post", "")),
-                "dev" => Some(("dev", "")),
-                _ => None,
-            };
-            let (kind, prelabel) = label?;
-            // Optional trailing number for this qualifier.
-            let n = if i + 1 < tokens.len() && tokens[i + 1].chars().all(|c| c.is_ascii_digit()) {
-                let parsed = tokens[i + 1].parse().ok()?;
-                i += 2;
-                parsed
-            } else {
-                i += 1;
-                0
-            };
-            match kind {
-                "pre" => pre = Some((prelabel, n)),
-                "post" => post = Some(n),
-                "dev" => dev = Some(n),
-                _ => unreachable!(),
-            }
-        }
-
-        let mut out = format!("{}!{}", epoch, release);
-        if let Some((label, n)) = pre {
+        let release = parts
+            .release
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(".");
+        let mut out = format!("{}!{}", parts.epoch, release);
+        if let Some((label, n)) = parts.pre {
             out.push_str(&format!("{}{}", label, n));
         }
-        if let Some(n) = post {
+        if let Some(n) = parts.post {
             out.push_str(&format!(".post{}", n));
         }
-        if let Some(n) = dev {
+        if let Some(n) = parts.dev {
             out.push_str(&format!(".dev{}", n));
         }
-        if let Some(local) = local {
-            // PEP 440 local version: one or more `[a-zA-Z0-9]+` segments joined
-            // by a single `.`/`-`/`_`. A present-but-empty local (`1.0+`), an
-            // empty segment from a leading/trailing/doubled separator
-            // (`1.0+_foo`, `1.0+a..b`), or a non-alphanumeric segment (`1.0++`)
-            // is INVALID — reject it rather than silently mangling it, so the
-            // canonical key can't false-equate two distinct/invalid inputs. (#3111)
-            if local.is_empty() {
-                return None;
-            }
-            let parts: Vec<&str> = local.split(['.', '-', '_']).collect();
-            if parts
-                .iter()
-                .any(|s| s.is_empty() || !s.chars().all(|c| c.is_ascii_alphanumeric()))
-            {
-                return None;
-            }
+        if let Some(local) = parts.local {
             out.push('+');
-            out.push_str(&parts.join(".").to_ascii_lowercase());
+            out.push_str(&local.join("."));
         }
         Some(out)
+    }
+
+    /// Ordering key for a PEP 440 version, for sorting version lists.
+    ///
+    /// `canonical_version` answers "are these the same version?"; this answers
+    /// "which is newer?". Both are built from the same [`parse_pep440`] output,
+    /// so they cannot disagree about how a version decomposes.
+    ///
+    /// Ordering follows PEP 440: epoch, then release compared component-wise
+    /// (trailing zeros stripped, so `1.0 == 1.0.0`), then
+    /// `dev < pre < final < post`, with local versions sorting after the
+    /// public version they qualify. Returns `None` for input that is not
+    /// recognisably PEP 440 — callers decide how to order unparseable values.
+    pub fn pep440_sort_key(version: &str) -> Option<Pep440Key> {
+        let parts = parse_pep440(version)?;
+
+        // Mirrors the sort key in pypa/packaging (`Version._cmpkey`).
+        let pre = match (parts.pre, parts.post, parts.dev) {
+            // A `.devN` with no pre/post sorts before every other spelling of
+            // the same release, including its own pre-releases.
+            (None, None, Some(_)) => Pep440Pre::DevOnly,
+            // A final release sorts after all of its pre-releases.
+            (None, _, _) => Pep440Pre::Final,
+            (Some((label, n)), _, _) => {
+                let rank = match label {
+                    "a" => 0,
+                    "b" => 1,
+                    _ => 2,
+                };
+                Pep440Pre::Pre(rank, n)
+            }
+        };
+
+        Some(Pep440Key {
+            epoch: parts.epoch,
+            release: parts.release,
+            pre,
+            post: parts.post.map_or(Pep440Post::NoPost, Pep440Post::Post),
+            dev: parts.dev.map_or(Pep440Dev::NoDev, Pep440Dev::Dev),
+            local: parts
+                .local
+                .unwrap_or_default()
+                .into_iter()
+                .map(|seg| match seg.parse::<u64>() {
+                    Ok(n) => Pep440LocalSeg::Num(n),
+                    Err(_) => Pep440LocalSeg::Alpha(seg),
+                })
+                .collect(),
+        })
     }
 
     /// Extract metadata from PKG-INFO or METADATA file in sdist
@@ -518,21 +480,200 @@ impl PypiHandler {
     }
 }
 
-/// Canonicalize a numeric PEP 440 release segment: drop leading zeros from
-/// each component and trailing zero components so `1.0` and `1.0.0` agree.
-fn canon_release(release: &str) -> String {
-    let parts: Vec<&str> = release.split('.').collect();
-    let mut nums: Vec<u64> = parts
-        .iter()
+/// Canonicalize a numeric PEP 440 release segment into its components: drop
+/// leading zeros from each component and trailing zero components so `1.0` and
+/// `1.0.0` agree.
+fn release_components(release: &str) -> Vec<u64> {
+    let mut nums: Vec<u64> = release
+        .split('.')
         .map(|p| p.parse::<u64>().unwrap_or(0))
         .collect();
     while nums.len() > 1 && *nums.last().unwrap() == 0 {
         nums.pop();
     }
-    nums.iter()
-        .map(|n| n.to_string())
-        .collect::<Vec<_>>()
-        .join(".")
+    nums
+}
+
+/// The pre-release position of a version, ordered `dev < pre < final`.
+///
+/// Variant order is the sort order — `derive(Ord)` on an enum compares by
+/// declaration order, so these must not be reordered.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440Pre {
+    /// A `.devN` with no pre/post qualifier: sorts before everything.
+    DevOnly,
+    /// `aN` / `bN` / `rcN`, ranked 0/1/2.
+    Pre(u8, u64),
+    /// No pre-release: a final release sorts after its pre-releases.
+    Final,
+}
+
+/// Post-release position: absent sorts before any `.postN`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440Post {
+    NoPost,
+    Post(u64),
+}
+
+/// Dev-release position: a `.devN` sorts before the same version without one.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440Dev {
+    Dev(u64),
+    NoDev,
+}
+
+/// One local-version segment. Alphabetic segments sort before numeric ones,
+/// matching pypa/packaging.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Pep440LocalSeg {
+    Alpha(String),
+    Num(u64),
+}
+
+/// Total ordering key for a PEP 440 version. Field order is the comparison
+/// order, so these must not be reordered. Built by
+/// [`PypiHandler::pep440_sort_key`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Pep440Key {
+    epoch: u64,
+    release: Vec<u64>,
+    pre: Pep440Pre,
+    post: Pep440Post,
+    dev: Pep440Dev,
+    /// Empty when the version has no local part, which sorts first.
+    local: Vec<Pep440LocalSeg>,
+}
+
+/// The decomposed parts of a PEP 440 version.
+///
+/// Single source of truth for how a version string is read. Both
+/// `canonical_version` (the equality key) and `pep440_sort_key` (the ordering
+/// key) are derived from this, so the two can never drift apart.
+struct Pep440Parts {
+    epoch: u64,
+    /// Trailing-zero-stripped release components.
+    release: Vec<u64>,
+    /// Normalised pre-release label (`a`/`b`/`rc`) and its number.
+    pre: Option<(&'static str, u64)>,
+    post: Option<u64>,
+    dev: Option<u64>,
+    /// Validated, lowercased local-version segments.
+    local: Option<Vec<String>>,
+}
+
+/// Parse a PEP 440 version into its components, or `None` if the input is not
+/// recognisably PEP 440.
+fn parse_pep440(version: &str) -> Option<Pep440Parts> {
+    let v = version.trim().trim_start_matches(['v', 'V']);
+    if v.is_empty() {
+        return None;
+    }
+
+    // Local segment (everything after the first `+`). A PEP 427 wheel filename
+    // escapes `+` and `.` runs in the local part to `_`, so treat `_` as a
+    // local separator alongside `.`/`-`.
+    let (public, local) = match v.split_once('+') {
+        Some((p, l)) => (p, Some(l)),
+        None => (v, None),
+    };
+
+    let lower = public.to_ascii_lowercase();
+
+    // Epoch: `N!`.
+    let (epoch_str, rest) = match lower.split_once('!') {
+        Some((e, r)) => {
+            if e.is_empty() || !e.chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
+            (e, r)
+        }
+        None => ("0", lower.as_str()),
+    };
+    let epoch: u64 = epoch_str.parse().ok()?;
+
+    // Greedily take the leading release: `digits(.digits)*`. The remainder
+    // holds the optional pre / post / dev / implicit-post qualifiers.
+    let (release_str, suffix) = split_release(rest)?;
+    let release = release_components(&release_str);
+
+    // Tokenize the qualifier suffix into alternating digit / alpha runs,
+    // treating `.`/`-`/`_` purely as separators (PEP 440 normalisation).
+    let tokens = tokenize_version(suffix)?;
+
+    let mut pre: Option<(&'static str, u64)> = None;
+    let mut post: Option<u64> = None;
+    let mut dev: Option<u64> = None;
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = &tokens[i];
+        // A bare number directly after the release is an implicit post
+        // release (`1.0-1`).
+        if tok.chars().all(|c| c.is_ascii_digit())
+            && pre.is_none()
+            && post.is_none()
+            && dev.is_none()
+        {
+            post = Some(tok.parse().ok()?);
+            i += 1;
+            continue;
+        }
+        let label = match tok.as_str() {
+            "a" | "alpha" => Some(("pre", "a")),
+            "b" | "beta" => Some(("pre", "b")),
+            "c" | "rc" | "pre" | "preview" => Some(("pre", "rc")),
+            "post" | "rev" | "r" => Some(("post", "")),
+            "dev" => Some(("dev", "")),
+            _ => None,
+        };
+        let (kind, prelabel) = label?;
+        // Optional trailing number for this qualifier.
+        let n = if i + 1 < tokens.len() && tokens[i + 1].chars().all(|c| c.is_ascii_digit()) {
+            let parsed = tokens[i + 1].parse().ok()?;
+            i += 2;
+            parsed
+        } else {
+            i += 1;
+            0
+        };
+        match kind {
+            "pre" => pre = Some((prelabel, n)),
+            "post" => post = Some(n),
+            "dev" => dev = Some(n),
+            _ => unreachable!(),
+        }
+    }
+
+    // PEP 440 local version: one or more `[a-zA-Z0-9]+` segments joined by a
+    // single `.`/`-`/`_`. A present-but-empty local (`1.0+`), an empty segment
+    // from a leading/trailing/doubled separator (`1.0+_foo`, `1.0+a..b`), or a
+    // non-alphanumeric segment (`1.0++`) is INVALID — reject it rather than
+    // silently mangling it, so the canonical key can't false-equate two
+    // distinct/invalid inputs. (#3111)
+    let local = match local {
+        None => None,
+        Some(l) => {
+            if l.is_empty() {
+                return None;
+            }
+            let segs: Vec<&str> = l.split(['.', '-', '_']).collect();
+            if segs
+                .iter()
+                .any(|s| s.is_empty() || !s.chars().all(|c| c.is_ascii_alphanumeric()))
+            {
+                return None;
+            }
+            Some(segs.iter().map(|s| s.to_ascii_lowercase()).collect())
+        }
+    };
+
+    Some(Pep440Parts {
+        epoch,
+        release,
+        pre,
+        post,
+        dev,
+        local,
+    })
 }
 
 /// Split the leading `digits(.digits)*` release off a PEP 440 public-version
@@ -1499,5 +1640,102 @@ Project-URL: Documentation, https://docs.example.com
         assert_eq!(PypiHandler::canonical_version(""), None);
         assert_eq!(PypiHandler::canonical_version("not a version"), None);
         assert_eq!(PypiHandler::canonical_version("1.0!@#"), None);
+    }
+
+    // ========================================================================
+    // pep440_sort_key tests (#3106): ordering, as distinct from equality. The
+    // vectors come from the PEP 440 spec's own ordering examples via the
+    // conformance corpus (pypa/packaging).
+    // ========================================================================
+
+    fn key(v: &str) -> Pep440Key {
+        PypiHandler::pep440_sort_key(v).unwrap_or_else(|| panic!("unparseable: {v}"))
+    }
+
+    /// Assert that `versions` is given in strictly ascending PEP 440 order.
+    fn assert_ascending(versions: &[&str]) {
+        for pair in versions.windows(2) {
+            let (lo, hi) = (pair[0], pair[1]);
+            assert!(
+                key(lo) < key(hi),
+                "expected {lo} < {hi}, but sort keys ordered them otherwise"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pep440_sort_key_numeric_release_not_lexicographic() {
+        // The #3106 bug in one line: lexicographically "1.10" < "1.9".
+        assert!(key("1.9") < key("1.10"));
+        assert_ascending(&["1.0", "1.9", "1.10", "1.11", "2.0", "10.0"]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_release_padding_is_equal() {
+        assert_eq!(key("1.0"), key("1.0.0"));
+        assert_eq!(key("1"), key("1.0.0.0"));
+    }
+
+    #[test]
+    fn test_pep440_sort_key_pre_post_dev_ordering() {
+        // PEP 440: dev < alpha < beta < rc < final < post.
+        assert_ascending(&[
+            "1.0.dev1",
+            "1.0a1",
+            "1.0a2",
+            "1.0b1",
+            "1.0rc1",
+            "1.0",
+            "1.0.post1",
+            "1.0.post2",
+        ]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_dev_of_prerelease_sorts_before_it() {
+        // `1.0a1.dev1` is a dev build *of* the alpha, so it precedes it, but
+        // still follows the plain `1.0.dev1` of the release itself.
+        assert_ascending(&["1.0.dev1", "1.0a1.dev1", "1.0a1", "1.0"]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_epoch_dominates_release() {
+        // An epoch bump outranks any release number.
+        assert!(key("1!1.0") > key("999.0"));
+        assert_ascending(&["1.0", "2.0", "1!0.1", "2!0.1"]);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_local_sorts_after_public() {
+        // A local version qualifies — and sorts after — its public version.
+        assert_ascending(&["1.0", "1.0+abc", "1.0+abc.1", "1.0+abc.2"]);
+        // Alphabetic local segments sort before numeric ones.
+        assert!(key("1.0+abc") < key("1.0+1"));
+    }
+
+    #[test]
+    fn test_pep440_sort_key_unparseable_returns_none() {
+        assert_eq!(PypiHandler::pep440_sort_key(""), None);
+        assert_eq!(PypiHandler::pep440_sort_key("not a version"), None);
+        // Invalid locals are rejected by the shared parser (#3111), so they
+        // have no ordering position either.
+        assert_eq!(PypiHandler::pep440_sort_key("1.0+"), None);
+    }
+
+    #[test]
+    fn test_pep440_sort_key_agrees_with_canonical_version_on_equality() {
+        // The two keys are derived from one parse, so versions PEP 440 calls
+        // equal must be equal under BOTH. This is the invariant that stops the
+        // equality key and the ordering key from drifting apart.
+        for (a, b) in [
+            ("1.0", "1.0.0"),
+            ("1.0a1", "1.0-alpha-1"),
+            ("1.0.post1", "1.0-1"),
+            ("v1.0", "1.0"),
+            ("1.0+abc.def", "1.0+abc-def"),
+        ] {
+            assert_eq!(canon(a), canon(b), "canonical_version disagreed on {a}/{b}");
+            assert_eq!(key(a), key(b), "pep440_sort_key disagreed on {a}/{b}");
+        }
     }
 }

--- a/backend/tests/pypi_version_conformance.rs
+++ b/backend/tests/pypi_version_conformance.rs
@@ -102,3 +102,17 @@ fn pep440_invalid_versions_are_rejected() {
         assert_eq!(canon(bad), None, "'{bad}' should be rejected as invalid");
     }
 }
+
+#[test]
+fn pep440_invalid_local_versions_are_rejected() {
+    // #3111: a local version must be `[a-zA-Z0-9]+` segments joined by a single
+    // `.`/`-`/`_`. These were silently mangled before, not rejected.
+    assert_eq!(canon("1.0+"), None, "empty local");
+    assert_eq!(canon("1.0++"), None, "non-alphanumeric local segment");
+    assert_eq!(canon("1.0+_foo"), None, "leading separator in local");
+    assert_eq!(canon("1.0+abc..def"), None, "doubled separator in local");
+    // ...but valid local versions still canonicalize.
+    assert!(canon("1.0+abc").is_some());
+    assert!(canon("1.0+ubuntu.1").is_some());
+    assert!(canon("1.0+abc-def").is_some());
+}


### PR DESCRIPTION
## Summary

Fixes #3111.

`PypiHandler::canonical_version` accepted local-version strings that PEP 440 and
`pypa/packaging` reject, and silently **mangled** them into a garbage-but-`Some` canonical key
rather than rejecting them:

| input | old canonical key | correct |
|---|---|---|
| `1.0+` (empty local) | `1.0` | reject |
| `1.0++` (non-alphanumeric segment) | `1.0` | reject |
| `1.0+_foo` (leading separator) | `1.0+foo` | reject |
| `1.0+abc..def` (doubled separator) | `1.0+abc.def` | reject |

Because this function is the **dedup / equality key**, an invalid input that canonicalizes to the
same key as a distinct valid version can false-equate the two in the dedup and shadowing paths.
`1.0+` collapsing to plain `1.0` is the clearest case: an invalid version silently becomes an
existing valid one.

The fix validates the local segment per PEP 440 — one or more `[a-zA-Z0-9]+` segments joined by a
single `.`, `-`, or `_` — and returns `None` otherwise. Valid local versions are unaffected.

## Stacking

This PR is based on `feat/pypi-oci-conformance-unit-tests` (#3104), not `main`, so it shows only
its own commit. GitHub will retarget it to `main` automatically once #3104 merges. Please merge
#3104 first.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`pep440_invalid_local_versions_are_rejected` in `backend/tests/pypi_version_conformance.rs`
asserts all four invalid forms are rejected and that three valid local versions
(`1.0+abc`, `1.0+ubuntu.1`, `1.0+abc-def`) still canonicalize. RED before this change, GREEN after.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Behavior change is confined to inputs PEP 440 already considers invalid; these previously
produced a misleading canonical key and now produce `None`.

## Provenance

Surfaced by the conformance corpus (artifact-keeper-test#333) via the `pypa/packaging`
version-invalid vectors.
