### PR TITLE
fix(docker): bump bundled trivy to 0.73.0 to unblock container CVE gate

### DIFF
--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -41,14 +41,17 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 # ---------- Stage 2: pull the matching trivy binary ----------
 # buildx selects this image's TARGETPLATFORM variant automatically, so the
 # arm64 build gets the arm64 trivy and the amd64 build gets amd64. Pinned to
-# 0.72.0, the latest release, which is rebuilt against a patched Go toolchain
-# and clears most of the bundled binary's Go-dependency CVEs (#2391; residuals
-# with no fixed trivy release yet are justified per-CVE in /.trivyignore).
+# 0.73.0, the latest release, which scans with ZERO fixable CVEs — verified
+# with `trivy image --ignore-unfixed ghcr.io/aquasecurity/trivy:0.73.0` (0
+# findings, vs 31 on 0.72.0). It drops the sigstore-go / timestamp-authority
+# stack entirely and bumps oras-go 2.6.0->2.6.1, x/text 0.38->0.40,
+# x/net 0.55->0.57, grpc 1.81->1.82.1 and Go 1.26.4->1.26.5, which clears every
+# trivy-related entry in /.trivyignore (those are now inert; see #3121).
 # Nothing couples the backend to a specific trivy version: the 0.71.2 strings
 # in backend/scanner-adapter tests are mock/stub fixtures, and the adapter
 # probes the real version at startup (ProbeVersion). Aqua publishes both
 # linux/amd64 and linux/arm64 for this tag.
-FROM ghcr.io/aquasecurity/trivy:0.72.0 AS trivy
+FROM ghcr.io/aquasecurity/trivy:0.73.0 AS trivy
 
 # ---------- Stage 3: minimal runtime ----------
 # alpine 3.20 reached EOL; 3.24 is the current stable with active security


### PR DESCRIPTION
## Summary

`Security Scan` in `docker-publish.yml` has failed on every `main` push for days. All four `merge-*` manifest jobs `needs:` it, so **no image tags have been published from `main`** in that window. This is the second of the two blockers keeping `main` red (the other is #3120).

The sole finding in `scanner-adapter-trivy.sarif`:

| | |
|---|---|
| CVE | `CVE-2026-54787` |
| Package | `github.com/sigstore/sigstore-go` |
| Installed → Fixed | `v1.1.4` → `1.2.1` |
| Severity | **LOW** (`security-severity: 3.1`, SARIF level `note`) |
| Layer | `usr/local/bin/trivy` — the trivy 0.72.0 CLI vendored into the image |

`backend-trivy.sarif` and `openscap-trivy.sarif` are both empty. The Alpine layer (54 pkgs) and the adapter's own binary are clean.

## Fix

```diff
-FROM ghcr.io/aquasecurity/trivy:0.72.0 AS trivy
+FROM ghcr.io/aquasecurity/trivy:0.73.0 AS trivy
```

An **upgrade, not a `.trivyignore` entry** — a clean tool release exists, so suppression isn't justifiable. 0.73.0 drops the sigstore-go / timestamp-authority stack entirely and bumps oras-go 2.6.0→2.6.1, x/text 0.38→0.40, x/net 0.55→0.57, grpc 1.81→1.82.1, Go 1.26.4→1.26.5.

## Verification

| Check | Result |
|---|---|
| `trivy:0.72.0` image, fixable CVEs | 31 |
| `trivy:0.73.0` image, fixable CVEs | **0** |
| **scanner-adapter image built from this PR**, all severities, `--ignore-unfixed`, scanned with **CI's own scanner (0.69.3)** | **0 findings** |
| Same, scanned with 0.73.0 | **0 findings** |
| Bundled binary version in built image | `Version: 0.73.0` |
| `0.73.0` multi-arch | `linux/amd64` + `linux/arm64` ✅ |
| Other trivy pins elsewhere in tree | none |

Scanning at **all** severities is deliberate, and is the check that actually matters — see below.

## Why the severity in the table is misleading

A **LOW** CVE blocked publication on a gate that declares `severity: 'CRITICAL,HIGH'`. That is not a Trivy quirk: `aquasecurity/trivy-action@ed142fd`, `entrypoint.sh:74-82`, does `unset TRIVY_SEVERITY` whenever `format: sarif` and `limit-severities-for-sarif` is not `true`. All four scan steps hit that branch, so the severity filter is silently discarded and `exit-code: '1'` fires on any fixable CVE at any severity. The failing job log contains the tell verbatim: `Building SARIF report with all severities`.

`.trivyignore` already records a previous encounter with this, misdiagnosed as *"Trivy filters on the vendor severity, not the NVD one"*. The filter was never applied at all.

That defect is filed separately as **#3122** with options; this PR does not change gate semantics. It clears the gate **as it actually behaves today**, which is why the verification above scans at all severities rather than CRITICAL/HIGH.

## Follow-ups (deliberately not in this PR)

- The trivy-0.72.0 entries in `.trivyignore` (`CVE-2026-48978`, `-50151`, `-50162`, `GHSA-vh4v-2xq2-g5cg`, `-56852`, `-46600`, `-49834`, `-49835`) are now inert and should be removed, with the header's version references updated. Note `CVE-2026-39822`, `-42505` and `GHSA-hrxh-6v49-42gf` must **stay** — they also cover the bundled grype binary.
- The CI scanner itself is pinned to trivy 0.69.3, which cannot parse Go 1.26 stdlib version strings (`malformed version: v1.26.4-X:jsonv2`, thousands of lines per run). That causes **missed** stdlib findings, not false ones — worth a separate bump.

Closes #3121

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

<!-- Dependency version bump to clear a CVE gate; correctness is enforced by the
     Security Scan job itself, which is the check that was failing. Verified by
     building the image and scanning it with CI's own scanner (table above). -->

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
