### PR TITLE
fix(nuget): proxy v3 search upstream for remote repos, with credential-stripped off-origin fetch

### DIFF
--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -19,8 +19,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, put};
 use axum::Extension;
 use axum::Router;
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::api::extractors::RequestBaseUrl;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
@@ -180,6 +181,7 @@ fn select_latest_version(versions: &[String], include_prerelease: bool) -> &str 
 struct NugetUpstreamResources {
     registration_base: Option<String>,
     package_base: Option<String>,
+    search_base: Option<String>,
 }
 
 /// Normalise a configured upstream URL to its `index.json` service document.
@@ -228,6 +230,11 @@ fn parse_upstream_resources(index: &serde_json::Value) -> NugetUpstreamResources
         registration_base: pick_resource(resources, "RegistrationsBaseUrl", "RegistrationsBaseUrl")
             .map(|s| s.trim_end_matches('/').to_string()),
         package_base: pick_resource(resources, "PackageBaseAddress/3.0.0", "PackageBaseAddress")
+            .map(|s| s.trim_end_matches('/').to_string()),
+        // Feeds advertise search under bare `SearchQueryService` and versioned
+        // spellings (`/3.0.0-beta`, `/3.0.0-rc`, ...); the exact/prefix pair
+        // covers all of them (#3130).
+        search_base: pick_resource(resources, "SearchQueryService", "SearchQueryService")
             .map(|s| s.trim_end_matches('/').to_string()),
     }
 }
@@ -416,6 +423,124 @@ async fn proxy_v3_registration(
         .unwrap())
 }
 
+/// Build the normalized query string for an upstream V3 search fetch.
+///
+/// `q` is user-controlled free text, so it is percent-encoded — it must not be
+/// able to smuggle extra query parameters or break out of the URL — and
+/// lowercased (NuGet search is case-insensitive) so equivalent queries share
+/// one upstream fetch/cache entry. Defaults are included explicitly so the
+/// same effective query always yields the same string.
+fn build_search_fetch_query(q: &str, skip: i64, take: i64, prerelease: bool) -> String {
+    format!(
+        "q={}&skip={}&take={}&prerelease={}",
+        urlencoding::encode(&q.to_lowercase()),
+        skip,
+        take,
+        prerelease
+    )
+}
+
+/// Build the proxy-cache key for an upstream V3 search response.
+///
+/// Unlike registrations (keyed by package id alone), a search response depends
+/// on **every** query parameter — a shared key would serve the first query's
+/// cached results to every later query. The key therefore hashes the full
+/// normalized parameter set ([`build_search_fetch_query`]); hashing (rather
+/// than sanitizing the raw string into the key) prevents distinct queries from
+/// colliding after filesystem-unsafe characters are squashed.
+fn build_search_cache_key(q: &str, skip: i64, take: i64, prerelease: bool) -> String {
+    let normalized = build_search_fetch_query(q, skip, take, prerelease);
+    let digest = Sha256::digest(normalized.as_bytes());
+    format!("v3/search/{:x}", digest)
+}
+
+/// Proxy an upstream V3 search query for one remote upstream and rewrite the
+/// embedded upstream registration/flat-container URLs back to this proxy
+/// (#3130). Returns the rewritten payload as JSON so callers can either serve
+/// it directly (Remote repos) or merge it with local rows (Virtual repos).
+///
+/// The discovered `SearchQueryService` base goes through
+/// [`guard_upstream_base`] like every other discovered resource: credentialed
+/// fetches stay pinned to the operator-configured upstream origin (#2925).
+#[allow(clippy::too_many_arguments)]
+async fn proxy_v3_search(
+    proxy: &crate::services::proxy_service::ProxyService,
+    fetch_repo_id: uuid::Uuid,
+    fetch_repo_key: &str,
+    upstream_url: &str,
+    query_term: &str,
+    skip: i64,
+    take: i64,
+    prerelease: bool,
+    ak_base: &str,
+    client_repo_key: &str,
+) -> Result<serde_json::Value, Response> {
+    let resources =
+        discover_upstream_resources(proxy, fetch_repo_id, fetch_repo_key, upstream_url).await?;
+    let search_base = guard_upstream_base(
+        resources.search_base.as_ref(),
+        upstream_url,
+        "SearchQueryService",
+    )?;
+    let fetch_url = format!(
+        "{}?{}",
+        search_base,
+        build_search_fetch_query(query_term, skip, take, prerelease)
+    );
+    let cache_path = build_search_cache_key(query_term, skip, take, prerelease);
+    let (content, _content_type) = proxy_helpers::proxy_fetch_capped_with_cache_key(
+        proxy,
+        fetch_repo_id,
+        fetch_repo_key,
+        upstream_url,
+        &fetch_url,
+        &cache_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await?;
+    let body = String::from_utf8_lossy(&content);
+    let rewritten = rewrite_v3_registration(&body, &resources, ak_base, client_repo_key);
+    serde_json::from_str(&rewritten).map_err(|_| {
+        (
+            StatusCode::BAD_GATEWAY,
+            "Upstream NuGet search response was not valid JSON",
+        )
+            .into_response()
+    })
+}
+
+/// Merge upstream search `data` entries into the local result set, deduped
+/// case-insensitively by package id with local entries winning, bounded by
+/// `take`. Returns how many upstream entries were added.
+fn merge_upstream_search_data(
+    data: &mut Vec<serde_json::Value>,
+    upstream: &serde_json::Value,
+    take: usize,
+) -> usize {
+    let mut seen: std::collections::HashSet<String> = data
+        .iter()
+        .filter_map(|e| e.get("id").and_then(|v| v.as_str()))
+        .map(str::to_ascii_lowercase)
+        .collect();
+    let mut added = 0;
+    let Some(entries) = upstream.get("data").and_then(|d| d.as_array()) else {
+        return added;
+    };
+    for entry in entries {
+        if data.len() >= take {
+            break;
+        }
+        let Some(id) = entry.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if seen.insert(id.to_ascii_lowercase()) {
+            data.push(entry.clone());
+            added += 1;
+        }
+    }
+    added
+}
+
 /// Proxy an upstream V3 flat-container document (version list or `.nupkg`).
 /// `sub_path` is the portion after the package-content base, e.g.
 /// `{id}/index.json` or `{id}/{version}/{file}`. Version lists carry no URLs so
@@ -580,7 +705,7 @@ async fn search_packages(
 
     // Federate over virtual members (local/staging) when the repo is virtual;
     // otherwise query the repo itself.
-    let (repo_ids, _members) = effective_local_repo_ids(&state.db, &repo).await?;
+    let (repo_ids, members) = effective_local_repo_ids(&state.db, &repo).await?;
 
     // Pull the latest-by-created_at description per package via a LATERAL
     // join so the search payload carries the package summary instead of a
@@ -632,7 +757,7 @@ async fn search_packages(
     .await
     .map_err(crate::api::handlers::db_err)?;
 
-    let data: Vec<serde_json::Value> = packages
+    let mut data: Vec<serde_json::Value> = packages
         .iter()
         .map(|p| {
             let id = &p.name;
@@ -659,8 +784,102 @@ async fn search_packages(
         })
         .collect();
 
+    let mut total_hits = total_count;
+
+    // Remote repo: proxy the search to the upstream feed (#3130). The service
+    // index advertises SearchQueryService, so answering purely from local
+    // `artifacts` rows returned an empty result for an uncached remote. Any
+    // failure (no advertised SearchQueryService, off-origin base refused by
+    // the #2925 guard, fetch error, non-JSON payload) degrades to the local
+    // result rather than 5xx-ing — a hard error here breaks the client's
+    // package-manager UI entirely.
+    if repo.repo_type == RepositoryType::Remote {
+        if let (Some(ref upstream_url), Some(ref proxy)) =
+            (&repo.upstream_url, &state.proxy_service)
+        {
+            match proxy_v3_search(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &query_term,
+                skip,
+                take,
+                prerelease,
+                base_url.as_str(),
+                &repo_key,
+            )
+            .await
+            {
+                Ok(upstream) => {
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(CONTENT_TYPE, "application/json")
+                        .body(Body::from(serde_json::to_string(&upstream).unwrap()))
+                        .unwrap());
+                }
+                Err(resp) => {
+                    warn!(
+                        repo_key = %repo_key,
+                        status = %resp.status(),
+                        "upstream NuGet search failed; falling back to local results"
+                    );
+                }
+            }
+        }
+    }
+
+    // Virtual repo: merge each remote member's upstream results into the local
+    // ones, deduped case-insensitively by package id with local entries
+    // winning. `totalHits` takes the max of the local and upstream totals —
+    // the true merged total is unknowable without enumerating both corpora,
+    // and max never double-counts a package present on both sides.
+    if repo.repo_type == RepositoryType::Virtual {
+        if let Some(proxy) = &state.proxy_service {
+            for member in &members {
+                if member.repo_type != RepositoryType::Remote {
+                    continue;
+                }
+                let Some(upstream_url) = member.upstream_url.as_deref() else {
+                    continue;
+                };
+                match proxy_v3_search(
+                    proxy,
+                    member.id,
+                    &member.key,
+                    upstream_url,
+                    &query_term,
+                    skip,
+                    take,
+                    prerelease,
+                    base_url.as_str(),
+                    &repo_key,
+                )
+                .await
+                {
+                    Ok(upstream) => {
+                        let upstream_total = upstream
+                            .get("totalHits")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0);
+                        total_hits = total_hits.max(upstream_total);
+                        merge_upstream_search_data(&mut data, &upstream, take as usize);
+                    }
+                    Err(resp) => {
+                        warn!(
+                            repo_key = %repo_key,
+                            member_key = %member.key,
+                            status = %resp.status(),
+                            "upstream NuGet search failed for virtual member; skipping"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     let response = serde_json::json!({
-        "totalHits": total_count,
+        "totalHits": total_hits,
         "data": data
     });
 
@@ -2059,6 +2278,166 @@ mod tests {
     // `read_db_tests::test_advertised_v3_urls_resolve_against_real_router`.
 
     // -----------------------------------------------------------------------
+    // Upstream search proxying (#3130)
+    // -----------------------------------------------------------------------
+
+    /// A minimal upstream service index advertising search under `@type`
+    /// `search_type`, with resources on the same host as the index itself.
+    fn upstream_index_with_search_type(search_type: &str) -> serde_json::Value {
+        serde_json::json!({
+            "version": "3.0.0",
+            "resources": [
+                {
+                    "@id": "https://feed.example.com/v3/registration/",
+                    "@type": "RegistrationsBaseUrl"
+                },
+                {
+                    "@id": "https://feed.example.com/v3-flatcontainer/",
+                    "@type": "PackageBaseAddress/3.0.0"
+                },
+                {
+                    "@id": "https://feed.example.com/query",
+                    "@type": search_type
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_parse_upstream_resources_picks_each_search_query_service_spelling() {
+        // NuGet feeds advertise the search resource under several `@type`
+        // spellings; each must resolve the search base (#3130).
+        for search_type in [
+            "SearchQueryService",
+            "SearchQueryService/3.0.0-beta",
+            "SearchQueryService/3.0.0-rc",
+        ] {
+            let parsed = parse_upstream_resources(&upstream_index_with_search_type(search_type));
+            assert_eq!(
+                parsed.search_base.as_deref(),
+                Some("https://feed.example.com/query"),
+                "@type {search_type} must resolve the search base"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_upstream_resources_no_search_resource() {
+        let index = serde_json::json!({
+            "version": "3.0.0",
+            "resources": [
+                {"@id": "https://feed.example.com/v3/registration/", "@type": "RegistrationsBaseUrl"}
+            ]
+        });
+        assert_eq!(parse_upstream_resources(&index).search_base, None);
+    }
+
+    #[test]
+    fn test_guard_upstream_base_rejects_off_origin_search_base() {
+        // #2925: a hostile upstream service index must not be able to point
+        // the search base at another host and have the proxy send the
+        // configured upstream credentials there.
+        let upstream = "https://feed.example.com/v3/index.json";
+        let off_origin = "https://evil.example.net/query".to_string();
+        let err = guard_upstream_base(Some(&off_origin), upstream, "SearchQueryService")
+            .expect_err("off-origin SearchQueryService must be refused");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+
+        // Same-origin base is accepted.
+        let same_origin = "https://feed.example.com/query".to_string();
+        let ok = guard_upstream_base(Some(&same_origin), upstream, "SearchQueryService")
+            .expect("same-origin SearchQueryService is allowed");
+        assert_eq!(ok, "https://feed.example.com/query");
+    }
+
+    #[test]
+    fn test_rewrite_search_payload_rebinds_registration_urls_to_proxy() {
+        // The upstream search payload embeds upstream registration URLs; they
+        // must be rewritten to AK's own base so the client's follow-up
+        // registration fetches come back through the proxy.
+        let resources = NugetUpstreamResources {
+            registration_base: Some("https://feed.example.com/v3/registration".to_string()),
+            package_base: Some("https://feed.example.com/v3-flatcontainer".to_string()),
+            search_base: Some("https://feed.example.com/query".to_string()),
+        };
+        let body = r#"{"totalHits":1,"data":[{
+            "@id":"https://feed.example.com/v3/registration/newtonsoft.json/index.json",
+            "registration":"https://feed.example.com/v3/registration/newtonsoft.json/index.json",
+            "id":"Newtonsoft.Json",
+            "versions":[{"version":"13.0.1",
+                "@id":"https://feed.example.com/v3/registration/newtonsoft.json/13.0.1.json"}]
+        }]}"#;
+        let out = rewrite_v3_registration(body, &resources, "http://ak.local:8080", "nuget-remote");
+        assert!(
+            out.contains("http://ak.local:8080/nuget/nuget-remote/v3/registration/newtonsoft.json/index.json"),
+            "registration URLs must be rebound to the proxy: {out}"
+        );
+        assert!(
+            !out.contains("https://feed.example.com/v3/registration"),
+            "no upstream registration URL may survive the rewrite: {out}"
+        );
+    }
+
+    #[test]
+    fn test_search_cache_key_encodes_every_parameter() {
+        // Regression test for cross-query cache contamination: the proxy-cache
+        // key must differ whenever any search parameter differs, or every
+        // query would serve the first query's cached results.
+        let base = build_search_cache_key("newtonsoft", 0, 20, false);
+        assert_ne!(base, build_search_cache_key("serilog", 0, 20, false), "q");
+        assert_ne!(
+            base,
+            build_search_cache_key("newtonsoft", 5, 20, false),
+            "skip"
+        );
+        assert_ne!(
+            base,
+            build_search_cache_key("newtonsoft", 0, 50, false),
+            "take"
+        );
+        assert_ne!(
+            base,
+            build_search_cache_key("newtonsoft", 0, 20, true),
+            "prerelease"
+        );
+
+        // Deterministic normalization: equivalent queries share a key.
+        assert_eq!(base, build_search_cache_key("NewtonSoft", 0, 20, false));
+    }
+
+    #[test]
+    fn test_search_fetch_query_encodes_user_controlled_q() {
+        // `q` is attacker/user-controlled free text: it must not be able to
+        // inject extra query parameters or break out of the URL.
+        let query = build_search_fetch_query("a&take=1000#frag", 0, 20, false);
+        assert_eq!(
+            query,
+            "q=a%26take%3D1000%23frag&skip=0&take=20&prerelease=false"
+        );
+    }
+
+    #[test]
+    fn test_merge_upstream_search_data_dedupes_local_wins() {
+        let mut data = vec![serde_json::json!({"id": "Newtonsoft.Json", "version": "1.0.0-local"})];
+        let upstream = serde_json::json!({
+            "totalHits": 3,
+            "data": [
+                {"id": "newtonsoft.json", "version": "13.0.1"},
+                {"id": "Serilog", "version": "3.1.1"},
+                {"id": "Dapper", "version": "2.1.0"}
+            ]
+        });
+        let added = merge_upstream_search_data(&mut data, &upstream, 2);
+        assert_eq!(added, 1, "bounded by take and deduped case-insensitively");
+        assert_eq!(data.len(), 2);
+        assert_eq!(
+            data[0]["version"], "1.0.0-local",
+            "the local entry wins over the upstream duplicate"
+        );
+        assert_eq!(data[1]["id"], "Serilog");
+    }
+
+    // -----------------------------------------------------------------------
     // extract_xml_tag
     // -----------------------------------------------------------------------
 
@@ -3373,6 +3752,7 @@ mod read_db_tests {
                 "https://api.nuget.org/v3/registration5-gz-semver2".to_string(),
             ),
             package_base: Some("https://api.nuget.org/v3-flatcontainer".to_string()),
+            search_base: None,
         };
         let upstream_doc = r#"{
             "@id":"https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/index.json",

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -312,12 +312,21 @@ fn rewrite_v3_registration(
 ///
 /// Comparison is host + effective port (`port_or_known_default`, so an
 /// `https`→`http` downgrade to the same host is also rejected because 443 ≠ 80)
-/// and case-insensitive on the host. The real nuget.org feed, GitHub Packages,
-/// Azure DevOps Artifacts and other private feeds all serve their registration
-/// and flat-container resources from the same host as their `index.json`, so
-/// this does not affect legitimate proxying; an upstream that legitimately
-/// fans resources out to a different host is refused by design (host-match on
-/// the upstream origin is the conservative default for a credentialed proxy).
+/// and case-insensitive on the host.
+///
+/// How real feeds relate to this check is SPLIT by resource type (#3130):
+///
+/// * **Registration / flat-container**: nuget.org, GitHub Packages, Azure
+///   DevOps Artifacts and other private feeds serve these from the same host
+///   as their `index.json`, so origin-pinning them ([`guard_upstream_base`])
+///   does not affect legitimate proxying.
+/// * **Search**: nuget.org itself advertises `SearchQueryService` on sibling
+///   hosts — `azuresearch-usnc.nuget.org` / `azuresearch-ussc.nuget.org` —
+///   while its `index.json` lives on `api.nuget.org`. An off-origin search
+///   base is therefore NOT refused; instead [`guard_search_base`] reports the
+///   mismatch and the caller fetches it **without** the repo's configured
+///   upstream credentials, preserving the #2925 invariant (credentials only
+///   ever go to the operator-configured origin) without breaking search.
 fn same_upstream_origin(upstream_url: &str, resource_url: &str) -> bool {
     match (
         reqwest::Url::parse(upstream_url),
@@ -351,6 +360,24 @@ fn guard_upstream_base(
     upstream_url: &str,
     what: &str,
 ) -> Result<String, Response> {
+    let base = require_http_base(base, what)?;
+    if !same_upstream_origin(upstream_url, &base) {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!(
+                "Upstream {what} points off the configured upstream host; \
+                 refusing to send upstream credentials off-host"
+            ),
+        )
+            .into_response());
+    }
+    Ok(base)
+}
+
+/// Presence + scheme validation shared by every discovered-base guard: the
+/// service index must advertise the resource and it must be an http(s) URL.
+#[allow(clippy::result_large_err)]
+fn require_http_base(base: Option<&String>, what: &str) -> Result<String, Response> {
     let base = base.ok_or_else(|| {
         (
             StatusCode::BAD_GATEWAY,
@@ -365,17 +392,28 @@ fn guard_upstream_base(
         )
             .into_response());
     }
-    if !same_upstream_origin(upstream_url, base) {
-        return Err((
-            StatusCode::BAD_GATEWAY,
-            format!(
-                "Upstream {what} points off the configured upstream host; \
-                 refusing to send upstream credentials off-host"
-            ),
-        )
-            .into_response());
-    }
     Ok(base.clone())
+}
+
+/// Resolve the discovered `SearchQueryService` base (#3130).
+///
+/// Unlike registration / flat-container ([`guard_upstream_base`]) an
+/// off-origin search base is NOT refused: real feeds legitimately advertise
+/// search on a sibling host (nuget.org's `index.json` on `api.nuget.org`
+/// names `azuresearch-*.nuget.org`). The #2925 invariant — never send the
+/// repo's configured upstream credentials to a host the operator did not
+/// configure — is preserved by the caller instead: the returned `bool`
+/// reports whether the base shares the configured upstream's origin, and an
+/// off-origin base is fetched anonymously (no credentials loaded at all).
+/// A missing or non-http(s) base is still refused.
+#[allow(clippy::result_large_err)]
+fn guard_search_base(
+    base: Option<&String>,
+    upstream_url: &str,
+) -> Result<(String, bool), Response> {
+    let base = require_http_base(base, "SearchQueryService")?;
+    let same_origin = same_upstream_origin(upstream_url, &base);
+    Ok((base, same_origin))
 }
 
 /// Proxy + rewrite an upstream V3 registration index for one remote upstream.
@@ -460,8 +498,12 @@ fn build_search_cache_key(q: &str, skip: i64, take: i64, prerelease: bool) -> St
 /// it directly (Remote repos) or merge it with local rows (Virtual repos).
 ///
 /// The discovered `SearchQueryService` base goes through
-/// [`guard_upstream_base`] like every other discovered resource: credentialed
-/// fetches stay pinned to the operator-configured upstream origin (#2925).
+/// [`guard_search_base`]: a same-origin base is fetched with the repo's
+/// configured upstream credentials through the proxy cache exactly like
+/// registration documents; an off-origin base (nuget.org's `azuresearch-*`)
+/// is fetched WITHOUT credentials and WITHOUT the cache, preserving the #2925
+/// invariant that configured upstream credentials only ever go to the
+/// operator-configured origin.
 #[allow(clippy::too_many_arguments)]
 async fn proxy_v3_search(
     proxy: &crate::services::proxy_service::ProxyService,
@@ -477,27 +519,41 @@ async fn proxy_v3_search(
 ) -> Result<serde_json::Value, Response> {
     let resources =
         discover_upstream_resources(proxy, fetch_repo_id, fetch_repo_key, upstream_url).await?;
-    let search_base = guard_upstream_base(
-        resources.search_base.as_ref(),
-        upstream_url,
-        "SearchQueryService",
-    )?;
+    let (search_base, same_origin) =
+        guard_search_base(resources.search_base.as_ref(), upstream_url)?;
     let fetch_url = format!(
         "{}?{}",
         search_base,
         build_search_fetch_query(query_term, skip, take, prerelease)
     );
-    let cache_path = build_search_cache_key(query_term, skip, take, prerelease);
-    let (content, _content_type) = proxy_helpers::proxy_fetch_capped_with_cache_key(
-        proxy,
-        fetch_repo_id,
-        fetch_repo_key,
-        upstream_url,
-        &fetch_url,
-        &cache_path,
-        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-    )
-    .await?;
+    let (content, _content_type) = if same_origin {
+        let cache_path = build_search_cache_key(query_term, skip, take, prerelease);
+        proxy_helpers::proxy_fetch_capped_with_cache_key(
+            proxy,
+            fetch_repo_id,
+            fetch_repo_key,
+            upstream_url,
+            &fetch_url,
+            &cache_path,
+            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await?
+    } else {
+        // Off-origin advertised search host: fetch anonymously and uncached.
+        // Every cached-entry code path (single-flight refill, stale
+        // revalidation) attaches the repo's configured credentials, so the
+        // uncached anonymous fetch is the narrowest surface that provably
+        // cannot carry them (#2925). The SSRF connect-time DNS guard and the
+        // byte ceiling still apply.
+        proxy_helpers::proxy_fetch_capped_anonymous(
+            proxy,
+            fetch_repo_id,
+            fetch_repo_key,
+            &fetch_url,
+            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await?
+    };
     let body = String::from_utf8_lossy(&content);
     let rewritten = rewrite_v3_registration(&body, &resources, ak_base, client_repo_key);
     serde_json::from_str(&rewritten).map_err(|_| {
@@ -789,10 +845,10 @@ async fn search_packages(
     // Remote repo: proxy the search to the upstream feed (#3130). The service
     // index advertises SearchQueryService, so answering purely from local
     // `artifacts` rows returned an empty result for an uncached remote. Any
-    // failure (no advertised SearchQueryService, off-origin base refused by
-    // the #2925 guard, fetch error, non-JSON payload) degrades to the local
-    // result rather than 5xx-ing — a hard error here breaks the client's
-    // package-manager UI entirely.
+    // failure (no advertised SearchQueryService, a non-http(s) base, fetch
+    // error, non-JSON payload) degrades to the local result rather than
+    // 5xx-ing — a hard error here breaks the client's package-manager UI
+    // entirely.
     if repo.repo_type == RepositoryType::Remote {
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
@@ -2333,21 +2389,60 @@ mod tests {
     }
 
     #[test]
-    fn test_guard_upstream_base_rejects_off_origin_search_base() {
-        // #2925: a hostile upstream service index must not be able to point
-        // the search base at another host and have the proxy send the
-        // configured upstream credentials there.
+    fn test_guard_search_base_same_origin_is_credentialed() {
+        // A same-origin search base fetches exactly as before: with the
+        // repo's configured upstream credentials (`same_origin == true`).
         let upstream = "https://feed.example.com/v3/index.json";
-        let off_origin = "https://evil.example.net/query".to_string();
-        let err = guard_upstream_base(Some(&off_origin), upstream, "SearchQueryService")
-            .expect_err("off-origin SearchQueryService must be refused");
-        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
-
-        // Same-origin base is accepted.
-        let same_origin = "https://feed.example.com/query".to_string();
-        let ok = guard_upstream_base(Some(&same_origin), upstream, "SearchQueryService")
+        let same_origin = Some("https://feed.example.com/query".to_string());
+        let (base, credentialed) = guard_search_base(same_origin.as_ref(), upstream)
             .expect("same-origin SearchQueryService is allowed");
-        assert_eq!(ok, "https://feed.example.com/query");
+        assert_eq!(base, "https://feed.example.com/query");
+        assert!(credentialed, "same-origin search base fetches credentialed");
+    }
+
+    #[test]
+    fn test_guard_search_base_off_origin_allowed_but_anonymous() {
+        // nuget.org advertises SearchQueryService on azuresearch-*.nuget.org
+        // while index.json lives on api.nuget.org: an off-origin search base
+        // is ALLOWED, but flagged for an anonymous (credential-free) fetch —
+        // the #2925 invariant is enforced by stripping credentials, not by
+        // refusing the fetch.
+        let upstream = "https://api.nuget.org/v3/index.json";
+        let off_origin = Some("https://azuresearch-usnc.nuget.org/query".to_string());
+        let (base, credentialed) = guard_search_base(off_origin.as_ref(), upstream)
+            .expect("off-origin SearchQueryService is allowed (anonymous)");
+        assert_eq!(base, "https://azuresearch-usnc.nuget.org/query");
+        assert!(
+            !credentialed,
+            "off-origin search base must never fetch with the repo's configured credentials"
+        );
+    }
+
+    #[test]
+    fn test_guard_search_base_rejects_non_http_and_missing() {
+        let upstream = "https://feed.example.com/v3/index.json";
+        // A non-http(s) base is still refused.
+        let ftp = Some("ftp://feed.example.com/query".to_string());
+        let err = guard_search_base(ftp.as_ref(), upstream)
+            .expect_err("non-http(s) SearchQueryService must be refused");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        // A feed that advertises no search resource is refused (the caller
+        // degrades to the local result).
+        let err = guard_search_base(None, upstream)
+            .expect_err("absent SearchQueryService must be refused");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_guard_upstream_base_registration_still_rejects_off_origin() {
+        // #2925 regression pin: the search-only anonymous allowance must NOT
+        // leak into registration / flat-container resolution — those remain
+        // origin-pinned and refuse an off-origin base outright.
+        let upstream = "https://feed.example.com/v3/index.json";
+        let off_origin = Some("https://evil.example.net/reg".to_string());
+        let err = guard_upstream_base(off_origin.as_ref(), upstream, "RegistrationsBaseUrl")
+            .expect_err("off-origin RegistrationsBaseUrl must be refused");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
     }
 
     #[test]
@@ -3822,17 +3917,21 @@ mod read_db_tests {
     }
 
     // Mount an upstream V3 service index at `/v3/index.json` advertising the
-    // registration/flat bases under `/reg/` and `/flat/` on the mock server.
-    async fn mount_v3_index(upstream: &wiremock::MockServer) {
+    // registration/flat bases under `/reg/` and `/flat/` on the mock server,
+    // plus (optionally) a `SearchQueryService` at `search_base` — which may be
+    // on a different origin, as nuget.org's azuresearch-* is (#3130).
+    async fn mount_v3_index_with(upstream: &wiremock::MockServer, search_base: Option<&str>) {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, ResponseTemplate};
-        let index = serde_json::json!({
-            "version": "3.0.0",
-            "resources": [
-                {"@id": format!("{}/reg/", upstream.uri()), "@type": "RegistrationsBaseUrl"},
-                {"@id": format!("{}/flat/", upstream.uri()), "@type": "PackageBaseAddress/3.0.0"}
-            ]
-        });
+        let mut resources = vec![
+            serde_json::json!({"@id": format!("{}/reg/", upstream.uri()), "@type": "RegistrationsBaseUrl"}),
+            serde_json::json!({"@id": format!("{}/flat/", upstream.uri()), "@type": "PackageBaseAddress/3.0.0"}),
+        ];
+        if let Some(search) = search_base {
+            resources
+                .push(serde_json::json!({"@id": search, "@type": "SearchQueryService/3.0.0-rc"}));
+        }
+        let index = serde_json::json!({"version": "3.0.0", "resources": resources});
         Mock::given(method("GET"))
             .and(path("/v3/index.json"))
             .respond_with(
@@ -3842,6 +3941,180 @@ mod read_db_tests {
             )
             .mount(upstream)
             .await;
+    }
+
+    async fn mount_v3_index(upstream: &wiremock::MockServer) {
+        mount_v3_index_with(upstream, None).await;
+    }
+
+    /// Mount a `/query` search endpoint returning one upstream-hosted result.
+    async fn mount_search_endpoint(server: &wiremock::MockServer, reg_base: &str) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        let payload = serde_json::json!({
+            "totalHits": 1,
+            "data": [{
+                "id": "Newtonsoft.Json",
+                "version": "13.0.1",
+                "registration": format!("{}/newtonsoft.json/index.json", reg_base)
+            }]
+        });
+        Mock::given(method("GET"))
+            .and(path("/query"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(serde_json::to_string(&payload).unwrap()),
+            )
+            .mount(server)
+            .await;
+    }
+
+    /// Configure bearer upstream credentials + `upstream_url` on the fixture
+    /// repo, run a `q=newtonsoft` search through the real handler, and return
+    /// the parsed response JSON.
+    async fn run_search_against(
+        fx: &tdh::Fixture,
+        index_host: &wiremock::MockServer,
+    ) -> serde_json::Value {
+        let creds = crate::services::upstream_auth::build_credentials_json(
+            &crate::services::upstream_auth::UpstreamAuthType::Bearer {
+                token: "sekret-token".to_string(),
+            },
+        );
+        crate::services::upstream_auth::save_upstream_auth(&fx.pool, fx.repo_id, "bearer", &creds)
+            .await
+            .expect("save upstream auth");
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(format!("{}/v3/index.json", index_host.uri()))
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .unwrap();
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), &storage_path);
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), &storage_path, proxy);
+
+        let resp = super::search_packages(
+            axum::extract::State(state),
+            axum::extract::Path(fx.repo_key.clone()),
+            axum::extract::Query(SearchQuery {
+                q: Some("newtonsoft".to_string()),
+                skip: None,
+                take: None,
+                prerelease: None,
+            }),
+            crate::api::extractors::RequestBaseUrl("https://ak.example".to_string()),
+        )
+        .await
+        .expect("remote search must succeed");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        serde_json::from_slice(&body).expect("search response is JSON")
+    }
+
+    /// Same-origin `SearchQueryService`: the search fetch must carry the
+    /// repo's configured upstream credentials, exactly like every other
+    /// same-origin discovered-resource fetch (#3130).
+    #[tokio::test]
+    async fn test_remote_v3_search_same_origin_fetches_with_credentials() {
+        use wiremock::MockServer;
+        // `save_upstream_auth` encrypts via `encryption_key()`; skip when no
+        // key env is configured (same guard as the upstream_auth DB tests).
+        if std::env::var("JWT_SECRET").is_err() && std::env::var("SSO_ENCRYPTION_KEY").is_err() {
+            return;
+        }
+        let Some(fx) = tdh::Fixture::setup("remote", "nuget").await else {
+            return;
+        };
+        let upstream = MockServer::start().await;
+        let search_base = format!("{}/query", upstream.uri());
+        mount_v3_index_with(&upstream, Some(&search_base)).await;
+        mount_search_endpoint(&upstream, &format!("{}/reg", upstream.uri())).await;
+
+        let json = run_search_against(&fx, &upstream).await;
+
+        let reqs = upstream.received_requests().await.expect("recorded");
+        let auth = reqs
+            .iter()
+            .find(|r| r.url.path() == "/query")
+            .expect("upstream search endpoint must be queried")
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        fx.teardown().await;
+
+        assert_eq!(json["data"][0]["id"], "Newtonsoft.Json");
+        assert_eq!(
+            auth.as_deref(),
+            Some("Bearer sekret-token"),
+            "a same-origin search fetch must carry the configured upstream credentials"
+        );
+    }
+
+    /// Off-origin `SearchQueryService` (the nuget.org azuresearch shape): the
+    /// search is ALLOWED and served, but the actual outbound request to the
+    /// off-origin host must carry NO Authorization header — while the
+    /// same-origin index fetch in the same flow proves the credentials were
+    /// configured and applied where permitted (#3130 / #2925).
+    #[tokio::test]
+    async fn test_remote_v3_search_off_origin_is_served_but_anonymous() {
+        use wiremock::MockServer;
+        if std::env::var("JWT_SECRET").is_err() && std::env::var("SSO_ENCRYPTION_KEY").is_err() {
+            return;
+        }
+        let Some(fx) = tdh::Fixture::setup("remote", "nuget").await else {
+            return;
+        };
+        // Two servers on different ports = different origins.
+        let index_host = MockServer::start().await;
+        let search_host = MockServer::start().await;
+        mount_v3_index_with(&index_host, Some(&format!("{}/query", search_host.uri()))).await;
+        mount_search_endpoint(&search_host, &format!("{}/reg", index_host.uri())).await;
+
+        let json = run_search_against(&fx, &index_host).await;
+
+        let index_reqs = index_host.received_requests().await.expect("recorded");
+        let index_fetch_credentialed = index_reqs
+            .iter()
+            .find(|r| r.url.path() == "/v3/index.json")
+            .expect("service index must be fetched")
+            .headers
+            .get("authorization")
+            .is_some();
+        let search_reqs = search_host.received_requests().await.expect("recorded");
+        let search_req = search_reqs
+            .iter()
+            .find(|r| r.url.path() == "/query")
+            .expect("off-origin search host must be queried")
+            .clone();
+        let search_auth_header = search_req
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        let q_forwarded = search_req
+            .url
+            .query_pairs()
+            .any(|(k, v)| k == "q" && v == "newtonsoft");
+        fx.teardown().await;
+
+        assert!(
+            index_fetch_credentialed,
+            "control: the same-origin index fetch must carry the configured credentials, \
+             proving they exist and are applied where permitted"
+        );
+        assert_eq!(
+            search_auth_header, None,
+            "the outbound off-origin search request must carry NO Authorization header"
+        );
+        assert!(q_forwarded, "client query must be forwarded upstream");
+        assert_eq!(
+            json["data"][0]["id"], "Newtonsoft.Json",
+            "off-origin upstream search results are served to the client"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1352,6 +1352,26 @@ pub async fn proxy_fetch_with_cache_key_and_accept(
     .await
 }
 
+/// Anonymous (credential-free) capped metadata fetch for a URL a service index
+/// advertises on a host other than the configured upstream (#3130 / #2925).
+///
+/// Same SSRF connect-time guard and `max`-byte ceiling as the other capped
+/// helpers, but the repo's configured upstream credentials are never loaded
+/// (see [`ProxyService::fetch_metadata_capped_anonymous`]) and the proxy cache
+/// is not consulted or written.
+pub async fn proxy_fetch_capped_anonymous(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    url: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>), Response> {
+    proxy_service
+        .fetch_metadata_capped_anonymous(url, repo_id, max)
+        .await
+        .map_err(|e| map_proxy_error(repo_key, url, e))
+}
+
 /// Byte-ceiling-bounded sibling of [`proxy_fetch_with_cache_key`] (#1608 Phase
 /// 4b / #2181). See [`proxy_fetch_capped`] for the `max` semantics.
 pub async fn proxy_fetch_capped_with_cache_key(

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1841,16 +1841,23 @@ impl UpstreamClient {
         repo_id: Uuid,
         accept: Option<&str>,
         max: usize,
+        auth_mode: crate::services::upstream_auth::UpstreamAuthMode,
     ) -> Result<UpstreamResponse> {
         let diagnostic_url = redact_url_for_diagnostics(url);
         tracing::info!(
-            "Fetching artifact from upstream: {} (accept={:?})",
+            "Fetching artifact from upstream: {} (accept={:?}, auth_mode={:?})",
             diagnostic_url,
-            accept
+            accept,
+            auth_mode
         );
 
-        let upstream_auth =
-            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
+        // #3130: `Anonymous` short-circuits to `None` before the credential
+        // store is read, so neither the initial request nor the bearer retry
+        // below can attach the repo's configured upstream credentials.
+        let upstream_auth = crate::services::upstream_auth::load_upstream_auth_for_mode(
+            &self.db, repo_id, auth_mode,
+        )
+        .await?;
         let custom_ua = self.get_custom_user_agent(repo_id).await;
 
         let mut request = self.http_client.get(url);
@@ -5087,8 +5094,49 @@ impl ProxyService {
         max: usize,
     ) -> Result<UpstreamResponse> {
         self.upstream_client
-            .fetch_buffered(url, repo_id, accept, max)
+            .fetch_buffered(
+                url,
+                repo_id,
+                accept,
+                max,
+                crate::services::upstream_auth::UpstreamAuthMode::RepoConfigured,
+            )
             .await
+    }
+
+    /// Buffered, byte-capped upstream metadata fetch that NEVER attaches the
+    /// repository's configured upstream credentials (#3130 / #2925).
+    ///
+    /// For URLs a service index legitimately advertises on a host other than
+    /// the configured upstream (nuget.org's `SearchQueryService` lives on
+    /// `azuresearch-*.nuget.org` while its `index.json` is on
+    /// `api.nuget.org`). The request still goes through the shared proxy HTTP
+    /// client — so the connect-time SSRF DNS guard (`is_blocked_resolved_ip`,
+    /// #1832/#2570) and the `max`-byte body ceiling both apply — but auth
+    /// resolution is [`UpstreamAuthMode::Anonymous`], which short-circuits
+    /// before the credential store is read.
+    ///
+    /// Deliberately does NOT touch the proxy cache: every cached-entry code
+    /// path (single-flight refill, stale revalidation via `check_etag_changed`,
+    /// conditional refetch) loads the repo's credentials, so an uncached
+    /// direct fetch is the narrowest surface that provably cannot carry them.
+    pub async fn fetch_metadata_capped_anonymous(
+        &self,
+        url: &str,
+        repo_id: Uuid,
+        max: usize,
+    ) -> Result<(Bytes, Option<String>)> {
+        let resp = self
+            .upstream_client
+            .fetch_buffered(
+                url,
+                repo_id,
+                None,
+                max,
+                crate::services::upstream_auth::UpstreamAuthMode::Anonymous,
+            )
+            .await?;
+        Ok((resp.content, resp.content_type))
     }
 
     /// Streaming variant of [`Self::fetch_from_upstream`] used by the

--- a/backend/src/services/upstream_auth.rs
+++ b/backend/src/services/upstream_auth.rs
@@ -77,6 +77,45 @@ pub enum UpstreamAuthType {
     Bearer { token: String },
 }
 
+/// Whether an upstream fetch may carry the repository's configured upstream
+/// credentials (#2925 / #3130).
+///
+/// `Anonymous` exists for fetching a URL discovered on a host the operator did
+/// NOT configure. A NuGet upstream's service index may legitimately advertise
+/// its `SearchQueryService` on a sibling host (nuget.org's search lives on
+/// `azuresearch-*.nuget.org` while `index.json` is on `api.nuget.org`).
+/// #2925's invariant is "never send the repo's configured upstream credentials
+/// to a host the operator did not configure" — it is a credential-exfiltration
+/// guard, not a general egress ban — so such fetches are allowed, but only
+/// anonymously. SSRF is unaffected: the connect-time DNS guard
+/// (`is_blocked_resolved_ip`, #1832/#2570) applies to every request through
+/// the shared client regardless of auth mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpstreamAuthMode {
+    /// Load and apply the repository's configured upstream credentials
+    /// (the default for every fetch against the configured upstream origin).
+    #[default]
+    RepoConfigured,
+    /// Never attach the repository's configured upstream credentials.
+    Anonymous,
+}
+
+/// Mode-aware sibling of [`load_upstream_auth`]: the single choke point where
+/// credentials enter an upstream request. [`UpstreamAuthMode::Anonymous`]
+/// short-circuits to `Ok(None)` BEFORE the credential store is read, so an
+/// anonymous fetch cannot pick up credentials on any code path — there is
+/// nothing loaded for a later `apply_upstream_auth` or bearer retry to attach.
+pub async fn load_upstream_auth_for_mode(
+    db: &PgPool,
+    repo_id: Uuid,
+    mode: UpstreamAuthMode,
+) -> Result<Option<UpstreamAuthType>> {
+    match mode {
+        UpstreamAuthMode::Anonymous => Ok(None),
+        UpstreamAuthMode::RepoConfigured => load_upstream_auth(db, repo_id).await,
+    }
+}
+
 /// Load upstream auth credentials for a repository.
 /// Returns None if no auth is configured.
 pub async fn load_upstream_auth(db: &PgPool, repo_id: Uuid) -> Result<Option<UpstreamAuthType>> {
@@ -581,6 +620,53 @@ mod tests {
         let hex = encrypt_credentials_hex(r#"{"token":"secret"}"#, "correct-key");
         let result = decrypt_credentials_hex(&hex, "wrong-key");
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // load_upstream_auth_for_mode (#3130 anonymous off-origin fetches)
+    // -----------------------------------------------------------------------
+
+    /// A pool whose every acquire fails: any code path that touches the
+    /// credential store through it errors instead of returning data.
+    fn unreachable_pool() -> PgPool {
+        use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+        PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(std::time::Duration::from_secs(1))
+            .connect_lazy_with(
+                PgConnectOptions::new()
+                    .host("127.0.0.1")
+                    .port(1)
+                    .username("invalid")
+                    .password("invalid")
+                    .database("invalid"),
+            )
+    }
+
+    /// Anonymous mode must resolve to "no credentials" WITHOUT consulting the
+    /// credential store at all: against a pool where any DB access errors, it
+    /// still returns `Ok(None)` while `RepoConfigured` surfaces the DB error.
+    /// This pins the stripping as structural (short-circuit before the load),
+    /// not incidental.
+    #[tokio::test]
+    async fn test_load_upstream_auth_for_mode_anonymous_never_reads_credential_store() {
+        let pool = unreachable_pool();
+        let repo_id = Uuid::new_v4();
+        // Ensure the negative cache cannot mask a would-be DB read.
+        invalidate_upstream_auth_cache(repo_id);
+
+        let anon = load_upstream_auth_for_mode(&pool, repo_id, UpstreamAuthMode::Anonymous)
+            .await
+            .expect("anonymous mode must not touch the DB");
+        assert_eq!(anon, None, "anonymous mode must never yield credentials");
+
+        let configured =
+            load_upstream_auth_for_mode(&pool, repo_id, UpstreamAuthMode::RepoConfigured).await;
+        assert!(
+            configured.is_err(),
+            "RepoConfigured against an unreachable pool must error, proving the \
+             anonymous Ok(None) above short-circuited before any credential read"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #3131

A NuGet **remote** repository advertised `SearchQueryService` in its service index but answered
search purely from the local `artifacts` table, so a proxy repo with nothing cached returned
`{"totalHits":0,"data":[]}` for every query. Clients showed "No packages found" with no error to
explain it, while `dotnet restore` against the same repo worked, because registration and
flat-container already proxy upstream and search never got the same treatment.

Surfaced by an external report in discussion #3130 and reproduced live against
`https://api.nuget.org/v3/index.json`.

**What changed.** `NugetUpstreamResources` now parses `SearchQueryService` (all three `@type`
spellings). A new `proxy_v3_search` mirrors `proxy_v3_registration`: discover the resource, fetch
it, and rewrite embedded upstream URLs back to the proxy via the existing
`rewrite_v3_registration` helper so the client's follow-up requests stay on us. Any failure — no
advertised search, guard refusal, transport error, non-JSON — logs at `warn` and falls back to the
local result. A 5xx would break the client's package manager outright, which is worse than the bug.
Virtual repos merge remote members' results with local ones, deduped case-insensitively with local
winning. Local and Staging repos are untouched.

## The off-origin problem, and why credentials are stripped

`api.nuget.org` serves its search from a **different host** than the rest of its API:

```
RegistrationsBaseUrl      https://api.nuget.org/...
PackageBaseAddress/3.0.0  https://api.nuget.org/...
SearchQueryService        https://azuresearch-usnc.nuget.org/query
SearchQueryService        https://azuresearch-ussc.nuget.org/query
```

So `guard_upstream_base`, the #2925 credential-exfiltration origin pin, rejects nuget.org's own
search resource. Reusing that pin unchanged makes the fix a no-op for the single most common
upstream.

#2925's actual invariant is *"never send the repo's configured upstream credentials to a host the
operator did not configure."* It is a credential guard, not an egress ban. So instead of trusting a
host relationship, this removes the thing that needs protecting: an off-origin search base is
allowed, but fetched with **no upstream credentials**. Same-origin search keeps them. Registration
and flat-container remain hard origin-pinned and are not touched.

A registrable-domain allowance was considered and rejected: a compromised upstream index could name
any subdomain and would still receive credentials.

The strip is structural, not a flag check. Tracing the call chain turned up **three** places
credentials attach — `fetch_buffered` on cache miss, its bearer-401 retry, and the stale-revalidation
path (`revalidate_stale` → `check_etag_changed`), which independently loads repo auth.
`UpstreamAuthMode::Anonymous` short-circuits `load_upstream_auth_for_mode` *before any credential
store read*, so there is nothing for any of them to attach.

Off-origin search deliberately **bypasses the proxy cache**. Making the stale-revalidation
machinery mode-aware would have touched ~8 functions in a 14k-line security-hot file, and a missed
edge would silently re-attach credentials. Uncached is the narrowest surface that provably cannot
carry them. Trade-off: off-origin search results are not cached, so each search reaches upstream.
Same-origin search keeps the full cached path with a hashed per-parameter cache key.

That cache key is worth calling out: registration can use a static key because its response depends
only on the package id, but **search depends on every query parameter**. One key for all searches
would serve query A's payload for query B. The key is `sha256(q&skip&take&prerelease)`, hashed
rather than sanitized because `sanitize_cache_segment` squashes `%` and `&` to `_` and would collide
`q=a%26b` with `q=a_26b`.

## Live verification

Built and deployed to an isolated stack, remote repo pointed at nuget.org:

| query | before | after |
|---|---|---|
| `newtonsoft` | `totalHits: 0` | **1037**, `Newtonsoft.Json` first |
| `json` | `totalHits: 0` | **10964** |
| `serilog` | `totalHits: 0` | **2262** |

Also confirmed: result `registration`/`@id`/version URLs are rewritten back to the proxy with no
`api.nuget.org` or `azuresearch-*` left in the payload; a nonsense query returns 0; `serilog` →
nonsense → `serilog` returns correct distinct results each time; `skip`/`take` are honoured; and
the registration path still returns a byte-identical 367,542-byte response.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Unit tests cover the three `SearchQueryService` spellings, same-origin fetches carrying
`Authorization` and off-origin fetches carrying none (asserted on the actual outbound request via
wiremock across two origins), `Anonymous` never reading the credential store (proved against a pool
where every DB access errors), non-http(s) bases refused, the #2925 registration pin still rejecting
off-origin, URL rewriting, per-parameter cache-key distinctness, and virtual-repo merge semantics.

A deployment-level gate lands separately in artifact-keeper-test (`nuget-remote-search` tier).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — DTF tier in artifact-keeper-test
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --all -- --check` clean, `cargo clippy -p artifact-keeper-backend --all-targets -- -D warnings`
clean, `cargo nextest run --workspace --lib` **14,697/14,697 passed**, jscpd adds zero clone pairs
(net duplication on the changed files went down). No new `sqlx::query!` macros, so no
`cargo sqlx prepare` needed.

Two `storage_gc_service` tests were excluded from the full run; they fail identically on unmodified
`main` because the shared test DB holds rows referencing an unregistered `s3` backend. Pre-existing,
tracked separately.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No new routes or schema types; `/v3/search` already existed and now answers correctly for remote repos.

## Follow-ups

* The DTF tier's mock serves search same-origin, so it would not have caught the azuresearch case.
  It needs a second mock host and an off-origin probe.
* A short-TTL cache for off-origin search that is structurally incapable of holding credentials,
  to recover the caching given up above.
* `same_upstream_origin`'s doc comment is corrected here to state the registration-vs-search split
  and cite azuresearch as the counterexample.
