### PR TITLE
fix(tests): poll for detached SAML audit writes and clean up before asserting

### DIFF
--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 
 use artifact_keeper_backend::api::{AppState, SharedState};
 use artifact_keeper_backend::config::Config;
+use artifact_keeper_backend::services::audit_service::{AuditLogEntryWithActor, AuditService};
 
 /// `AuthConfigService` encrypts the stored OIDC client secret with a key read
 /// from `SSO_ENCRYPTION_KEY`/`JWT_SECRET` in the *process* environment (not the
@@ -80,6 +81,43 @@ pub fn build_state(pool: PgPool) -> SharedState {
 /// pre-auth public endpoints).
 pub fn sso_app(state: SharedState) -> axum::Router {
     artifact_keeper_backend::api::handlers::sso::router().with_state(state)
+}
+
+/// Poll an audit query until some returned row satisfies `pred`, or a bounded
+/// ~2s budget is exhausted. Returns whether a match was observed.
+///
+/// Load-bearing since #2905: `audit_fire_and_forget` SPAWNS the audit INSERT
+/// rather than awaiting it, so the SSO callback handlers (OIDC callback, SAML
+/// ACS) return to the client *before* their LOGIN / LOGIN_FAILED row is
+/// durable. Reading the trail synchronously right after the callback therefore
+/// races the detached write and fails intermittently-to-always depending on
+/// scheduling.
+///
+/// This mirrors `audit_count_eventually` in
+/// `backend/src/api/handlers/test_db_helpers.rs`, which #2905 added to fix the
+/// same race for the in-crate assertions. That module lives in `src/` and so is
+/// unreachable from these separate integration-test binaries, which is exactly
+/// how these call sites were missed (#3120 fixed OIDC, #3128 SAML).
+pub async fn audit_row_eventually<F>(
+    audit: &AuditService,
+    user_id: Option<Uuid>,
+    action: &str,
+    pred: F,
+) -> bool
+where
+    F: Fn(&AuditLogEntryWithActor) -> bool,
+{
+    for _ in 0..100 {
+        let (rows, _) = audit
+            .query(user_id, Some(action), None, None, None, None, None, 0, 200)
+            .await
+            .expect("audit query");
+        if rows.iter().any(&pred) {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    false
 }
 
 /// Discover a non-loopback local IP for binding the mock IdP.

--- a/backend/tests/sso_oidc_login_callback_e2e_tests.rs
+++ b/backend/tests/sso_oidc_login_callback_e2e_tests.rs
@@ -71,14 +71,14 @@ use wiremock::matchers::{method, path as wm_path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use artifact_keeper_backend::api::SharedState;
-use artifact_keeper_backend::services::audit_service::{AuditLogEntryWithActor, AuditService};
+use artifact_keeper_backend::services::audit_service::AuditService;
 use artifact_keeper_backend::services::auth_config_service::{
     AuthConfigService, CreateOidcConfigRequest,
 };
 
 use common::sso_support::{
-    allow_private_sso_ip, build_state, ensure_sso_encryption_key, non_loopback_bind_ip, sso_app,
-    try_pool,
+    allow_private_sso_ip, audit_row_eventually, build_state, ensure_sso_encryption_key,
+    non_loopback_bind_ip, sso_app, try_pool,
 };
 
 // ===========================================================================
@@ -313,42 +313,6 @@ async fn delete_user_by_sub(pool: &PgPool, external_id: &str) {
         .bind(external_id)
         .execute(pool)
         .await;
-}
-
-/// Poll an audit query until some returned row satisfies `pred`, or a bounded
-/// ~2s budget is exhausted. Returns whether a match was observed.
-///
-/// Load-bearing since #2905: `audit_fire_and_forget` SPAWNS the audit INSERT
-/// rather than awaiting it, so the OIDC callback handler returns to the client
-/// *before* its LOGIN / LOGIN_FAILED row is durable. Reading the trail
-/// synchronously right after the callback therefore races the detached write
-/// and fails intermittently-to-always depending on scheduling.
-///
-/// This mirrors `audit_count_eventually` in
-/// `backend/src/api/handlers/test_db_helpers.rs`, which #2905 added to fix the
-/// same race for the in-crate assertions. That module lives in `src/` and so is
-/// unreachable from this separate integration-test binary, which is exactly how
-/// this call site was missed.
-async fn audit_row_eventually<F>(
-    audit: &AuditService,
-    user_id: Option<Uuid>,
-    action: &str,
-    pred: F,
-) -> bool
-where
-    F: Fn(&AuditLogEntryWithActor) -> bool,
-{
-    for _ in 0..100 {
-        let (rows, _) = audit
-            .query(user_id, Some(action), None, None, None, None, None, 0, 200)
-            .await
-            .expect("audit query");
-        if rows.iter().any(&pred) {
-            return true;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-    }
-    false
 }
 
 /// Look up a provisioned federated user by `external_id`.

--- a/backend/tests/sso_saml_acs_e2e_tests.rs
+++ b/backend/tests/sso_saml_acs_e2e_tests.rs
@@ -69,8 +69,9 @@ use artifact_keeper_backend::services::auth_config_service::{
 };
 
 use common::sso_support::{
-    base64_standard, build_state, ensure_sso_encryption_key, saml_idp_cert_pem, sign_saml_document,
-    sign_saml_document_with_key, sso_app, try_pool, SamlResponseSpec,
+    audit_row_eventually, base64_standard, build_state, ensure_sso_encryption_key,
+    saml_idp_cert_pem, sign_saml_document, sign_saml_document_with_key, sso_app, try_pool,
+    SamlResponseSpec,
 };
 
 // ===========================================================================
@@ -797,31 +798,17 @@ async fn test_saml_acs_emits_audit_records() {
     assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
 
     let (user_id, _, _, _) = get_saml_user(&pool, &name_id).await.expect("provisioned");
-    let (login_rows, _) = audit
-        .query(
-            Some(user_id),
-            Some("LOGIN"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            0,
-            50,
-        )
-        .await
-        .expect("audit query LOGIN");
-    assert!(
-        login_rows.iter().any(|r| {
-            r.resource_type == "user"
-                && r.details
-                    .as_ref()
-                    .and_then(|d| d.get("provider"))
-                    .and_then(|p| p.as_str())
-                    == Some("saml")
-        }),
-        "a LOGIN audit row with details.provider=saml must exist for the user"
-    );
+    // Poll: the LOGIN row is written by a detached task (#2905), so it is not
+    // guaranteed to be visible the instant the ACS handler returns.
+    let login_ok = audit_row_eventually(&audit, Some(user_id), "LOGIN", |r| {
+        r.resource_type == "user"
+            && r.details
+                .as_ref()
+                .and_then(|d| d.get("provider"))
+                .and_then(|p| p.as_str())
+                == Some("saml")
+    })
+    .await;
 
     // --- failure → LOGIN_FAILED (unsolicited response, rejected before user sync) ---
     let mut unsolicited = happy_spec(
@@ -837,33 +824,30 @@ async fn test_saml_acs_emits_audit_records() {
     .await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let (fail_rows, _) = audit
-        .query(
-            None,
-            Some("LOGIN_FAILED"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            0,
-            200,
-        )
-        .await
-        .expect("audit query LOGIN_FAILED");
-    assert!(
-        fail_rows.iter().any(|r| {
-            r.details
-                .as_ref()
-                .and_then(|d| d.get("provider"))
-                .and_then(|p| p.as_str())
-                == Some("saml")
-        }),
-        "a LOGIN_FAILED audit row with details.provider=saml must exist"
-    );
+    // Same detached-write race as the LOGIN row above.
+    let fail_ok = audit_row_eventually(&audit, None, "LOGIN_FAILED", |r| {
+        r.details
+            .as_ref()
+            .and_then(|d| d.get("provider"))
+            .and_then(|p| p.as_str())
+            == Some("saml")
+    })
+    .await;
 
+    // Clean up BEFORE asserting (#3120 pattern): a panicking assertion would
+    // otherwise skip these deletes and strand the provisioned user + provider
+    // for the rest of the run.
     delete_saml_user(&pool, &name_id).await;
     delete_saml_provider(&pool, provider_id).await;
+
+    assert!(
+        login_ok,
+        "a LOGIN audit row with details.provider=saml must exist for the user"
+    );
+    assert!(
+        fail_ok,
+        "a LOGIN_FAILED audit row with details.provider=saml must exist"
+    );
 }
 
 /// Full flow: `GET /saml/{id}/login` persists a pending SSO session whose id is


### PR DESCRIPTION
## Summary
`test_saml_acs_emits_audit_records` (backend/tests/sso_saml_acs_e2e_tests.rs) fails deterministically on every `main` Backend Integration Tests run (`15 passed; 1 failed`, reproduced across four CI runs including re-runs of identical commits), blocking the v1.7.1 cut.

Root cause is the same detached-audit-write race #3120 fixed for the OIDC suite: since #2905, `audit_fire_and_forget` spawns the audit INSERT instead of awaiting it, so the SAML ACS handler returns to the client before its `LOGIN` / `LOGIN_FAILED` row is durable. The test POSTed to the ACS route, asserted the 307, then read the audit trail synchronously — racing the detached write. #3120 (e250970c) only touched `sso_oidc_login_callback_e2e_tests.rs` and left this SAML sibling behind.

This PR applies #3120's pattern to the SAML suite:
- Replace both one-shot audit queries with a bounded ~2s poll (100 x 20ms) with a clear failure message — no blanket sleep.
- Run the test's cleanup **before** its assertions, so a failing assertion cannot strand the provisioned user/provider and cascade into sibling tests (the #3120 lesson).
- Instead of duplicating the `audit_row_eventually` helper #3120 added, hoist it from the OIDC test file into `common::sso_support`, which both SSO e2e binaries already share, and point both suites at it. No behavior change for the OIDC suite.

Audited the rest of the SAML file for the same unguarded shape: every other assertion reads state written synchronously before the handler responds (`users`, `user_group_members`, consumed SSO sessions) or asserts on the HTTP response itself. The audit trail is the only detached write in this path, so those two audit assertions were the only racy call sites.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The fix *is* the test change: the previously-failing test now passes deterministically. Verified against a local Postgres with `AK_TESTS_REQUIRE_DB=1` (so a silent DB-skip cannot fake a green):
- `cargo test --test sso_saml_acs_e2e_tests test_saml_acs_emits_audit_records -- --ignored --test-threads=1` passes **5/5 consecutive runs**.
- Full `sso_saml_acs_e2e_tests` suite: **16/16 pass**.
- Full `sso_oidc_login_callback_e2e_tests` suite (helper hoist): **13/13 pass**.

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Fixes #3128
