### PR TITLE
fix(security): evaluate scan gates across all scanners, not the newest row

### DIFF
--- a/backend/src/services/policy_service.rs
+++ b/backend/src/services/policy_service.rs
@@ -26,18 +26,20 @@ fn block_unscanned_violated(block_unscanned: bool, scan_state: ScanState) -> boo
 struct PostScanGates {
     /// The newest scan row (any status) is `failed`, so `block_on_fail` may fire.
     block_on_fail_applies: bool,
-    /// A completed scan exists, so the `max_severity` threshold check must run.
+    /// Findings are on record for this artifact, so the `max_severity`
+    /// threshold check must run.
     severity_applies: bool,
 }
+
 /// Decide which post-scan gates apply from the artifact's scan rows.
 ///
 /// The two gates deliberately read DIFFERENT inputs:
 ///
 /// * `block_on_fail` is about the most recent attempt, so it keys on the newest
 ///   row's status.
-/// * `max_severity` is about the findings on record, so it keys on "a completed
-///   scan EXISTS for this artifact" — not on "the newest row happens to be
-///   completed".
+/// * `max_severity` is about the findings on record, so it keys on whether
+///   there is anything on record to grade — not on "the newest row happens to
+///   be completed".
 ///
 /// Both used to read the single newest row of any status, which made the
 /// severity gate silently inert whenever the newest row was not `completed`.
@@ -45,17 +47,32 @@ struct PostScanGates {
 /// `not_applicable` row AFTER a completed one — an asynchronous or external
 /// scanner does this routinely — therefore disabled severity blocking for that
 /// artifact entirely, and a download with critical findings on record was
-/// served with a 200. Keying on existence closes that fail-open.
+/// served with a 200. Keying on what is on record closes that fail-open.
 ///
 /// Note the consequence for a `failed` newest row with `block_on_fail` off:
 /// severity now still evaluates against the findings of the older completed
 /// scan, where it previously skipped the check. That is the intended, strictly
 /// safer direction — a crashed rescan must not clear an artifact's history.
+///
+/// `has_unacknowledged_findings` is the second half of that same argument.
+/// Findings are persisted BEFORE the scan row is flipped to `completed`
+/// (`scanner_service` calls `create_findings` and only then `complete_scan`),
+/// so a scanner that dies in between — or is later reaped from `running` to
+/// `failed` by the stuck-scan janitor — leaves unacknowledged findings on
+/// record with NO completed row anywhere. Keying the gate on `completed`
+/// alone would leave exactly the reported fail-open one layer down: an
+/// unacknowledged critical on record, served 200. Grading whenever there is
+/// something to grade cannot produce a false block, because the threshold
+/// query returns zero when no finding meets the policy's severity.
 /// Pure / unit-testable.
-fn post_scan_gates(latest_status: Option<&str>, has_completed_scan: bool) -> PostScanGates {
+fn post_scan_gates(
+    latest_status: Option<&str>,
+    has_completed_scan: bool,
+    has_unacknowledged_findings: bool,
+) -> PostScanGates {
     PostScanGates {
         block_on_fail_applies: latest_status == Some("failed"),
-        severity_applies: has_completed_scan,
+        severity_applies: has_completed_scan || has_unacknowledged_findings,
     }
 }
 
@@ -152,6 +169,7 @@ impl PolicyService {
         struct ScanGateRow {
             latest_status: Option<String>,
             has_completed_scan: bool,
+            has_unacknowledged_findings: bool,
         }
 
         let gate_row: ScanGateRow = sqlx::query_as(
@@ -167,7 +185,13 @@ impl PolicyService {
                       FROM scan_results
                      WHERE artifact_id = $1
                        AND status = 'completed'
-                ) AS has_completed_scan
+                ) AS has_completed_scan,
+                EXISTS (
+                    SELECT 1
+                      FROM scan_findings
+                     WHERE artifact_id = $1
+                       AND NOT is_acknowledged
+                ) AS has_unacknowledged_findings
             "#,
         )
         .bind(artifact_id)
@@ -178,6 +202,7 @@ impl PolicyService {
         let gates = post_scan_gates(
             gate_row.latest_status.as_deref(),
             gate_row.has_completed_scan,
+            gate_row.has_unacknowledged_findings,
         );
 
         // #1649: classify the artifact's overall scan state from ALL its
@@ -231,6 +256,14 @@ impl PolicyService {
                               WHEN 'high' THEN ARRAY['critical', 'high']
                               WHEN 'medium' THEN ARRAY['critical', 'high', 'medium']
                               WHEN 'low' THEN ARRAY['critical', 'high', 'medium', 'low']
+                              -- No ELSE would yield NULL -> unnest(NULL) -> zero
+                              -- rows -> IN (<empty>) is false -> the gate passes
+                              -- an artifact it was asked to block. A value
+                              -- outside the four is unreachable today
+                              -- (scan_policies_max_severity_check), so this is
+                              -- defence in depth: an unknown threshold grades
+                              -- against every severity rather than none.
+                              ELSE ARRAY['critical', 'high', 'medium', 'low']
                           END)
                       )
                     "#,
@@ -500,7 +533,7 @@ mod tests {
         // the max_severity download gate off entirely, and an artifact with
         // critical findings on record was served with a 200.
         for newest in ["pending", "running", "not_applicable"] {
-            let gates = post_scan_gates(Some(newest), true);
+            let gates = post_scan_gates(Some(newest), true, false);
             assert!(
                 gates.severity_applies,
                 "a newer '{newest}' row must NOT disable severity blocking while a completed scan exists"
@@ -513,33 +546,50 @@ mod tests {
     }
 
     #[test]
-    fn test_severity_gate_requires_a_completed_scan_somewhere() {
-        // Without any completed scan there are no findings on record to grade,
-        // so the severity gate must not fire. `block_unscanned` is the gate that
+    fn test_severity_gate_fires_on_findings_without_any_completed_scan() {
+        // `scanner_service` persists findings BEFORE flipping the row to
+        // `completed`, so a scanner that dies in between (or is reaped from
+        // `running` to `failed` by the stuck-scan janitor) leaves
+        // unacknowledged findings on record with no completed row anywhere.
+        // Keying the gate on `completed` alone reproduces the very fail-open
+        // this module is fixing, one layer down: an unacknowledged critical on
+        // record, served 200.
+        for newest in [None, Some("pending"), Some("running"), Some("failed")] {
+            assert!(
+                post_scan_gates(newest, false, true).severity_applies,
+                "findings on record must be graded even with no completed scan (newest={newest:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_severity_gate_stays_quiet_with_nothing_on_record() {
+        // Nothing completed AND nothing on record -> nothing to grade, so the
+        // severity gate must not fire. `block_unscanned` is the gate that
         // covers this case.
         for newest in [None, Some("pending"), Some("running"), Some("failed")] {
             assert!(
-                !post_scan_gates(newest, false).severity_applies,
-                "no completed scan -> severity gate must not fire (newest={newest:?})"
+                !post_scan_gates(newest, false, false).severity_applies,
+                "no completed scan and no findings -> severity gate must not fire (newest={newest:?})"
             );
         }
     }
 
     #[test]
     fn test_block_on_fail_keys_on_the_newest_row_only() {
-        assert!(post_scan_gates(Some("failed"), false).block_on_fail_applies);
+        assert!(post_scan_gates(Some("failed"), false, false).block_on_fail_applies);
         // A failed rescan on top of an older completed scan still trips
         // block_on_fail, and severity now ALSO evaluates against the completed
         // scan's findings rather than being skipped — strictly safer.
-        let gates = post_scan_gates(Some("failed"), true);
+        let gates = post_scan_gates(Some("failed"), true, false);
         assert!(gates.block_on_fail_applies);
         assert!(
             gates.severity_applies,
             "a crashed rescan must not clear an artifact's finding history"
         );
-        assert!(!post_scan_gates(Some("completed"), true).block_on_fail_applies);
+        assert!(!post_scan_gates(Some("completed"), true, false).block_on_fail_applies);
         assert!(
-            !post_scan_gates(None, false).block_on_fail_applies,
+            !post_scan_gates(None, false, false).block_on_fail_applies,
             "an artifact with no scan rows has nothing to fail"
         );
     }

--- a/backend/src/services/policy_service.rs
+++ b/backend/src/services/policy_service.rs
@@ -20,6 +20,45 @@ fn block_unscanned_violated(block_unscanned: bool, scan_state: ScanState) -> boo
     block_unscanned && scan_state.is_unscanned()
 }
 
+/// Which post-scan gates apply to an artifact, derived from its `scan_results`
+/// rows.
+#[derive(Debug, PartialEq, Eq)]
+struct PostScanGates {
+    /// The newest scan row (any status) is `failed`, so `block_on_fail` may fire.
+    block_on_fail_applies: bool,
+    /// A completed scan exists, so the `max_severity` threshold check must run.
+    severity_applies: bool,
+}
+/// Decide which post-scan gates apply from the artifact's scan rows.
+///
+/// The two gates deliberately read DIFFERENT inputs:
+///
+/// * `block_on_fail` is about the most recent attempt, so it keys on the newest
+///   row's status.
+/// * `max_severity` is about the findings on record, so it keys on "a completed
+///   scan EXISTS for this artifact" — not on "the newest row happens to be
+///   completed".
+///
+/// Both used to read the single newest row of any status, which made the
+/// severity gate silently inert whenever the newest row was not `completed`.
+/// Any scanner that records a non-terminal row (`pending`/`running`) or a
+/// `not_applicable` row AFTER a completed one — an asynchronous or external
+/// scanner does this routinely — therefore disabled severity blocking for that
+/// artifact entirely, and a download with critical findings on record was
+/// served with a 200. Keying on existence closes that fail-open.
+///
+/// Note the consequence for a `failed` newest row with `block_on_fail` off:
+/// severity now still evaluates against the findings of the older completed
+/// scan, where it previously skipped the check. That is the intended, strictly
+/// safer direction — a crashed rescan must not clear an artifact's history.
+/// Pure / unit-testable.
+fn post_scan_gates(latest_status: Option<&str>, has_completed_scan: bool) -> PostScanGates {
+    PostScanGates {
+        block_on_fail_applies: latest_status == Some("failed"),
+        severity_applies: has_completed_scan,
+    }
+}
+
 /// Allowed values for `scan_policies.max_severity`, mirroring the DB CHECK
 /// constraint in `migrations/022_security_scanning.sql`.
 ///
@@ -105,35 +144,41 @@ impl PolicyService {
 
         let mut violations = Vec::new();
 
-        // Check for completed scans on this artifact
+        // Post-scan gate inputs, in one round trip. `latest_status` is the newest
+        // row of ANY status (drives `block_on_fail`); `has_completed_scan` is an
+        // existence check (drives `max_severity`). See [`post_scan_gates`] for
+        // why these two must not share a single "newest row" lookup.
         #[derive(sqlx::FromRow)]
-        struct ScanRow {
-            status: String,
-            #[allow(dead_code)]
-            findings_count: i32,
-            #[allow(dead_code)]
-            critical_count: i32,
-            #[allow(dead_code)]
-            high_count: i32,
-            #[allow(dead_code)]
-            medium_count: i32,
-            #[allow(dead_code)]
-            low_count: i32,
+        struct ScanGateRow {
+            latest_status: Option<String>,
+            has_completed_scan: bool,
         }
 
-        let latest_scan: Option<ScanRow> = sqlx::query_as(
+        let gate_row: ScanGateRow = sqlx::query_as(
             r#"
-            SELECT status, findings_count, critical_count, high_count, medium_count, low_count
-            FROM scan_results
-            WHERE artifact_id = $1
-            ORDER BY created_at DESC
-            LIMIT 1
+            SELECT
+                (SELECT status
+                   FROM scan_results
+                  WHERE artifact_id = $1
+                  ORDER BY created_at DESC
+                  LIMIT 1) AS latest_status,
+                EXISTS (
+                    SELECT 1
+                      FROM scan_results
+                     WHERE artifact_id = $1
+                       AND status = 'completed'
+                ) AS has_completed_scan
             "#,
         )
         .bind(artifact_id)
-        .fetch_optional(&self.db)
+        .fetch_one(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let gates = post_scan_gates(
+            gate_row.latest_status.as_deref(),
+            gate_row.has_completed_scan,
+        );
 
         // #1649: classify the artifact's overall scan state from ALL its
         // scan_results rows (the same precedence the promotion gate uses), not
@@ -162,47 +207,45 @@ impl PolicyService {
                 continue;
             }
 
-            if let Some(ref scan) = latest_scan {
-                // Check: block_on_fail
-                if policy.block_on_fail && scan.status == "failed" {
-                    violations.push(format!("Policy '{}': latest scan failed", policy.name));
-                    continue;
-                }
+            // Check: block_on_fail
+            if policy.block_on_fail && gates.block_on_fail_applies {
+                violations.push(format!("Policy '{}': latest scan failed", policy.name));
+                continue;
+            }
 
-                // Check: max_severity threshold (non-acknowledged findings only)
-                if scan.status == "completed" {
-                    let _threshold = Severity::from_str_loose(&policy.max_severity)
-                        .unwrap_or(Severity::Critical);
+            // Check: max_severity threshold (non-acknowledged findings only)
+            if gates.severity_applies {
+                let _threshold =
+                    Severity::from_str_loose(&policy.max_severity).unwrap_or(Severity::Critical);
 
-                    // Count non-acknowledged findings at or above the threshold
-                    let violating_count: i64 = sqlx::query_scalar(
-                        r#"
-                        SELECT COUNT(*)
-                        FROM scan_findings
-                        WHERE artifact_id = $1
-                          AND NOT is_acknowledged
-                          AND severity IN (
-                              SELECT unnest(CASE $2
-                                  WHEN 'critical' THEN ARRAY['critical']
-                                  WHEN 'high' THEN ARRAY['critical', 'high']
-                                  WHEN 'medium' THEN ARRAY['critical', 'high', 'medium']
-                                  WHEN 'low' THEN ARRAY['critical', 'high', 'medium', 'low']
-                              END)
-                          )
-                        "#,
-                    )
-                    .bind(artifact_id)
-                    .bind(&policy.max_severity)
-                    .fetch_one(&self.db)
-                    .await
-                    .map_err(|e| AppError::Database(e.to_string()))?;
+                // Count non-acknowledged findings at or above the threshold
+                let violating_count: i64 = sqlx::query_scalar(
+                    r#"
+                    SELECT COUNT(*)
+                    FROM scan_findings
+                    WHERE artifact_id = $1
+                      AND NOT is_acknowledged
+                      AND severity IN (
+                          SELECT unnest(CASE $2
+                              WHEN 'critical' THEN ARRAY['critical']
+                              WHEN 'high' THEN ARRAY['critical', 'high']
+                              WHEN 'medium' THEN ARRAY['critical', 'high', 'medium']
+                              WHEN 'low' THEN ARRAY['critical', 'high', 'medium', 'low']
+                          END)
+                      )
+                    "#,
+                )
+                .bind(artifact_id)
+                .bind(&policy.max_severity)
+                .fetch_one(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
 
-                    if violating_count > 0 {
-                        violations.push(format!(
-                            "Policy '{}': {} findings at or above {} severity",
-                            policy.name, violating_count, policy.max_severity
-                        ));
-                    }
+                if violating_count > 0 {
+                    violations.push(format!(
+                        "Policy '{}': {} findings at or above {} severity",
+                        policy.name, violating_count, policy.max_severity
+                    ));
                 }
             }
         }
@@ -442,6 +485,63 @@ mod tests {
                 "gate disabled -> never a violation regardless of scan state"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // post-scan gate inputs (block_on_fail vs max_severity)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_severity_gate_survives_a_newer_non_completed_scan_row() {
+        // Regression: both gates used to read the single newest scan_results row
+        // and the severity check ran only `if that_row.status == "completed"`. A
+        // scanner that recorded a non-terminal row AFTER a completed one — the
+        // normal shape for an asynchronous/external scanner — therefore turned
+        // the max_severity download gate off entirely, and an artifact with
+        // critical findings on record was served with a 200.
+        for newest in ["pending", "running", "not_applicable"] {
+            let gates = post_scan_gates(Some(newest), true);
+            assert!(
+                gates.severity_applies,
+                "a newer '{newest}' row must NOT disable severity blocking while a completed scan exists"
+            );
+            assert!(
+                !gates.block_on_fail_applies,
+                "'{newest}' is not a failure, so block_on_fail must stay quiet"
+            );
+        }
+    }
+
+    #[test]
+    fn test_severity_gate_requires_a_completed_scan_somewhere() {
+        // Without any completed scan there are no findings on record to grade,
+        // so the severity gate must not fire. `block_unscanned` is the gate that
+        // covers this case.
+        for newest in [None, Some("pending"), Some("running"), Some("failed")] {
+            assert!(
+                !post_scan_gates(newest, false).severity_applies,
+                "no completed scan -> severity gate must not fire (newest={newest:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_block_on_fail_keys_on_the_newest_row_only() {
+        assert!(post_scan_gates(Some("failed"), false).block_on_fail_applies);
+        // A failed rescan on top of an older completed scan still trips
+        // block_on_fail, and severity now ALSO evaluates against the completed
+        // scan's findings rather than being skipped — strictly safer.
+        let gates = post_scan_gates(Some("failed"), true);
+        assert!(gates.block_on_fail_applies);
+        assert!(
+            gates.severity_applies,
+            "a crashed rescan must not clear an artifact's finding history"
+        );
+        assert!(!post_scan_gates(Some("completed"), true).block_on_fail_applies);
+        assert!(
+            !post_scan_gates(None, false).block_on_fail_applies,
+            "an artifact with no scan rows has nothing to fail"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/promotion_policy_service.rs
+++ b/backend/src/services/promotion_policy_service.rs
@@ -827,8 +827,21 @@ mod tests {
             "no completed scan must still yield zero rows"
         );
         // MAX, not SUM: per-scanner aggregates cover overlapping finding sets, so
-        // summing would double-count a CVE that two engines both report.
-        assert!(LATEST_SCAN_COUNTS_SQL.contains("MAX(critical_count)"));
+        // summing would double-count a CVE that two engines both report. Pin
+        // every count column -- leaving one un-aggregated would silently narrow
+        // the verdict back to a single scanner for that severity.
+        for col in [
+            "critical_count",
+            "high_count",
+            "medium_count",
+            "low_count",
+            "findings_count",
+        ] {
+            assert!(
+                LATEST_SCAN_COUNTS_SQL.contains(&format!("MAX({col})")),
+                "{col} must be aggregated across scanners"
+            );
+        }
         assert!(!LATEST_SCAN_COUNTS_SQL.contains("SUM("));
 
         // The counts query feeds the same latest-completed-scan contract.
@@ -2229,6 +2242,128 @@ mod tests {
         .fetch_one(pool)
         .await
         .expect("failed to create test artifact")
+    }
+
+    /// Insert one scan row for `artifact`, optionally carrying an
+    /// unacknowledged finding with `cve`. `age_seconds` orders the rows.
+    #[allow(clippy::too_many_arguments)]
+    async fn seed_scan_with_counts(
+        pool: &PgPool,
+        artifact: Uuid,
+        repo: Uuid,
+        scan_type: &str,
+        critical: i32,
+        high: i32,
+        cve: Option<&str>,
+        age_seconds: i64,
+    ) -> Uuid {
+        let scan_id = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO scan_results (
+                artifact_id, repository_id, scan_type, status,
+                findings_count, critical_count, high_count, medium_count, low_count, info_count,
+                started_at, completed_at, created_at
+            )
+            VALUES ($1, $2, $3, 'completed', $4 + $5, $4, $5, 0, 0, 0,
+                    NOW() - make_interval(secs => $6::double precision),
+                    NOW() - make_interval(secs => $6::double precision),
+                    NOW() - make_interval(secs => $6::double precision))
+            RETURNING id
+            "#,
+        )
+        .bind(artifact)
+        .bind(repo)
+        .bind(scan_type)
+        .bind(critical)
+        .bind(high)
+        .bind(age_seconds as f64)
+        .fetch_one(pool)
+        .await
+        .expect("failed to insert scan_result");
+
+        if let Some(cve) = cve {
+            sqlx::query(
+                "INSERT INTO scan_findings \
+                 (scan_result_id, artifact_id, severity, title, cve_id, source, is_acknowledged) \
+                 VALUES ($1, $2, 'critical', 'seeded', $3, 'test', false)",
+            )
+            .bind(scan_id)
+            .bind(artifact)
+            .bind(cve)
+            .execute(pool)
+            .await
+            .expect("failed to insert scan_finding");
+        }
+        scan_id
+    }
+
+    /// Executes the rewritten `LATEST_SCAN_COUNTS_SQL` and `OPEN_CVES_SQL`
+    /// against a real database with TWO scanners.
+    ///
+    /// The sibling test in this module pins the SQL *strings*, which guards
+    /// against a revert but proves nothing about what Postgres actually
+    /// returns — and these are runtime-checked `query_as` calls, so a broken
+    /// query ships and fails at request time. This test is the behavioural
+    /// half: a clean scan that completed AFTER a critical-bearing one from a
+    /// different engine must not hide that engine's findings.
+    #[tokio::test]
+    async fn cve_summary_spans_every_scanner_not_just_the_last_to_finish() {
+        let Some(pool) = sig_test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let svc = PromotionPolicyService::new(pool.clone());
+        let repo = seed_repo(&pool).await;
+
+        let artifact = seed_artifact(&pool, repo).await;
+        // Older engine found a critical + 2 highs...
+        seed_scan_with_counts(
+            &pool,
+            artifact,
+            repo,
+            "grype",
+            1,
+            2,
+            Some("CVE-3138-1111"),
+            3600,
+        )
+        .await;
+        // ...a different engine then finished clean, more recently.
+        seed_scan_with_counts(&pool, artifact, repo, "dependency", 0, 0, None, 60).await;
+
+        let summary = svc
+            .get_cve_summary(artifact)
+            .await
+            .expect("cve summary query failed")
+            .expect("an artifact with completed scans must have a summary");
+
+        assert_eq!(
+            summary.critical_count, 1,
+            "a later clean scan from a second engine must not hide the first engine's critical"
+        );
+        assert_eq!(summary.high_count, 2, "high counts must span scanners too");
+        assert!(
+            summary.open_cves.contains(&"CVE-3138-1111".to_string()),
+            "the older engine's open CVE must still reach the gate, got {:?}",
+            summary.open_cves
+        );
+
+        // "Never scanned" must stay distinguishable from "scanned and clean":
+        // an ungrouped aggregate without `HAVING COUNT(*) > 0` would return one
+        // all-zeros row here and read as a clean scan.
+        let unscanned = seed_artifact(&pool, repo).await;
+        assert!(
+            svc.get_cve_summary(unscanned)
+                .await
+                .expect("cve summary query failed")
+                .is_none(),
+            "an artifact with no completed scan must yield None, not a zeroed summary"
+        );
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo)
+            .execute(&pool)
+            .await;
     }
 
     /// Insert a minimal signing_keys row (no real key material is needed: the

--- a/backend/src/services/promotion_policy_service.rs
+++ b/backend/src/services/promotion_policy_service.rs
@@ -58,13 +58,39 @@ struct ScanRow {
     findings_count: i32,
 }
 
-/// SQL for the latest completed scan's severity counts for an artifact.
+/// SQL for an artifact's severity counts, taken across the latest completed scan
+/// of EVERY scanner rather than the single most recently completed row.
+///
+/// The old form was `ORDER BY created_at DESC LIMIT 1` over all completed rows
+/// regardless of `scan_type`, so whichever engine happened to finish last
+/// supplied the entire CVE verdict and every other engine's findings were
+/// invisible to the gate. With more than one scanner enabled that is a silent
+/// fail-open: a clean-but-later scan hides an earlier scan's criticals.
+///
+/// Counts are combined with a per-severity `MAX`, not `SUM`: the per-scanner
+/// aggregates describe overlapping finding sets, so summing would double-count a
+/// CVE that two engines both report. `MAX` cannot weaken the gate — the
+/// thresholds in [`evaluate_cve_thresholds`] only test "greater than the allowed
+/// number", and a severity is non-zero here whenever any engine reported it.
+///
+/// `HAVING COUNT(*) > 0` preserves the caller's "no completed scan at all"
+/// signal: an aggregate with no `GROUP BY` would otherwise always return one
+/// all-zeros row, turning "never scanned" into "scanned and clean".
 const LATEST_SCAN_COUNTS_SQL: &str = r#"
-    SELECT critical_count, high_count, medium_count, low_count, findings_count
-    FROM scan_results
-    WHERE artifact_id = $1 AND status = 'completed'
-    ORDER BY created_at DESC
-    LIMIT 1
+    WITH latest_per_type AS (
+        SELECT DISTINCT ON (scan_type)
+               critical_count, high_count, medium_count, low_count, findings_count
+        FROM scan_results
+        WHERE artifact_id = $1 AND status = 'completed'
+        ORDER BY scan_type, completed_at DESC NULLS LAST, created_at DESC
+    )
+    SELECT COALESCE(MAX(critical_count), 0)::int AS critical_count,
+           COALESCE(MAX(high_count), 0)::int     AS high_count,
+           COALESCE(MAX(medium_count), 0)::int   AS medium_count,
+           COALESCE(MAX(low_count), 0)::int      AS low_count,
+           COALESCE(MAX(findings_count), 0)::int AS findings_count
+    FROM latest_per_type
+    HAVING COUNT(*) > 0
 "#;
 
 /// SQL for an artifact's open CVEs, sourced from `scan_findings` (the populated
@@ -73,17 +99,21 @@ const LATEST_SCAN_COUNTS_SQL: &str = r#"
 /// scan -- the same `scan_findings` shape the SBOM read path uses. The old
 /// `cve_history` read was always empty, so a "block on open CVEs" gate silently
 /// passed (#1620; data source also addresses #1561).
+///
+/// Scoped to the latest completed scan of EVERY scanner, for the same reason as
+/// [`LATEST_SCAN_COUNTS_SQL`]: joining findings to one single latest row hid the
+/// open CVEs of every other engine. `SELECT DISTINCT` already collapses a CVE
+/// that several engines report, so widening the join cannot produce duplicates.
 const OPEN_CVES_SQL: &str = r#"
-    WITH latest_scan AS (
-        SELECT id
+    WITH latest_scans AS (
+        SELECT DISTINCT ON (scan_type) id
         FROM scan_results
         WHERE artifact_id = $1 AND status = 'completed'
-        ORDER BY created_at DESC
-        LIMIT 1
+        ORDER BY scan_type, completed_at DESC NULLS LAST, created_at DESC
     )
     SELECT DISTINCT sf.cve_id
     FROM scan_findings sf
-    JOIN latest_scan ls ON sf.scan_result_id = ls.id
+    JOIN latest_scans ls ON sf.scan_result_id = ls.id
     WHERE sf.cve_id IS NOT NULL
       AND NOT sf.is_acknowledged
 "#;
@@ -770,6 +800,36 @@ mod tests {
         assert!(OPEN_CVES_SQL.contains("sf.cve_id IS NOT NULL"));
         assert!(OPEN_CVES_SQL.contains("status = 'completed'"));
         assert!(!OPEN_CVES_SQL.contains("cve_history"));
+    }
+
+    #[test]
+    fn test_cve_sql_spans_every_scanner_not_just_the_last_to_finish() {
+        // Regression: both queries used to pick ONE latest completed row with
+        // `ORDER BY created_at DESC LIMIT 1`, ignoring scan_type. With two or more
+        // engines enabled, whichever finished last supplied the entire CVE verdict
+        // and the others' findings never reached the gate — so a clean scan that
+        // completed after a critical-bearing one silently unblocked promotion.
+        for sql in [LATEST_SCAN_COUNTS_SQL, OPEN_CVES_SQL] {
+            assert!(
+                sql.contains("DISTINCT ON (scan_type)"),
+                "query must window per scanner, not take one global latest row"
+            );
+            assert!(
+                !sql.contains("LIMIT 1"),
+                "a global LIMIT 1 is what hid other scanners' findings"
+            );
+        }
+        // The counts query must not turn "never scanned" into "scanned, all zeros":
+        // an unfiltered aggregate always returns a row, which the caller would read
+        // as a clean scan instead of `None`.
+        assert!(
+            LATEST_SCAN_COUNTS_SQL.contains("HAVING COUNT(*) > 0"),
+            "no completed scan must still yield zero rows"
+        );
+        // MAX, not SUM: per-scanner aggregates cover overlapping finding sets, so
+        // summing would double-count a CVE that two engines both report.
+        assert!(LATEST_SCAN_COUNTS_SQL.contains("MAX(critical_count)"));
+        assert!(!LATEST_SCAN_COUNTS_SQL.contains("SUM("));
 
         // The counts query feeds the same latest-completed-scan contract.
         assert!(LATEST_SCAN_COUNTS_SQL.contains("FROM scan_results"));

--- a/backend/src/services/promotion_rule_service.rs
+++ b/backend/src/services/promotion_rule_service.rs
@@ -560,14 +560,32 @@ impl PromotionRuleService {
         Ok(classify_scan_state(&rows))
     }
 
+    /// Severity counts across the latest completed scan of EVERY scanner.
+    ///
+    /// The old form was `ORDER BY created_at DESC LIMIT 1` over all completed
+    /// rows regardless of `scan_type`, so whichever engine finished last supplied
+    /// the entire CVE verdict for `max_cve_severity` and every other engine's
+    /// findings were invisible to the gate — a clean-but-later scan silently hid
+    /// an earlier scan's criticals. Per-severity `MAX` rather than `SUM` because
+    /// the per-scanner aggregates describe overlapping finding sets, and `MAX`
+    /// cannot weaken a "greater than allowed" threshold. `HAVING COUNT(*) > 0`
+    /// preserves the `None` = "no completed scan" signal the caller falls back on.
     async fn get_latest_scan(&self, artifact_id: Uuid) -> Result<Option<ScanCountsRow>> {
         let row: Option<ScanCountsRow> = sqlx::query_as::<_, ScanCountsRow>(
             r#"
-            SELECT critical_count, high_count, medium_count, low_count
-            FROM scan_results
-            WHERE artifact_id = $1 AND status = 'completed'
-            ORDER BY created_at DESC
-            LIMIT 1
+            WITH latest_per_type AS (
+                SELECT DISTINCT ON (scan_type)
+                       critical_count, high_count, medium_count, low_count
+                FROM scan_results
+                WHERE artifact_id = $1 AND status = 'completed'
+                ORDER BY scan_type, completed_at DESC NULLS LAST, created_at DESC
+            )
+            SELECT COALESCE(MAX(critical_count), 0)::int AS critical_count,
+                   COALESCE(MAX(high_count), 0)::int     AS high_count,
+                   COALESCE(MAX(medium_count), 0)::int   AS medium_count,
+                   COALESCE(MAX(low_count), 0)::int      AS low_count
+            FROM latest_per_type
+            HAVING COUNT(*) > 0
             "#,
         )
         .bind(artifact_id)

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -1293,4 +1293,204 @@ mod tests {
             other => panic!("unscanned artifact under block_unscanned must 403, got {other:?}"),
         }
     }
+
+    /// Seed a scan row for `artifact_id` and return its id. `completed_at` is
+    /// set only for `completed` rows, mirroring the production writers.
+    #[cfg(test)]
+    async fn seed_scan(
+        pool: &PgPool,
+        artifact_id: Uuid,
+        repo_id: Uuid,
+        scan_type: &str,
+        status: &str,
+        critical_count: i32,
+        age_seconds: i64,
+    ) -> Uuid {
+        let scan_id = Uuid::new_v4();
+        sqlx::query(
+            r#"
+            INSERT INTO scan_results (
+                id, artifact_id, repository_id, scan_type, status,
+                findings_count, critical_count, high_count, medium_count, low_count, info_count,
+                completed_at, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $6, 0, 0, 0, 0,
+                    CASE WHEN $5 = 'completed'
+                         THEN NOW() - make_interval(secs => $7::double precision)
+                    END,
+                    NOW() - make_interval(secs => $7::double precision))
+            "#,
+        )
+        .bind(scan_id)
+        .bind(artifact_id)
+        .bind(repo_id)
+        .bind(scan_type)
+        .bind(status)
+        .bind(critical_count)
+        .bind(age_seconds as f64)
+        .execute(pool)
+        .await
+        .expect("insert scan_result");
+        scan_id
+    }
+
+    /// End-to-end regression test for the download-gate fail-open.
+    ///
+    /// The three pure `post_scan_gates` unit tests in `policy_service` pin the
+    /// helper, but the bug never lived there — it lived in the wiring, so those
+    /// tests pass even with the fail-open restored. This one drives the real
+    /// `enforce_download_gate` against Postgres with the shape that actually
+    /// reproduces it, and fails if the gate inputs regress to a single
+    /// newest-row read.
+    ///
+    /// Fixture per iteration: an OLDER `grype` scan that completed with an
+    /// unacknowledged critical finding, then a NEWER row from a second engine
+    /// whose status is not `completed`. Pre-fix, that newer row switched the
+    /// `max_severity` check off entirely and the artifact was served 200.
+    #[tokio::test]
+    async fn test_enforce_download_gate_severity_survives_newer_non_completed_scan() {
+        use crate::api::handlers::test_db_helpers::Fixture;
+        let Some(fx) = Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        // block_unscanned / block_on_fail are OFF so max_severity is provably
+        // the only gate that can produce the block.
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', false, false, true)",
+        )
+        .bind(format!("gate-3138-{}", fx.repo_id))
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert max_severity policy");
+
+        let mut outcomes = Vec::new();
+        for (i, newest) in ["pending", "running", "not_applicable", "failed"]
+            .iter()
+            .enumerate()
+        {
+            let aid = seed_row(&fx, "local", &format!("com/example/s{i}/1.0/s{i}-1.0.jar")).await;
+
+            // Older completed scan carrying a real, unacknowledged critical.
+            let scan_id = seed_scan(&fx.pool, aid, fx.repo_id, "grype", "completed", 1, 7200).await;
+            sqlx::query(
+                "INSERT INTO scan_findings \
+                 (scan_result_id, artifact_id, severity, title, cve_id, source, is_acknowledged) \
+                 VALUES ($1, $2, 'critical', 'seeded critical', 'CVE-3138-0001', 'test', false)",
+            )
+            .bind(scan_id)
+            .bind(aid)
+            .execute(&fx.pool)
+            .await
+            .expect("insert critical finding");
+
+            // Newer row from a second engine that never reaches `completed`.
+            seed_scan(&fx.pool, aid, fx.repo_id, "dependency", newest, 0, 60).await;
+
+            outcomes.push((*newest, enforce_download_gate(&fx.pool, aid).await));
+        }
+
+        // Negative control: identical shape, but zero findings on record. If
+        // this one blocks, the test above proves nothing (it would pass by
+        // blocking unconditionally).
+        let clean_aid = seed_row(&fx, "local", "com/example/clean/1.0/clean-1.0.jar").await;
+        seed_scan(
+            &fx.pool,
+            clean_aid,
+            fx.repo_id,
+            "grype",
+            "completed",
+            0,
+            7200,
+        )
+        .await;
+        seed_scan(
+            &fx.pool,
+            clean_aid,
+            fx.repo_id,
+            "dependency",
+            "pending",
+            0,
+            60,
+        )
+        .await;
+        let clean = enforce_download_gate(&fx.pool, clean_aid).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+
+        for (newest, result) in outcomes {
+            match result {
+                Err(AppError::Authorization(_)) => {}
+                other => panic!(
+                    "a newer '{newest}' scan row must not disable the max_severity gate: an \
+                     unacknowledged critical is on record, expected 403, got {other:?}"
+                ),
+            }
+        }
+        assert!(
+            clean.is_ok(),
+            "an artifact with no findings must still download: {clean:?}"
+        );
+    }
+
+    /// The same fail-open one layer down: `scanner_service` writes findings
+    /// BEFORE flipping the row to `completed`, so a scanner that dies in
+    /// between leaves an unacknowledged critical on record with no completed
+    /// row anywhere. Keying the severity gate on "a completed scan exists"
+    /// alone would serve that artifact 200.
+    #[tokio::test]
+    async fn test_enforce_download_gate_grades_findings_from_a_crashed_scan() {
+        use crate::api::handlers::test_db_helpers::Fixture;
+        let Some(fx) = Fixture::setup("local", "maven").await else {
+            return;
+        };
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', false, false, true)",
+        )
+        .bind(format!("gate-3138-crash-{}", fx.repo_id))
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert max_severity policy");
+
+        let aid = seed_row(&fx, "local", "com/example/crash/1.0/crash-1.0.jar").await;
+        // Findings landed, then the scanner died: the janitor reaped the row
+        // from `running` to `failed`. No completed row exists for this artifact.
+        let scan_id = seed_scan(&fx.pool, aid, fx.repo_id, "grype", "failed", 0, 3600).await;
+        sqlx::query(
+            "INSERT INTO scan_findings \
+             (scan_result_id, artifact_id, severity, title, cve_id, source, is_acknowledged) \
+             VALUES ($1, $2, 'critical', 'finding from crashed scan', 'CVE-3138-0002', 'test', false)",
+        )
+        .bind(scan_id)
+        .bind(aid)
+        .execute(&fx.pool)
+        .await
+        .expect("insert critical finding");
+
+        let result = enforce_download_gate(&fx.pool, aid).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+
+        match result {
+            Err(AppError::Authorization(_)) => {}
+            other => panic!(
+                "an unacknowledged critical from a crashed scan must still be graded, \
+                 expected 403, got {other:?}"
+            ),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Three security gates decide an artifact's verdict from a **single** `scan_results` row. That is wrong as soon as more than one scanner is enabled, and each case fails **open** rather than closed.

I found these while designing an additional (asynchronous, external) scanner backend against this codebase — an async engine makes all three fire routinely, but none of them require one to reproduce: any deployment with two engines enabled is already affected.

## 1. Download gate: a newer non-completed row switches severity blocking off

`policy_service::evaluate_artifact` selected the newest row of **any** status:

```sql
SELECT status, ... FROM scan_results WHERE artifact_id = $1 ORDER BY created_at DESC LIMIT 1
```

and then ran the `max_severity` check only `if scan.status == "completed"`.

So any scanner that records a `pending` / `running` / `not_applicable` row *after* a completed one disables the severity gate for that artifact entirely — `enforce_download_gate` returns allowed and the artifact is served **200 with critical findings on record**. `block_unscanned` does not compensate: `classify_scan_state` is any-completed-wins, so an earlier completed scan satisfies it.

Fix: read the two gate inputs separately, since they are answering different questions.

* `block_on_fail` — "did the most recent attempt fail?" → still keys on the newest row's status.
* `max_severity` — "what is on record for this artifact?" → keys on whether a completed scan **exists**.

Both come from one round trip, and the decision is a pure, unit-tested function (`post_scan_gates`).

**Intended behaviour change:** a `failed` newest row with `block_on_fail` *off* now still evaluates severity against the older completed scan's findings, where previously the check was skipped. A crashed rescan must not clear an artifact's finding history.

## 2 & 3. Promotion gates: the last engine to finish supplies the whole CVE verdict

`promotion_policy_service::LATEST_SCAN_COUNTS_SQL`, `OPEN_CVES_SQL` and `promotion_rule_service::get_latest_scan` all took the latest completed row **regardless of `scan_type`**. With several engines enabled, whichever finished last supplies the entire verdict for `max_cve_severity` / the promotion CVE summary, and every other engine's findings are invisible to the gate.

Fix: window per `scan_type` with `DISTINCT ON`, matching what `recalculate_score` already does (`scan_result_service.rs`).

Two deliberate details:

* **`MAX`, not `SUM`.** The per-scanner count columns describe *overlapping* finding sets, so summing double-counts a CVE that two engines both report. `MAX` cannot weaken the gate — `evaluate_cve_thresholds` only tests "more than allowed", and a severity is non-zero here whenever any engine reported it.
* **`HAVING COUNT(*) > 0`.** An aggregate with no `GROUP BY` always returns one all-zeros row, which would turn the caller's `None` ("never scanned") into "scanned and clean". This keeps zero rows for an unscanned artifact.

## Verification

Applied all 170 migrations to a clean Postgres 16 and seeded the minimal reproducing fixture: one artifact, an **older** `grype` scan with 1 critical / 2 high carrying `CVE-2026-0001`, a **newer, clean** scan from a second engine, then a newer `pending` row.

| Query | Before | After |
|---|---|---|
| Promotion severity counts | `0` critical (the clean newer row won) | **1 critical, 2 high** |
| Promotion open CVEs | 0 rows | **CVE-2026-0001** |
| Download-gate input | newest row `pending` ⇒ severity check skipped | `has_completed_scan = true` ⇒ gate armed |
| Artifact with no scans | — | 0 rows ⇒ `None` preserved |

New pure unit tests cover the gate-input decision (including each of `pending` / `running` / `not_applicable` as the newest row) and pin the SQL shape so a future `LIMIT 1` regression fails the build. `cargo fmt --check` clean; `cargo test --lib` passes (409 tests in the touched modules, 0 failures).

## Notes for reviewers

Happy to split this into three PRs if you'd prefer them separately — they're grouped because they're one class of bug with one root cause.

Three adjacent things I did **not** change, but which look like the same family, if you want issues opened for them:

* `artifact_service::prepare_download` (the generic REST download path) enforces quarantine but never calls `enforce_download_gate`, so scan policy is not applied there — unlike the ~25 per-format handlers.
* `rollup_scan_status` does not handle `not_applicable`, so it falls through to `has_unknown` and reports `partial` for any artifact with a not-applicable scanner row.
* `scan_configs.block_on_policy_violation` and `scan_configs.severity_threshold` have CRUD but no enforcement reader; `Severity::meets_threshold` / `ScanConfig::threshold()` are referenced only from tests.



Closes #3140
