### PR TITLE
fix(scanner-adapter): build on our own hardened trivy image to clear CVE-2026-50163

### DIFF
--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -39,19 +39,28 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w" -o /out/scanner-adapter .
 
 # ---------- Stage 2: pull the matching trivy binary ----------
-# buildx selects this image's TARGETPLATFORM variant automatically, so the
-# arm64 build gets the arm64 trivy and the amd64 build gets amd64. Pinned to
-# 0.73.0, the latest release, which scans with ZERO fixable CVEs — verified
-# with `trivy image --ignore-unfixed ghcr.io/aquasecurity/trivy:0.73.0` (0
-# findings, vs 31 on 0.72.0). It drops the sigstore-go / timestamp-authority
-# stack entirely and bumps oras-go 2.6.0->2.6.1, x/text 0.38->0.40,
-# x/net 0.55->0.57, grpc 1.81->1.82.1 and Go 1.26.4->1.26.5, which clears every
-# trivy-related entry in /.trivyignore (those are now inert; see #3121).
+# Our own build of upstream trivy v0.73.0 (artifact-keeper/trivy): the same
+# upstream source tag, built with our pinned Go toolchain plus one documented
+# dependency override, oras-go v2.6.1 -> v2.6.2, which clears CVE-2026-50163.
+# Upstream merged that bump on main but has not released it, and 0.73.0 is
+# still the latest release, so no upstream tag carries the fix. Leaving this on
+# ghcr.io/aquasecurity/trivy:0.73.0 fails the Docker Publish security gate,
+# which skips every multi-arch manifest and blocks the release chain.
+#
+# Worth remembering: upstream 0.73.0 scanned clean when #3123 landed — the CVE
+# was published against its bundled oras-go afterwards. A clean scan at merge
+# time does not stay clean, which is why the source repo rebuilds and re-gates
+# on a schedule rather than trusting a one-time result.
+#
+# Pinned by DIGEST, not tag: that repo rebuilds weekly to pick up RPM errata,
+# so its tags are moving targets by design. buildx selects the TARGETPLATFORM
+# variant from the multi-arch index automatically, so the arm64 build gets the
+# arm64 trivy and the amd64 build gets amd64 — both are published.
+#
 # Nothing couples the backend to a specific trivy version: the 0.71.2 strings
 # in backend/scanner-adapter tests are mock/stub fixtures, and the adapter
-# probes the real version at startup (ProbeVersion). Aqua publishes both
-# linux/amd64 and linux/arm64 for this tag.
-FROM ghcr.io/aquasecurity/trivy:0.73.0 AS trivy
+# probes the real version at startup (ProbeVersion).
+FROM ghcr.io/artifact-keeper/trivy@sha256:202c9b4cbb16242cd9d8ee675efc23ba3491f919f4686a1dacaa7dd8605c74ad AS trivy
 
 # ---------- Stage 3: minimal runtime ----------
 # alpine 3.20 reached EOL; 3.24 is the current stable with active security
@@ -68,6 +77,12 @@ RUN apk add --no-cache ca-certificates git rpm \
     && chown -R scanner:scanner /home/scanner
 
 COPY --from=trivy /usr/local/bin/trivy /usr/local/bin/trivy
+# Apache-2.0 §4(a)/(b): the trivy binary we ship is built from upstream source
+# with a documented dependency override, so the licence, NOTICE, build info and
+# the modification record must travel with it. They are assembled in the
+# artifact-keeper/trivy image; copy them through rather than leaving a modified
+# Apache-2.0 binary in the runtime with no accompanying notice.
+COPY --from=trivy /licenses/trivy /licenses/trivy
 COPY --from=build /out/scanner-adapter /usr/local/bin/scanner-adapter
 
 # DB-download resilience (#2167): the trivy vuln-DB pull defaults to the


### PR DESCRIPTION
## Summary

Fixes #3131

The scanner-adapter vendored `ghcr.io/aquasecurity/trivy:0.73.0`, whose bundled `oras-go v2.6.1` carries **CVE-2026-50163 (HIGH)**. That fails `Docker Publish`'s Security Scan, which cascades into skipping **all four** multi-arch manifest jobs — so no digests exist for a release to promote. It has blocked the release chain since Aug 6.

There is no upstream fix to move to: Trivy merged the `oras-go` bump on `main`, but **0.73.0 is still the latest release** (verified against releases including prereleases, tags, and direct probes for `v0.73.1`/`v0.73.2`).

This points the trivy stage at **`artifact-keeper/trivy`** — the same upstream v0.73.0 source, built with a pinned Go toolchain plus that one documented dependency override. Verified: our image's gate exits **0** where upstream's exits **1**.

## Pinned by digest, not tag

`ghcr.io/artifact-keeper/trivy@sha256:202c9b4c…` — that repo rebuilds weekly to pick up RPM errata, so its tags move by design. buildx still selects the right arch from the multi-arch index.

## Licence compliance fix included

The runtime previously copied only the binary. Now that we ship a **modified** Apache-2.0 work, §4(a) and §4(b) require the licence and a modification notice to accompany it — so `/licenses/trivy` (LICENSE, NOTICE, BUILDINFO.txt, MODIFICATIONS-overrides.yaml) is copied through. Previously the runtime carried none of it.

## Blast radius: none at runtime

Trivy is a **build-time source** — the binary is copied *into* this image. There is no trivy container at runtime, the Helm chart never references one (it names exactly one image repository, `nginx`), and customers keep pulling `artifact-keeper-scanner-adapter:<version>` unchanged. **Released images are unaffected**; this only changes images built after it merges. Air-gapped consumers mirror scanner-adapter exactly as before.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is a base-image change, not a code change. The regression gate is `Docker Publish`'s own Security Scan, which currently fails on this CVE and must go green on this PR's build. Verification of the replacement image lives in `artifact-keeper/trivy` (blocking CVE gate, build verification that fails closed, DISA STIG evaluation, all on both arches).

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Binary path verified compatible (`/usr/local/bin/trivy`). Nothing couples the backend to a trivy version — the `0.71.2` strings in the adapter tests are stub fixtures and the adapter probes the real version at startup via `ProbeVersion`.

## API Changes
- [x] N/A - no API changes

## Note

Upstream 0.73.0 scanned **clean** when #3123 landed; the CVE was published against its bundled `oras-go` afterwards. A clean scan at merge time does not stay clean — which is why the source repo rebuilds and re-gates weekly rather than trusting a one-time result. The stale "scans with ZERO fixable CVEs" comment is corrected here.