### PR TITLE
fix(helm): reject OCI pushes to classic repositories

### DIFF
--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -94,6 +94,30 @@ fn is_prov_filename(filename: &str) -> bool {
     filename.ends_with(PROV_SUFFIX)
 }
 
+/// OCI manifest rows are not classic Helm chart packages and must never be
+/// rendered into `index.yaml`.
+///
+/// The path check repairs the read side for rows already written through the
+/// OCI Distribution API before repository-format validation was added (#3150).
+/// The media-type check is a second guard in case an imported manifest uses a
+/// non-standard path.
+fn is_oci_manifest_artifact(path: &str, content_type: &str) -> bool {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim();
+
+    (path.starts_with("v2/") && path.contains("/manifests/"))
+        || matches!(
+            media_type,
+            "application/vnd.oci.image.manifest.v1+json"
+                | "application/vnd.oci.image.index.v1+json"
+                | "application/vnd.docker.distribution.manifest.v2+json"
+                | "application/vnd.docker.distribution.manifest.list.v2+json"
+        )
+}
+
 /// Validate that an uploaded `prov` part really is a clearsigned provenance
 /// document before it is stored.
 ///
@@ -174,7 +198,7 @@ async fn query_charts_from_repo(
 ) -> Result<(), Response> {
     let rows = sqlx::query(
         r#"
-        SELECT a.id, a.name, a.version, a.path, a.size_bytes, a.checksum_sha256,
+        SELECT a.id, a.name, a.version, a.path, a.content_type, a.checksum_sha256,
                a.created_at,
                am.metadata
         FROM artifacts a
@@ -194,9 +218,14 @@ async fn query_charts_from_repo(
         let name: String = row.get("name");
         let version: Option<String> = row.get("version");
         let path: String = row.get("path");
+        let content_type: String = row.get("content_type");
         let checksum_sha256: String = row.get("checksum_sha256");
         let created_at: chrono::DateTime<chrono::Utc> = row.get("created_at");
         let metadata: Option<serde_json::Value> = row.get("metadata");
+
+        if is_oci_manifest_artifact(&path, &content_type) {
+            continue;
+        }
 
         let version = match version {
             Some(v) => v,
@@ -1312,6 +1341,31 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
     }
 
     #[test]
+    fn test_oci_manifests_are_not_classic_helm_chart_artifacts() {
+        for content_type in [
+            "application/vnd.oci.image.manifest.v1+json",
+            "application/vnd.oci.image.index.v1+json; charset=utf-8",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+        ] {
+            assert!(is_oci_manifest_artifact("imported/manifest", content_type));
+        }
+
+        assert!(is_oci_manifest_artifact(
+            "v2/keycloak/manifests/26.7.0",
+            "application/json"
+        ));
+        assert!(!is_oci_manifest_artifact(
+            "keycloak/26.7.0/keycloak-26.7.0.tgz",
+            "application/gzip"
+        ));
+        assert!(!is_oci_manifest_artifact(
+            "keycloak-26.7.0.tgz",
+            "application/octet-stream"
+        ));
+    }
+
+    #[test]
     fn test_sha256_computation() {
         let mut hasher = Sha256::new();
         hasher.update(b"chart content");
@@ -1452,6 +1506,58 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
             "the URL helm derives from index.yaml must serve the chart"
         );
         assert_eq!(&got[..], b"helm-chart-bytes");
+
+        f.teardown().await;
+    }
+
+    /// Regression guard for #3150: OCI manifest rows written into a classic
+    /// Helm repository by older versions must not leak into `index.yaml`.
+    #[tokio::test]
+    async fn test_helm_index_excludes_existing_oci_manifest_rows() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let repo = f.repo_info("local", None);
+
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            "helm/keycloak/26.7.0/keycloak-26.7.0.tgz",
+            "keycloak/26.7.0/keycloak-26.7.0.tgz",
+            "keycloak",
+            "26.7.0",
+            "application/gzip",
+            bytes::Bytes::from_static(b"classic-chart"),
+            f.user_id,
+        )
+        .await;
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &repo,
+            "oci/manifests/abcdef",
+            "v2/keycloak/manifests/26.7.0",
+            "keycloak:26.7.0",
+            "26.7.0",
+            "application/vnd.oci.image.manifest.v1+json",
+            bytes::Bytes::from_static(br#"{"schemaVersion":2}"#),
+            f.user_id,
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(app, tdh::get(format!("/{}/index.yaml", f.repo_key))).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "index generation failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let index: HelmIndex = serde_yaml::from_slice(&body).expect("valid Helm index");
+        assert_eq!(index.entries.len(), 1);
+        assert!(index.entries.contains_key("keycloak"));
+        assert!(!index.entries.contains_key("keycloak:26.7.0"));
 
         f.teardown().await;
     }

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -101,6 +101,21 @@ fn is_prov_filename(filename: &str) -> bool {
 /// OCI Distribution API before repository-format validation was added (#3150).
 /// The media-type check is a second guard in case an imported manifest uses a
 /// non-standard path.
+///
+/// This filter is LOAD-BEARING, not redundant with the `/v2` write gate. That
+/// gate only covers the Distribution API; `services/oci_referenced_content.rs`
+/// (migration import) and `services/peer_instance_service.rs` (federation
+/// replication) also write OCI manifest rows and apply NO repository-format
+/// check. Removing this filter would let those two paths put manifests back
+/// into a classic Helm `index.yaml`.
+///
+/// NOTE on the `"v2/"` literal: this is the artifact PATH prefix written by
+/// `oci_v2::upsert_manifest_artifact` (`format!("v2/{image}/manifests/{ref}")`,
+/// the `artifacts.path` column). Do NOT "unify" it with
+/// `storage::keys::OCI_MANIFEST_STORAGE_PREFIX` (`"oci-manifests/"`) — that
+/// constant is a STORAGE KEY prefix (the `artifacts.storage_key` column). The
+/// two live in different namespaces and only coincidentally describe the same
+/// rows; substituting one for the other silently breaks this filter.
 fn is_oci_manifest_artifact(path: &str, content_type: &str) -> bool {
     let media_type = content_type
         .split(';')
@@ -1340,21 +1355,62 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
         assert_eq!(url, "/helm/helm-local/charts/ingress-nginx-4.8.0.tgz");
     }
 
+    /// Pins the PATH arm on its own: an OCI-shaped `artifacts.path` with a
+    /// content type that matches NO entry in the media-type list. If the
+    /// `path.starts_with("v2/") && path.contains("/manifests/")` arm is
+    /// deleted, this case flips to false.
     #[test]
-    fn test_oci_manifests_are_not_classic_helm_chart_artifacts() {
+    fn test_oci_manifest_detected_by_path_arm_alone() {
+        assert!(is_oci_manifest_artifact(
+            "v2/keycloak/manifests/26.7.0",
+            "application/json"
+        ));
+        // The exact shape upsert_manifest_artifact writes, with the generic
+        // content type an older row may carry.
+        assert!(is_oci_manifest_artifact(
+            "v2/org/keycloak/manifests/sha256:abc",
+            "application/octet-stream"
+        ));
+    }
+
+    /// Pins the MEDIA-TYPE arm on its own: a path that fails the `v2/` test so
+    /// only the media type can match. If the media-type arm is deleted, these
+    /// flip to false.
+    #[test]
+    fn test_oci_manifest_detected_by_media_type_arm_alone() {
         for content_type in [
             "application/vnd.oci.image.manifest.v1+json",
             "application/vnd.oci.image.index.v1+json; charset=utf-8",
             "application/vnd.docker.distribution.manifest.v2+json",
             "application/vnd.docker.distribution.manifest.list.v2+json",
         ] {
-            assert!(is_oci_manifest_artifact("imported/manifest", content_type));
+            assert!(
+                is_oci_manifest_artifact("imported/manifest", content_type),
+                "{content_type} must be recognised without an OCI-shaped path"
+            );
         }
+    }
 
-        assert!(is_oci_manifest_artifact(
-            "v2/keycloak/manifests/26.7.0",
-            "application/json"
+    /// Pins the `&&` INSIDE the path arm. Each of these satisfies exactly one
+    /// half of the path test and carries a non-OCI media type, so flipping the
+    /// `&&` to `||` turns them true and fails this test.
+    #[test]
+    fn test_oci_manifest_path_arm_requires_both_halves() {
+        // `v2/` prefix but not a manifest path (a blob).
+        assert!(!is_oci_manifest_artifact(
+            "v2/keycloak/blobs/sha256:abc",
+            "application/octet-stream"
         ));
+        // `/manifests/` present but not under the `v2/` prefix: a classic
+        // chart that merely lives in a directory called `manifests`.
+        assert!(!is_oci_manifest_artifact(
+            "keycloak/manifests/keycloak-26.7.0.tgz",
+            "application/gzip"
+        ));
+    }
+
+    #[test]
+    fn test_classic_helm_chart_artifacts_are_not_oci_manifests() {
         assert!(!is_oci_manifest_artifact(
             "keycloak/26.7.0/keycloak-26.7.0.tgz",
             "application/gzip"

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -37,6 +37,7 @@ use crate::error::AppError;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::models::user::User;
 use crate::services::auth_service::AuthService;
+use crate::services::repository_service::{format_handler_key, parse_format_str};
 use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
 
 // ---------------------------------------------------------------------------
@@ -2334,6 +2335,32 @@ struct OciRepoInfo {
     image: String,
 }
 
+/// Reject repository formats that are not backed by the OCI handler.
+///
+/// Repository keys share a namespace across all package formats, so resolving
+/// a key alone is not enough to authorize use of the Distribution API. Without
+/// this gate, an OCI client can push manifests into a classic `helm` repository
+/// and those rows later leak into its `index.yaml` (#3150).
+#[allow(clippy::result_large_err)]
+fn validate_oci_repository_format(repo_key: &str, format: &str) -> Result<(), Response> {
+    let is_oci = parse_format_str(format)
+        .map(|format| format_handler_key(&format) == "oci")
+        .unwrap_or(false);
+
+    if is_oci {
+        return Ok(());
+    }
+
+    Err(oci_error(
+        StatusCode::BAD_REQUEST,
+        "UNSUPPORTED",
+        &format!(
+            "repository '{}' does not support the OCI Distribution API (format: {})",
+            repo_key, format
+        ),
+    ))
+}
+
 /// Build an [`OciRepoInfo`] for a virtual repo's resolving MEMBER so the scan
 /// gate runs in the member's context (its id/key/upstream/storage), while the
 /// `image` path stays the pull's image name (#3023). Used only on the virtual
@@ -2399,8 +2426,9 @@ async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Resp
 
     let select_repo_by_key = |key: String| async move {
         sqlx::query(
-            "SELECT id, key, storage_backend, storage_path, repo_type::text as repo_type, \
-             upstream_url, is_public FROM repositories WHERE key = $1",
+            "SELECT id, key, storage_backend, storage_path, format::text as format, \
+             repo_type::text as repo_type, upstream_url, is_public \
+             FROM repositories WHERE key = $1",
         )
         .bind(key)
         .fetch_optional(db)
@@ -2447,6 +2475,10 @@ async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Resp
         )
     })?;
 
+    let resolved_key: String = repo.try_get("key").map_err(map_db_err)?;
+    let format: String = repo.try_get("format").map_err(map_db_err)?;
+    validate_oci_repository_format(&resolved_key, &format)?;
+
     let location = crate::storage::StorageLocation {
         backend: repo.try_get("storage_backend").map_err(map_db_err)?,
         path: repo.try_get("storage_path").map_err(map_db_err)?,
@@ -2454,7 +2486,7 @@ async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Resp
 
     Ok(OciRepoInfo {
         id: repo.try_get("id").map_err(map_db_err)?,
-        key: repo.try_get("key").map_err(map_db_err)?,
+        key: resolved_key,
         location,
         repo_type: repo.try_get("repo_type").map_err(map_db_err)?,
         upstream_url: repo.try_get("upstream_url").map_err(map_db_err)?,
@@ -11921,6 +11953,66 @@ mod tests {
         assert!(info.upstream_url.is_none());
     }
 
+    #[test]
+    fn test_validate_oci_repository_format_accepts_oci_handler_formats() {
+        for format in ["docker", "podman", "buildx", "oras", "wasm_oci", "helm_oci"] {
+            assert!(
+                validate_oci_repository_format("packages", format).is_ok(),
+                "{format} must be served by the OCI Distribution API"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_oci_repository_format_rejects_classic_helm() {
+        let response = validate_oci_repository_format("helm-local", "helm")
+            .expect_err("a classic Helm repository must reject OCI requests");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .expect("OCI error body");
+        let error: serde_json::Value = serde_json::from_slice(&body).expect("OCI error JSON");
+        assert_eq!(error["errors"][0]["code"], "UNSUPPORTED");
+        assert!(error["errors"][0]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("format: helm"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_repo_rejects_classic_helm_repository() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let image_name = format!("{}/keycloak", f.repo_key);
+        let response = match resolve_repo(&f.pool, &image_name).await {
+            Ok(_) => panic!("classic Helm repository resolved through the OCI API"),
+            Err(response) => response,
+        };
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_repo_accepts_helm_oci_repository() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(f) = tdh::Fixture::setup("local", "helm_oci").await else {
+            return;
+        };
+        let image_name = format!("{}/keycloak", f.repo_key);
+        let repo = match resolve_repo(&f.pool, &image_name).await {
+            Ok(repo) => repo,
+            Err(_) => panic!("helm_oci repository must resolve through the OCI API"),
+        };
+        assert_eq!(repo.id, f.repo_id);
+        assert_eq!(repo.image, "keycloak");
+        f.teardown().await;
+    }
+
     // --- Docker Hub library/ prefix tests ---
 
     #[test]
@@ -15092,6 +15184,57 @@ mod manifest_digest_db_tests {
                 .await;
         }
         fx.teardown().await;
+    }
+
+    /// Regression guard for #3150: a manifest PUT must fail before it can
+    /// write OCI rows into a classic Helm repository.
+    #[tokio::test]
+    async fn manifest_put_rejects_classic_helm_repository_before_writes() {
+        if std::env::var("DATABASE_URL").is_err() {
+            if require_db_under_coverage() {
+                panic!("DATABASE_URL must be set for OCI manifest digest tests");
+            }
+            return;
+        }
+        let fx = tdh::Fixture::setup("local", "helm")
+            .await
+            .expect("fixture setup");
+        let auth = bearer(&fx).await;
+        let manifest = Bytes::from_static(
+            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.cncf.helm.config.v1+json","digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","size":1},"layers":[]}"#,
+        );
+
+        let (status, _, body) = send(
+            router().with_state(fx.state.clone()),
+            req(
+                Method::PUT,
+                format!("/{}/keycloak/manifests/26.7.0", fx.repo_key),
+                &auth,
+                Some("application/vnd.oci.image.manifest.v1+json"),
+                manifest,
+            ),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let error: serde_json::Value = serde_json::from_slice(&body).expect("OCI error JSON");
+        assert_eq!(error["errors"][0]["code"], "UNSUPPORTED");
+        let artifact_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(fx.repo_id)
+                .fetch_one(&fx.pool)
+                .await
+                .expect("artifact count");
+        let tag_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM oci_tags WHERE repository_id = $1")
+                .bind(fx.repo_id)
+                .fetch_one(&fx.pool)
+                .await
+                .expect("OCI tag count");
+        assert_eq!(artifact_count, 0);
+        assert_eq!(tag_count, 0);
+
+        cleanup(&fx).await;
     }
 
     /// The core #1681 scenario end to end: a manifest pushed under a tag stays

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2341,6 +2341,8 @@ struct OciRepoInfo {
 /// a key alone is not enough to authorize use of the Distribution API. Without
 /// this gate, an OCI client can push manifests into a classic `helm` repository
 /// and those rows later leak into its `index.yaml` (#3150).
+///
+/// Applied on the MUTATING seam only — see [`resolve_repo_for_write`].
 #[allow(clippy::result_large_err)]
 fn validate_oci_repository_format(repo_key: &str, format: &str) -> Result<(), Response> {
     let is_oci = parse_format_str(format)
@@ -2404,7 +2406,48 @@ fn default_docker_mirror_repo() -> Option<&'static str> {
         .as_deref()
 }
 
+/// Resolve a repository for a READ request (`GET`/`HEAD` manifests, blobs and
+/// tag listings).
+///
+/// Deliberately does NOT apply [`validate_oci_repository_format`]. A
+/// deployment that was hit by #3150 before the write gate landed already has
+/// OCI rows sitting in a classic `helm` repository; gating reads too would
+/// make those bytes unreachable by BOTH protocols at once (the OCI route would
+/// 400 and the `index.yaml` read-side filter already omits them) while they
+/// keep consuming quota, with no repair or export path. Reads stay open so an
+/// operator can pull the content back out; the read-side filter in
+/// `handlers/helm.rs` keeps the classic view correct meanwhile.
 async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Response> {
+    resolve_repo_inner(db, image_name)
+        .await
+        .map(|(repo, _format)| repo)
+}
+
+/// Resolve a repository for a MUTATING request, rejecting keys whose format is
+/// not served by the OCI handler.
+///
+/// Writes are what corrupt the classic view: `upsert_manifest_artifact` and
+/// the blob/upload path create the `artifacts` / `oci_tags` rows that later
+/// leak into a classic Helm repository's `index.yaml` (#3150). Gating here
+/// stops new corruption at the source while leaving existing content readable
+/// (see [`resolve_repo`]).
+///
+/// Callers: `handle_start_upload`, `handle_patch_upload`,
+/// `handle_cancel_upload`, `handle_complete_upload`, `handle_put_manifest`,
+/// `handle_delete_manifest`.
+async fn resolve_repo_for_write(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Response> {
+    let (repo, format) = resolve_repo_inner(db, image_name).await?;
+    validate_oci_repository_format(&repo.key, &format)?;
+    Ok(repo)
+}
+
+/// Shared resolution body. Returns the descriptor alongside the repository's
+/// declared format so the write seam can gate on it without threading a
+/// `format` field through every [`OciRepoInfo`] construction site.
+async fn resolve_repo_inner(
+    db: &PgPool,
+    image_name: &str,
+) -> Result<(OciRepoInfo, String), Response> {
     use sqlx::Row;
     // Split: "test/python" → repo_key="test", image="python"
     // Or:    "myrepo/org/image" → repo_key="myrepo", image="org/image"
@@ -2477,22 +2520,24 @@ async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Resp
 
     let resolved_key: String = repo.try_get("key").map_err(map_db_err)?;
     let format: String = repo.try_get("format").map_err(map_db_err)?;
-    validate_oci_repository_format(&resolved_key, &format)?;
 
     let location = crate::storage::StorageLocation {
         backend: repo.try_get("storage_backend").map_err(map_db_err)?,
         path: repo.try_get("storage_path").map_err(map_db_err)?,
     };
 
-    Ok(OciRepoInfo {
-        id: repo.try_get("id").map_err(map_db_err)?,
-        key: resolved_key,
-        location,
-        repo_type: repo.try_get("repo_type").map_err(map_db_err)?,
-        upstream_url: repo.try_get("upstream_url").map_err(map_db_err)?,
-        is_public: repo.try_get("is_public").map_err(map_db_err)?,
-        image: effective_image,
-    })
+    Ok((
+        OciRepoInfo {
+            id: repo.try_get("id").map_err(map_db_err)?,
+            key: resolved_key,
+            location,
+            repo_type: repo.try_get("repo_type").map_err(map_db_err)?,
+            upstream_url: repo.try_get("upstream_url").map_err(map_db_err)?,
+            is_public: repo.try_get("is_public").map_err(map_db_err)?,
+            image: effective_image,
+        },
+        format,
+    ))
 }
 
 /// Check whether an upstream URL points to Docker Hub.
@@ -4707,6 +4752,9 @@ async fn try_mount_blob(
     let digest = Sha256Digest::parse_digest_param(mount_digest).ok()?;
     let canonical = digest.as_prefixed();
 
+    // Read-side resolve on purpose: this only READS the source repo to confirm
+    // it holds the blob. The repo being WRITTEN is `target_repo_id`, already
+    // format-gated by `handle_start_upload`'s `resolve_repo_for_write`.
     let source = resolve_repo(&state.db, from_image).await.ok()?;
     // Mounting from the target itself is a no-op; let the normal path run.
     if source.id == target_repo_id {
@@ -4795,7 +4843,7 @@ async fn handle_start_upload(
         return oci_forbidden_scope("write:artifacts");
     }
 
-    let repo = match resolve_repo(&state.db, image_name).await {
+    let repo = match resolve_repo_for_write(&state.db, image_name).await {
         Ok(r) => r,
         Err(e) => return e,
     };
@@ -5147,7 +5195,7 @@ async fn handle_patch_upload(
     // session created against repo A cannot be driven via repo B's URL
     // (issue #1317). Same 404 shape for "no session" and "session in another
     // repo" avoids leaking session existence across repos.
-    let repo = match resolve_repo(&state.db, image_name).await {
+    let repo = match resolve_repo_for_write(&state.db, image_name).await {
         Ok(r) => r,
         Err(e) => return e,
     };
@@ -5392,7 +5440,7 @@ async fn handle_cancel_upload(
         }
     };
 
-    let repo = match resolve_repo(&state.db, image_name).await {
+    let repo = match resolve_repo_for_write(&state.db, image_name).await {
         Ok(r) => r,
         Err(e) => return e,
     };
@@ -5633,7 +5681,7 @@ async fn handle_complete_upload(
     // Resolve repo from URL first, then bind it into the session lookup so a
     // session created against repo A cannot be completed via repo B's URL
     // (issue #1317).
-    let repo = match resolve_repo(&state.db, image_name).await {
+    let repo = match resolve_repo_for_write(&state.db, image_name).await {
         Ok(r) => r,
         Err(e) => return e,
     };
@@ -7999,7 +8047,7 @@ async fn handle_put_manifest(
         return oci_forbidden_scope("write:artifacts");
     }
 
-    let repo = match resolve_repo(&state.db, image_name).await {
+    let repo = match resolve_repo_for_write(&state.db, image_name).await {
         Ok(r) => r,
         Err(e) => return e,
     };
@@ -9032,7 +9080,7 @@ async fn handle_delete_manifest(
         return oci_forbidden_scope("delete:artifacts");
     }
 
-    let repo = match resolve_repo(&state.db, image_name).await {
+    let repo = match resolve_repo_for_write(&state.db, image_name).await {
         Ok(r) => r,
         Err(e) => return e,
     };
@@ -11981,30 +12029,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_repo_rejects_classic_helm_repository() {
+    async fn test_resolve_repo_for_write_rejects_classic_helm_repository() {
         use crate::api::handlers::test_db_helpers as tdh;
 
         let Some(f) = tdh::Fixture::setup("local", "helm").await else {
             return;
         };
         let image_name = format!("{}/keycloak", f.repo_key);
-        let response = match resolve_repo(&f.pool, &image_name).await {
-            Ok(_) => panic!("classic Helm repository resolved through the OCI API"),
+        let response = match resolve_repo_for_write(&f.pool, &image_name).await {
+            Ok(_) => panic!("classic Helm repository resolved through the OCI write seam"),
             Err(response) => response,
         };
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        // Assert the specific OCI error code, not just "some 400": without
+        // this, any unrelated 400 (a malformed name, a bad digest) satisfies
+        // the test and the format gate could be gone entirely.
+        let body = to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .expect("OCI error body");
+        let error: serde_json::Value = serde_json::from_slice(&body).expect("OCI error JSON");
+        assert_eq!(error["errors"][0]["code"], "UNSUPPORTED");
+
+        f.teardown().await;
+    }
+
+    /// The read seam must stay OPEN on a classic Helm repo. A deployment that
+    /// already took OCI writes before the gate landed must still be able to
+    /// pull that content back out (#3150); gating reads would strand the bytes
+    /// behind both protocols at once.
+    #[tokio::test]
+    async fn test_resolve_repo_read_allows_classic_helm_repository() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let image_name = format!("{}/keycloak", f.repo_key);
+        let repo = resolve_repo(&f.pool, &image_name)
+            .await
+            .unwrap_or_else(|_| panic!("read seam must stay open on a classic Helm repository"));
+        assert_eq!(repo.id, f.repo_id);
+        assert_eq!(repo.image, "keycloak");
         f.teardown().await;
     }
 
     #[tokio::test]
-    async fn test_resolve_repo_accepts_helm_oci_repository() {
+    async fn test_resolve_repo_for_write_accepts_helm_oci_repository() {
         use crate::api::handlers::test_db_helpers as tdh;
 
         let Some(f) = tdh::Fixture::setup("local", "helm_oci").await else {
             return;
         };
         let image_name = format!("{}/keycloak", f.repo_key);
-        let repo = match resolve_repo(&f.pool, &image_name).await {
+        let repo = match resolve_repo_for_write(&f.pool, &image_name).await {
             Ok(repo) => repo,
             Err(_) => panic!("helm_oci repository must resolve through the OCI API"),
         };
@@ -15188,6 +15266,13 @@ mod manifest_digest_db_tests {
 
     /// Regression guard for #3150: a manifest PUT must fail before it can
     /// write OCI rows into a classic Helm repository.
+    ///
+    /// Carries its own POSITIVE CONTROL. The rejection assertions alone are
+    /// satisfied by a validator that rejects *everything* — including the
+    /// `helm_oci` repositories the OCI API is supposed to serve — so the same
+    /// test also pushes an identical manifest into a `helm_oci` repo and
+    /// requires a 201 plus exactly one artifact row. A gate that over-rejects
+    /// now fails here instead of passing silently.
     #[tokio::test]
     async fn manifest_put_rejects_classic_helm_repository_before_writes() {
         if std::env::var("DATABASE_URL").is_err() {
@@ -15196,13 +15281,16 @@ mod manifest_digest_db_tests {
             }
             return;
         }
+        let manifest = Bytes::from_static(
+            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.cncf.helm.config.v1+json","digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","size":1},"layers":[]}"#,
+        );
+        let ct = "application/vnd.oci.image.manifest.v1+json";
+
+        // --- Negative: a classic `helm` repository must reject the push. ---
         let fx = tdh::Fixture::setup("local", "helm")
             .await
             .expect("fixture setup");
         let auth = bearer(&fx).await;
-        let manifest = Bytes::from_static(
-            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.cncf.helm.config.v1+json","digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","size":1},"layers":[]}"#,
-        );
 
         let (status, _, body) = send(
             router().with_state(fx.state.clone()),
@@ -15210,8 +15298,8 @@ mod manifest_digest_db_tests {
                 Method::PUT,
                 format!("/{}/keycloak/manifests/26.7.0", fx.repo_key),
                 &auth,
-                Some("application/vnd.oci.image.manifest.v1+json"),
-                manifest,
+                Some(ct),
+                manifest.clone(),
             ),
         )
         .await;
@@ -15235,6 +15323,40 @@ mod manifest_digest_db_tests {
         assert_eq!(tag_count, 0);
 
         cleanup(&fx).await;
+
+        // --- Positive control: the same push into `helm_oci` must SUCCEED. ---
+        let ok = tdh::Fixture::setup("local", "helm_oci")
+            .await
+            .expect("helm_oci fixture setup");
+        let ok_auth = bearer(&ok).await;
+
+        let (status, _, body) = send(
+            router().with_state(ok.state.clone()),
+            req(
+                Method::PUT,
+                format!("/{}/keycloak/manifests/26.7.0", ok.repo_key),
+                &ok_auth,
+                Some(ct),
+                manifest,
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "helm_oci manifest PUT must still be accepted: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let ok_artifacts: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(ok.repo_id)
+                .fetch_one(&ok.pool)
+                .await
+                .expect("artifact count");
+        assert_eq!(ok_artifacts, 1, "helm_oci push must write its artifact row");
+
+        cleanup(&ok).await;
     }
 
     /// The core #1681 scenario end to end: a manifest pushed under a tag stays


### PR DESCRIPTION
## Summary

- Reject OCI Distribution requests when the target repository format is not backed by the OCI handler, returning `400 UNSUPPORTED` before writes.
- Continue accepting `helm_oci` and the other OCI-backed repository formats.
- Exclude legacy OCI manifest rows from classic Helm `index.yaml` generation so already affected repositories produce a valid index without destructive data migration.
- Fixes #3150.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

Validated locally:

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib` (14,722 passed; 0 failed; 6 ignored)

## API Changes

The existing OCI endpoints now reject classic `helm` repositories. No endpoints, request/response schemas, or migrations were added.

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes