### PR TITLE
fix(pub): accept non-string dependency forms in pubspec.yaml

### DIFF
--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -1167,6 +1167,68 @@ mod tests {
         encoder.finish().expect("gzip finish")
     }
 
+    /// Negative controls for the #3058 widening.
+    ///
+    /// `dependencies` moved from `HashMap<String, String>` to an untyped
+    /// value, which is the right fix -- but it also means a fully
+    /// attacker-controlled pubspec now drives an untyped deserializer at
+    /// publish time. These pin that malformed input still degrades to a clean
+    /// `Err` (a 400) rather than a panic or a stack overflow, which is the
+    /// property the widening could plausibly have broken.
+    ///
+    /// Deliberately assert `is_err()` and not a specific message: the point is
+    /// that the request fails gracefully, not how the error is worded.
+    #[test]
+    fn test_malformed_pubspec_dependencies_fail_cleanly_3058() {
+        // Deeply nested map. serde_yaml caps nesting at 128 and returns
+        // RecursionLimitExceeded; without a limit this is a stack overflow,
+        // which aborts the process rather than the request.
+        let deep = format!(
+            "name: x\nversion: 1.0.0\ndependencies:\n  bomb:{}",
+            // Indentation must INCREASE per level -- a constant indent is 200
+            // siblings, not 200 levels deep, and parses fine.
+            (0..200)
+                .map(|i| format!("\n{}k:", " ".repeat(4 + i * 2)))
+                .collect::<String>()
+        );
+        assert!(
+            extract_pubspec_from_archive(&archive_with_pubspec(&deep)).is_err(),
+            "a 200-deep dependency map must be rejected, not overflow the stack"
+        );
+
+        // Non-string mapping keys, at both levels. Measured rather than
+        // assumed: serde coerces a scalar key to a string in BOTH the outer
+        // `HashMap<String, _>` and the untyped value, so these parse rather
+        // than erroring. That is benign -- what matters is that neither
+        // panics on the conversion, which is the failure mode a widened
+        // untyped deserializer could plausibly introduce.
+        for coerced in [
+            "name: x\nversion: 1.0.0\ndependencies:\n  1: foo\n",
+            "name: x\nversion: 1.0.0\ndependencies:\n  foo:\n    1: bar\n",
+        ] {
+            assert!(
+                extract_pubspec_from_archive(&archive_with_pubspec(coerced)).is_ok(),
+                "scalar mapping keys are coerced to strings, not rejected: {coerced:?}"
+            );
+        }
+
+        // Wrong container shape where a mapping is required.
+        let sequence = "name: x\nversion: 1.0.0\ndependencies:\n  - a\n  - b\n";
+        assert!(
+            extract_pubspec_from_archive(&archive_with_pubspec(sequence)).is_err(),
+            "a sequence where a mapping is required must be rejected cleanly"
+        );
+
+        // Positive control. Without this the three assertions above are
+        // satisfied by a parser that rejects everything -- including every
+        // real Flutter pubspec, which is the bug #3058 fixed.
+        let good = "name: x\nversion: 1.0.0\ndependencies:\n  flutter:\n    sdk: flutter\n";
+        assert!(
+            extract_pubspec_from_archive(&archive_with_pubspec(good)).is_ok(),
+            "the legitimate map form must still parse"
+        );
+    }
+
     /// Regression test for #3058: a real Flutter plugin archive must survive
     /// pubspec extraction. Every non-string dependency form Pub permits is
     /// present here; each one previously aborted the upload with 400.

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -1145,6 +1145,90 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Build a gzipped tar containing exactly one `pubspec.yaml` with `body`.
+    fn archive_with_pubspec(body: &str) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut tar_builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_path("pubspec.yaml").unwrap();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar_builder
+            .append(&header, body.as_bytes())
+            .expect("append pubspec");
+        let tar_bytes = tar_builder.into_inner().expect("finish tar");
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar_bytes).expect("gzip write");
+        encoder.finish().expect("gzip finish")
+    }
+
+    /// Regression test for #3058: a real Flutter plugin archive must survive
+    /// pubspec extraction. Every non-string dependency form Pub permits is
+    /// present here; each one previously aborted the upload with 400.
+    #[test]
+    fn test_extract_pubspec_from_flutter_plugin_archive_3058() {
+        let pubspec = r#"
+name: my_flutter_plugin
+version: 2.1.0
+description: A Flutter plugin with the full range of dependency forms.
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.0
+  some_git_pkg:
+    git:
+      url: https://example.com/pkg.git
+      ref: main
+  some_path_pkg:
+    path: ../local_pkg
+  some_hosted_pkg:
+    hosted:
+      name: some_hosted_pkg
+      url: https://pub.example.com
+    version: ^1.0.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  test: ^1.16.0
+"#;
+
+        let spec = extract_pubspec_from_archive(&archive_with_pubspec(pubspec))
+            .expect("Flutter plugin archive must yield a pubspec");
+
+        assert_eq!(spec.name, "my_flutter_plugin");
+        assert_eq!(spec.version, "2.1.0");
+
+        let deps = spec.dependencies.expect("dependencies present");
+        assert_eq!(deps["flutter"], serde_json::json!({ "sdk": "flutter" }));
+        assert_eq!(deps["http"], serde_json::json!("^0.13.0"));
+        assert_eq!(
+            deps["some_path_pkg"],
+            serde_json::json!({ "path": "../local_pkg" })
+        );
+        assert_eq!(
+            deps["some_git_pkg"]["git"]["url"],
+            serde_json::json!("https://example.com/pkg.git")
+        );
+        assert_eq!(
+            deps["some_hosted_pkg"]["hosted"]["url"],
+            serde_json::json!("https://pub.example.com")
+        );
+
+        let dev_deps = spec.dev_dependencies.expect("dev_dependencies present");
+        assert_eq!(
+            dev_deps["flutter_test"],
+            serde_json::json!({ "sdk": "flutter" })
+        );
+    }
+
     #[test]
     fn test_pub_error_response_format() {
         let resp = pub_error_response(StatusCode::NOT_FOUND, "NOT_FOUND", "Package not found");

--- a/backend/src/formats/pub.rs
+++ b/backend/src/formats/pub.rs
@@ -243,9 +243,18 @@ mod tests {
                     .collect(),
             ),
             dependencies: Some(
-                vec![("http".to_string(), serde_json::json!("^0.13.0"))]
-                    .into_iter()
-                    .collect(),
+                vec![
+                    ("http".to_string(), serde_json::json!("^0.13.0")),
+                    // The map form #3058 added support for. It has to survive
+                    // SERIALIZATION too, not just parsing: `newUpload`
+                    // persists `serde_json::to_value(&pubspec)` and the
+                    // registry serves that back as the published pubspec, so
+                    // a `skip_serializing` on this field would leave every
+                    // client resolving against an empty dependency set.
+                    ("flutter".to_string(), serde_json::json!({"sdk": "flutter"})),
+                ]
+                .into_iter()
+                .collect(),
             ),
             dev_dependencies: Some(
                 vec![("test".to_string(), serde_json::json!("^1.16.0"))]
@@ -258,6 +267,13 @@ mod tests {
         assert_eq!(json["name"], "my_package");
         assert_eq!(json["version"], "1.0.0");
         assert_eq!(json["description"], "A test package");
+        assert_eq!(json["dependencies"]["http"], "^0.13.0");
+        assert_eq!(
+            json["dependencies"]["flutter"],
+            serde_json::json!({"sdk": "flutter"}),
+            "the map dependency form must survive the round trip the registry \
+             actually serves"
+        );
     }
 
     #[test]

--- a/backend/src/formats/pub.rs
+++ b/backend/src/formats/pub.rs
@@ -28,10 +28,16 @@ pub struct PubSpec {
     pub repository: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<HashMap<String, String>>,
+    /// Dependency constraints, keyed by package name.
+    ///
+    /// Values are intentionally untyped: Pub allows a plain version string
+    /// (`http: ^0.13.0`) *or* a mapping for SDK, git, path and hosted
+    /// dependencies (`flutter: {sdk: flutter}`). Modelling this as a string
+    /// rejected every Flutter package at publish time (#3058).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dependencies: Option<HashMap<String, String>>,
+    pub dependencies: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dev_dependencies: Option<HashMap<String, String>>,
+    pub dev_dependencies: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Handler for Pub.dev format (Dart/Flutter packages)
@@ -237,12 +243,12 @@ mod tests {
                     .collect(),
             ),
             dependencies: Some(
-                vec![("http".to_string(), "^0.13.0".to_string())]
+                vec![("http".to_string(), serde_json::json!("^0.13.0"))]
                     .into_iter()
                     .collect(),
             ),
             dev_dependencies: Some(
-                vec![("test".to_string(), "^1.16.0".to_string())]
+                vec![("test".to_string(), serde_json::json!("^1.16.0"))]
                     .into_iter()
                     .collect(),
             ),
@@ -297,5 +303,41 @@ mod tests {
         assert!(result.is_ok());
         let info = result.unwrap();
         assert_eq!(info.version, Some("1.0.0-beta.1".to_string()));
+    }
+
+    /// A Flutter plugin's pubspec.yaml declares SDK dependencies as nested
+    /// mappings (`flutter: {sdk: flutter}`), not as version strings. Parsing
+    /// must accept them; rejecting them made `dart pub publish` fail with 400
+    /// during the multipart upload step (#3058).
+    #[test]
+    fn test_deserialize_pubspec_with_flutter_sdk_dependencies_3058() {
+        let yaml = r#"
+name: my_flutter_plugin
+version: 1.0.0
+description: A Flutter plugin
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  test: ^1.16.0
+"#;
+
+        let spec: PubSpec = serde_yaml::from_str(yaml).expect("Flutter pubspec must parse");
+
+        assert_eq!(spec.name, "my_flutter_plugin");
+        let deps = spec.dependencies.expect("dependencies present");
+        assert_eq!(deps["flutter"], serde_json::json!({ "sdk": "flutter" }));
+        assert_eq!(deps["http"], serde_json::json!("^0.13.0"));
+        let dev_deps = spec.dev_dependencies.expect("dev_dependencies present");
+        assert_eq!(
+            dev_deps["flutter_test"],
+            serde_json::json!({ "sdk": "flutter" })
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3058.

Publishing any Flutter package to a hosted Pub repository failed with `400 Bad Request` during the multipart upload step. The reporter's hypothesis was correct, and the failure is reproducible at the exact line they suspected.

`PubSpec` modelled dependency values as strings:

```rust
pub dependencies: Option<HashMap<String, String>>,
pub dev_dependencies: Option<HashMap<String, String>>,
```

Pub allows a dependency value to be either a version string (`http: ^0.13.0`) **or** a mapping — for SDK, git, path and hosted dependencies. Every Flutter package declares `flutter: {sdk: flutter}`, so `serde_yaml` rejected the pubspec outright:

```
dependencies.flutter: invalid type: map, expected a string at line 10 column 5
```

`extract_pubspec_from_staged` turns that error into the `400` the reporter saw, which is why step 1 of the upload flow (`GET /api/packages/versions/new`) succeeded while step 2 failed.

This types both fields as `serde_json::Value` so every dependency form round-trips. That mirrors how `CargoToml::dev_dependencies` already solves the identical problem with `toml::Value` (`backend/src/formats/cargo.rs:406`), so it introduces no new pattern.

**Scope of impact:** `PubSpec` is only deserialized in the publish path — `extract_pubspec_from_staged` / `extract_pubspec_from_archive` are its sole call sites. Proxied metadata from an upstream registry is passed through as raw JSON and only has `archive_url` rewritten, so remote and virtual Pub repositories are unaffected by this change.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Two tests, at different levels:

1. `formats::pub::tests::test_deserialize_pubspec_with_flutter_sdk_dependencies_3058` — deserializes a Flutter pubspec directly.
2. `api::handlers::pub_registry::tests::test_extract_pubspec_from_flutter_plugin_archive_3058` — runs a real gzipped tar through `extract_pubspec_from_archive`, the function whose error becomes the 400. It covers all four non-string dependency forms: sdk, git, path and hosted.

Both were confirmed to fail on `main` before the fix. The archive-level test fails with the production error string:

```
Failed to parse pubspec.yaml: dependencies.flutter: invalid type: map, expected a string at line 10 column 5
```

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

Local gate results:

```
cargo fmt --check                                       clean
cargo clippy --workspace --all-targets -- -D warnings    no warnings
cargo test --workspace --lib                            14721 passed; 0 failed; 6 ignored
```

One box deliberately left unchecked, so a reviewer does not have to guess: **Manually tested locally** — I did not run a real `dart pub publish` against a running instance. The tests cover the parse stage that produced the 400, but not the remainder of the upload protocol (`newUpload` → `newUploadFinish` → query → download) that the reporter enumerated under Expected Behavior. If you would like that verified end to end before merging, an E2E case in artifact-keeper-test exercising a Flutter plugin would be the right place, and I am happy to add one.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

`PubSpec` is an internal parsing type; it is not part of the OpenAPI surface. The wire format of the Pub metadata this affects is unchanged for every pubspec that parsed before — a string dependency still serializes as a string.

## Follow-up (not in this PR)

While tracing this I noticed a separate defect worth its own issue: `PubSpec` has no catch-all field, and the metadata stored at publish time is the re-serialized struct. Fields Pub permits but the struct does not declare — `flutter:`, `topics:`, `executables:`, `publish_to:` — are silently dropped from the pubspec served by `/api/packages/<name>`. It does not affect version solving (`dependencies` and `environment` survive), which is why it is not bundled here. Happy to file it separately if that is useful.
