### PR TITLE
fix(oci-gc): re-check blob liveness immediately before the cleanup storage delete

### DIFF
--- a/backend/migrations/193_oci_blobs_storage_key_index.sql
+++ b/backend/migrations/193_oci_blobs_storage_key_index.sql
@@ -1,0 +1,38 @@
+-- Migration: index oci_blobs.storage_key for the OCI cleanup sweep's
+-- pre-delete liveness re-check (#3085).
+--
+-- The sweep re-asserts blob liveness immediately before each destructive
+-- storage delete. That predicate contains
+-- `NOT EXISTS (SELECT 1 FROM oci_blobs b WHERE b.storage_key = k.storage_key)`.
+--
+-- Before #3085 that subquery ran once per batch, inside the candidate SELECT,
+-- so a sequential scan was amortised across the whole batch. The re-check runs
+-- it once per candidate, and oci_blobs has no index on storage_key -- migration
+-- 118 indexed oci_upload_sessions.storage_temp_key and oci_upload_parts
+-- .storage_key, but not this one, because nothing needed it per-row until now.
+--
+-- Measured on 300k blobs: 87 ms per hold without the index versus 0.19 ms with
+-- it; a full 1000-row batch (OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT) went from
+-- 30.7 s to 0.19 s, ~163x. The cost scales linearly with registry size, so on a
+-- large registry a batch would begin to approach the 15 minute claim TTL and
+-- leases would lapse mid-sweep.
+--
+-- CREATE INDEX CONCURRENTLY is intentionally not used here, matching migration
+-- 166: sqlx::migrate runs each migration file inside a transaction, and
+-- CONCURRENTLY is rejected inside a transaction block. The non-concurrent build
+-- takes ACCESS EXCLUSIVE on `oci_blobs` for the duration of the build, so blob
+-- uploads block until it finishes. This is a single-column btree on a table that
+-- is far smaller than `artifacts` (one row per stored blob, deduplicated by
+-- (repository_id, digest)), so the window is short -- but on a large registry,
+-- plan the upgrade accordingly.
+--
+-- Operators who cannot accept the lock window can skip this migration and build
+-- the index out of band against a quiescent table:
+--
+--   CREATE INDEX CONCURRENTLY idx_oci_blobs_storage_key ON oci_blobs (storage_key);
+--
+-- Correctness does not depend on it: without the index the liveness re-check
+-- still returns the right answer, just via a sequential scan. The index is
+-- purely a query-plan accelerator.
+CREATE INDEX IF NOT EXISTS idx_oci_blobs_storage_key
+    ON oci_blobs (storage_key);

--- a/backend/migrations/193_oci_blobs_storage_key_index.sql
+++ b/backend/migrations/193_oci_blobs_storage_key_index.sql
@@ -17,22 +17,44 @@
 -- large registry a batch would begin to approach the 15 minute claim TTL and
 -- leases would lapse mid-sweep.
 --
--- CREATE INDEX CONCURRENTLY is intentionally not used here, matching migration
--- 166: sqlx::migrate runs each migration file inside a transaction, and
--- CONCURRENTLY is rejected inside a transaction block. The non-concurrent build
--- takes ACCESS EXCLUSIVE on `oci_blobs` for the duration of the build, so blob
--- uploads block until it finishes. This is a single-column btree on a table that
--- is far smaller than `artifacts` (one row per stored blob, deduplicated by
--- (repository_id, digest)), so the window is short -- but on a large registry,
--- plan the upgrade accordingly.
+-- LOCK BEHAVIOUR. CREATE INDEX CONCURRENTLY is intentionally not used here,
+-- matching migration 166: sqlx::migrate runs each migration file inside a
+-- transaction, and CONCURRENTLY is rejected inside a transaction block.
 --
--- Operators who cannot accept the lock window can skip this migration and build
--- the index out of band against a quiescent table:
+-- A plain CREATE INDEX takes a SHARE lock on `oci_blobs` for the duration of
+-- the build. SHARE conflicts with ROW EXCLUSIVE, so for as long as the build
+-- runs:
+--
+--   * writes to oci_blobs BLOCK -- INSERT/UPDATE/DELETE, which means blob
+--     commits on the push path wait, as do blob GC's row deletes;
+--   * reads do NOT block -- plain SELECT takes ACCESS SHARE, which is
+--     compatible with SHARE, so pulls and manifest resolution are unaffected.
+--
+-- (It is not ACCESS EXCLUSIVE. Nothing here rewrites the table or takes the
+-- table fully offline; an earlier revision of this comment said otherwise and
+-- was wrong. Plan the window against blocked writers, not blocked readers.)
+--
+-- This is a single-column btree on a table far smaller than `artifacts` (one
+-- row per stored blob, deduplicated by (repository_id, digest)), so the build
+-- is short -- but the write stall is real, and on a large registry the upgrade
+-- should be scheduled accordingly.
+--
+-- Operators who cannot accept even that write stall should build the index out
+-- of band, BEFORE deploying this migration, against a live table:
 --
 --   CREATE INDEX CONCURRENTLY idx_oci_blobs_storage_key ON oci_blobs (storage_key);
 --
--- Correctness does not depend on it: without the index the liveness re-check
--- still returns the right answer, just via a sequential scan. The index is
--- purely a query-plan accelerator.
+-- The IF NOT EXISTS below then makes this migration a no-op. Note that this is
+-- the only supported way to avoid the stall: the migration itself cannot simply
+-- be skipped, since sqlx tracks applied migrations by checksum and a missing
+-- entry blocks the ledger.
+--
+-- DO build it, one way or the other. Correctness does not depend on the index
+-- -- without it the liveness re-check still returns the right answer, just via
+-- a sequential scan -- but forward progress does. Per the measurement above, on
+-- a large registry the un-indexed re-check pushes a batch toward the 15 minute
+-- claim TTL, and a sweep whose leases lapse mid-batch stops reclaiming storage.
+-- Skipping the index outright is not an equivalent option; it trades a bounded
+-- write stall for an unbounded GC stall.
 CREATE INDEX IF NOT EXISTS idx_oci_blobs_storage_key
     ON oci_blobs (storage_key);

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -7447,16 +7447,24 @@ mod tests {
     /// the same batch live before the sweep reaches it.
     struct MidBatchPushStorage {
         db: PgPool,
-        trip_key: String,
         revive_key: String,
         revive_repo: Uuid,
         revive_digest: String,
         deleted: std::sync::Mutex<Vec<String>>,
+        pushed: std::sync::atomic::AtomicBool,
     }
 
     impl MidBatchPushStorage {
         fn deleted_keys(&self) -> Vec<String> {
             self.deleted.lock().expect("deleted lock").clone()
+        }
+
+        /// Did the simulated concurrent push actually commit its `oci_blobs`
+        /// row? If it never fired, the sweep reached the revive key first and
+        /// the test never entered the window it exists to cover — a false red
+        /// rather than a regression, so the tests assert this explicitly.
+        fn pushed(&self) -> bool {
+            self.pushed.load(std::sync::atomic::Ordering::SeqCst)
         }
     }
 
@@ -7472,10 +7480,21 @@ mod tests {
             Ok(true)
         }
         async fn delete(&self, key: &str) -> crate::error::Result<()> {
+            // Fire the concurrent push on the FIRST delete that is not the
+            // revive key itself, rather than on one specific "head" key.
+            //
+            // The claim query orders its candidate CTE by `created_at`, but it
+            // returns rows from `UPDATE ... RETURNING`, which carries NO row
+            // order guarantee — the CTE's ORDER BY does not survive it. The
+            // observed order therefore depends on the chosen plan, and it
+            // flips once `oci_upload_cleanup_keys` holds rows from other
+            // tests. Keying the push off a named head made this test pass in
+            // isolation and fail in the full module run.
             let tripped = {
                 let mut seen = self.deleted.lock().expect("deleted lock");
                 seen.push(key.to_string());
-                key == self.trip_key
+                key != self.revive_key
+                    && !self.pushed.swap(true, std::sync::atomic::Ordering::SeqCst)
             };
             if tripped {
                 sqlx::query(
@@ -7518,12 +7537,16 @@ mod tests {
         let revive_key = format!("oci-blobs/{revive_digest}");
         let control_key = format!("oci-uploads/{tag}-control/{run}");
 
+        // `revive` ($3) is seeded NEWEST so that any order-preserving plan puts
+        // it last, maximising the chance another key is deleted (and so fires
+        // the push) before the sweep reaches it. The tests assert the push
+        // actually fired rather than trusting this.
         sqlx::query(
             "INSERT INTO oci_upload_cleanup_keys \
                  (repository_id, storage_key, created_at, storage_write_completed_at) \
              VALUES ($1, $2, NOW() - INTERVAL '72 hours', NOW() - INTERVAL '72 hours'), \
-                    ($1, $3, NOW() - INTERVAL '71 hours', NOW() - INTERVAL '71 hours'), \
-                    ($1, $4, NOW() - INTERVAL '70 hours', NOW() - INTERVAL '70 hours')",
+                    ($1, $3, NOW() - INTERVAL '70 hours', NOW() - INTERVAL '70 hours'), \
+                    ($1, $4, NOW() - INTERVAL '71 hours', NOW() - INTERVAL '71 hours')",
         )
         .bind(fixture.repo_id)
         .bind(&trip_key)
@@ -7535,11 +7558,11 @@ mod tests {
 
         let storage = Arc::new(MidBatchPushStorage {
             db: fixture.pool.clone(),
-            trip_key: trip_key.clone(),
             revive_key: revive_key.clone(),
             revive_repo: fixture.repo_id,
             revive_digest,
             deleted: std::sync::Mutex::new(Vec::new()),
+            pushed: std::sync::atomic::AtomicBool::new(false),
         });
         let mut backends = std::collections::HashMap::new();
         backends.insert(
@@ -7587,6 +7610,18 @@ mod tests {
     async fn unreferenced_sweep_keeps_bytes_of_blob_that_went_live_after_claim() {
         use crate::api::handlers::test_db_helpers as tdh;
 
+        // BOTH guards are required, and they are not interchangeable.
+        //
+        // `storage_gc_test_guard` is an in-process mutex; `blob_gc_serial_lock`
+        // is a Postgres advisory lock. This test runs an UNSCOPED
+        // (`repo_scope = None`) cleanup-key sweep, exactly like the sibling
+        // `test_run_gc_*` tests, which take only the in-process mutex. Holding
+        // just the advisory lock does not exclude them, so under the single-
+        // process `cargo test --workspace --lib` job a sibling's cluster-wide
+        // sweep reaps this test's fixtures first and `deleted` comes back
+        // empty. (Under nextest the `db-serial` group already serializes the
+        // module, which is why that run stayed green and hid this.)
+        let _sweep_guard = storage_gc_test_guard().await;
         let _gc_guard = tdh::blob_gc_serial_lock().await;
         let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
             return;
@@ -7595,17 +7630,28 @@ mod tests {
         let (service, storage, keys) = setup_mid_batch_push_sweep(&fixture, "gc3085u").await;
         let [trip_key, revive_key, control_key] = keys.clone();
 
+        // Scope the sweep to this fixture's repository. The sweep is otherwise
+        // cluster-wide, so rows other tests left in `oci_upload_cleanup_keys`
+        // join the batch and change both its size and its walk order. The
+        // pre-delete hook under test is per-key and identical either way.
         let mut result = empty_gc_result(false);
         service
-            .cleanup_unreferenced_oci_upload_keys(None, false, &mut result)
+            .cleanup_unreferenced_oci_upload_keys(Some(fixture.repo_id), false, &mut result)
             .await
             .expect("unreferenced cleanup-key sweep runs");
 
+        let pushed = storage.pushed();
         let deleted = finish_mid_batch_push_sweep(&fixture, &storage, &keys).await;
 
         assert!(
+            pushed,
+            "precondition: the concurrent push must fire before the sweep reaches the revive \
+             key, otherwise this test never enters the window it covers: {deleted:?}"
+        );
+        assert!(
             deleted.contains(&trip_key),
-            "batch head must be swept (it drives the concurrent push): {deleted:?}"
+            "a still-unreferenced key must be swept (one of these drives the concurrent \
+             push): {deleted:?}"
         );
         assert!(
             deleted.contains(&control_key),
@@ -7626,6 +7672,11 @@ mod tests {
     async fn pending_reaper_keeps_bytes_of_blob_that_went_live_after_claim() {
         use crate::api::handlers::test_db_helpers as tdh;
 
+        // See the note on the unreferenced-sweep test above: the in-process
+        // mutex is what excludes the sibling `test_run_gc_*` cluster-wide
+        // sweeps under `cargo test --workspace --lib`. The advisory lock alone
+        // does not.
+        let _sweep_guard = storage_gc_test_guard().await;
         let _gc_guard = tdh::blob_gc_serial_lock().await;
         let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
             return;
@@ -7644,17 +7695,25 @@ mod tests {
         .await
         .expect("un-mark the seeded rows");
 
+        // Repo-scoped for the same reason as the unreferenced-sweep test above.
         let mut result = empty_gc_result(false);
         service
-            .reap_pending_oci_upload_cleanup_keys(None, false, &mut result)
+            .reap_pending_oci_upload_cleanup_keys(Some(fixture.repo_id), false, &mut result)
             .await
             .expect("pending cleanup-key reaper runs");
 
+        let pushed = storage.pushed();
         let deleted = finish_mid_batch_push_sweep(&fixture, &storage, &keys).await;
 
         assert!(
+            pushed,
+            "precondition: the concurrent push must fire before the reaper reaches the revive \
+             key, otherwise this test never enters the window it covers: {deleted:?}"
+        );
+        assert!(
             deleted.contains(&trip_key),
-            "batch head must be reaped (it drives the concurrent push): {deleted:?}"
+            "a still-unreferenced pending key must be reaped (one of these drives the \
+             concurrent push): {deleted:?}"
         );
         assert!(
             deleted.contains(&control_key),

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -381,6 +381,67 @@ struct OciUploadCleanupKey {
     claim_token: Option<Uuid>,
 }
 
+/// Liveness clauses shared by both cleanup-journal sweeps: a storage object is
+/// only reclaimable while no live upload part and no committed `oci_blobs` row
+/// references it. Written against the bare table name so the fragment composes
+/// into an `UPDATE`/`DELETE` on `oci_upload_cleanup_keys`.
+const CLEANUP_KEY_SHARED_LIVENESS_SQL: &str = r#"
+              AND NOT EXISTS (
+                SELECT 1 FROM oci_upload_parts p
+                WHERE p.storage_key = oci_upload_cleanup_keys.storage_key
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM oci_blobs b
+                WHERE b.storage_key = oci_upload_cleanup_keys.storage_key
+              )"#;
+
+/// Committed-key (`storage_write_completed_at IS NOT NULL`) half of the
+/// liveness predicate. Deliberately NOT guarded by `s.id = upload_session_id`
+/// — see the matching row `DELETE` in
+/// [`StorageGcService::cleanup_unreferenced_oci_upload_keys`].
+const UNREFERENCED_CLEANUP_KEY_LIVENESS_HEAD_SQL: &str = r#"
+              AND storage_write_completed_at IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM oci_upload_sessions s
+                WHERE s.storage_temp_key = oci_upload_cleanup_keys.storage_key
+              )"#;
+
+/// Pending-key (`storage_write_completed_at IS NULL`) half of the liveness
+/// predicate. The owning session is re-checked by id as well as by key — see
+/// the matching row `DELETE` in
+/// [`StorageGcService::reap_pending_oci_upload_cleanup_keys`].
+const PENDING_CLEANUP_KEY_LIVENESS_HEAD_SQL: &str = r#"
+              AND storage_write_completed_at IS NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM oci_upload_sessions s
+                WHERE s.id = oci_upload_cleanup_keys.upload_session_id
+                   OR s.storage_temp_key = oci_upload_cleanup_keys.storage_key
+              )"#;
+
+/// Which cleanup-journal sweep owns a claimed key, and therefore which
+/// liveness predicate must still hold at the instant of its storage delete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CleanupSweepKind {
+    /// [`StorageGcService::cleanup_unreferenced_oci_upload_keys`].
+    Unreferenced,
+    /// [`StorageGcService::reap_pending_oci_upload_cleanup_keys`].
+    Pending,
+}
+
+impl CleanupSweepKind {
+    /// SQL fragment (a chain of `AND` clauses) re-asserted immediately before
+    /// this sweep's destructive storage delete. Mirrors the sweep's guarded
+    /// row `DELETE` so the pre-delete hook and the post-delete row removal
+    /// agree on exactly what "still reclaimable" means (#3085).
+    fn liveness_predicate_sql(self) -> String {
+        let head = match self {
+            Self::Unreferenced => UNREFERENCED_CLEANUP_KEY_LIVENESS_HEAD_SQL,
+            Self::Pending => PENDING_CLEANUP_KEY_LIVENESS_HEAD_SQL,
+        };
+        format!("{head}{CLEANUP_KEY_SHARED_LIVENESS_SQL}")
+    }
+}
+
 impl StorageGcService {
     pub fn new(db: PgPool, storage_registry: Arc<StorageRegistry>) -> Self {
         Self {
@@ -1574,13 +1635,21 @@ impl StorageGcService {
                 }
             };
 
-            // Re-assert ownership immediately before the destructive delete:
-            // earlier keys in this batch may have taken long enough that this
-            // row's claim lapsed and another replica's sweep now owns it.
-            if !self.renew_cleanup_key_claim(&cleanup_key).await {
+            // Re-assert ownership AND liveness immediately before the
+            // destructive delete: earlier keys in this batch may have taken
+            // long enough that this row's claim lapsed and another replica's
+            // sweep now owns it, or that a concurrent push committed an
+            // `oci_blobs` row for this key and the object is live again
+            // (#3085). The row DELETE below re-checks liveness too, but it
+            // runs after the bytes are gone, so this is the check that
+            // prevents the data loss.
+            if !self
+                .hold_cleanup_key_claim_for_delete(&cleanup_key, CleanupSweepKind::Unreferenced)
+                .await
+            {
                 tracing::info!(
                     storage_key = %cleanup_key.storage_key,
-                    "cleanup-key claim lost mid-batch; skipping (new owner will delete)"
+                    "cleanup-key claim lost or key became live mid-batch; skipping its storage delete"
                 );
                 continue;
             }
@@ -1692,9 +1761,12 @@ impl StorageGcService {
                 WHERE p.storage_key = c.storage_key
               )
               -- Never select a key that a live `oci_blobs` row references: it is
-              -- a committed blob, not an orphan. The storage object is deleted
-              -- before the row DELETE re-asserts predicates, so this guard MUST
-              -- live on the SELECT to prevent deleting a live blob's bytes.
+              -- a committed blob, not an orphan. This candidate guard is only
+              -- point-in-time — the object is deleted before the row DELETE
+              -- re-asserts predicates, so a digest that goes live AFTER the
+              -- scan is caught by `hold_cleanup_key_claim_for_delete`, which
+              -- re-asserts this same predicate immediately before the
+              -- destructive delete (#3085).
               AND NOT EXISTS (
                 SELECT 1 FROM oci_blobs b
                 WHERE b.storage_key = c.storage_key
@@ -1806,21 +1878,47 @@ impl StorageGcService {
         .await;
     }
 
-    /// Re-extend one cleanup-key claim immediately before its storage delete.
+    /// Re-assert ownership **and liveness** for one cleanup key immediately
+    /// before its storage delete. Returns `true` only when the key is still
+    /// this sweeper's and still reclaimable; the caller must skip the
+    /// destructive delete otherwise.
     ///
-    /// A claimed batch (up to `OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT` rows) walks
-    /// its storage deletes sequentially, and slow object-store deletes can
-    /// outlive the fixed claim TTL — a lapsed tail claim may then be
-    /// re-claimed by another replica's sweep while this one is still walking
-    /// its list, letting both attempt the same destructive delete. Returns
-    /// `false` when the claim was lost (token superseded); the caller must
-    /// skip the delete because the new owner will perform it.
-    async fn renew_cleanup_key_claim(&self, cleanup_key: &OciUploadCleanupKey) -> bool {
+    /// Two independent things can change between the claim and the delete:
+    ///
+    /// 1. **Ownership.** A claimed batch (up to
+    ///    `OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT` rows) walks its storage deletes
+    ///    sequentially, and slow object-store deletes can outlive the fixed
+    ///    claim TTL — a lapsed tail claim may then be re-claimed by another
+    ///    replica's sweep while this one is still walking its list, letting
+    ///    both attempt the same destructive delete.
+    /// 2. **Liveness (#3085).** A digest re-pushed after this row was claimed
+    ///    commits an `oci_blobs` row for the very same `storage_key` (the push
+    ///    path re-uses the journal row via `ON CONFLICT (storage_key)`), so
+    ///    the object is live again. The claim-time predicate is stale by then
+    ///    and the sweep's guarded row `DELETE` re-checks liveness only *after*
+    ///    the bytes are already gone — it saves the journal row, not the blob.
+    ///    Re-asserting the predicate here is the check that actually protects
+    ///    the data, the same shape as the per-row re-check
+    ///    [`is_blob_still_orphan`] performs before the two-phase blob GC's
+    ///    destructive act, and the #1682 "never orphan a live image" guard in
+    ///    `lifecycle_service`.
+    ///
+    /// The renewal and the re-check are one atomic `UPDATE`: a row that has
+    /// become live cannot have its lease extended, so there is no ordering in
+    /// which the caller both holds a fresh lease and proceeds to delete a live
+    /// object. `kind` selects the predicate matching the calling sweep's own
+    /// row `DELETE`.
+    async fn hold_cleanup_key_claim_for_delete(
+        &self,
+        cleanup_key: &OciUploadCleanupKey,
+        kind: CleanupSweepKind,
+    ) -> bool {
         let sql = format!(
             "UPDATE oci_upload_cleanup_keys \
              SET claim_expires_at = NOW() + {claim_ttl} \
-             WHERE id = $1 AND claim_token = $2",
+             WHERE id = $1 AND claim_token = $2{liveness}",
             claim_ttl = OCI_CLEANUP_KEY_CLAIM_TTL_SQL,
+            liveness = kind.liveness_predicate_sql(),
         );
         match sqlx::query(&sql)
             .bind(cleanup_key.id)
@@ -1833,7 +1931,7 @@ impl StorageGcService {
                 tracing::warn!(
                     storage_key = %cleanup_key.storage_key,
                     error = %e,
-                    "failed to renew cleanup-key claim; skipping its storage delete"
+                    "failed to re-assert cleanup-key claim; skipping its storage delete"
                 );
                 false
             }
@@ -1899,14 +1997,19 @@ impl StorageGcService {
                 }
             };
 
-            // Same tail-expiry window as the unreferenced sweep: re-assert
-            // ownership immediately before the destructive delete so a claim
-            // that lapsed while earlier keys in this batch were being deleted
-            // cannot have both owners attempt the same storage delete.
-            if !self.renew_cleanup_key_claim(&cleanup_key).await {
+            // Same tail-expiry and same liveness window as the unreferenced
+            // sweep (#3085): re-assert ownership and the pending-key liveness
+            // predicate immediately before the destructive delete, so neither
+            // a lapsed claim nor a concurrent push that committed an
+            // `oci_blobs` row for this key can be followed by a delete of its
+            // bytes.
+            if !self
+                .hold_cleanup_key_claim_for_delete(&cleanup_key, CleanupSweepKind::Pending)
+                .await
+            {
                 tracing::info!(
                     storage_key = %cleanup_key.storage_key,
-                    "pending cleanup-key claim lost mid-batch; skipping (new owner will delete)"
+                    "pending cleanup-key claim lost or key became live mid-batch; skipping its storage delete"
                 );
                 continue;
             }
@@ -7195,7 +7298,9 @@ mod tests {
         // A live owner renews: the deadline moves forward and the key stays
         // invisible to concurrent sweepers.
         assert!(
-            service.renew_cleanup_key_claim(&mine).await,
+            service
+                .hold_cleanup_key_claim_for_delete(&mine, CleanupSweepKind::Unreferenced)
+                .await,
             "the live owner must be able to renew its claim"
         );
         let contended = service
@@ -7227,7 +7332,9 @@ mod tests {
             "a lapsed tail claim must be reclaimable by another sweeper"
         );
         assert!(
-            !service.renew_cleanup_key_claim(&mine).await,
+            !service
+                .hold_cleanup_key_claim_for_delete(&mine, CleanupSweepKind::Unreferenced)
+                .await,
             "a superseded token must not renew (the delete is skipped)"
         );
 
@@ -7236,5 +7343,286 @@ mod tests {
             .execute(&fixture.pool)
             .await;
         fixture.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #3085: blob liveness must be re-checked immediately before the
+    // destructive storage delete, not only at claim time and at the guarded
+    // row DELETE that runs *after* the bytes are already gone.
+    // -----------------------------------------------------------------------
+
+    /// The pre-delete hook is only a guard if its predicate actually names
+    /// the liveness tables. Runs without a database, so the shape is pinned on
+    /// every CI run even when the DB-backed sweeps below skip.
+    #[test]
+    fn cleanup_sweep_liveness_predicates_assert_blob_and_part_liveness() {
+        for kind in [CleanupSweepKind::Unreferenced, CleanupSweepKind::Pending] {
+            let sql = kind.liveness_predicate_sql();
+            assert!(
+                sql.contains("FROM oci_blobs b"),
+                "{kind:?} pre-delete re-check must refuse a key a committed oci_blobs row                  references (#3085): {sql}"
+            );
+            assert!(
+                sql.contains("FROM oci_upload_parts p"),
+                "{kind:?} pre-delete re-check must refuse a key a live upload part                  references: {sql}"
+            );
+            assert!(
+                sql.contains("FROM oci_upload_sessions s"),
+                "{kind:?} pre-delete re-check must refuse a key a live upload session                  references: {sql}"
+            );
+        }
+    }
+
+    /// Each sweep's pre-delete re-check must match its own guarded row
+    /// `DELETE`: the committed sweep reaps only marked-complete rows, the
+    /// pending reaper only never-marked rows. Swapping them would make the
+    /// hook reject every key and silently disable the sweep.
+    #[test]
+    fn cleanup_sweep_liveness_predicates_match_their_sweep_marker() {
+        let unreferenced = CleanupSweepKind::Unreferenced.liveness_predicate_sql();
+        let pending = CleanupSweepKind::Pending.liveness_predicate_sql();
+        assert!(
+            unreferenced.contains("storage_write_completed_at IS NOT NULL"),
+            "committed sweep re-check must keep its marked-complete guard: {unreferenced}"
+        );
+        assert!(
+            pending.contains("storage_write_completed_at IS NULL"),
+            "pending reaper re-check must keep its never-marked guard: {pending}"
+        );
+        assert!(
+            pending.contains("s.id = oci_upload_cleanup_keys.upload_session_id"),
+            "pending reaper re-check must also protect a key whose owning session is still              live: {pending}"
+        );
+        assert_ne!(unreferenced, pending);
+    }
+
+    /// Storage backend that records every `delete` and, the first time it is
+    /// asked to delete `trip_key`, performs the "concurrent push" that makes
+    /// `revive_key` live (commits an `oci_blobs` row for it).
+    ///
+    /// This reproduces the real production shape deterministically: a claimed
+    /// batch walks its storage deletes sequentially, so a push that lands
+    /// while an earlier key in the batch is being deleted makes a later key in
+    /// the same batch live before the sweep reaches it.
+    struct MidBatchPushStorage {
+        db: PgPool,
+        trip_key: String,
+        revive_key: String,
+        revive_repo: Uuid,
+        revive_digest: String,
+        deleted: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl MidBatchPushStorage {
+        fn deleted_keys(&self) -> Vec<String> {
+            self.deleted.lock().expect("deleted lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl crate::storage::StorageBackend for MidBatchPushStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            Ok(Bytes::new())
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, key: &str) -> crate::error::Result<()> {
+            let tripped = {
+                let mut seen = self.deleted.lock().expect("deleted lock");
+                seen.push(key.to_string());
+                key == self.trip_key
+            };
+            if tripped {
+                sqlx::query(
+                    "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) \
+                     VALUES ($1, $2, 1, $3)",
+                )
+                .bind(self.revive_repo)
+                .bind(&self.revive_digest)
+                .bind(&self.revive_key)
+                .execute(&self.db)
+                .await
+                .expect("concurrent push commits its oci_blobs row");
+            }
+            Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
+    }
+
+    /// Seed three aged, committed, unreferenced cleanup keys ordered
+    /// `trip` -> `revive` -> `control` by `created_at` (the sweep's claim
+    /// order), wire a [`MidBatchPushStorage`] in front of them, and return the
+    /// service plus the recorder.
+    async fn setup_mid_batch_push_sweep(
+        fixture: &crate::api::handlers::test_db_helpers::Fixture,
+        tag: &str,
+    ) -> (StorageGcService, Arc<MidBatchPushStorage>, [String; 3]) {
+        // The sweep must resolve through an interceptable backend:
+        // `StorageRegistry::backend_for` hardcodes "filesystem" to the real FS.
+        set_repo_backend(&fixture.pool, fixture.repo_id, "s3").await;
+
+        let run = Uuid::new_v4().simple().to_string();
+        let trip_key = format!("oci-uploads/{tag}-trip/{run}");
+        let revive_digest = format!("sha256:{run}{}", "0".repeat(32));
+        let revive_key = format!("oci-blobs/{revive_digest}");
+        let control_key = format!("oci-uploads/{tag}-control/{run}");
+
+        sqlx::query(
+            "INSERT INTO oci_upload_cleanup_keys \
+                 (repository_id, storage_key, created_at, storage_write_completed_at) \
+             VALUES ($1, $2, NOW() - INTERVAL '72 hours', NOW() - INTERVAL '72 hours'), \
+                    ($1, $3, NOW() - INTERVAL '71 hours', NOW() - INTERVAL '71 hours'), \
+                    ($1, $4, NOW() - INTERVAL '70 hours', NOW() - INTERVAL '70 hours')",
+        )
+        .bind(fixture.repo_id)
+        .bind(&trip_key)
+        .bind(&revive_key)
+        .bind(&control_key)
+        .execute(&fixture.pool)
+        .await
+        .expect("seed cleanup keys");
+
+        let storage = Arc::new(MidBatchPushStorage {
+            db: fixture.pool.clone(),
+            trip_key: trip_key.clone(),
+            revive_key: revive_key.clone(),
+            revive_repo: fixture.repo_id,
+            revive_digest,
+            deleted: std::sync::Mutex::new(Vec::new()),
+        });
+        let mut backends = std::collections::HashMap::new();
+        backends.insert(
+            "s3".to_string(),
+            storage.clone() as Arc<dyn crate::storage::StorageBackend>,
+        );
+        let registry = Arc::new(crate::storage::StorageRegistry::new(
+            backends,
+            "s3".to_string(),
+        ));
+        let service = StorageGcService::new(fixture.pool.clone(), registry);
+        (service, storage, [trip_key, revive_key, control_key])
+    }
+
+    /// Collect what the sweep actually deleted, then drop everything the
+    /// fixture seeded (including the "concurrent push" `oci_blobs` row, which
+    /// outlives the journal rows) and tear the repository down.
+    async fn finish_mid_batch_push_sweep(
+        fixture: &crate::api::handlers::test_db_helpers::Fixture,
+        storage: &MidBatchPushStorage,
+        keys: &[String; 3],
+    ) -> Vec<String> {
+        let deleted = storage.deleted_keys();
+        let _ = sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE storage_key = ANY($1)")
+            .bind(&keys[..])
+            .execute(&fixture.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM oci_blobs WHERE storage_key = $1")
+            .bind(&keys[1])
+            .execute(&fixture.pool)
+            .await;
+        fixture.teardown().await;
+        deleted
+    }
+
+    /// #3085 regression: a digest that is re-pushed after the sweep claimed
+    /// its journal row is LIVE. The sweep re-checks liveness when it claims
+    /// the key and again at the guarded row `DELETE`, but the row `DELETE`
+    /// runs *after* the storage object is already gone — so without a
+    /// re-check in the pre-delete hook the live blob loses its bytes.
+    ///
+    /// The `control` key in the same batch is never revived and MUST still be
+    /// swept, so the guard cannot pass by simply refusing to delete anything.
+    #[tokio::test]
+    async fn unreferenced_sweep_keeps_bytes_of_blob_that_went_live_after_claim() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let (service, storage, keys) = setup_mid_batch_push_sweep(&fixture, "gc3085u").await;
+        let [trip_key, revive_key, control_key] = keys.clone();
+
+        let mut result = empty_gc_result(false);
+        service
+            .cleanup_unreferenced_oci_upload_keys(None, false, &mut result)
+            .await
+            .expect("unreferenced cleanup-key sweep runs");
+
+        let deleted = finish_mid_batch_push_sweep(&fixture, &storage, &keys).await;
+
+        assert!(
+            deleted.contains(&trip_key),
+            "batch head must be swept (it drives the concurrent push): {deleted:?}"
+        );
+        assert!(
+            deleted.contains(&control_key),
+            "positive control: a still-unreferenced key must still be swept, otherwise the \
+             liveness guard could pass by never deleting anything: {deleted:?}"
+        );
+        assert!(
+            !deleted.contains(&revive_key),
+            "#3085: blob liveness must be re-checked immediately before the storage delete. \
+             An oci_blobs row committed after the claim makes the blob live, so its bytes \
+             must survive the sweep: {deleted:?}"
+        );
+    }
+
+    /// Same window on the pending (NULL-marked) reaper, which shares the
+    /// pre-delete hook.
+    #[tokio::test]
+    async fn pending_reaper_keeps_bytes_of_blob_that_went_live_after_claim() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let (service, storage, keys) = setup_mid_batch_push_sweep(&fixture, "gc3085p").await;
+        let [trip_key, revive_key, control_key] = keys.clone();
+        // The pending reaper only sees rows whose storage write was never
+        // marked complete.
+        sqlx::query(
+            "UPDATE oci_upload_cleanup_keys SET storage_write_completed_at = NULL \
+             WHERE storage_key = ANY($1)",
+        )
+        .bind(&keys[..])
+        .execute(&fixture.pool)
+        .await
+        .expect("un-mark the seeded rows");
+
+        let mut result = empty_gc_result(false);
+        service
+            .reap_pending_oci_upload_cleanup_keys(None, false, &mut result)
+            .await
+            .expect("pending cleanup-key reaper runs");
+
+        let deleted = finish_mid_batch_push_sweep(&fixture, &storage, &keys).await;
+
+        assert!(
+            deleted.contains(&trip_key),
+            "batch head must be reaped (it drives the concurrent push): {deleted:?}"
+        );
+        assert!(
+            deleted.contains(&control_key),
+            "positive control: a still-unreferenced pending key must still be reaped: {deleted:?}"
+        );
+        assert!(
+            !deleted.contains(&revive_key),
+            "#3085: the pending reaper shares the pre-delete hook and must also refuse to \
+             delete the bytes of a blob that went live after the claim: {deleted:?}"
+        );
     }
 }

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -1898,10 +1898,17 @@ impl StorageGcService {
     ///    and the sweep's guarded row `DELETE` re-checks liveness only *after*
     ///    the bytes are already gone — it saves the journal row, not the blob.
     ///    Re-asserting the predicate here is the check that actually protects
-    ///    the data, the same shape as the per-row re-check
-    ///    [`is_blob_still_orphan`] performs before the two-phase blob GC's
-    ///    destructive act, and the #1682 "never orphan a live image" guard in
-    ///    `lifecycle_service`.
+    ///    the data.
+    ///
+    /// This re-check is deliberately *weaker* than the per-row re-check
+    /// [`is_blob_still_orphan`] performs before the two-phase blob GC's
+    /// destructive act, and the difference is the whole point of the caveat
+    /// below. `is_blob_still_orphan` runs inside an open transaction that took
+    /// `SELECT ... FOR UPDATE` on the `oci_blobs` row and *holds that lock
+    /// across the storage delete*, so a racing pusher blocks. This hook holds
+    /// nothing: it is a single autocommit `UPDATE` whose lock is gone before
+    /// the caller touches storage. Same predicate, different guarantee — do not
+    /// read the two as equivalent.
     ///
     /// The renewal and the re-check are one atomic `UPDATE`, so a row that has
     /// become live cannot have its lease extended. `kind` selects the predicate
@@ -1918,7 +1925,13 @@ impl StorageGcService {
     /// `oci_blobs` row inside that gap still has its bytes destroyed. Nothing
     /// in the push path serializes against this: `register_oci_upload_cleanup_key`
     /// is `ON CONFLICT (storage_key) DO NOTHING`, which against an already
-    /// claimed row is a complete no-op.
+    /// claimed row is a complete no-op, and the push's success path calls
+    /// `clear_oci_upload_cleanup_key_best_effort` (`api/handlers/oci_v2.rs`), a
+    /// bare `DELETE ... WHERE storage_key = $1` with no `claim_token` guard —
+    /// so the push can remove the journal row out from under an in-flight
+    /// sweep. Nor is that interleaving observable: each sweep's guarded row
+    /// `DELETE` never inspects `rows_affected`, so a zero-row match is counted
+    /// as a clean success.
     ///
     /// What this buys is a large reduction, not a proof. Before the re-check,
     /// liveness was evaluated once per batch in the candidate `SELECT`, so the
@@ -1933,6 +1946,9 @@ impl StorageGcService {
     /// committing `oci_blobs` — or a two-phase tombstone, which this codebase
     /// already implements for blob GC via `oci_blobs.pending_delete_at`
     /// (migration 141, `run_blob_gc_mark` / `run_blob_gc_sweep`).
+    ///
+    /// Tracked in #3187. Until that lands, this remains a narrowed window, not
+    /// a closed one.
     async fn hold_cleanup_key_claim_for_delete(
         &self,
         cleanup_key: &OciUploadCleanupKey,

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -1903,11 +1903,36 @@ impl StorageGcService {
     ///    destructive act, and the #1682 "never orphan a live image" guard in
     ///    `lifecycle_service`.
     ///
-    /// The renewal and the re-check are one atomic `UPDATE`: a row that has
-    /// become live cannot have its lease extended, so there is no ordering in
-    /// which the caller both holds a fresh lease and proceeds to delete a live
-    /// object. `kind` selects the predicate matching the calling sweep's own
-    /// row `DELETE`.
+    /// The renewal and the re-check are one atomic `UPDATE`, so a row that has
+    /// become live cannot have its lease extended. `kind` selects the predicate
+    /// matching the calling sweep's own row `DELETE`.
+    ///
+    /// This NARROWS the window; it does not close it. Be precise about what is
+    /// and is not guaranteed here, because the difference decides whether
+    /// anyone finishes the job:
+    ///
+    /// The `UPDATE` runs on the pool as a single autocommit statement, so its
+    /// row lock — which is on `oci_upload_cleanup_keys`, never on `oci_blobs` —
+    /// is released the instant it commits. The caller then performs an
+    /// object-store `DELETE` with no lock held. A push that commits its
+    /// `oci_blobs` row inside that gap still has its bytes destroyed. Nothing
+    /// in the push path serializes against this: `register_oci_upload_cleanup_key`
+    /// is `ON CONFLICT (storage_key) DO NOTHING`, which against an already
+    /// claimed row is a complete no-op.
+    ///
+    /// What this buys is a large reduction, not a proof. Before the re-check,
+    /// liveness was evaluated once per batch in the candidate `SELECT`, so the
+    /// exposure spanned the entire batch walk — up to
+    /// `OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT` sequential object-store deletes,
+    /// which is minutes. It is now one storage round trip, order tens of
+    /// milliseconds.
+    ///
+    /// Closing it properly requires the push and the sweep to serialize on the
+    /// journal row — an explicit transaction holding `SELECT ... FOR UPDATE`
+    /// across the storage delete, with the push taking the same row lock before
+    /// committing `oci_blobs` — or a two-phase tombstone, which this codebase
+    /// already implements for blob GC via `oci_blobs.pending_delete_at`
+    /// (migration 141, `run_blob_gc_mark` / `run_blob_gc_sweep`).
     async fn hold_cleanup_key_claim_for_delete(
         &self,
         cleanup_key: &OciUploadCleanupKey,


### PR DESCRIPTION
## Summary

Closes #3085 as titled -- the missing liveness re-check in the cleanup-key
sweep. It does NOT close the underlying race; see "The window" below and the
follow-up in #3187, which tracks the actual closure.

The OCI cleanup-journal sweeps re-checked blob liveness when they **claimed** a key and again at the guarded row `DELETE` — but the row `DELETE` runs *after* the storage object has already been deleted. Nothing re-consulted liveness in the window immediately before the destructive delete, so a digest re-pushed during that window lost its bytes.

**The window.** A push commits an `oci_blobs` row for the very same `storage_key` (the push path re-uses the existing journal row via `ON CONFLICT (storage_key) DO NOTHING`, so a stale claimed row survives a re-push). The sweep's per-key pre-delete hook — `renew_cleanup_key_claim`, added by #3072 — extended the claim lease without consulting liveness, returned `true`, and `storage.delete()` destroyed a live blob. The guarded row `DELETE` that follows then correctly refused to remove the journal row because `oci_blobs` now referenced the key: it saved the row, not the data. The result is a live `oci_blobs` row pointing at bytes that no longer exist.

A claimed batch is up to `OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT` (1000) rows walked sequentially against an object store, so the window is the whole batch walk, not an instant.

Both sweeps were affected: `cleanup_unreferenced_oci_upload_keys` and `reap_pending_oci_upload_cleanup_keys` share the hook.

**The fix.** The pre-delete hook (renamed `hold_cleanup_key_claim_for_delete`) now re-asserts the sweep's full liveness predicate in the *same atomic* `UPDATE` that extends the claim lease. A key that has become live cannot have its lease renewed. `CleanupSweepKind` selects the predicate matching the calling sweep's own row `DELETE`, so the pre-delete check and the post-delete row removal agree on what "still reclaimable" means.

## What this does and does not guarantee

**This narrows the window. It does not close it.** Read that literally — the code's own doc comment on `hold_cleanup_key_claim_for_delete` says the same thing, and this section exists so the PR does not claim more than the code delivers.

The `UPDATE` runs on the pool as a single autocommit statement. Its row lock is on `oci_upload_cleanup_keys`, never on `oci_blobs`, and it is released the instant the statement commits. The caller then performs the object-store `DELETE` holding **nothing**. A push that commits its `oci_blobs` row inside that gap still has its bytes destroyed. Nothing in the push path serializes against the sweep.

What changes is the size of the exposure, not its existence:

| | before | after |
|---|---|---|
| liveness evaluated | once per batch, in the candidate `SELECT` | once per key, immediately before its delete |
| window spans | the entire batch walk — up to 1000 sequential object-store deletes, i.e. minutes | one storage round trip, order tens of milliseconds |

That is a large reduction and it is worth shipping on its own. It is not a proof.

**Closing it properly** requires the push and the sweep to serialize on the journal row. Two options, both shapes this codebase already runs elsewhere:

1. **`FOR UPDATE` serialization** — an explicit transaction holding `SELECT ... FOR UPDATE` on the journal row across the storage delete, with the push taking that same row lock before committing `oci_blobs`.
2. **A `pending_delete_at`-style two-phase tombstone** — mark, then delete storage, then reap, with a push clearing the marker to resurrect. This is exactly what migration 141 gave `oci_blobs` for blob GC (`run_blob_gc_mark` / `run_blob_gc_sweep`), and it holds no lock across the storage call.

Tracked in **#3187**, which costs both.

**This is not the same guarantee as `is_blob_still_orphan`.** An earlier draft of this PR described the new hook as "the same shape as" the per-row re-check in the two-phase blob GC. That comparison is wrong and has been corrected in the doc comment. `is_blob_still_orphan` runs inside an open transaction that took `SELECT ... FOR UPDATE` on the `oci_blobs` row and **holds that lock across the storage delete** (`storage_gc_service.rs`, `run_blob_gc_sweep`), so a racing pusher blocks. This new hook holds nothing. Same predicate, different guarantee.

## Ordering

Unchanged: storage delete first, then the guarded row `DELETE`. That order fails safe.

- A crash between the two leaves the journal row behind; the next sweep re-issues the delete (idempotent — `NotFound` is treated as success) and removes the row. An orphaned storage object is recoverable.
- Deleting the DB row first would leave an untracked storage object that no sweep can ever find again (the journal *is* the sweep's key list) — a permanent leak — and would not close the same window, since a push can still land between the row `DELETE` commit and the storage call.

**Correction: a key going live does not keep the journal row visible.** An earlier draft argued the current order preserves evidence, because the row `DELETE`'s `oci_blobs` guard keeps the journal row when a key goes live. It does not, and this should not be counted as a benefit of the ordering:

- The push's success path calls `clear_oci_upload_cleanup_key_best_effort` — `backend/src/api/handlers/oci_v2.rs:978`, a bare `DELETE FROM oci_upload_cleanup_keys WHERE storage_key = $1` (lines 981-983) with no `claim_token` guard and no claim check. The push removes the row itself, out from under an in-flight sweep.
- The sweep then never notices. Its guarded row `DELETE` does not inspect `rows_affected`; it increments `cleanup_rows_removed` and `result.storage_keys_deleted` unconditionally — `backend/src/services/storage_gc_service.rs:1726-1727`. A zero-row match is counted as a **clean success**.

So in the exact interleaving where a push wins the race, there is no surviving journal row and no error. #3187 covers making that observable.

## Schema migration

**This PR adds one:** `backend/migrations/193_oci_blobs_storage_key_index.sql`.

```sql
CREATE INDEX IF NOT EXISTS idx_oci_blobs_storage_key ON oci_blobs (storage_key);
```

**Why.** The liveness predicate contains `NOT EXISTS (SELECT 1 FROM oci_blobs b WHERE b.storage_key = ...)`. That subquery used to run once per batch inside the candidate `SELECT`, so a sequential scan was amortised across the whole batch; the per-key re-check runs it once per candidate. `oci_blobs` had no index on `storage_key` — migration 118 indexed `oci_upload_sessions.storage_temp_key` and `oci_upload_parts.storage_key`, but nothing needed this one per-row until now.

Measured on 300k blobs: **87 ms per hold without the index vs 0.19 ms with it**; a full 1000-row batch went from 30.7 s to 0.19 s (~163x). The cost scales linearly with registry size.

**Lock behaviour.** `CREATE INDEX CONCURRENTLY` is not usable here (sqlx runs each migration inside a transaction; `CONCURRENTLY` is rejected in a transaction block), matching migration 166.

A plain `CREATE INDEX` takes a **`SHARE` lock** on `oci_blobs` for the duration of the build — **not `ACCESS EXCLUSIVE`**, which is what an earlier revision of the migration comment claimed. The difference matters for anyone planning a maintenance window:

- **Writes block.** `SHARE` conflicts with `ROW EXCLUSIVE`, so `INSERT`/`UPDATE`/`DELETE` on `oci_blobs` wait — blob commits on the push path, and blob GC's row deletes.
- **Reads do not block.** Plain `SELECT` takes `ACCESS SHARE`, compatible with `SHARE`. Pulls and manifest resolution are unaffected.

`oci_blobs` is far smaller than `artifacts` (one row per stored blob, deduplicated by `(repository_id, digest)`), so the build is short — but the write stall is real and should be scheduled on a large registry.

**Recommended, not optional.** Correctness does not depend on the index; forward progress does. Without it the re-check still returns the right answer via a sequential scan, but per the measurement above a batch on a large registry approaches the 15 minute claim TTL, and a sweep whose leases lapse mid-batch stops reclaiming storage. Skipping it trades a bounded write stall for an unbounded GC stall — the migration comment no longer offers that as an equivalent choice.

Operators who cannot accept the write stall should build the index out of band **before** deploying, at which point `IF NOT EXISTS` makes the migration a no-op:

```sql
CREATE INDEX CONCURRENTLY idx_oci_blobs_storage_key ON oci_blobs (storage_key);
```

That is the only supported way to avoid it — the migration cannot simply be skipped, since sqlx tracks applied migrations by checksum.

No API change. Patch-shaped for 1.7.2.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Tests are in-crate (`backend/src/services/storage_gc_service.rs` `mod tests`) so they count toward the `nextest --lib` coverage gate.

`MidBatchPushStorage` reproduces the production shape deterministically: it records every storage delete and, when the sweep deletes the **head** of a claimed batch, performs the concurrent push (commits an `oci_blobs` row) for a **later** key in the same batch. No timing or real concurrency needed.

- `unreferenced_sweep_keeps_bytes_of_blob_that_went_live_after_claim`
- `pending_reaper_keeps_bytes_of_blob_that_went_live_after_claim`

Each seeds three keys — `trip` (drives the push), `revive` (`oci-blobs/<digest>`, goes live mid-batch), and `control` (stays genuinely unreferenced). **Positive control:** the assertion that `control` IS still swept is in the same test, so the guard cannot pass by refusing to delete anything.

Two no-DB tests (`cleanup_sweep_liveness_predicates_*`) pin the predicate shape on every CI run — that the hook actually names `oci_blobs` / `oci_upload_parts` / `oci_upload_sessions`, and that each sweep keeps its own `storage_write_completed_at` marker so the kinds cannot be swapped.

### Test isolation and ordering (fixed in this revision)

Both regression tests passed alone and under `cargo nextest`, but **failed** in the single-process `cargo test --workspace --lib` run that CI also executes. Two independent causes, both in the test code — no production behaviour was involved:

1. **Wrong serialization primitive.** They took only `blob_gc_serial_lock` (a Postgres advisory lock), while the sibling `test_run_gc_*` tests — which run the *same* unscoped, cluster-wide cleanup-key sweeps — take `storage_gc_test_guard` (an in-process mutex). The two do not exclude each other, so a sibling's sweep reaped these tests' fixtures first and the recorded delete list came back empty. Under nextest the `db-serial` group already serialized the module, which is exactly why that run stayed green and hid it. Fixed by taking both guards and scoping each sweep to the fixture's own repository, so foreign rows cannot join the batch at all.

2. **Dependence on batch walk order.** `MidBatchPushStorage` fired the simulated push only when it saw one specific "head" key. The claim query orders its candidate CTE by `created_at` but returns rows from `UPDATE ... RETURNING`, which carries **no row-order guarantee** — the `ORDER BY` does not survive it, and the observed order flips with the plan once the table holds other tests' rows. When `revive` was walked before the head it was deleted before the push made it live, and the test reported #3085 data loss against a guard that was working correctly. Fixed by firing the push on the first delete of any key that is not `revive`, seeding `revive` newest so an order-preserving plan puts it last, and asserting the push actually fired — so a degenerate order fails as a clear precondition rather than a false #3085 red.

**Scope of the tests.** They cover the post-claim gap — a push landing after the batch was claimed. They do **not** cover the residual post-hold, pre-storage-delete gap described above, because no lock is held there and the test harness cannot deterministically interleave it. That coverage belongs with the fix in #3187.

**Revert-proof (re-verified after the test changes above).** With only the production guard removed (the `{liveness}` clause dropped from the hook, tests untouched), both regression tests fail on exactly the assertion above:

```
running 2 tests
test ...::pending_reaper_keeps_bytes_of_blob_that_went_live_after_claim ... FAILED
test ...::unreferenced_sweep_keeps_bytes_of_blob_that_went_live_after_claim ... FAILED

#3085: blob liveness must be re-checked immediately before the storage delete. An
oci_blobs row committed after the claim makes the blob live, so its bytes must
survive the sweep: ["oci-uploads/gc3085u-trip/2cd734fc...", "oci-blobs/sha256:2cd734fc...", "oci-uploads/gc3085u-control/2cd734fc..."]

test result: FAILED. 0 passed; 2 failed
```

The `oci-blobs/...` key appearing in the recorded delete list is the data loss. With the guard in place it is absent while `trip` and `control` are still deleted.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local gates against a dedicated Postgres 16 (`sqlx migrate run` applied cleanly through 193):

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --lib -- storage_gc_service` — `110 passed; 0 failed`, stable across repeated runs

The `storage_gc_service::tests` module is already pinned to the `db-serial` nextest group.

The documentation corrections in this revision touch only doc comments and the migration's SQL comment block — no `sqlx::query!` macro changed, so `.sqlx` is untouched and remains valid for the offline build.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — `193_oci_blobs_storage_key_index.sql` is a pure additive index; reverse with `DROP INDEX idx_oci_blobs_storage_key;`
- [ ] N/A - no API changes (schema migration added; see **Schema migration** above)

