### PR TITLE
fix(maven): accept both files[] key spellings in flat-object delete guards

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3955,8 +3955,19 @@ async fn purge_storage_object_keys(
 /// artifact's metadata `files[]` reference): deleting this repository must
 /// never destroy an object another tenant still serves. Best-effort: a DB
 /// error logs and returns the empty set.
+///
+/// The `files[]` guard is a `NOT EXISTS`, so a *missed* reference means
+/// DELETE. It therefore has to match every spelling the read path accepts, and
+/// gets that from the shared [`metadata_files_name_key_sql`] fragment rather
+/// than an inline copy: the inline copy matched snake_case `storage_key` only,
+/// so the camelCase `storageKey` entries the GAV-grouped upload handler
+/// actually writes were invisible to it and this repository's delete purged
+/// companions another repository's live parent artifact still referenced
+/// (#3156). Once this repository's attribution rows CASCADE away with it, that
+/// other repository becomes the key's sole read-path owner -- of bytes the
+/// delete has already destroyed.
 async fn collect_repo_maven_flat_keys(state: &SharedState, repo_id: Uuid) -> Vec<String> {
-    sqlx::query_scalar(
+    let sql = format!(
         "SELECT o.storage_key \
          FROM maven_flat_object_owner o \
          WHERE o.repository_id = $1 \
@@ -3973,24 +3984,25 @@ async fn collect_repo_maven_flat_keys(state: &SharedState, repo_id: Uuid) -> Vec
                JOIN repositories pr ON pr.id = pa.repository_id \
                WHERE pa.repository_id <> $1 \
                  AND pr.storage_backend = o.storage_backend \
-                 AND jsonb_typeof(am.metadata->'files') = 'array' \
-                 AND EXISTS ( \
-                     SELECT 1 FROM jsonb_array_elements(am.metadata->'files') f \
-                     WHERE f->>'storage_key' = o.storage_key \
-                 ) \
+                 AND {files_match} \
            )",
-    )
-    .bind(repo_id)
-    .fetch_all(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::warn!(
-            repo_id = %repo_id,
-            error = %e,
-            "Failed to list Maven flat-object keys to purge before repository delete"
-        );
-        Vec::new()
-    })
+        files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
+            "am.metadata->'files'",
+            "o.storage_key",
+        ),
+    );
+    sqlx::query_scalar(&sql)
+        .bind(repo_id)
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                repo_id = %repo_id,
+                error = %e,
+                "Failed to list Maven flat-object keys to purge before repository delete"
+            );
+            Vec::new()
+        })
 }
 
 /// Derived row-less Maven keys for a FILESYSTEM repository being deleted:
@@ -21077,5 +21089,132 @@ mod apt_validation_tests {
                 .await;
         }
         tdh::cleanup_user(&pool, user_id).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // collect_repo_maven_flat_keys: the pre-repository-delete purge list
+    // (#2668), and its `files[]` key-spelling guard (#3156).
+    // -----------------------------------------------------------------------
+
+    /// Seed a parent artifact plus an `artifact_metadata` row whose `files[]`
+    /// lists a row-less companion under the given JSON key spelling. The entry
+    /// shape mirrors what the GAV-grouped upload handler writes -- see the
+    /// fixture in `test_expand_maven_secondary_files_emits_each_file`.
+    async fn seed_flat_parent(
+        pool: &sqlx::PgPool,
+        repo_id: Uuid,
+        parent_key: &str,
+        json_key_name: &str,
+        companion_key: &str,
+    ) {
+        let parent_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO artifacts \
+                 (id, repository_id, path, name, size_bytes, checksum_sha256, \
+                  content_type, storage_key, is_deleted) \
+             VALUES ($1, $2, $3, $3, 1, repeat('0', 64), \
+                     'application/java-archive', $4, false)",
+        )
+        .bind(parent_id)
+        .bind(repo_id)
+        .bind(format!("p/{parent_id}.jar"))
+        .bind(parent_key)
+        .execute(pool)
+        .await
+        .expect("seed flat parent artifact");
+        crate::api::handlers::test_db_helpers::attach_maven_files_metadata(
+            pool,
+            parent_key,
+            json_key_name,
+            companion_key,
+        )
+        .await;
+    }
+
+    /// Record an aged `maven_flat_object_owner` claim, as migration 170's
+    /// backfill or a write-time claim would.
+    async fn seed_flat_claim(pool: &sqlx::PgPool, repo_id: Uuid, storage_key: &str) {
+        sqlx::query(
+            "INSERT INTO maven_flat_object_owner \
+                 (storage_backend, storage_key, repository_id, source, created_at) \
+             VALUES ('filesystem', $1, $2, 'metadata_files', NOW() - INTERVAL '2 hours')",
+        )
+        .bind(storage_key)
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("seed flat attribution claim");
+    }
+
+    /// #3156: deleting a repository must not purge a flat Maven object that
+    /// ANOTHER repository's live parent artifact still lists in its metadata
+    /// `files[]` -- including (in fact, primarily) when that entry uses the
+    /// camelCase `storageKey` spelling the GAV-grouped upload handler writes.
+    ///
+    /// The guard is a `NOT EXISTS`, so a missed reference means DELETE. Before
+    /// the fix it matched `f->>'storage_key'` only, so the camelCase entry was
+    /// invisible and the companion was collected for purge. This test FAILS if
+    /// the production predicate is reverted to the snake_case-only form.
+    ///
+    /// The positive control -- a genuinely unreferenced key -- must still be
+    /// collected, so the fix cannot pass by simply never purging anything.
+    #[tokio::test]
+    async fn collect_repo_maven_flat_keys_spares_camelcase_referenced_companion_3156() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (owner_repo, _, dir) = tdh::create_repo(&pool, "local", "maven").await;
+        let (other_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let uid = Uuid::new_v4().simple().to_string();
+
+        // Two companions the OTHER repository's live parent still references,
+        // one per spelling; plus a key nothing references at all.
+        let camel_key = format!("maven/gav3156/{uid}/demo-1.0.0.pom");
+        let snake_key = format!("maven/gav3156/{uid}/demo-1.0.0-sources.jar");
+        let orphan_key = format!("maven/gav3156/{uid}/gone-9.9.9.pom");
+        seed_flat_parent(
+            &pool,
+            other_repo,
+            &format!("maven/gav3156/{uid}/demo-1.0.0.jar"),
+            "storageKey",
+            &camel_key,
+        )
+        .await;
+        seed_flat_parent(
+            &pool,
+            other_repo,
+            &format!("maven/gav3156/{uid}/legacy-1.0.0.jar"),
+            "storage_key",
+            &snake_key,
+        )
+        .await;
+        // ...but the repository being deleted holds all three claims.
+        for key in [&camel_key, &snake_key, &orphan_key] {
+            seed_flat_claim(&pool, owner_repo, key).await;
+        }
+
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let collected = collect_repo_maven_flat_keys(&state, owner_repo).await;
+
+        tdh::cleanup(&pool, other_repo, Uuid::nil()).await;
+        tdh::cleanup(&pool, owner_repo, Uuid::nil()).await;
+
+        assert!(
+            !collected.contains(&camel_key),
+            "a companion another repository's live parent lists as camelCase \
+             `storageKey` must NOT be purged by this repository's delete (#3156); \
+             collected: {collected:?}"
+        );
+        assert!(
+            !collected.contains(&snake_key),
+            "the snake_case spelling must keep being honoured too; \
+             collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&orphan_key),
+            "positive control: a key no parent references must still be \
+             collected for purge; collected: {collected:?}"
+        );
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3960,8 +3960,8 @@ async fn purge_storage_object_keys(
 /// DELETE. It therefore has to match every spelling the read path accepts, and
 /// gets that from the shared [`metadata_files_name_key_sql`] fragment rather
 /// than an inline copy: the inline copy matched snake_case `storage_key` only,
-/// so the camelCase `storageKey` entries the GAV-grouped upload handler
-/// actually writes were invisible to it and this repository's delete purged
+/// so the camelCase `storageKey` entries the legacy #418-era GAV-grouped
+/// upload handler wrote were invisible to it and this repository's delete purged
 /// companions another repository's live parent artifact still referenced
 /// (#3156). Once this repository's attribution rows CASCADE away with it, that
 /// other repository becomes the key's sole read-path owner -- of bytes the

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -887,6 +887,39 @@ pub async fn wait_for_cache_commit(dir: &std::path::Path, min_size: u64) {
     );
 }
 
+/// Attach a Maven GAV-grouped `files[]` metadata document to the artifact at
+/// `parent_key`, listing one row-less companion under the JSON key spelling
+/// `json_key_name` (`"storageKey"` is what the upload handler writes;
+/// `"storage_key"` is the hand-repair fallback, #2706).
+///
+/// The entry shape mirrors the production fixture in
+/// `test_expand_maven_secondary_files_emits_each_file`. Shared by the
+/// repository-delete and GC flat-object guard tests (#3156) so the two do not
+/// carry independent copies of the same seed.
+pub async fn attach_maven_files_metadata(
+    pool: &PgPool,
+    parent_key: &str,
+    json_key_name: &str,
+    companion_key: &str,
+) {
+    sqlx::query(
+        "INSERT INTO artifact_metadata (artifact_id, format, metadata) \
+         SELECT id, 'maven', jsonb_build_object('files', $2::jsonb) \
+         FROM artifacts WHERE storage_key = $1",
+    )
+    .bind(parent_key)
+    .bind(serde_json::json!([{
+        "path": "com/example/demo/1.0.0/demo-1.0.0.pom",
+        "extension": "pom",
+        json_key_name: companion_key,
+        "sizeBytes": 200,
+        "sha256": "pom-sha",
+    }]))
+    .execute(pool)
+    .await
+    .expect("attach maven files[] metadata");
+}
+
 pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
         .bind(repo_id)

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -889,8 +889,8 @@ pub async fn wait_for_cache_commit(dir: &std::path::Path, min_size: u64) {
 
 /// Attach a Maven GAV-grouped `files[]` metadata document to the artifact at
 /// `parent_key`, listing one row-less companion under the JSON key spelling
-/// `json_key_name` (`"storageKey"` is what the upload handler writes;
-/// `"storage_key"` is the hand-repair fallback, #2706).
+/// `json_key_name` (`"storageKey"` is what the legacy #418-era upload handler
+/// wrote; `"storage_key"` is the hand-repair fallback, #2706).
 ///
 /// The entry shape mirrors the production fixture in
 /// `test_expand_maven_secondary_files_emits_each_file`. Shared by the

--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -27,6 +27,7 @@
 //! entry point short-circuits to the pre-existing behavior there and never
 //! consults the catalog.
 
+use once_cell::sync::Lazy;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -57,30 +58,64 @@ const OWNER_BY_ARTIFACT_ROW_SQL: &str = "SELECT DISTINCT a.repository_id FROM ar
      WHERE a.storage_key = $1 AND a.is_deleted = false AND r.storage_backend = $2 \
      LIMIT 2";
 
+/// The one definition of "does a parent artifact's metadata `files[]` array
+/// name this storage key?", shared by every caller that asks the question
+/// (#3156).
+///
+/// `files_expr` is the SQL expression yielding the `files` array (e.g.
+/// `am.metadata->'files'`) and `key_expr` the expression yielding the storage
+/// key to look for -- a bind parameter (`$1::text`) on the read path, an outer
+/// column (`o.storage_key`) or a derived expression (`regexp_replace(...)`) in
+/// the delete guards. Both are SQL fragments composed by this crate, never
+/// caller input.
+///
+/// Two facts are encoded here, and both must hold for every caller:
+///
+/// * **Both key spellings match.** The GAV-grouped upload handler has always
+///   serialized `files[]` entries with camelCase keys (`"storageKey"`, since
+///   #418); snake_case `storage_key` is accepted as a fallback spelling for
+///   hand-repaired rows (#2706). Migration 170 backfills the attribution table
+///   from both spellings, and `expand_maven_secondary_files` /
+///   `sbom.rs` read camelCase. A caller that matched only one spelling had a
+///   predicate that never fired on real data -- harmless on the read path
+///   (fails closed, 404) but *destructive* in a `NOT EXISTS` delete guard,
+///   where an unmatched live companion reads as unreferenced and is purged
+///   (#3156). Keeping the fragment in one place is what stops the two sides
+///   drifting apart again (the #418 -> #2706 shape).
+/// * **Containment, not `jsonb_array_elements`.** Matching with `@>` lets the
+///   GIN index from migration 179 serve the lookup; the per-row `EXISTS` over
+///   `jsonb_array_elements` it replaces cannot use any index and forced a
+///   sequential scan of all of `artifact_metadata` (#2942). Containment
+///   against an array operand is false when `files` is not an array, so the
+///   explicit `jsonb_typeof(...) = 'array'` guard the `EXISTS` form needed is
+///   implicit here.
+pub(crate) fn metadata_files_name_key_sql(files_expr: &str, key_expr: &str) -> String {
+    format!(
+        "({files_expr} @> jsonb_build_array(jsonb_build_object('storageKey', {key_expr})) \
+          OR {files_expr} @> jsonb_build_array(jsonb_build_object('storage_key', {key_expr})))"
+    )
+}
+
 /// Distinct owning repositories of a live parent artifact whose metadata
 /// `files[]` array lists this key (legacy GAV-grouped uploads whose companion
 /// files have no row of their own), restricted to repositories on `$2`. LIMIT 2
 /// for the same ambiguity test.
 ///
-/// The GAV-grouped upload handler has always serialized `files[]` entries with
-/// camelCase keys (`"storageKey"`, since #418); snake_case `storage_key` is
-/// accepted as a fallback spelling for hand-repaired rows (#2706). Both
-/// spellings are matched with jsonb containment (`@>`) rather than a per-row
-/// `EXISTS` over `jsonb_array_elements` so the lookup is served by the GIN
-/// index from migration 179 -- the EXISTS predicate cannot use any index and
-/// forced a sequential scan of all of `artifact_metadata` on every row-less
-/// read (#2942). Containment against an array operand is false when `files`
-/// is not an array, so the explicit `jsonb_typeof` guard the EXISTS form
-/// needed is implicit here.
-const OWNER_BY_METADATA_FILES_SQL: &str = "SELECT DISTINCT a.repository_id \
-     FROM artifact_metadata am \
-     JOIN artifacts a ON a.id = am.artifact_id \
-     JOIN repositories r ON r.id = a.repository_id \
-     WHERE a.is_deleted = false \
-       AND r.storage_backend = $2 \
-       AND (am.metadata->'files' @> jsonb_build_array(jsonb_build_object('storageKey', $1::text)) \
-         OR am.metadata->'files' @> jsonb_build_array(jsonb_build_object('storage_key', $1::text))) \
-     LIMIT 2";
+/// The `files[]` match is [`metadata_files_name_key_sql`] -- the same fragment
+/// the repository-delete and GC delete guards use.
+static OWNER_BY_METADATA_FILES_SQL: Lazy<String> = Lazy::new(|| {
+    format!(
+        "SELECT DISTINCT a.repository_id \
+         FROM artifact_metadata am \
+         JOIN artifacts a ON a.id = am.artifact_id \
+         JOIN repositories r ON r.id = a.repository_id \
+         WHERE a.is_deleted = false \
+           AND r.storage_backend = $2 \
+           AND {files_match} \
+         LIMIT 2",
+        files_match = metadata_files_name_key_sql("am.metadata->'files'", "$1::text"),
+    )
+});
 
 /// The attribution table (backfilled legacy keys + write-time claims). The
 /// `(storage_backend, storage_key)` primary key means this yields at most one
@@ -147,7 +182,7 @@ async fn resolve_direct(
     for sql in [
         OWNER_BY_ARTIFACT_ROW_SQL,
         OWNER_BY_ATTRIBUTION_TABLE_SQL,
-        OWNER_BY_METADATA_FILES_SQL,
+        OWNER_BY_METADATA_FILES_SQL.as_str(),
     ] {
         match query_layer(db, sql, storage_backend, storage_key).await? {
             LayerResult::Absent => continue,
@@ -437,6 +472,46 @@ pub async fn release_flat_key_claim(
 mod tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
+
+    /// The shared `files[]` fragment must always emit BOTH spellings and use
+    /// containment. Every caller — the read path and the three delete guards
+    /// (#3156) — is built from it, so this is the one place the property has
+    /// to hold. Cheap enough to run without a database.
+    #[test]
+    fn metadata_files_name_key_sql_matches_both_spellings_by_containment() {
+        let sql = metadata_files_name_key_sql("am.metadata->'files'", "o.storage_key");
+        assert!(
+            sql.contains("jsonb_build_object('storageKey', o.storage_key)"),
+            "camelCase spelling (what the GAV-grouped upload handler writes) \
+             must be matched: {sql}"
+        );
+        assert!(
+            sql.contains("jsonb_build_object('storage_key', o.storage_key)"),
+            "snake_case fallback spelling must be matched: {sql}"
+        );
+        assert_eq!(
+            sql.matches("am.metadata->'files' @>").count(),
+            2,
+            "both spellings must be tested with jsonb containment so the \
+             migration-179 GIN index can serve them: {sql}"
+        );
+        assert!(
+            !sql.contains("jsonb_array_elements"),
+            "the per-row EXISTS form is not index-eligible: {sql}"
+        );
+    }
+
+    /// The read path's owner lookup is built from the shared fragment, not an
+    /// inline copy — this is what stopped it drifting from the delete guards.
+    #[test]
+    fn owner_by_metadata_files_sql_uses_the_shared_fragment() {
+        assert!(
+            OWNER_BY_METADATA_FILES_SQL.contains(&metadata_files_name_key_sql(
+                "am.metadata->'files'",
+                "$1::text"
+            ))
+        );
+    }
 
     async fn seed_artifact(pool: &PgPool, repo_id: Uuid, path: &str, storage_key: &str) {
         sqlx::query(

--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -71,10 +71,13 @@ const OWNER_BY_ARTIFACT_ROW_SQL: &str = "SELECT DISTINCT a.repository_id FROM ar
 ///
 /// Two facts are encoded here, and both must hold for every caller:
 ///
-/// * **Both key spellings match.** The GAV-grouped upload handler has always
-///   serialized `files[]` entries with camelCase keys (`"storageKey"`, since
-///   #418); snake_case `storage_key` is accepted as a fallback spelling for
-///   hand-repaired rows (#2706). Migration 170 backfills the attribution table
+/// * **Both key spellings match.** No handler in the current tree writes
+///   `files[]` -- the #418-era GAV-grouped upload handler that did has since
+///   been removed, so every such row is legacy, carried by deployments
+///   upgraded through that version. It serialized entries with camelCase keys
+///   (`"storageKey"`); snake_case `storage_key` is accepted as a fallback
+///   spelling for hand-repaired rows (#2706). Migration 170 backfills the
+///   attribution table
 ///   from both spellings, and `expand_maven_secondary_files` /
 ///   `sbom.rs` read camelCase. A caller that matched only one spelling had a
 ///   predicate that never fired on real data -- harmless on the read path
@@ -498,6 +501,29 @@ mod tests {
         assert!(
             !sql.contains("jsonb_array_elements"),
             "the per-row EXISTS form is not index-eligible: {sql}"
+        );
+
+        // The two branches must be a DISJUNCTION, and nothing above pins that:
+        // every assertion so far still holds if `OR` is "simplified" to `AND`.
+        // A `files[]` entry carries ONE spelling, so requiring both would make
+        // the fragment match nothing on real data -- silently restoring the
+        // #3156 data loss in all three NOT EXISTS delete guards (an unmatched
+        // live companion reads as unreferenced and is purged) and breaking the
+        // read path at the same time. Assert the connective directly, then pin
+        // the whole rendered fragment.
+        assert!(
+            !sql.contains(" AND "),
+            "the two spellings must be OR-ed, never AND-ed: a files[] entry \
+             carries one spelling, so an AND matches nothing on real data and \
+             re-opens the #3156 purge of live companions: {sql}"
+        );
+        assert_eq!(
+            sql,
+            "(am.metadata->'files' @> jsonb_build_array(jsonb_build_object('storageKey', o.storage_key)) \
+             OR am.metadata->'files' @> jsonb_build_array(jsonb_build_object('storage_key', o.storage_key)))",
+            "rendered fragment changed; every caller (read path + three delete \
+             guards) depends on this exact shape -- update deliberately, and \
+             keep the two branches OR-ed"
         );
     }
 

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -213,8 +213,9 @@ const ORPHAN_MAVEN_FLAT_SCAN_LIMIT: i64 = 1000;
 /// Guards 2 and 5 -- the `files[]` reference tests -- are built from the
 /// shared [`crate::services::maven_flat_attribution::metadata_files_name_key_sql`]
 /// fragment rather than an inline copy. Their inline copies matched snake_case
-/// `storage_key` only, while the GAV-grouped upload handler writes camelCase
-/// `storageKey`; in a `NOT EXISTS` guard a missed reference means DELETE, so
+/// `storage_key` only, while the legacy #418-era GAV-grouped upload handler
+/// wrote camelCase `storageKey`; in a `NOT EXISTS` guard a missed reference
+/// means DELETE, so
 /// every live GAV companion (and every checksum sidecar of one) read as
 /// unreferenced and was purged by the sweep while its parent artifact was
 /// still serving it (#3156).

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -4,6 +4,7 @@
 //! by any live artifact, deletes the physical storage files, and hard-deletes
 //! the artifact records from the database.
 
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::sync::Arc;
@@ -208,7 +209,18 @@ const ORPHAN_MAVEN_FLAT_SCAN_LIMIT: i64 = 1000;
 /// publishes, whose claim row is inserted just before the object bytes are
 /// written. Scan and per-row locked re-check share this constant so the two
 /// predicates cannot drift (the #1180 lesson).
-const ORPHAN_MAVEN_FLAT_PREDICATE_SQL: &str = r#"
+///
+/// Guards 2 and 5 -- the `files[]` reference tests -- are built from the
+/// shared [`crate::services::maven_flat_attribution::metadata_files_name_key_sql`]
+/// fragment rather than an inline copy. Their inline copies matched snake_case
+/// `storage_key` only, while the GAV-grouped upload handler writes camelCase
+/// `storageKey`; in a `NOT EXISTS` guard a missed reference means DELETE, so
+/// every live GAV companion (and every checksum sidecar of one) read as
+/// unreferenced and was purged by the sweep while its parent artifact was
+/// still serving it (#3156).
+static ORPHAN_MAVEN_FLAT_PREDICATE_SQL: Lazy<String> = Lazy::new(|| {
+    format!(
+        r#"
 o.storage_key LIKE 'maven/%'
 AND o.created_at < NOW() - INTERVAL '1 hour'
 AND NOT EXISTS (
@@ -222,11 +234,7 @@ AND NOT EXISTS (
     JOIN artifacts pa ON pa.id = am.artifact_id
     JOIN repositories pr ON pr.id = pa.repository_id
     WHERE pr.storage_backend = o.storage_backend
-      AND jsonb_typeof(am.metadata->'files') = 'array'
-      AND EXISTS (
-        SELECT 1 FROM jsonb_array_elements(am.metadata->'files') f
-        WHERE f->>'storage_key' = o.storage_key
-      )
+      AND {files_match}
 )
 AND NOT EXISTS (
     SELECT 1 FROM artifacts a2
@@ -255,14 +263,20 @@ AND NOT EXISTS (
     JOIN repositories pr2 ON pr2.id = pa2.repository_id
     WHERE o.storage_key ~ '\.(md5|sha1|sha256|sha512)$'
       AND pr2.storage_backend = o.storage_backend
-      AND jsonb_typeof(am2.metadata->'files') = 'array'
-      AND EXISTS (
-        SELECT 1 FROM jsonb_array_elements(am2.metadata->'files') f2
-        WHERE f2->>'storage_key'
-              = regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', '')
-      )
+      AND {sidecar_base_files_match}
 )
-"#;
+"#,
+        files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
+            "am.metadata->'files'",
+            "o.storage_key",
+        ),
+        sidecar_base_files_match =
+            crate::services::maven_flat_attribution::metadata_files_name_key_sql(
+                "am2.metadata->'files'",
+                r"regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', '')",
+            ),
+    )
+});
 
 /// Result of a storage GC run.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -2217,7 +2231,7 @@ impl StorageGcService {
             ORDER BY o.storage_key
             LIMIT $1
             "#,
-            predicate = ORPHAN_MAVEN_FLAT_PREDICATE_SQL,
+            predicate = ORPHAN_MAVEN_FLAT_PREDICATE_SQL.as_str(),
             scope = repo_scope_clause("o.repository_id", 2, repo_scope),
         );
         let mut query = sqlx::query(&sql).bind(ORPHAN_MAVEN_FLAT_SCAN_LIMIT);
@@ -2413,7 +2427,7 @@ async fn is_maven_flat_object_still_orphan(
               AND {predicate}
         ) AS still_orphan
         "#,
-        predicate = ORPHAN_MAVEN_FLAT_PREDICATE_SQL,
+        predicate = ORPHAN_MAVEN_FLAT_PREDICATE_SQL.as_str(),
     );
     let row = sqlx::query(&sql)
         .bind(storage_backend)
@@ -3701,6 +3715,111 @@ mod tests {
             "the SQL sidecar regex alternation must be built from \
              MAVEN_SIDECAR_SUFFIXES; expected {expected_alternation}"
         );
+    }
+
+    /// #3156: a live parent artifact's metadata `files[]` must anchor its
+    /// row-less companion against the flat-object sweep under BOTH spellings —
+    /// primarily camelCase `storageKey`, which is what the GAV-grouped upload
+    /// handler writes. The two guards this covers are `NOT EXISTS`, so a missed
+    /// reference means DELETE: pre-fix, the sweep collected a live companion
+    /// (guard 2) and its checksum sidecar (guard 5) for purge while the parent
+    /// was still serving them.
+    ///
+    /// This test FAILS if either production predicate is reverted to the
+    /// `jsonb_array_elements ... f->>'storage_key'` form, and its positive
+    /// control (a genuinely unreferenced key) keeps the fix from passing by
+    /// never collecting anything.
+    ///
+    /// The scan is repository-scoped, so this test does not race the
+    /// cluster-wide `test_run_gc_*` tests and needs no GC lock (#1493 pattern).
+    #[tokio::test]
+    async fn test_orphan_maven_flat_scan_spares_camelcase_referenced_companion_3156() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fixture) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+        let service =
+            StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
+        let uid = Uuid::new_v4().simple().to_string();
+
+        let camel_key = format!("maven/gav3156/{uid}/demo-1.0.0.pom");
+        let camel_sidecar = format!("{camel_key}.sha1");
+        let snake_key = format!("maven/gav3156/{uid}/demo-1.0.0-sources.jar");
+        let orphan_key = format!("maven/gav3156/{uid}/gone-9.9.9.pom");
+
+        seed_flat_parent_metadata(
+            &fixture.pool,
+            fixture.repo_id,
+            fixture.user_id,
+            &format!("maven/gav3156/{uid}/demo-1.0.0.jar"),
+            "storageKey",
+            &camel_key,
+        )
+        .await;
+        seed_flat_parent_metadata(
+            &fixture.pool,
+            fixture.repo_id,
+            fixture.user_id,
+            &format!("maven/gav3156/{uid}/legacy-1.0.0.jar"),
+            "storage_key",
+            &snake_key,
+        )
+        .await;
+        for key in [&camel_key, &camel_sidecar, &snake_key, &orphan_key] {
+            insert_flat_attribution_row(&fixture.pool, fixture.repo_id, key, 2).await;
+        }
+
+        let rows = service
+            .select_orphan_maven_flat_objects(Some(fixture.repo_id))
+            .await;
+        let collected: Vec<String> = rows
+            .expect("scan succeeds")
+            .iter()
+            .map(|r| r.get::<String, _>("storage_key"))
+            .collect();
+        fixture.teardown().await;
+
+        assert!(
+            !collected.contains(&camel_key),
+            "guard 2: a companion its live parent lists as camelCase \
+             `storageKey` must NOT be collected for purge (#3156); \
+             collected: {collected:?}"
+        );
+        assert!(
+            !collected.contains(&camel_sidecar),
+            "guard 5: the checksum sidecar of a camelCase-listed companion \
+             must NOT be collected either (#3156); collected: {collected:?}"
+        );
+        assert!(
+            !collected.contains(&snake_key),
+            "the snake_case spelling must keep being honoured too; \
+             collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&orphan_key),
+            "positive control: a key no parent references must still be \
+             collected for purge; collected: {collected:?}"
+        );
+    }
+
+    /// Seed a parent `artifacts` row plus an `artifact_metadata` row whose
+    /// `files[]` array lists a row-less companion under `json_key_name`.
+    async fn seed_flat_parent_metadata(
+        pool: &PgPool,
+        repo_id: Uuid,
+        user_id: Uuid,
+        parent_key: &str,
+        json_key_name: &str,
+        companion_key: &str,
+    ) {
+        insert_maven_artifact_row(pool, repo_id, user_id, parent_key, false).await;
+        crate::api::handlers::test_db_helpers::attach_maven_files_metadata(
+            pool,
+            parent_key,
+            json_key_name,
+            companion_key,
+        )
+        .await;
     }
 
     /// Insert a Maven `artifacts` row pointing at `storage_key`


### PR DESCRIPTION
## Summary

Fixes #3156.

Three `NOT EXISTS` delete guards for row-less Maven flat objects matched only the
snake_case `files[]` key spelling (`f->>'storage_key'`), while the affected rows record
the companion under camelCase `storageKey` and the read path deliberately accepts both
(#2706). A `NOT EXISTS` guard answers *"is anything still referencing this key?"* and
**a miss means DELETE**, so a live companion file — and its checksum sidecars — read as
unreferenced and were purged while a live parent artifact still referenced them.

**Which rows these are.** No handler in the current tree writes `files[].storageKey` —
the #418-era GAV-grouped upload handler that did has since been removed, and `files[]`
is now read-only (`sbom.rs`, `expand_maven_secondary_files`, and the attribution SQL all
read it, nothing writes it). So this fix protects **legacy rows on deployments upgraded
through that version**, plus the hand-repaired snake_case rows of #2706. It is not
guarding against writes a current handler is still making. That also bounds the blast
radius: affected deployments are those with pre-#418-removal Maven history on a shared
cloud namespace (S3/GCS/Azure); filesystem backends isolate each repository's key space
and are unaffected.

Sites fixed:

1. `backend/src/api/handlers/repositories.rs` — `collect_repo_maven_flat_keys`, the
   purge list built before a repository delete (cross-repository reference test).
2. `backend/src/services/storage_gc_service.rs` — `ORPHAN_MAVEN_FLAT_PREDICATE_SQL`
   guard 2, the parent-artifact test.
3. Same statement, guard 5 — the checksum-sidecar base-key test.

### Reproduced first (against the base commit)

Bare `postgres:16-alpine` with all 178 migrations applied, seeded with the `files[]`
entry shape the repo's own fixture uses
(`repositories.rs` `test_expand_maven_secondary_files_emits_each_file`), and the
`maven_flat_object_owner` rows migration 170 backfills. Running each production
predicate verbatim:

```
READ PATH  OWNER_BY_METADATA_FILES_SQL for maven/com/example/demo/1.0.0/demo-1.0.0.pom
  gav-a, gav-b            <- attributed under camelCase

SITE 1  collect_repo_maven_flat_keys(gav-a)  -> purged on repo delete
  maven/com/example/demo/1.0.0/demo-1.0.0-sources.jar
  maven/com/example/demo/1.0.0/demo-1.0.0.pom          <- gav-b's LIVE parent lists it
  maven/com/example/demo/1.0.0/demo-1.0.0.pom.sha1
  maven/com/example/gone/9.9.9/gone-9.9.9.pom          <- genuine orphan (control)

SITES 2+3  select_orphan_maven_flat_objects()  -> collected by the GC sweep
  maven/com/example/demo/1.0.0/demo-1.0.0-sources.jar   metadata_files
  maven/com/example/demo/1.0.0/demo-1.0.0.pom           metadata_files
  maven/com/example/demo/1.0.0/demo-1.0.0.pom.sha1      derived_checksum
  maven/com/example/gone/9.9.9/gone-9.9.9.pom           metadata_files
```

Every live companion is collected for purge alongside the genuine orphan. For site 1
the loss is not hypothetical: once the deleted repository's attribution rows CASCADE
away, the *other* repository becomes the key's sole read-path owner —

```
DELETE FROM repositories WHERE id = <gav-a>;
  attribution_rows_left = 0
  OWNER_BY_METADATA_FILES_SQL -> gav-b   (sole owner, now serving bytes just purged)
```

After the fix the same predicates collect only the genuine orphan (sites 2+3), and
site 1 spares the cross-repository-referenced key.

### Shared predicate

The read path and the guards encoded the same fact in two places, which is how they
drifted (#418 -> #2706). They now share one definition,
`maven_flat_attribution::metadata_files_name_key_sql(files_expr, key_expr)`, which
renders the containment test against both spellings. It is parameterised by the SQL
expressions for the array and the key so all four callers can use it: a bind parameter
(`$1::text`) on the read path, an outer column (`o.storage_key`) in guards 1–2, and a
derived expression (`regexp_replace(...)`) in guard 3. Both fragments are composed by
this crate — no caller input reaches the SQL.

### Query plans

Containment is index-eligible via `idx_artifact_metadata_files_gin` (migration 179),
so the fix carries a genuine plan improvement as well. Measured on 20 002
`artifact_metadata` rows. The per-key form is
`is_maven_flat_object_still_orphan` — the locked re-check that runs once per GC
candidate:

| | before (`jsonb_array_elements` EXISTS) | after (containment) |
|---|---|---|
| plan | `Seq Scan on artifact_metadata` | `BitmapOr` of two `idx_artifact_metadata_files_gin` probes |
| buffers | 1000 | 12 |
| execution | 11.053 ms | 0.114 ms |

The whole-table sweep predicate stays a hash anti-join (no single key to probe with),
but its buffer count still drops from 61 009 to 1 891 because the containment test no
longer expands every `files[]` array per candidate row.

### Deliberately out of scope

`collect_repo_maven_flat_keys` has no sidecar-base guard at all — in either spelling —
so `<companion>.sha1` is still collected when the companion itself is spared. That is a
distinct pre-existing gap (the GC predicate has such a guard; the repository-delete
path does not), unchanged by this PR.

**Filed as #3188** rather than widened into this fix. Note this PR makes that gap
reachable in a new way: previously the camelCase-referenced companion was itself purged,
so losing its sidecar was the lesser half of a larger loss; now the companion is
correctly spared and the sidecar alone is destroyed. Deleting repo A leaves repo B
serving `demo-1.0.0.pom` with its `.sha1` gone — a warning under Maven's default
`checksumPolicy=warn`, a hard failure under `checksumPolicy=fail` and under Gradle
dependency verification. #3188 carries the reproduction and the suggested fix.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Four tests, all in-crate (`src/... mod tests`) so they count toward the
`nextest --lib` coverage gate:

- `repositories.rs` `collect_repo_maven_flat_keys_spares_camelcase_referenced_companion_3156`
- `storage_gc_service.rs` `test_orphan_maven_flat_scan_spares_camelcase_referenced_companion_3156`
  (covers guards 2 and 5)
- `maven_flat_attribution.rs` `metadata_files_name_key_sql_matches_both_spellings_by_containment`
- `maven_flat_attribution.rs` `owner_by_metadata_files_sql_uses_the_shared_fragment`

Each DB test asserts a camelCase-recorded companion is **not** collected, that the
snake_case spelling keeps working, and carries a **positive control** — a genuinely
unreferenced key that must still be collected, so the fix cannot pass by never purging
anything.

**The connective is pinned.** `metadata_files_name_key_sql_matches_both_spellings_by_containment`
originally asserted only that both spellings appear, that both use containment, and that
`jsonb_array_elements` is gone — every one of which still holds if the two-branch
predicate is "simplified" from `OR` to `AND`. A `files[]` entry carries **one** spelling,
so an `AND` matches nothing on real data: it would silently restore the #3156 data loss
across all three guards *and* break the read path, while looking like a tidy-up. The test
now asserts the connective directly and pins the whole rendered fragment.

Mutation-proved: flipping `OR` to `AND` in `metadata_files_name_key_sql` fails the test
with

```
the two spellings must be OR-ed, never AND-ed: a files[] entry carries one spelling,
so an AND matches nothing on real data and re-opens the #3156 purge of live companions
```

This matters because it is the only guard-correctness check that runs **without** a
database: both DB-backed tests above skip silently when `DATABASE_URL` is unset.

**Revert-proved.** With the three production guards reverted to their snake_case-only
form (tests untouched), both DB tests fail:

```
collect_repo_maven_flat_keys_spares_camelcase_referenced_companion_3156 ... FAILED
  a companion another repository's live parent lists as camelCase `storageKey` must
  NOT be purged by this repository's delete (#3156); collected:
  ["maven/gav3156/.../demo-1.0.0.pom", "maven/gav3156/.../gone-9.9.9.pom"]

test_orphan_maven_flat_scan_spares_camelcase_referenced_companion_3156 ... FAILED
  guard 2: a companion its live parent lists as camelCase `storageKey` must NOT be
  collected for purge (#3156); collected:
  ["maven/gav3156/.../demo-1.0.0.pom", "maven/gav3156/.../demo-1.0.0.pom.sha1",
   "maven/gav3156/.../gone-9.9.9.pom"]

test result: FAILED. 0 passed; 2 failed
```

Note in both failure sets that the snake_case key is absent (it was already spared) and
the control key is present — the assertions distinguish the two spellings rather than
just counting.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — the two DB-backed `--lib` tests
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local gates, isolated Postgres 16 (not a shared instance):

```
cargo fmt --check                                       clean
cargo clippy --workspace --all-targets -- -D warnings   clean
cargo test --workspace --lib                            ok. 14727 passed; 0 failed; 6 ignored
```

Duplication measured with the gate's own settings (`jscpd --min-lines 10 --format rust`)
over `backend/src/services` and `backend/src/api/handlers`, before and after: unchanged
at 0.51 % and 1.8 % respectively (identical duplicated-line counts), both well under
3 %. The shared fixture the two new DB tests need was factored into
`test_db_helpers::attach_maven_files_metadata` rather than copied.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No schema migration: `idx_artifact_metadata_files_gin` already exists (migration 179).
Patch-shaped, targeting 1.7.2.

