### PR TITLE
fix(repositories): scope virtual repo storage total to members the caller can see

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -218,6 +218,33 @@ pub(crate) async fn require_repo_admin(
     }
 }
 
+/// Resolve the caller's repository visibility (issue #3081).
+///
+/// This is the single derivation of [`RepoVisibility`] from an authenticated
+/// (or anonymous) principal, shared by the repository listing and by every
+/// path that aggregates over OTHER repositories on the caller's behalf — today
+/// the virtual-repository storage total, whose members are separate
+/// repositories with their own ACLs.
+///
+/// * anonymous              -> public repositories only
+/// * global admin           -> everything
+/// * repo-scoped API token  -> exactly the token's allowed set (checked before
+///   the general user arm; admin tokens are handled above and bypass scope)
+/// * any other principal    -> public repositories plus their own grants
+pub(crate) fn visibility_for_auth(auth: Option<&AuthExtension>) -> RepoVisibility {
+    match auth {
+        None => RepoVisibility::PublicOnly,
+        Some(a) if a.is_admin => RepoVisibility::All,
+        Some(a) if matches!(a.allowed_repo_ids, AccessScope::Restricted(_)) => RepoVisibility::Ids(
+            a.allowed_repo_ids
+                .as_allowed_repo_ids()
+                .unwrap_or_default()
+                .to_vec(),
+        ),
+        Some(a) => RepoVisibility::User(a.user_id),
+    }
+}
+
 /// Ensure a repository is visible to the current user.
 ///
 /// Public repos are visible to everyone. Private repos require authentication
@@ -2184,21 +2211,10 @@ pub async fn list_repositories(
         .map(|t| parse_repo_type(t))
         .transpose()?;
 
-    let visibility = match &auth {
-        None => RepoVisibility::PublicOnly,
-        Some(a) if a.is_admin => RepoVisibility::All,
-        // Repo-scoped token: the listing must reflect ONLY the token's
-        // allowed repositories, not every repo the owning user can reach.
-        // Checked before the general `User` arm. Admin tokens are handled
-        // above and bypass scope restrictions.
-        Some(a) if matches!(a.allowed_repo_ids, AccessScope::Restricted(_)) => RepoVisibility::Ids(
-            a.allowed_repo_ids
-                .as_allowed_repo_ids()
-                .unwrap_or_default()
-                .to_vec(),
-        ),
-        Some(a) => RepoVisibility::User(a.user_id),
-    };
+    // The listing must reflect ONLY what this caller may see — including, for
+    // a repo-scoped token, only the token's allowed repositories rather than
+    // every repo the owning user can reach.
+    let visibility = visibility_for_auth(auth.as_ref());
     let service = RepositoryService::new(state.db.clone());
     let (repos, total) = service
         .list(
@@ -2206,7 +2222,7 @@ pub async fn list_repositories(
             per_page as i64,
             format_filter,
             type_filter,
-            visibility,
+            visibility.clone(),
             query.q.as_deref(),
             query.project,
         )
@@ -2272,9 +2288,12 @@ pub async fn list_repositories(
         for id in &virtual_ids {
             storage_map.insert(*id, 0);
         }
+        // #3081: aggregate only over the members THIS caller may see — a
+        // member the caller cannot read must not disclose its byte size
+        // through the virtual's total.
         storage_map.extend(
             service
-                .get_virtual_storage_usage_batch(&virtual_ids)
+                .get_virtual_storage_usage_batch(&virtual_ids, &visibility)
                 .await?,
         );
     }
@@ -2793,7 +2812,11 @@ pub async fn get_repository(
     require_visible(&repo, &auth, &service).await?;
     // #2785: virtual repos report the union of their members' contents, not
     // their own (empty) rows, so the displayed total matches the child repos.
-    let storage_used = service.get_display_storage_usage(&repo).await?;
+    // #3081: that union is scoped to the members THIS caller may see, so the
+    // aggregate cannot disclose the size of a member whose own GET 404s.
+    let storage_used = service
+        .get_display_storage_usage(&repo, &visibility_for_auth(auth.as_ref()))
+        .await?;
     let auth_type =
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
 
@@ -3621,7 +3644,10 @@ pub async fn update_repository(
     }
 
     // #2785: virtual repos report the union of their members' contents.
-    let storage_used = service.get_display_storage_usage(&repo).await?;
+    // #3081: scoped to the members this caller may see.
+    let storage_used = service
+        .get_display_storage_usage(&repo, &visibility_for_auth(Some(&auth)))
+        .await?;
 
     state.event_bus.emit_repository_event(
         "repository.updated",
@@ -21110,7 +21136,7 @@ mod apt_validation_tests {
         for (id, tag, expected) in matrix {
             let oracle = if tag == "virt" || tag == "hollow" {
                 service
-                    .get_virtual_storage_usage(id)
+                    .get_virtual_storage_usage(id, &RepoVisibility::All)
                     .await
                     .expect("virtual oracle")
             } else {
@@ -21382,5 +21408,340 @@ mod apt_validation_tests {
              every sidecar unconditionally would pass this test; \
              collected: {collected:?}"
         );
+    }
+    // -----------------------------------------------------------------------
+    // #3081: a virtual repository's storage total must not disclose the byte
+    // size of member repositories the caller cannot read. Both aggregation
+    // paths are covered: the per-repo walk behind `GET /{key}` and the
+    // ledger-backed batch behind the listing (#3079).
+    // -----------------------------------------------------------------------
+
+    /// Read `storage_used_bytes` for `key` from `GET /{key}` (detail, the
+    /// per-repo walk) and from `GET /?q={prefix}` (listing, the batch), as
+    /// `auth`. Both must agree; the shared value is returned.
+    async fn virtual_total_seen_by_3081(
+        pool: &sqlx::PgPool,
+        prefix: &str,
+        key: &str,
+        auth: crate::api::middleware::auth::AuthExtension,
+    ) -> i64 {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let state = tdh::build_state(pool.clone(), "/tmp/vs3081-unused");
+        let router = tdh::router_with_auth(super::router(), state, auth.clone());
+        let (status, body) = tdh::send(router, tdh::get(format!("/{key}"))).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "detail GET /{key} failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let detail: serde_json::Value = serde_json::from_slice(&body).expect("detail json");
+        let from_detail = detail["storage_used_bytes"]
+            .as_i64()
+            .expect("detail storage figure");
+
+        let state = tdh::build_state(pool.clone(), "/tmp/vs3081-unused");
+        let router = tdh::router_with_auth(super::router(), state, auth);
+        let (status, body) = tdh::send(router, tdh::get(format!("/?q={prefix}&per_page=50"))).await;
+        assert_eq!(status, StatusCode::OK, "listing failed");
+        let listing: serde_json::Value = serde_json::from_slice(&body).expect("listing json");
+        let from_listing = listing["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .find(|item| item["key"].as_str() == Some(key))
+            .map(|item| item["storage_used_bytes"].as_i64().expect("listing figure"))
+            .expect("virtual repo present in listing");
+
+        assert_eq!(
+            from_detail, from_listing,
+            "detail (per-repo walk) and listing (ledger batch) must report the same \
+             caller-scoped total for {key}"
+        );
+        from_detail
+    }
+
+    /// Assert `GET /{key}` returns 404 for this caller (the existence-hiding
+    /// denial `require_visible` produces for an invisible private repo).
+    async fn assert_repo_hidden_3081(
+        pool: &sqlx::PgPool,
+        key: &str,
+        auth: crate::api::middleware::auth::AuthExtension,
+    ) {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let state = tdh::build_state(pool.clone(), "/tmp/vs3081-unused");
+        let router = tdh::router_with_auth(super::router(), state, auth);
+        let (status, _body) = tdh::send(router, tdh::get(format!("/{key}"))).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{key} must be hidden");
+    }
+
+    /// #3081 regression: the virtual total is aggregated ONLY over members the
+    /// caller may see.
+    ///
+    /// Fixture: private virtual `virt` with two private members — `vis`
+    /// (1,000 bytes) and `hidden` (500,000 bytes).
+    ///
+    /// * `outsider` holds the virtual only  -> 0 (both members hidden)
+    /// * `member` holds the virtual + `vis` -> 1,000 (`hidden`'s bytes excluded
+    ///   while `vis`'s are still counted — this is the control that a
+    ///   fix which always returned 0 would fail)
+    /// * `admin`                            -> 501,000, the full correct total
+    ///
+    /// Before the fix every caller saw 501,000 even though `GET` on both
+    /// members correctly 404s for `outsider` and on `hidden` for `member`.
+    #[tokio::test]
+    async fn test_virtual_storage_total_excludes_invisible_members_3081() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _serial = tdh::usage_ledger_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let prefix = format!("vs3081{}", &Uuid::new_v4().simple().to_string()[..12]);
+
+        let virt = seeded_repo_3078(&pool, &prefix, "virt", "virtual").await;
+        let vis = seeded_repo_3078(&pool, &prefix, "vis", "local").await;
+        let hidden = seeded_repo_3078(&pool, &prefix, "hidden", "local").await;
+
+        // `vis` holds 1,000 hosted bytes; `hidden` holds a 500,000-byte blob.
+        sqlx::query(
+            "INSERT INTO artifacts (id, repository_id, path, name, size_bytes, \
+             checksum_sha256, content_type, storage_key, is_deleted) \
+             VALUES ($1, $2, $3, $3, 1000, repeat('b', 64), 'application/octet-stream', $4, false)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(vis)
+        .bind(format!("p/{prefix}"))
+        .bind(format!("cas/00/{}", Uuid::new_v4()))
+        .execute(&pool)
+        .await
+        .expect("insert visible member artifact");
+        sqlx::query(
+            "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
+             VALUES ($1, $2, $3, 500000, $4)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(hidden)
+        .bind(format!("sha256:{}", Uuid::new_v4().simple()))
+        .bind(format!("oci-blobs/{}", Uuid::new_v4()))
+        .execute(&pool)
+        .await
+        .expect("insert hidden member blob");
+
+        for (member, prio) in [(vis, 1), (hidden, 2)] {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virt)
+            .bind(member)
+            .bind(prio)
+            .execute(&pool)
+            .await
+            .expect("add virtual member");
+        }
+
+        let (outsider_id, outsider_name) = tdh::create_user(&pool).await;
+        let (member_id, member_name) = tdh::create_user(&pool).await;
+        let (admin_id, admin_name) = tdh::create_user(&pool).await;
+        tdh::grant_repo_access(&pool, virt, outsider_id).await;
+        tdh::grant_repo_access(&pool, virt, member_id).await;
+        tdh::grant_repo_access(&pool, vis, member_id).await;
+
+        let virt_key = format!("{prefix}-virt");
+        let vis_key = format!("{prefix}-vis");
+        let hidden_key = format!("{prefix}-hidden");
+
+        // The premise: both members are genuinely invisible to `outsider`, and
+        // `hidden` is invisible to `member`.
+        let outsider = tdh::make_auth(outsider_id, &outsider_name);
+        assert_repo_hidden_3081(&pool, &vis_key, outsider.clone()).await;
+        assert_repo_hidden_3081(&pool, &hidden_key, outsider.clone()).await;
+        assert_repo_hidden_3081(&pool, &hidden_key, tdh::make_auth(member_id, &member_name)).await;
+
+        // A caller who can see the virtual but neither member learns nothing.
+        assert_eq!(
+            virtual_total_seen_by_3081(&pool, &prefix, &virt_key, outsider).await,
+            0,
+            "virtual total must not disclose bytes of members the caller cannot read"
+        );
+
+        // Control against an always-zero "fix": the visible member's bytes are
+        // still counted, and only the hidden member's are withheld.
+        assert_eq!(
+            virtual_total_seen_by_3081(
+                &pool,
+                &prefix,
+                &virt_key,
+                tdh::make_auth(member_id, &member_name)
+            )
+            .await,
+            1_000,
+            "a caller who can see one member must still get that member's bytes"
+        );
+
+        // Positive control: an admin sees every member, so the total is the
+        // full, correct union — unchanged from before the fix.
+        assert_eq!(
+            virtual_total_seen_by_3081(
+                &pool,
+                &prefix,
+                &virt_key,
+                tdh::admin_auth(admin_id, &admin_name)
+            )
+            .await,
+            501_000,
+            "a caller who can see all members must still get the full total"
+        );
+
+        for id in [virt, vis, hidden] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await;
+        }
+        for id in [outsider_id, member_id, admin_id] {
+            tdh::cleanup_user(&pool, id).await;
+        }
+    }
+    /// #3081: the caller-visibility derivation shared by the listing and the
+    /// virtual-storage aggregation. DB-free — it is a pure mapping from the
+    /// authenticated principal to a `RepoVisibility` variant.
+    #[test]
+    fn test_visibility_for_auth_maps_each_principal_3081() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::models::access_scope::AccessScope;
+
+        assert_eq!(visibility_for_auth(None), RepoVisibility::PublicOnly);
+
+        let user_id = Uuid::new_v4();
+        let admin = tdh::admin_auth(user_id, "admin-3081");
+        assert_eq!(visibility_for_auth(Some(&admin)), RepoVisibility::All);
+
+        let plain = tdh::make_auth(user_id, "user-3081");
+        assert_eq!(
+            visibility_for_auth(Some(&plain)),
+            RepoVisibility::User(user_id)
+        );
+
+        // A repo-scoped token is limited to exactly its allowed set, so a
+        // member outside that set contributes nothing to a virtual total.
+        let scoped_to = vec![Uuid::new_v4()];
+        let scoped = AuthExtension {
+            allowed_repo_ids: AccessScope::Restricted(scoped_to.clone()),
+            ..tdh::make_auth(user_id, "scoped-3081")
+        };
+        assert_eq!(
+            visibility_for_auth(Some(&scoped)),
+            RepoVisibility::Ids(scoped_to)
+        );
+
+        // An ADMIN repo-scoped token still resolves to `All`: the admin arm is
+        // matched first, mirroring the listing.
+        let scoped_admin = AuthExtension {
+            is_admin: true,
+            ..scoped
+        };
+        assert_eq!(
+            visibility_for_auth(Some(&scoped_admin)),
+            RepoVisibility::All
+        );
+    }
+    /// #3081, anonymous arm: a PUBLIC virtual repository is readable without
+    /// authentication, so its total must count only its PUBLIC members. This
+    /// also exercises the `RepoVisibility::PublicOnly` bind shape of the two
+    /// aggregation queries, whose visibility parameter is bound but not
+    /// referenced by the generated clause.
+    #[tokio::test]
+    async fn test_public_virtual_total_excludes_private_members_3081() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let _serial = tdh::usage_ledger_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let prefix = format!("vp3081{}", &Uuid::new_v4().simple().to_string()[..12]);
+
+        let virt = seeded_repo_3078(&pool, &prefix, "virt", "virtual").await;
+        let open = seeded_repo_3078(&pool, &prefix, "open", "local").await;
+        let secret = seeded_repo_3078(&pool, &prefix, "secret", "local").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![virt, open])
+            .execute(&pool)
+            .await
+            .expect("publish virtual + open member");
+
+        for (repo, size) in [(open, 3_000i64), (secret, 900_000i64)] {
+            sqlx::query(
+                "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(Uuid::new_v4())
+            .bind(repo)
+            .bind(format!("sha256:{}", Uuid::new_v4().simple()))
+            .bind(size)
+            .bind(format!("oci-blobs/{}", Uuid::new_v4()))
+            .execute(&pool)
+            .await
+            .expect("insert member blob");
+        }
+        for (member, prio) in [(open, 1), (secret, 2)] {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virt)
+            .bind(member)
+            .bind(prio)
+            .execute(&pool)
+            .await
+            .expect("add virtual member");
+        }
+
+        let virt_key = format!("{prefix}-virt");
+        let state = tdh::build_state(pool.clone(), "/tmp/vp3081-unused");
+        let router = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(router, tdh::get(format!("/{virt_key}"))).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "anonymous GET of a public virtual failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let detail: serde_json::Value = serde_json::from_slice(&body).expect("detail json");
+        assert_eq!(
+            detail["storage_used_bytes"].as_i64(),
+            Some(3_000),
+            "anonymous total must count the public member only, not the private one"
+        );
+
+        let state = tdh::build_state(pool.clone(), "/tmp/vp3081-unused");
+        let router = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(router, tdh::get(format!("/?q={prefix}&per_page=50"))).await;
+        assert_eq!(status, StatusCode::OK, "anonymous listing failed");
+        let listing: serde_json::Value = serde_json::from_slice(&body).expect("listing json");
+        let listed = listing["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .find(|item| item["key"].as_str() == Some(virt_key.as_str()))
+            .map(|item| item["storage_used_bytes"].as_i64().expect("listing figure"))
+            .expect("public virtual present in anonymous listing");
+        assert_eq!(
+            listed, 3_000,
+            "anonymous listing must not disclose the private member's bytes"
+        );
+
+        for id in [virt, open, secret] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await;
+        }
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -245,6 +245,41 @@ pub(crate) fn visibility_for_auth(auth: Option<&AuthExtension>) -> RepoVisibilit
     }
 }
 
+/// The GRANT half of [`require_visible`], for rows reached *through* an
+/// already-authorized parent — a virtual repository's members.
+///
+/// Deliberately not [`visibility_for_auth`]. That function answers "which
+/// repositories may this principal LIST", and for a repo-scoped token the
+/// answer is exactly its allowed set — the listing's documented contract.
+/// Membership is a different question, and reusing the `Ids` arm for it gets
+/// two things wrong, because `require_visible` is
+///
+/// ```text
+/// is_public OR (in_scope AND (is_admin OR grants))
+/// ```
+///
+/// and the `Ids` arm is `in_scope` alone. It drops the `is_public` arm — so a
+/// token scoped to a virtual reported 0 bytes for members it could plainly
+/// read, and an authenticated scoped caller saw a SMALLER total than an
+/// anonymous one — and it drops the grant conjunct, so a token kept counting a
+/// member's bytes after its owner's grant was revoked. Scope is a mint-time
+/// snapshot; entitlement is not.
+///
+/// The scope half is already satisfied here: `require_visible` gated the parent
+/// before any aggregation runs, so the caller is entitled to read this virtual,
+/// and a virtual's members are its content. That is the same read-through the
+/// by-path download already grants such a token.
+///
+/// NOTE: PR #3173 adds an identical helper to this file for the member
+/// LISTING paths. Whichever lands second should drop its copy.
+pub(crate) fn member_grant_visibility(auth: Option<&AuthExtension>) -> RepoVisibility {
+    match auth {
+        None => RepoVisibility::PublicOnly,
+        Some(a) if a.is_admin => RepoVisibility::All,
+        Some(a) => RepoVisibility::User(a.user_id),
+    }
+}
+
 /// Ensure a repository is visible to the current user.
 ///
 /// Public repos are visible to everyone. Private repos require authentication
@@ -2215,6 +2250,9 @@ pub async fn list_repositories(
     // a repo-scoped token, only the token's allowed repositories rather than
     // every repo the owning user can reach.
     let visibility = visibility_for_auth(auth.as_ref());
+    // The LISTING uses token scope; the per-virtual byte AGGREGATE uses the
+    // grant half only. See  for why they differ.
+    let member_visibility = member_grant_visibility(auth.as_ref());
     let service = RepositoryService::new(state.db.clone());
     let (repos, total) = service
         .list(
@@ -2293,7 +2331,7 @@ pub async fn list_repositories(
         // through the virtual's total.
         storage_map.extend(
             service
-                .get_virtual_storage_usage_batch(&virtual_ids, &visibility)
+                .get_virtual_storage_usage_batch(&virtual_ids, &member_visibility)
                 .await?,
         );
     }
@@ -2815,7 +2853,7 @@ pub async fn get_repository(
     // #3081: that union is scoped to the members THIS caller may see, so the
     // aggregate cannot disclose the size of a member whose own GET 404s.
     let storage_used = service
-        .get_display_storage_usage(&repo, &visibility_for_auth(auth.as_ref()))
+        .get_display_storage_usage(&repo, &member_grant_visibility(auth.as_ref()))
         .await?;
     let auth_type =
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
@@ -3646,7 +3684,7 @@ pub async fn update_repository(
     // #2785: virtual repos report the union of their members' contents.
     // #3081: scoped to the members this caller may see.
     let storage_used = service
-        .get_display_storage_usage(&repo, &visibility_for_auth(Some(&auth)))
+        .get_display_storage_usage(&repo, &member_grant_visibility(Some(&auth)))
         .await?;
 
     state.event_bus.emit_repository_event(
@@ -21533,6 +21571,17 @@ mod apt_validation_tests {
         .await
         .expect("insert visible member artifact");
         seed_oci_blob_test(&pool, hidden, 500_000).await;
+
+        // A repo `member` CAN see, holding bytes, that is deliberately NOT a
+        // member of the virtual. Without it, removing the
+        // `virtual_repo_members` join entirely -- making `leaves` "every repo
+        // the caller can see" -- still satisfies the outsider (0) and member
+        // (1,000) assertions below. Only the admin total would catch it, and
+        // only incidentally, via unrelated repos left in the shared database.
+        // That is state-dependent rather than by construction.
+        let outside = seeded_repo_3078(&pool, &prefix, "outside", "local").await;
+        seed_oci_blob_test(&pool, outside, 7_000).await;
+
         link_virtual_members_test(&pool, virt, &[(vis, 1), (hidden, 2)]).await;
 
         let (outsider_id, outsider_name) = tdh::create_user(&pool).await;
@@ -21541,6 +21590,7 @@ mod apt_validation_tests {
         tdh::grant_repo_access(&pool, virt, outsider_id).await;
         tdh::grant_repo_access(&pool, virt, member_id).await;
         tdh::grant_repo_access(&pool, vis, member_id).await;
+        tdh::grant_repo_access(&pool, outside, member_id).await;
 
         let virt_key = format!("{prefix}-virt");
         let vis_key = format!("{prefix}-vis");

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -40,8 +40,8 @@ use crate::services::cache_classifier;
 use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
 use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
 use crate::services::repository_service::{
-    derive_format_key, CreateRepositoryRequest as ServiceCreateRepoReq, RepoVisibility,
-    RepositoryService, UpdateRepositoryRequest as ServiceUpdateRepoReq,
+    derive_format_key, CreateRepositoryRequest as ServiceCreateRepoReq, MemberVisibility,
+    RepoVisibility, RepositoryService, UpdateRepositoryRequest as ServiceUpdateRepoReq,
 };
 use crate::services::routing_rules::{self, RoutingRule};
 use crate::services::signing_service::SigningService;
@@ -218,13 +218,18 @@ pub(crate) async fn require_repo_admin(
     }
 }
 
-/// Resolve the caller's repository visibility (issue #3081).
+/// Resolve the caller's repository LISTING visibility (issue #3081).
 ///
 /// This is the single derivation of [`RepoVisibility`] from an authenticated
-/// (or anonymous) principal, shared by the repository listing and by every
-/// path that aggregates over OTHER repositories on the caller's behalf — today
-/// the virtual-repository storage total, whose members are separate
-/// repositories with their own ACLs.
+/// (or anonymous) principal for the repository listing.
+///
+/// It answers "which repositories may this principal LIST", which is NOT the
+/// same question as `require_visible`: for a repo-scoped token the listing's
+/// documented contract is exactly the token's allowed set, so the `Ids` arm
+/// deliberately drops both the `is_public` arm and the grant conjunct. Any
+/// path that aggregates over OTHER repositories on the caller's behalf — a
+/// virtual repository's members, which are separate repositories with their
+/// own ACLs — must use [`member_read_visibility`] instead.
 ///
 /// * anonymous              -> public repositories only
 /// * global admin           -> everything
@@ -245,38 +250,60 @@ pub(crate) fn visibility_for_auth(auth: Option<&AuthExtension>) -> RepoVisibilit
     }
 }
 
-/// The GRANT half of [`require_visible`], for rows reached *through* an
-/// already-authorized parent — a virtual repository's members.
+/// [`require_visible`] as a filter, for repositories reached *through* an
+/// already-authorized parent — a virtual repository's members, whose bytes are
+/// folded into the parent's storage total (issue #3081).
 ///
-/// Deliberately not [`visibility_for_auth`]. That function answers "which
-/// repositories may this principal LIST", and for a repo-scoped token the
-/// answer is exactly its allowed set — the listing's documented contract.
-/// Membership is a different question, and reusing the `Ids` arm for it gets
-/// two things wrong, because `require_visible` is
+/// Deliberately not [`visibility_for_auth`], and deliberately not the grant
+/// half on its own. `require_visible` is
 ///
 /// ```text
 /// is_public OR (in_scope AND (is_admin OR grants))
 /// ```
 ///
-/// and the `Ids` arm is `in_scope` alone. It drops the `is_public` arm — so a
-/// token scoped to a virtual reported 0 bytes for members it could plainly
-/// read, and an authenticated scoped caller saw a SMALLER total than an
-/// anonymous one — and it drops the grant conjunct, so a token kept counting a
-/// member's bytes after its owner's grant was revoked. Scope is a mint-time
-/// snapshot; entitlement is not.
+/// and BOTH conjuncts have to survive:
 ///
-/// The scope half is already satisfied here: `require_visible` gated the parent
-/// before any aggregation runs, so the caller is entitled to read this virtual,
-/// and a virtual's members are its content. That is the same read-through the
-/// by-path download already grants such a token.
+/// * [`RepoVisibility::Ids`] is `in_scope` alone. It drops the `is_public`
+///   arm — so a token scoped to a virtual would report 0 bytes for members it
+///   could plainly read, and an authenticated scoped caller would see a
+///   SMALLER total than an anonymous one — and it drops the grant conjunct, so
+///   a token would keep counting a member's bytes after its owner's grant was
+///   revoked. Scope is a mint-time snapshot; entitlement is not.
+/// * [`RepoVisibility::User`] is `is_public OR grants`, i.e. the grant half
+///   alone. Gating the PARENT does not supply the missing scope half:
+///   `require_visible` early-returns `Ok` on `repo.is_public` **without ever
+///   calling `can_access_repo`**, and `get_repository` carries no
+///   `require_repo_access`. So a token scoped to some unrelated repository can
+///   reach a PUBLIC virtual, and the grant-half aggregate then hands it a byte
+///   total for private members it is scoped away from and whose own `GET`
+///   correctly 404s. Nor is read-through the right premise:
+///   `proxy_helpers::caller_can_read_member` gates the by-path download on
+///   `can_access_repo(member.id)` with no parent term anywhere, so such a
+///   token is DENIED those members' bytes.
 ///
-/// NOTE: PR #3173 adds an identical helper to this file for the member
-/// LISTING paths. Whichever lands second should drop its copy.
-pub(crate) fn member_grant_visibility(auth: Option<&AuthExtension>) -> RepoVisibility {
+/// [`MemberVisibility`] therefore carries the whole principal, and
+/// [`build_member_visibility_clause`] renders the predicate above verbatim.
+/// This agrees with PR #3173, which denies the same shape for the member
+/// LISTING paths by composing `member_grant_visibility` (the grant half, in
+/// SQL) with `member_passes_token_scope` (the scope half, per row) — the same
+/// predicate, applied row-wise because that path has the rows in hand. The
+/// aggregate sums its rows inside the database, so it renders one clause.
+///
+/// The consequence #3173 accepts deliberately holds here too: a token scoped
+/// only to a virtual sees 0 bytes for members it does not carry. That is
+/// consistent with the download, which also refuses. Scope tokens to the
+/// members, or to both.
+pub(crate) fn member_read_visibility(auth: Option<&AuthExtension>) -> MemberVisibility {
     match auth {
-        None => RepoVisibility::PublicOnly,
-        Some(a) if a.is_admin => RepoVisibility::All,
-        Some(a) => RepoVisibility::User(a.user_id),
+        None => MemberVisibility::Anonymous,
+        Some(a) => MemberVisibility::Principal {
+            user_id: a.user_id,
+            is_admin: a.is_admin,
+            allowed_repo_ids: a
+                .allowed_repo_ids
+                .as_allowed_repo_ids()
+                .map(<[Uuid]>::to_vec),
+        },
     }
 }
 
@@ -2250,9 +2277,11 @@ pub async fn list_repositories(
     // a repo-scoped token, only the token's allowed repositories rather than
     // every repo the owning user can reach.
     let visibility = visibility_for_auth(auth.as_ref());
-    // The LISTING uses token scope; the per-virtual byte AGGREGATE uses the
-    // grant half only. See  for why they differ.
-    let member_visibility = member_grant_visibility(auth.as_ref());
+    // The LISTING is token scope alone (its documented contract); the
+    // per-virtual byte AGGREGATE is `require_visible` in full, because its
+    // members are other repositories with their own ACLs. See
+    // [`member_read_visibility`] for why they differ.
+    let member_visibility = member_read_visibility(auth.as_ref());
     let service = RepositoryService::new(state.db.clone());
     let (repos, total) = service
         .list(
@@ -2851,9 +2880,12 @@ pub async fn get_repository(
     // #2785: virtual repos report the union of their members' contents, not
     // their own (empty) rows, so the displayed total matches the child repos.
     // #3081: that union is scoped to the members THIS caller may see, so the
-    // aggregate cannot disclose the size of a member whose own GET 404s.
+    // aggregate cannot disclose the size of a member whose own GET 404s. Note
+    // `require_visible` above proves nothing about token scope when `repo` is
+    // public — it early-returns before `can_access_repo` — so the member
+    // filter re-derives BOTH halves from the principal.
     let storage_used = service
-        .get_display_storage_usage(&repo, &member_grant_visibility(auth.as_ref()))
+        .get_display_storage_usage(&repo, &member_read_visibility(auth.as_ref()))
         .await?;
     let auth_type =
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
@@ -3682,9 +3714,11 @@ pub async fn update_repository(
     }
 
     // #2785: virtual repos report the union of their members' contents.
-    // #3081: scoped to the members this caller may see.
+    // #3081: scoped to the members this caller may see. `require_repo_access`
+    // above checked the caller's scope against the PARENT only; each member is
+    // a separate repository with its own ACL.
     let storage_used = service
-        .get_display_storage_usage(&repo, &member_grant_visibility(Some(&auth)))
+        .get_display_storage_usage(&repo, &member_read_visibility(Some(&auth)))
         .await?;
 
     state.event_bus.emit_repository_event(
@@ -21191,7 +21225,7 @@ mod apt_validation_tests {
         for (id, tag, expected) in matrix {
             let oracle = if tag == "virt" || tag == "hollow" {
                 service
-                    .get_virtual_storage_usage(id, &RepoVisibility::All)
+                    .get_virtual_storage_usage(id, &MemberVisibility::Unfiltered)
                     .await
                     .expect("virtual oracle")
             } else {
@@ -21466,10 +21500,40 @@ mod apt_validation_tests {
     // ledger-backed batch behind the listing (#3079).
     // -----------------------------------------------------------------------
 
-    /// Read `storage_used_bytes` for `key` from `GET /{key}` (detail, the
-    /// per-repo walk) and from `GET /?q={prefix}` (listing, the batch), as
-    /// `auth`. Both must agree; the shared value is returned.
-    async fn virtual_total_seen_by_3081(
+    /// Read `storage_used_bytes` for `key` from `GET /{key}` — the DETAIL
+    /// path, whose aggregate is the live per-repo walk
+    /// (`get_virtual_storage_usage`).
+    async fn virtual_total_from_detail_3081(
+        pool: &sqlx::PgPool,
+        key: &str,
+        auth: crate::api::middleware::auth::AuthExtension,
+    ) -> i64 {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let state = tdh::build_state(pool.clone(), "/tmp/vs3081-unused");
+        let router = tdh::router_with_auth(super::router(), state, auth);
+        let (status, body) = tdh::send(router, tdh::get(format!("/{key}"))).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "detail GET /{key} failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let detail: serde_json::Value = serde_json::from_slice(&body).expect("detail json");
+        detail["storage_used_bytes"]
+            .as_i64()
+            .expect("detail storage figure")
+    }
+
+    /// Read `storage_used_bytes` for `key` from `GET /?q={prefix}` — the
+    /// LISTING path, whose aggregate is the ledger batch
+    /// (`get_virtual_storage_usage_batch`).
+    ///
+    /// The repo must be present in the listing; a caller whose *listing*
+    /// visibility excludes it (e.g. a repo-scoped token that does not carry
+    /// it) cannot exercise this path at all.
+    async fn virtual_total_from_listing_3081(
         pool: &sqlx::PgPool,
         prefix: &str,
         key: &str,
@@ -21479,38 +21543,53 @@ mod apt_validation_tests {
         use axum::http::StatusCode;
 
         let state = tdh::build_state(pool.clone(), "/tmp/vs3081-unused");
-        let router = tdh::router_with_auth(super::router(), state, auth.clone());
-        let (status, body) = tdh::send(router, tdh::get(format!("/{key}"))).await;
-        assert_eq!(
-            status,
-            StatusCode::OK,
-            "detail GET /{key} failed: {}",
-            String::from_utf8_lossy(&body)
-        );
-        let detail: serde_json::Value = serde_json::from_slice(&body).expect("detail json");
-        let from_detail = detail["storage_used_bytes"]
-            .as_i64()
-            .expect("detail storage figure");
-
-        let state = tdh::build_state(pool.clone(), "/tmp/vs3081-unused");
         let router = tdh::router_with_auth(super::router(), state, auth);
         let (status, body) = tdh::send(router, tdh::get(format!("/?q={prefix}&per_page=50"))).await;
         assert_eq!(status, StatusCode::OK, "listing failed");
         let listing: serde_json::Value = serde_json::from_slice(&body).expect("listing json");
-        let from_listing = listing["items"]
+        listing["items"]
             .as_array()
             .expect("items array")
             .iter()
             .find(|item| item["key"].as_str() == Some(key))
             .map(|item| item["storage_used_bytes"].as_i64().expect("listing figure"))
-            .expect("virtual repo present in listing");
+            .expect("virtual repo present in listing")
+    }
 
+    /// Read `storage_used_bytes` for `key` from both aggregation paths as
+    /// `auth`. Both must agree; the shared value is returned.
+    async fn virtual_total_seen_by_3081(
+        pool: &sqlx::PgPool,
+        prefix: &str,
+        key: &str,
+        auth: crate::api::middleware::auth::AuthExtension,
+    ) -> i64 {
+        let from_detail = virtual_total_from_detail_3081(pool, key, auth.clone()).await;
+        let from_listing = virtual_total_from_listing_3081(pool, prefix, key, auth).await;
         assert_eq!(
             from_detail, from_listing,
             "detail (per-repo walk) and listing (ledger batch) must report the same \
              caller-scoped total for {key}"
         );
         from_detail
+    }
+
+    /// Build a repo-scoped API token for `user` restricted to exactly
+    /// `allowed` (`AccessScope::Restricted`). This is the principal shape that
+    /// [`tdh::make_auth`] does NOT produce: `make_auth` yields
+    /// `AccessScope::Admin`, i.e. unrestricted token scope.
+    fn scoped_token_3081(
+        user_id: Uuid,
+        username: &str,
+        allowed: Vec<Uuid>,
+    ) -> crate::api::middleware::auth::AuthExtension {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::models::access_scope::AccessScope;
+        AuthExtension {
+            is_api_token: true,
+            allowed_repo_ids: AccessScope::Restricted(allowed),
+            ..tdh::make_auth(user_id, username)
+        }
     }
 
     /// Assert `GET /{key}` returns 404 for this caller (the existence-hiding
@@ -21643,9 +21722,13 @@ mod apt_validation_tests {
             tdh::cleanup_user(&pool, id).await;
         }
     }
-    /// #3081: the caller-visibility derivation shared by the listing and the
-    /// virtual-storage aggregation. DB-free — it is a pure mapping from the
-    /// authenticated principal to a `RepoVisibility` variant.
+    /// #3081: the LISTING's caller-visibility derivation. DB-free — it is a
+    /// pure mapping from the authenticated principal to a `RepoVisibility`
+    /// variant.
+    ///
+    /// This is the listing's contract only. The virtual-storage aggregate uses
+    /// `member_read_visibility`, covered by
+    /// `test_member_read_visibility_is_require_visible_3081`.
     #[test]
     fn test_visibility_for_auth_maps_each_principal_3081() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -21663,8 +21746,12 @@ mod apt_validation_tests {
             RepoVisibility::User(user_id)
         );
 
-        // A repo-scoped token is limited to exactly its allowed set, so a
-        // member outside that set contributes nothing to a virtual total.
+        // A repo-scoped token LISTS exactly its allowed set. This says nothing
+        // about what a virtual repository's total may include: that is
+        // `member_read_visibility`'s question, and the `Ids` arm is the wrong
+        // answer to it (it drops both the `is_public` arm and the grant
+        // conjunct). Asserted separately in
+        // `test_member_read_visibility_is_require_visible_3081`.
         let scoped_to = vec![Uuid::new_v4()];
         let scoped = AuthExtension {
             allowed_repo_ids: AccessScope::Restricted(scoped_to.clone()),
@@ -21686,10 +21773,140 @@ mod apt_validation_tests {
             RepoVisibility::All
         );
     }
+
+    /// #3081: `member_read_visibility` must be `require_visible` for EVERY
+    /// principal shape, i.e.
+    ///
+    /// ```text
+    /// is_public OR (in_scope AND (is_admin OR grants))
+    /// ```
+    ///
+    /// Walks all five: anonymous, admin unrestricted, admin + `Restricted`,
+    /// non-admin unrestricted, non-admin + `Restricted`. DB-free.
+    ///
+    /// The two arms this pins hardest are the ones `RepoVisibility` gets
+    /// wrong: an admin's repo-scoped token must NOT widen to everything
+    /// (`require_visible` checks `can_access_repo` BEFORE the admin bypass),
+    /// and a non-admin repo-scoped token must keep BOTH conjuncts rather than
+    /// collapsing to the grant half.
+    #[test]
+    fn test_member_read_visibility_is_require_visible_3081() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::models::access_scope::AccessScope;
+        use crate::services::repository_service::build_member_visibility_clause;
+
+        let user_id = Uuid::new_v4();
+        let scoped_to = vec![Uuid::new_v4()];
+        let restrict = |a: AuthExtension| AuthExtension {
+            allowed_repo_ids: AccessScope::Restricted(scoped_to.clone()),
+            ..a
+        };
+
+        // 1. anonymous -> the public arm alone.
+        assert_eq!(member_read_visibility(None), MemberVisibility::Anonymous);
+
+        // 2. admin, unrestricted scope -> entitlement true, scope true.
+        let admin = tdh::admin_auth(user_id, "admin-3081");
+        assert_eq!(
+            member_read_visibility(Some(&admin)),
+            MemberVisibility::Principal {
+                user_id,
+                is_admin: true,
+                allowed_repo_ids: None,
+            }
+        );
+
+        // 3. admin + Restricted -> entitlement true, but scope is RETAINED.
+        //    `require_visible` checks `can_access_repo` before the admin
+        //    bypass, so an admin's repo-scoped token is still confined.
+        let scoped_admin = restrict(admin.clone());
+        assert_eq!(
+            member_read_visibility(Some(&scoped_admin)),
+            MemberVisibility::Principal {
+                user_id,
+                is_admin: true,
+                allowed_repo_ids: Some(scoped_to.clone()),
+            }
+        );
+
+        // 4. non-admin, unrestricted scope -> grants gate, scope open.
+        let plain = tdh::make_auth(user_id, "user-3081");
+        assert_eq!(
+            member_read_visibility(Some(&plain)),
+            MemberVisibility::Principal {
+                user_id,
+                is_admin: false,
+                allowed_repo_ids: None,
+            }
+        );
+
+        // 5. non-admin + Restricted -> BOTH conjuncts survive.
+        let scoped = restrict(plain);
+        assert_eq!(
+            member_read_visibility(Some(&scoped)),
+            MemberVisibility::Principal {
+                user_id,
+                is_admin: false,
+                allowed_repo_ids: Some(scoped_to.clone()),
+            }
+        );
+
+        // And the rendered SQL matches, arm by arm. `$2` is the user bind,
+        // `$3` the scope bind, for every variant. Compared on whitespace-
+        // collapsed SQL so the assertions pin STRUCTURE, not indentation.
+        let clause = |auth: Option<&AuthExtension>| {
+            let (sql, user_bind, scope_bind) =
+                build_member_visibility_clause(&member_read_visibility(auth), "leaf", 2);
+            (
+                sql.split_whitespace().collect::<Vec<_>>().join(" "),
+                user_bind,
+                scope_bind,
+            )
+        };
+
+        let (sql, user_bind, scope_bind) = clause(None);
+        assert_eq!(sql, "is_public = true");
+        assert_eq!((user_bind, scope_bind), (None, None));
+
+        // Admin, unrestricted: both conjuncts collapse to `true`, so the arm
+        // is unconditionally satisfied — the pre-#3081 total, unchanged.
+        let (sql, user_bind, scope_bind) = clause(Some(&admin));
+        assert_eq!(sql, "( is_public = true OR (true AND true) )");
+        assert_eq!((user_bind, scope_bind), (None, None));
+
+        // Admin + Restricted: the entitlement half is `true`, but the SCOPE
+        // conjunct is retained. This is the arm `RepoVisibility::All` loses.
+        let (sql, user_bind, scope_bind) = clause(Some(&scoped_admin));
+        assert_eq!(
+            sql, "( is_public = true OR (leaf.id = ANY($3) AND true) )",
+            "admin + Restricted must stay confined to its scope"
+        );
+        assert_eq!((user_bind, scope_bind), (None, Some(scoped_to.clone())));
+
+        // Non-admin + Restricted: all three pieces survive.
+        let (sql, user_bind, scope_bind) = clause(Some(&scoped));
+        assert!(
+            sql.starts_with("( is_public = true OR (leaf.id = ANY($3) AND ("),
+            "public arm and scope conjunct survive, in that order: {sql}"
+        );
+        assert!(
+            sql.contains("ra.user_id = $2") && sql.contains("p.principal_id = $2"),
+            "grant conjunct survives, on the same user bind: {sql}"
+        );
+        assert_eq!((user_bind, scope_bind), (Some(user_id), Some(scoped_to)));
+
+        // The internal arm is the unfiltered pre-#3081 sum, and is NOT
+        // reachable from any principal.
+        let (sql, user_bind, scope_bind) =
+            build_member_visibility_clause(&MemberVisibility::Unfiltered, "leaf", 2);
+        assert_eq!(sql, "true");
+        assert_eq!((user_bind, scope_bind), (None, None));
+    }
+
     /// #3081, anonymous arm: a PUBLIC virtual repository is readable without
     /// authentication, so its total must count only its PUBLIC members. This
-    /// also exercises the `RepoVisibility::PublicOnly` bind shape of the two
-    /// aggregation queries, whose visibility parameter is bound but not
+    /// also exercises the `MemberVisibility::Anonymous` bind shape of the two
+    /// aggregation queries, whose visibility parameters are bound but not
     /// referenced by the generated clause.
     #[tokio::test]
     async fn test_public_virtual_total_excludes_private_members_3081() {
@@ -21750,5 +21967,186 @@ mod apt_validation_tests {
         );
 
         drop_repos_test(&pool, &[virt, open, secret]).await;
+    }
+
+    /// #3081, TOKEN-SCOPE arm: the aggregate must apply BOTH halves of
+    /// `require_visible`, not just the grant half.
+    ///
+    /// `require_visible` is
+    ///
+    /// ```text
+    /// is_public OR (in_scope AND (is_admin OR grants))
+    /// ```
+    ///
+    /// and it early-returns `Ok` on `is_public` *without ever consulting
+    /// `can_access_repo`*, while `get_repository` carries no
+    /// `require_repo_access`. So gating the virtual parent proves nothing
+    /// about the caller's token scope, and a member aggregate that answers
+    /// only the grant half discloses bytes for repositories the token is
+    /// scoped away from.
+    ///
+    /// Fixture: PUBLIC virtual `virt` over two PRIVATE members the user `u`
+    /// holds grants on — `far` (10 GiB) and `near` (1,000 bytes) — plus an
+    /// unrelated private repo `x`.
+    ///
+    /// * token scoped to `[x]` only          -> 0     (V reachable via the
+    ///   `is_public` arm; NEITHER member is in scope)
+    /// * token scoped to `[virt, near]`      -> 1,000 (`far` withheld, `near`
+    ///   still counted — the control against an always-zero "fix")
+    /// * the same user with an UNRESTRICTED credential -> 10 GiB + 1,000
+    ///   (proves the bytes are genuinely reachable, so the two figures above
+    ///   are caused by scope and not by a broken fixture)
+    ///
+    /// Both aggregation paths are asserted: the live per-repo walk behind
+    /// `GET /{key}` and the ledger batch behind the listing.
+    #[tokio::test]
+    async fn test_virtual_total_excludes_out_of_scope_members_3081() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _serial = tdh::usage_ledger_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let prefix = format!("ts3081{}", &Uuid::new_v4().simple().to_string()[..12]);
+
+        const FAR_BYTES: i64 = 10 * 1024 * 1024 * 1024; // 10 GiB
+        const NEAR_BYTES: i64 = 1_000;
+
+        let virt = seeded_repo_3078(&pool, &prefix, "virt", "virtual").await;
+        let far = seeded_repo_3078(&pool, &prefix, "far", "local").await;
+        let near = seeded_repo_3078(&pool, &prefix, "near", "local").await;
+        let x = seeded_repo_3078(&pool, &prefix, "x", "local").await;
+        // Only the VIRTUAL is public. Both members stay private, so their own
+        // `GET` 404s for a token scoped away from them.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(virt)
+            .execute(&pool)
+            .await
+            .expect("publish the virtual parent");
+
+        seed_oci_blob_test(&pool, far, FAR_BYTES).await;
+        seed_oci_blob_test(&pool, near, NEAR_BYTES).await;
+        link_virtual_members_test(&pool, virt, &[(far, 1), (near, 2)]).await;
+
+        // `u` holds grants on BOTH members, so the GRANT half passes for each
+        // and only token scope can withhold them.
+        let (u_id, u_name) = tdh::create_user(&pool).await;
+        tdh::grant_repo_access(&pool, far, u_id).await;
+        tdh::grant_repo_access(&pool, near, u_id).await;
+
+        let virt_key = format!("{prefix}-virt");
+        let far_key = format!("{prefix}-far");
+        let near_key = format!("{prefix}-near");
+
+        // Premise: a token scoped to `[x]` is refused BOTH members directly...
+        let scoped_elsewhere = scoped_token_3081(u_id, &u_name, vec![x]);
+        assert_repo_hidden_3081(&pool, &far_key, scoped_elsewhere.clone()).await;
+        assert_repo_hidden_3081(&pool, &near_key, scoped_elsewhere.clone()).await;
+
+        // ...yet reaches the PUBLIC virtual, whose total must disclose nothing.
+        assert_eq!(
+            virtual_total_from_detail_3081(&pool, &virt_key, scoped_elsewhere).await,
+            0,
+            "a token scoped to neither the virtual nor its members must not read \
+             a byte total for members it is scoped away from"
+        );
+
+        // A token carrying the virtual and ONE member: exactly that member's
+        // bytes, on both aggregation paths.
+        let scoped_near = scoped_token_3081(u_id, &u_name, vec![virt, near]);
+        assert_repo_hidden_3081(&pool, &far_key, scoped_near.clone()).await;
+        assert_eq!(
+            virtual_total_seen_by_3081(&pool, &prefix, &virt_key, scoped_near).await,
+            NEAR_BYTES,
+            "the total must count the in-scope member and withhold the out-of-scope one"
+        );
+
+        // Fixture control: the SAME user on an unrestricted credential sees
+        // every granted member, so the figures above are caused by scope.
+        assert_eq!(
+            virtual_total_seen_by_3081(&pool, &prefix, &virt_key, tdh::make_auth(u_id, &u_name))
+                .await,
+            FAR_BYTES + NEAR_BYTES,
+            "an unrestricted credential must still see every member the user is granted"
+        );
+
+        drop_repos_test(&pool, &[virt, far, near, x]).await;
+        tdh::cleanup_user(&pool, u_id).await;
+    }
+
+    /// #3081: the PATCH response carries the same aggregate as `GET`, and was
+    /// untested. `update_repository` gates on `require_repo_access` (token
+    /// scope on the PARENT) plus `repository:admin`, so the caller here is
+    /// scoped to the virtual — and must still be refused the bytes of a member
+    /// that scope does not carry.
+    #[tokio::test]
+    async fn test_patch_response_total_excludes_out_of_scope_members_3081() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let _serial = tdh::usage_ledger_serial_lock().await;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let prefix = format!("tp3081{}", &Uuid::new_v4().simple().to_string()[..12]);
+
+        let virt = seeded_repo_3078(&pool, &prefix, "virt", "virtual").await;
+        let far = seeded_repo_3078(&pool, &prefix, "far", "local").await;
+        let near = seeded_repo_3078(&pool, &prefix, "near", "local").await;
+        seed_oci_blob_test(&pool, far, 500_000).await;
+        seed_oci_blob_test(&pool, near, 1_000).await;
+        link_virtual_members_test(&pool, virt, &[(far, 1), (near, 2)]).await;
+
+        let (u_id, u_name) = tdh::create_user(&pool).await;
+        // Repo-admin on the virtual (the PATCH gate) and read grants on both
+        // members, so again only token scope can withhold a member.
+        tdh::grant_repo_admin(&pool, virt, u_id).await;
+        tdh::grant_repo_access(&pool, far, u_id).await;
+        tdh::grant_repo_access(&pool, near, u_id).await;
+
+        let virt_key = format!("{prefix}-virt");
+        let patch_total = |auth: crate::api::middleware::auth::AuthExtension| {
+            let pool = pool.clone();
+            let virt_key = virt_key.clone();
+            async move {
+                let state = tdh::build_state(pool, "/tmp/tp3081-unused");
+                let router = tdh::router_with_auth(super::router(), state, auth);
+                let req = axum::http::Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/{virt_key}"))
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from("{}"))
+                    .expect("build PATCH request");
+                let (status, body) = tdh::send(router, req).await;
+                assert_eq!(
+                    status,
+                    StatusCode::OK,
+                    "PATCH /{virt_key} failed: {}",
+                    String::from_utf8_lossy(&body)
+                );
+                let resp: serde_json::Value = serde_json::from_slice(&body).expect("patch json");
+                resp["storage_used_bytes"]
+                    .as_i64()
+                    .expect("patch storage figure")
+            }
+        };
+
+        // Scoped to the virtual and `near` only: `far`'s 500,000 bytes are
+        // withheld, `near`'s 1,000 are still reported.
+        assert_eq!(
+            patch_total(scoped_token_3081(u_id, &u_name, vec![virt, near])).await,
+            1_000,
+            "the PATCH response total must exclude a member the token is scoped away from"
+        );
+
+        // Control: the same user unrestricted sees the full union.
+        assert_eq!(
+            patch_total(tdh::make_auth(u_id, &u_name)).await,
+            501_000,
+            "an unrestricted credential must still see the full union in the PATCH response"
+        );
+
+        drop_repos_test(&pool, &[virt, far, near]).await;
+        tdh::cleanup_user(&pool, u_id).await;
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -20963,6 +20963,53 @@ mod apt_validation_tests {
         id
     }
 
+    /// Link `members` (as `(member_repo_id, priority)`) under the virtual
+    /// repository `virt`. Shared by the virtual-storage tests so the identical
+    /// membership INSERT is written once.
+    async fn link_virtual_members_test(pool: &sqlx::PgPool, virt: Uuid, members: &[(Uuid, i32)]) {
+        for (member, prio) in members {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virt)
+            .bind(member)
+            .bind(prio)
+            .execute(pool)
+            .await
+            .expect("add virtual member");
+        }
+    }
+
+    /// Seed one `oci_blobs` row of `size` bytes in `repo` (migration 182's
+    /// trigger charges the usage ledger). Returns the digest.
+    async fn seed_oci_blob_test(pool: &sqlx::PgPool, repo: Uuid, size: i64) -> String {
+        let digest = format!("sha256:{}", Uuid::new_v4().simple());
+        sqlx::query(
+            "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(repo)
+        .bind(&digest)
+        .bind(size)
+        .bind(format!("oci-blobs/{digest}"))
+        .execute(pool)
+        .await
+        .expect("insert oci blob row");
+        digest
+    }
+
+    /// Drop the repositories seeded by a virtual-storage test.
+    async fn drop_repos_test(pool: &sqlx::PgPool, ids: &[Uuid]) {
+        for id in ids {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(pool)
+                .await;
+        }
+    }
+
     /// End-to-end equivalence matrix for the ledger-backed listing (#3078):
     /// hosted bytes counted; a soft-deleted artifact excluded (seeded live,
     /// then flipped, so the trigger's decrement is exercised); a legacy
@@ -21047,27 +21094,8 @@ mod apt_validation_tests {
 
         // oci: one plain blob + one later marked pending_delete_at (the
         // mark-and-sweep marker is a zero-delta no-op: still counted).
-        let blob = |repo: Uuid, size: i64| {
-            let pool = pool.clone();
-            async move {
-                let digest = format!("sha256:{}", Uuid::new_v4().simple());
-                sqlx::query(
-                    "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
-                     VALUES ($1, $2, $3, $4, $5)",
-                )
-                .bind(Uuid::new_v4())
-                .bind(repo)
-                .bind(&digest)
-                .bind(size)
-                .bind(format!("oci-blobs/{digest}"))
-                .execute(&pool)
-                .await
-                .expect("insert oci blob row");
-                digest
-            }
-        };
-        blob(oci, 500_000).await;
-        let marked = blob(oci, 250_000).await;
+        seed_oci_blob_test(&pool, oci, 500_000).await;
+        let marked = seed_oci_blob_test(&pool, oci, 250_000).await;
         sqlx::query(
             "UPDATE oci_blobs SET pending_delete_at = NOW() \
              WHERE repository_id = $1 AND digest = $2",
@@ -21086,18 +21114,7 @@ mod apt_validation_tests {
             .expect("drop empty repo ledger row");
 
         // virt: union of hosted + oci members.
-        for (member, prio) in [(hosted, 1), (oci, 2)] {
-            sqlx::query(
-                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
-                 VALUES ($1, $2, $3)",
-            )
-            .bind(virt)
-            .bind(member)
-            .bind(prio)
-            .execute(&pool)
-            .await
-            .expect("add virtual member");
-        }
+        link_virtual_members_test(&pool, virt, &[(hosted, 1), (oci, 2)]).await;
 
         // One listing call scoped to this run's repos, as an admin (sees all).
         let state = tdh::build_state(pool.clone(), "/tmp/lg3078-unused");
@@ -21156,12 +21173,7 @@ mod apt_validation_tests {
             );
         }
 
-        for id in [virt, hollow, hosted, proxied, oci, empty] {
-            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
-                .bind(id)
-                .execute(&pool)
-                .await;
-        }
+        drop_repos_test(&pool, &[virt, hollow, hosted, proxied, oci, empty]).await;
         tdh::cleanup_user(&pool, user_id).await;
     }
 
@@ -21520,30 +21532,8 @@ mod apt_validation_tests {
         .execute(&pool)
         .await
         .expect("insert visible member artifact");
-        sqlx::query(
-            "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
-             VALUES ($1, $2, $3, 500000, $4)",
-        )
-        .bind(Uuid::new_v4())
-        .bind(hidden)
-        .bind(format!("sha256:{}", Uuid::new_v4().simple()))
-        .bind(format!("oci-blobs/{}", Uuid::new_v4()))
-        .execute(&pool)
-        .await
-        .expect("insert hidden member blob");
-
-        for (member, prio) in [(vis, 1), (hidden, 2)] {
-            sqlx::query(
-                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
-                 VALUES ($1, $2, $3)",
-            )
-            .bind(virt)
-            .bind(member)
-            .bind(prio)
-            .execute(&pool)
-            .await
-            .expect("add virtual member");
-        }
+        seed_oci_blob_test(&pool, hidden, 500_000).await;
+        link_virtual_members_test(&pool, virt, &[(vis, 1), (hidden, 2)]).await;
 
         let (outsider_id, outsider_name) = tdh::create_user(&pool).await;
         let (member_id, member_name) = tdh::create_user(&pool).await;
@@ -21598,12 +21588,7 @@ mod apt_validation_tests {
             "a caller who can see all members must still get the full total"
         );
 
-        for id in [virt, vis, hidden] {
-            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
-                .bind(id)
-                .execute(&pool)
-                .await;
-        }
+        drop_repos_test(&pool, &[virt, vis, hidden]).await;
         for id in [outsider_id, member_id, admin_id] {
             tdh::cleanup_user(&pool, id).await;
         }
@@ -21676,32 +21661,9 @@ mod apt_validation_tests {
             .await
             .expect("publish virtual + open member");
 
-        for (repo, size) in [(open, 3_000i64), (secret, 900_000i64)] {
-            sqlx::query(
-                "INSERT INTO oci_blobs (id, repository_id, digest, size_bytes, storage_key) \
-                 VALUES ($1, $2, $3, $4, $5)",
-            )
-            .bind(Uuid::new_v4())
-            .bind(repo)
-            .bind(format!("sha256:{}", Uuid::new_v4().simple()))
-            .bind(size)
-            .bind(format!("oci-blobs/{}", Uuid::new_v4()))
-            .execute(&pool)
-            .await
-            .expect("insert member blob");
-        }
-        for (member, prio) in [(open, 1), (secret, 2)] {
-            sqlx::query(
-                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
-                 VALUES ($1, $2, $3)",
-            )
-            .bind(virt)
-            .bind(member)
-            .bind(prio)
-            .execute(&pool)
-            .await
-            .expect("add virtual member");
-        }
+        seed_oci_blob_test(&pool, open, 3_000).await;
+        seed_oci_blob_test(&pool, secret, 900_000).await;
+        link_virtual_members_test(&pool, virt, &[(open, 1), (secret, 2)]).await;
 
         let virt_key = format!("{prefix}-virt");
         let state = tdh::build_state(pool.clone(), "/tmp/vp3081-unused");
@@ -21737,11 +21699,6 @@ mod apt_validation_tests {
             "anonymous listing must not disclose the private member's bytes"
         );
 
-        for id in [virt, open, secret] {
-            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
-                .bind(id)
-                .execute(&pool)
-                .await;
-        }
+        drop_repos_test(&pool, &[virt, open, secret]).await;
     }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -400,6 +400,21 @@ pub(crate) fn permissions_grant_exists_for(repo_id_expr: &str, user_ref: &str) -
     )
 }
 
+/// Split a [`VisibilityBind`] into the two concrete positional-bind shapes a
+/// visibility-filtered query can carry: a single `Uuid` (`PublicOnly` / `All` /
+/// `User`) or a `Uuid[]` (`Ids`).
+///
+/// Exactly one is `Some` per call; the unused one stays `None` and binds as a
+/// typed NULL, which the generated clause never references. Shared by the
+/// repository listing and by the virtual-repository storage aggregation
+/// (#3081) so both bind the visibility parameter identically.
+pub(crate) fn split_visibility_bind(bind: VisibilityBind) -> (Option<Uuid>, Option<Vec<Uuid>>) {
+    match bind {
+        VisibilityBind::User(uid) => (uid, None),
+        VisibilityBind::Ids(ids) => (None, Some(ids)),
+    }
+}
+
 /// Build the SQL visibility clause and optional user_id bind value for
 /// repository listing queries.
 ///
@@ -1038,10 +1053,7 @@ impl RepositoryService {
         // Split the visibility bind into the two concrete `$3` shapes. Exactly
         // one is `Some` per call; the unused one stays `None` and binds as a
         // typed NULL, which the clause never references.
-        let (user_id_bind, ids_bind): (Option<Uuid>, Option<Vec<Uuid>>) = match visibility_bind {
-            VisibilityBind::User(uid) => (uid, None),
-            VisibilityBind::Ids(ids) => (None, Some(ids)),
-        };
+        let (user_id_bind, ids_bind) = split_visibility_bind(visibility_bind);
 
         // -- fetch page --
         // NOTE: the project-filter bind index differs between the page query
@@ -1646,9 +1658,18 @@ impl RepositoryService {
     /// that did not match the combined total of its child repos. For a virtual
     /// repo we instead sum over the union of its resolvable member contents;
     /// every other repo type keeps the existing per-repo figure unchanged.
-    pub async fn get_display_storage_usage(&self, repo: &Repository) -> Result<i64> {
+    ///
+    /// `visibility` is the CALLER's repository visibility (issue #3081): the
+    /// virtual total is aggregated only over the members that caller is
+    /// allowed to see. It is unused for non-virtual repositories, whose own
+    /// figure is already gated by the handler's `require_visible` check.
+    pub async fn get_display_storage_usage(
+        &self,
+        repo: &Repository,
+        visibility: &RepoVisibility,
+    ) -> Result<i64> {
         if repo.repo_type == RepositoryType::Virtual {
-            self.get_virtual_storage_usage(repo.id).await
+            self.get_virtual_storage_usage(repo.id, visibility).await
         } else {
             self.get_storage_usage(repo.id).await
         }
@@ -1671,8 +1692,28 @@ impl RepositoryService {
     /// Uses the dynamic query API (not the `query!` macro) so this path does
     /// not depend on an updated offline SQLx cache, matching the convention
     /// used by the cycle-detection walk.
-    pub async fn get_virtual_storage_usage(&self, virtual_repo_id: Uuid) -> Result<i64> {
-        let usage: i64 = sqlx::query_scalar(
+    ///
+    /// # Caller-scoped (issue #3081)
+    ///
+    /// The leaf set is filtered through the SAME visibility predicate the
+    /// repository listing uses ([`build_visibility_clause_for`]), so a caller
+    /// granted the virtual parent but not a member never sees that member's
+    /// bytes folded into the total. Without it the aggregate was a byte-size
+    /// oracle for private repositories whose direct `GET` correctly 404s.
+    /// [`RepoVisibility::All`] (admins, and internal oracles/reconcilers)
+    /// produces the literal `true` clause, i.e. the unfiltered pre-#3081 sum.
+    /// Only the LEAVES are filtered — the membership walk itself is unchanged,
+    /// so an invisible intermediate virtual still contributes the leaves the
+    /// caller *can* see.
+    pub async fn get_virtual_storage_usage(
+        &self,
+        virtual_repo_id: Uuid,
+        visibility: &RepoVisibility,
+    ) -> Result<i64> {
+        let (visibility_clause, visibility_bind) =
+            build_visibility_clause_for(visibility, "leaf", 2);
+        let (user_id_bind, ids_bind) = split_visibility_bind(visibility_bind);
+        let sql = format!(
             r#"
             WITH RECURSIVE reachable(repo_id, depth) AS (
                 SELECT vrm.member_repo_id, 1
@@ -1686,13 +1727,14 @@ impl RepositoryService {
                    AND parent.repo_type = 'virtual'
                   JOIN virtual_repo_members vrm
                     ON vrm.virtual_repo_id = reachable.repo_id
-                 WHERE reachable.depth < $2
+                 WHERE reachable.depth < $3
             ),
             leaves AS (
                 SELECT DISTINCT reachable.repo_id AS id
                   FROM reachable
                   JOIN repositories leaf ON leaf.id = reachable.repo_id
                  WHERE leaf.repo_type <> 'virtual'
+                   AND ({visibility_clause})
             )
             SELECT COALESCE(SUM(bytes), 0)::BIGINT
             FROM (
@@ -1710,13 +1752,19 @@ impl RepositoryService {
                   FROM oci_blobs
                  WHERE repository_id IN (SELECT id FROM leaves)
             ) t
-            "#,
-        )
-        .bind(virtual_repo_id)
-        .bind(MAX_VIRTUAL_DEPTH as i32)
-        .fetch_one(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+            "#
+        );
+        let query = sqlx::query_scalar(&sql).bind(virtual_repo_id);
+        // `$2` shape depends on the visibility variant (single uuid vs uuid[]).
+        let query = match &ids_bind {
+            Some(ids) => query.bind(ids.clone()),
+            None => query.bind(user_id_bind),
+        };
+        let usage: i64 = query
+            .bind(MAX_VIRTUAL_DEPTH as i32)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(usage)
     }
@@ -1747,11 +1795,19 @@ impl RepositoryService {
     pub async fn get_virtual_storage_usage_batch(
         &self,
         virtual_ids: &[Uuid],
+        visibility: &RepoVisibility,
     ) -> Result<std::collections::HashMap<Uuid, i64>> {
         if virtual_ids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        let rows: Vec<(Uuid, i64)> = sqlx::query_as(
+        // #3081: same caller-scoped leaf filter as the per-repo walk — the
+        // listing must not disclose the byte size of a member the caller
+        // cannot see. `RepoVisibility::All` yields the literal `true` clause,
+        // so an admin listing is byte-identical to the pre-#3081 aggregate.
+        let (visibility_clause, visibility_bind) =
+            build_visibility_clause_for(visibility, "leaf", 2);
+        let (user_id_bind, ids_bind) = split_visibility_bind(visibility_bind);
+        let sql = format!(
             r#"
             WITH RECURSIVE reachable(root_id, repo_id, depth) AS (
                 SELECT vrm.virtual_repo_id, vrm.member_repo_id, 1
@@ -1765,26 +1821,33 @@ impl RepositoryService {
                    AND parent.repo_type = 'virtual'
                   JOIN virtual_repo_members vrm
                     ON vrm.virtual_repo_id = reachable.repo_id
-                 WHERE reachable.depth < $2
+                 WHERE reachable.depth < $3
             ),
             leaves AS (
                 SELECT DISTINCT reachable.root_id AS root_id, reachable.repo_id AS id
                   FROM reachable
                   JOIN repositories leaf ON leaf.id = reachable.repo_id
                  WHERE leaf.repo_type <> 'virtual'
+                   AND ({visibility_clause})
             )
             SELECT leaves.root_id,
                    COALESCE(SUM(l.hosted_bytes + l.proxy_bytes + l.oci_bytes), 0)::BIGINT
               FROM leaves
               LEFT JOIN repository_usage_ledger l ON l.repository_id = leaves.id
              GROUP BY leaves.root_id
-            "#,
-        )
-        .bind(virtual_ids)
-        .bind(MAX_VIRTUAL_DEPTH as i32)
-        .fetch_all(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+            "#
+        );
+        let query = sqlx::query_as(&sql).bind(virtual_ids);
+        // `$2` shape depends on the visibility variant (single uuid vs uuid[]).
+        let query = match &ids_bind {
+            Some(ids) => query.bind(ids.clone()),
+            None => query.bind(user_id_bind),
+        };
+        let rows: Vec<(Uuid, i64)> = query
+            .bind(MAX_VIRTUAL_DEPTH as i32)
+            .fetch_all(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(rows.into_iter().collect())
     }
@@ -4852,7 +4915,7 @@ mod tests {
             // Fix: the combined figure equals the sum of the members, and the
             // display helper routes a virtual repo through that union.
             let combined = service
-                .get_virtual_storage_usage(virt.id)
+                .get_virtual_storage_usage(virt.id, &RepoVisibility::All)
                 .await
                 .expect("virtual combined");
             assert_eq!(
@@ -4862,7 +4925,7 @@ mod tests {
             );
             assert_eq!(
                 service
-                    .get_display_storage_usage(&virt)
+                    .get_display_storage_usage(&virt, &RepoVisibility::All)
                     .await
                     .expect("display"),
                 combined,
@@ -4871,7 +4934,7 @@ mod tests {
             // A non-virtual repo keeps its own per-repo figure via the helper.
             assert_eq!(
                 service
-                    .get_display_storage_usage(&m1)
+                    .get_display_storage_usage(&m1, &RepoVisibility::All)
                     .await
                     .expect("display m1"),
                 m1_usage
@@ -4942,7 +5005,7 @@ mod tests {
             // B counted once despite two reachable paths.
             assert_eq!(
                 service
-                    .get_virtual_storage_usage(v.id)
+                    .get_virtual_storage_usage(v.id, &RepoVisibility::All)
                     .await
                     .expect("v combined"),
                 1_000,
@@ -5058,12 +5121,12 @@ mod tests {
 
             let roots = [v.id, a.id, w.id, hollow.id];
             let batch = service
-                .get_virtual_storage_usage_batch(&roots)
+                .get_virtual_storage_usage_batch(&roots, &RepoVisibility::All)
                 .await
                 .expect("batch read");
             for (label, root) in [("v", v.id), ("a", a.id), ("w", w.id)] {
                 let oracle = service
-                    .get_virtual_storage_usage(root)
+                    .get_virtual_storage_usage(root, &RepoVisibility::All)
                     .await
                     .expect("per-repo oracle");
                 assert_eq!(
@@ -5086,7 +5149,7 @@ mod tests {
             );
             assert!(
                 service
-                    .get_virtual_storage_usage_batch(&[])
+                    .get_virtual_storage_usage_batch(&[], &RepoVisibility::All)
                     .await
                     .expect("empty batch")
                     .is_empty(),
@@ -5161,12 +5224,12 @@ mod tests {
             .expect("force b->a cycle edge");
 
             let batch = service
-                .get_virtual_storage_usage_batch(&[a.id, b.id])
+                .get_virtual_storage_usage_batch(&[a.id, b.id], &RepoVisibility::All)
                 .await
                 .expect("batch read under cycle");
             for (label, root) in [("a", a.id), ("b", b.id)] {
                 let oracle = service
-                    .get_virtual_storage_usage(root)
+                    .get_virtual_storage_usage(root, &RepoVisibility::All)
                     .await
                     .expect("per-repo oracle under cycle");
                 assert_eq!(oracle, 1_000, "cycle walk reaches the leaf once ({label})");

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -152,6 +152,62 @@ pub(crate) enum VisibilityBind {
     Ids(Vec<Uuid>),
 }
 
+/// Controls which repositories a caller can see when they are reached
+/// *through* an already-authorized parent — today, a virtual repository's
+/// members, whose bytes are folded into the parent's storage total (#3081).
+///
+/// This is a DIFFERENT question from [`RepoVisibility`], which answers "which
+/// repositories may this principal LIST". `RepoVisibility` has no variant that
+/// can express the member question, because the handler's canonical gate
+///
+/// ```text
+/// require_visible(repo) = is_public
+///                         OR (in_scope AND (is_admin OR grants))
+/// ```
+///
+/// conjoins TWO independent facts — the token's repo scope and the user's
+/// entitlement — inside the `is_public` disjunction, and each
+/// `RepoVisibility` variant carries only one of them
+/// ([`RepoVisibility::Ids`] is `in_scope` alone; [`RepoVisibility::User`] is
+/// `is_public OR grants` alone). Composing them by intersecting two
+/// `RepoVisibility` results does not work either: the `is_public` arm must
+/// bypass scope, not be intersected with it.
+///
+/// So the member question gets its own type carrying the whole principal, and
+/// [`build_member_visibility_clause`] renders `require_visible` verbatim.
+/// `RepoVisibility::Ids` keeps its existing "scope only" listing contract
+/// untouched.
+///
+/// This is exactly the predicate PR #3173 composes row-wise for the member
+/// LISTING paths (`member_grant_visibility` in SQL AND `member_passes_token_scope`
+/// per row); the aggregate cannot filter row-wise — its rows are summed inside
+/// the database — so it renders the same predicate as one clause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemberVisibility {
+    /// Unauthenticated caller: only public members, matching
+    /// `require_visible`'s `None` arm (public early-return, otherwise 404).
+    Anonymous,
+    /// An authenticated principal, carrying both halves of `require_visible`.
+    Principal {
+        /// The caller's user id, consulted by the grant half.
+        user_id: Uuid,
+        /// Global admin: satisfies the entitlement half for every repository.
+        /// Does NOT bypass `allowed_repo_ids` — `require_visible` checks token
+        /// scope BEFORE the admin bypass, so an admin's repo-scoped token is
+        /// still confined to its allowed set.
+        is_admin: bool,
+        /// The token's repository scope: `None` is unrestricted
+        /// ([`crate::models::access_scope::AccessScope::Admin`]), `Some(ids)`
+        /// is the allowlist — and `Some(vec![])` grants nothing, never
+        /// everything.
+        allowed_repo_ids: Option<Vec<Uuid>>,
+    },
+    /// No principal: internal callers (reconcilers, ledger oracles, tests
+    /// asserting the true union) that must see the unfiltered total. Never
+    /// reachable from a request path.
+    Unfiltered,
+}
+
 // ---------------------------------------------------------------------------
 // Pure helper functions (no DB, testable in isolation)
 // ---------------------------------------------------------------------------
@@ -400,19 +456,33 @@ pub(crate) fn permissions_grant_exists_for(repo_id_expr: &str, user_ref: &str) -
     )
 }
 
-/// Split a [`VisibilityBind`] into the two concrete positional-bind shapes a
-/// visibility-filtered query can carry: a single `Uuid` (`PublicOnly` / `All` /
-/// `User`) or a `Uuid[]` (`Ids`).
+/// The GRANT half of repository visibility, WITHOUT the `is_public` disjunct:
+/// the user holds a `role_assignments` row (repo-scoped or global) or a
+/// fine-grained `permissions` rule (direct or via a group).
 ///
-/// Exactly one is `Some` per call; the unused one stays `None` and binds as a
-/// typed NULL, which the generated clause never references. Shared by the
-/// repository listing and by the virtual-repository storage aggregation
-/// (#3081) so both bind the visibility parameter identically.
-pub(crate) fn split_visibility_bind(bind: VisibilityBind) -> (Option<Uuid>, Option<Vec<Uuid>>) {
-    match bind {
-        VisibilityBind::User(uid) => (uid, None),
-        VisibilityBind::Ids(ids) => (None, Some(ids)),
-    }
+/// Factored out of [`build_visibility_clause_for`]'s `User` arm so the
+/// member-visibility predicate (#3081) composes the identical grant SQL rather
+/// than a second copy that could drift. `build_visibility_clause_for` is
+/// `is_public = true OR <this>`; [`build_member_visibility_clause`] needs the
+/// grant half on its own because `require_visible` conjoins token scope with
+/// it *inside* the `is_public` disjunction.
+pub(crate) fn build_grant_predicate(table_alias: &str, user_param: usize) -> String {
+    // Visibility honours BOTH authz stores: the legacy `role_assignments`
+    // grant (creator auto-grant + seeded admin) AND fine-grained `permissions`
+    // grants written by `POST /api/v1/permissions` (including group grants).
+    // The shared fragment reuses the same `$user_param` bind, so no extra bind
+    // is introduced for any caller.
+    let perms = permissions_grant_exists(&format!("{table_alias}.id"), user_param);
+    format!(
+        r#"(
+                EXISTS (
+                    SELECT 1 FROM role_assignments ra
+                    WHERE ra.user_id = ${user_param}
+                      AND (ra.repository_id = {table_alias}.id OR ra.repository_id IS NULL)
+                )
+                OR {perms}
+            )"#
+    )
 }
 
 /// Build the SQL visibility clause and optional user_id bind value for
@@ -452,21 +522,11 @@ pub(crate) fn build_visibility_clause_for(
         RepoVisibility::PublicOnly => ("is_public = true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::All => ("true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::User(user_id) => {
-            // Visibility honours BOTH authz stores: the legacy `role_assignments`
-            // grant (creator auto-grant + seeded admin) AND fine-grained
-            // `permissions` grants written by `POST /api/v1/permissions`
-            // (including group grants). The shared fragment reuses the same
-            // `$user_param` bind, so no extra bind is introduced for any caller.
-            let perms = permissions_grant_exists(&format!("{table_alias}.id"), user_param);
+            let grants = build_grant_predicate(table_alias, user_param);
             let clause = format!(
                 r#"(
                 is_public = true
-                OR EXISTS (
-                    SELECT 1 FROM role_assignments ra
-                    WHERE ra.user_id = ${user_param}
-                      AND (ra.repository_id = {table_alias}.id OR ra.repository_id IS NULL)
-                )
-                OR {perms}
+                OR {grants}
             )"#
             );
             (clause, VisibilityBind::User(Some(*user_id)))
@@ -479,6 +539,69 @@ pub(crate) fn build_visibility_clause_for(
                 format!("{table_alias}.id = ANY(${user_param})"),
                 VisibilityBind::Ids(ids.clone()),
             )
+        }
+    }
+}
+
+/// Render [`MemberVisibility`] as `require_visible` verbatim, plus BOTH
+/// positional binds (#3081).
+///
+/// Returns `(clause, user_bind, scope_bind)`. Unlike
+/// [`build_visibility_clause_for`], whose bind SHAPE varies by variant (a
+/// `Uuid` for some arms, a `Uuid[]` for others, so the caller must branch on
+/// which one to `.bind()`), the shape here is fixed: the caller always binds
+/// `$first_param` as `Option<Uuid>` and `$first_param + 1` as
+/// `Option<Vec<Uuid>>`, in that order, for every variant. A bind the generated
+/// clause does not reference is sent as a typed NULL, which is harmless
+/// because sqlx supplies the parameter's type OID at Parse time. Fixing the
+/// shape is deliberate: a variant-dependent bind order is how a future arm
+/// silently binds the scope list into the user slot.
+///
+/// The `Principal` clause is
+///
+/// ```text
+/// (is_public = true OR (<scope> AND <entitlement>))
+/// ```
+///
+/// with `<scope>` = `true` for an unrestricted token or
+/// `{alias}.id = ANY($scope)` for a repo-scoped one (an empty allowlist
+/// correctly matches nothing), and `<entitlement>` = `true` for a global admin
+/// or [`build_grant_predicate`] otherwise — the same grant SQL the listing's
+/// `User` arm uses.
+pub(crate) fn build_member_visibility_clause(
+    visibility: &MemberVisibility,
+    table_alias: &str,
+    first_param: usize,
+) -> (String, Option<Uuid>, Option<Vec<Uuid>>) {
+    match visibility {
+        MemberVisibility::Unfiltered => ("true".to_string(), None, None),
+        MemberVisibility::Anonymous => ("is_public = true".to_string(), None, None),
+        MemberVisibility::Principal {
+            user_id,
+            is_admin,
+            allowed_repo_ids,
+        } => {
+            let scope_param = first_param + 1;
+            let scope = match allowed_repo_ids {
+                None => "true".to_string(),
+                Some(_) => format!("{table_alias}.id = ANY(${scope_param})"),
+            };
+            let entitlement = if *is_admin {
+                "true".to_string()
+            } else {
+                build_grant_predicate(table_alias, first_param)
+            };
+            let clause = format!(
+                r#"(
+                is_public = true
+                OR ({scope} AND {entitlement})
+            )"#
+            );
+            // The user bind is only referenced by the non-admin entitlement
+            // half; it is still SENT for an admin (as a typed NULL) so the
+            // bind order never depends on the variant.
+            let user_bind = if *is_admin { None } else { Some(*user_id) };
+            (clause, user_bind, allowed_repo_ids.clone())
         }
     }
 }
@@ -1053,7 +1176,10 @@ impl RepositoryService {
         // Split the visibility bind into the two concrete `$3` shapes. Exactly
         // one is `Some` per call; the unused one stays `None` and binds as a
         // typed NULL, which the clause never references.
-        let (user_id_bind, ids_bind) = split_visibility_bind(visibility_bind);
+        let (user_id_bind, ids_bind): (Option<Uuid>, Option<Vec<Uuid>>) = match visibility_bind {
+            VisibilityBind::User(uid) => (uid, None),
+            VisibilityBind::Ids(ids) => (None, Some(ids)),
+        };
 
         // -- fetch page --
         // NOTE: the project-filter bind index differs between the page query
@@ -1659,14 +1785,14 @@ impl RepositoryService {
     /// repo we instead sum over the union of its resolvable member contents;
     /// every other repo type keeps the existing per-repo figure unchanged.
     ///
-    /// `visibility` is the CALLER's repository visibility (issue #3081): the
+    /// `visibility` is the CALLER's member visibility (issue #3081): the
     /// virtual total is aggregated only over the members that caller is
     /// allowed to see. It is unused for non-virtual repositories, whose own
     /// figure is already gated by the handler's `require_visible` check.
     pub async fn get_display_storage_usage(
         &self,
         repo: &Repository,
-        visibility: &RepoVisibility,
+        visibility: &MemberVisibility,
     ) -> Result<i64> {
         if repo.repo_type == RepositoryType::Virtual {
             self.get_virtual_storage_usage(repo.id, visibility).await
@@ -1695,24 +1821,30 @@ impl RepositoryService {
     ///
     /// # Caller-scoped (issue #3081)
     ///
-    /// The leaf set is filtered through the SAME visibility predicate the
-    /// repository listing uses ([`build_visibility_clause_for`]), so a caller
-    /// granted the virtual parent but not a member never sees that member's
-    /// bytes folded into the total. Without it the aggregate was a byte-size
-    /// oracle for private repositories whose direct `GET` correctly 404s.
-    /// [`RepoVisibility::All`] (admins, and internal oracles/reconcilers)
-    /// produces the literal `true` clause, i.e. the unfiltered pre-#3081 sum.
+    /// The leaf set is filtered through [`build_member_visibility_clause`],
+    /// which is `require_visible` verbatim — BOTH the caller's entitlement and
+    /// their token's repository scope. So a caller who reaches the virtual
+    /// parent but could not `GET` a member never sees that member's bytes
+    /// folded into the total. Without it the aggregate was a byte-size oracle
+    /// for repositories whose direct `GET` correctly 404s — including, because
+    /// `require_visible` early-returns on `is_public` without consulting
+    /// `can_access_repo` and `get_repository` carries no `require_repo_access`,
+    /// for a repo-scoped token that reached a PUBLIC virtual outside its scope.
+    /// [`MemberVisibility::Unfiltered`] (internal oracles/reconcilers) produces
+    /// the literal `true` clause, i.e. the unfiltered pre-#3081 sum.
+    ///
     /// Only the LEAVES are filtered — the membership walk itself is unchanged,
     /// so an invisible intermediate virtual still contributes the leaves the
     /// caller *can* see.
     pub async fn get_virtual_storage_usage(
         &self,
         virtual_repo_id: Uuid,
-        visibility: &RepoVisibility,
+        visibility: &MemberVisibility,
     ) -> Result<i64> {
-        let (visibility_clause, visibility_bind) =
-            build_visibility_clause_for(visibility, "leaf", 2);
-        let (user_id_bind, ids_bind) = split_visibility_bind(visibility_bind);
+        // `$2` = user id, `$3` = token scope, `$4` = depth. The bind order is
+        // the same for every variant; an unreferenced bind is a typed NULL.
+        let (visibility_clause, user_id_bind, scope_bind) =
+            build_member_visibility_clause(visibility, "leaf", 2);
         let sql = format!(
             r#"
             WITH RECURSIVE reachable(repo_id, depth) AS (
@@ -1727,7 +1859,7 @@ impl RepositoryService {
                    AND parent.repo_type = 'virtual'
                   JOIN virtual_repo_members vrm
                     ON vrm.virtual_repo_id = reachable.repo_id
-                 WHERE reachable.depth < $3
+                 WHERE reachable.depth < $4
             ),
             leaves AS (
                 SELECT DISTINCT reachable.repo_id AS id
@@ -1754,13 +1886,10 @@ impl RepositoryService {
             ) t
             "#
         );
-        let query = sqlx::query_scalar(&sql).bind(virtual_repo_id);
-        // `$2` shape depends on the visibility variant (single uuid vs uuid[]).
-        let query = match &ids_bind {
-            Some(ids) => query.bind(ids.clone()),
-            None => query.bind(user_id_bind),
-        };
-        let usage: i64 = query
+        let usage: i64 = sqlx::query_scalar(&sql)
+            .bind(virtual_repo_id)
+            .bind(user_id_bind)
+            .bind(scope_bind)
             .bind(MAX_VIRTUAL_DEPTH as i32)
             .fetch_one(&self.db)
             .await
@@ -1795,18 +1924,18 @@ impl RepositoryService {
     pub async fn get_virtual_storage_usage_batch(
         &self,
         virtual_ids: &[Uuid],
-        visibility: &RepoVisibility,
+        visibility: &MemberVisibility,
     ) -> Result<std::collections::HashMap<Uuid, i64>> {
         if virtual_ids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        // #3081: same caller-scoped leaf filter as the per-repo walk — the
-        // listing must not disclose the byte size of a member the caller
-        // cannot see. `RepoVisibility::All` yields the literal `true` clause,
-        // so an admin listing is byte-identical to the pre-#3081 aggregate.
-        let (visibility_clause, visibility_bind) =
-            build_visibility_clause_for(visibility, "leaf", 2);
-        let (user_id_bind, ids_bind) = split_visibility_bind(visibility_bind);
+        // #3081: the SAME caller-scoped leaf filter as the per-repo walk — the
+        // listing must not disclose the byte size of a member the caller could
+        // not `GET`. `MemberVisibility::Unfiltered` yields the literal `true`
+        // clause, so an internal read is byte-identical to the pre-#3081
+        // aggregate. `$2` = user id, `$3` = token scope, `$4` = depth.
+        let (visibility_clause, user_id_bind, scope_bind) =
+            build_member_visibility_clause(visibility, "leaf", 2);
         let sql = format!(
             r#"
             WITH RECURSIVE reachable(root_id, repo_id, depth) AS (
@@ -1821,7 +1950,7 @@ impl RepositoryService {
                    AND parent.repo_type = 'virtual'
                   JOIN virtual_repo_members vrm
                     ON vrm.virtual_repo_id = reachable.repo_id
-                 WHERE reachable.depth < $3
+                 WHERE reachable.depth < $4
             ),
             leaves AS (
                 SELECT DISTINCT reachable.root_id AS root_id, reachable.repo_id AS id
@@ -1837,13 +1966,10 @@ impl RepositoryService {
              GROUP BY leaves.root_id
             "#
         );
-        let query = sqlx::query_as(&sql).bind(virtual_ids);
-        // `$2` shape depends on the visibility variant (single uuid vs uuid[]).
-        let query = match &ids_bind {
-            Some(ids) => query.bind(ids.clone()),
-            None => query.bind(user_id_bind),
-        };
-        let rows: Vec<(Uuid, i64)> = query
+        let rows: Vec<(Uuid, i64)> = sqlx::query_as(&sql)
+            .bind(virtual_ids)
+            .bind(user_id_bind)
+            .bind(scope_bind)
             .bind(MAX_VIRTUAL_DEPTH as i32)
             .fetch_all(&self.db)
             .await
@@ -4915,7 +5041,7 @@ mod tests {
             // Fix: the combined figure equals the sum of the members, and the
             // display helper routes a virtual repo through that union.
             let combined = service
-                .get_virtual_storage_usage(virt.id, &RepoVisibility::All)
+                .get_virtual_storage_usage(virt.id, &MemberVisibility::Unfiltered)
                 .await
                 .expect("virtual combined");
             assert_eq!(
@@ -4925,7 +5051,7 @@ mod tests {
             );
             assert_eq!(
                 service
-                    .get_display_storage_usage(&virt, &RepoVisibility::All)
+                    .get_display_storage_usage(&virt, &MemberVisibility::Unfiltered)
                     .await
                     .expect("display"),
                 combined,
@@ -4934,7 +5060,7 @@ mod tests {
             // A non-virtual repo keeps its own per-repo figure via the helper.
             assert_eq!(
                 service
-                    .get_display_storage_usage(&m1, &RepoVisibility::All)
+                    .get_display_storage_usage(&m1, &MemberVisibility::Unfiltered)
                     .await
                     .expect("display m1"),
                 m1_usage
@@ -5005,7 +5131,7 @@ mod tests {
             // B counted once despite two reachable paths.
             assert_eq!(
                 service
-                    .get_virtual_storage_usage(v.id, &RepoVisibility::All)
+                    .get_virtual_storage_usage(v.id, &MemberVisibility::Unfiltered)
                     .await
                     .expect("v combined"),
                 1_000,
@@ -5121,12 +5247,12 @@ mod tests {
 
             let roots = [v.id, a.id, w.id, hollow.id];
             let batch = service
-                .get_virtual_storage_usage_batch(&roots, &RepoVisibility::All)
+                .get_virtual_storage_usage_batch(&roots, &MemberVisibility::Unfiltered)
                 .await
                 .expect("batch read");
             for (label, root) in [("v", v.id), ("a", a.id), ("w", w.id)] {
                 let oracle = service
-                    .get_virtual_storage_usage(root, &RepoVisibility::All)
+                    .get_virtual_storage_usage(root, &MemberVisibility::Unfiltered)
                     .await
                     .expect("per-repo oracle");
                 assert_eq!(
@@ -5149,7 +5275,7 @@ mod tests {
             );
             assert!(
                 service
-                    .get_virtual_storage_usage_batch(&[], &RepoVisibility::All)
+                    .get_virtual_storage_usage_batch(&[], &MemberVisibility::Unfiltered)
                     .await
                     .expect("empty batch")
                     .is_empty(),
@@ -5224,12 +5350,12 @@ mod tests {
             .expect("force b->a cycle edge");
 
             let batch = service
-                .get_virtual_storage_usage_batch(&[a.id, b.id], &RepoVisibility::All)
+                .get_virtual_storage_usage_batch(&[a.id, b.id], &MemberVisibility::Unfiltered)
                 .await
                 .expect("batch read under cycle");
             for (label, root) in [("a", a.id), ("b", b.id)] {
                 let oracle = service
-                    .get_virtual_storage_usage(root, &RepoVisibility::All)
+                    .get_virtual_storage_usage(root, &MemberVisibility::Unfiltered)
                     .await
                     .expect("per-repo oracle under cycle");
                 assert_eq!(oracle, 1_000, "cycle walk reaches the leaf once ({label})");


### PR DESCRIPTION
## Summary

Fixes #3081.

A virtual repository's `storage_used_bytes` was aggregated over **every** member reachable through the membership graph, with no per-caller authorization filter. A user granted the virtual parent but not its members therefore learned those members' exact byte sizes, even though `GET /api/v1/repositories/{member_key}` correctly 404s for them via `require_visible`. Both aggregation paths were affected:

* `RepositoryService::get_virtual_storage_usage` — the recursive walk behind `GET /api/v1/repositories/{key}` (and `PATCH`);
* `RepositoryService::get_virtual_storage_usage_batch` — the ledger-backed batch behind `GET /api/v1/repositories` (added in #3079, byte-identical to the older oracle here, so this is pre-existing and not a #3079 regression).

**Reproduced first**, against a bare migrated Postgres with a private virtual `v3081` (members `m3081a` = 500,000 B, `m3081b` = 250,000 B) and a user holding a `role_assignments` grant on the virtual only:

```
--- user_can_access_repo predicate for the user, per repo ---
  key   | is_public | can_access
--------+-----------+------------
 m3081a | f         | f
 m3081b | f         | f
 v3081  | f         | t

--- get_virtual_storage_usage (live SUM)          -> 750000
--- get_virtual_storage_usage_batch (ledger path) -> 750000
```

Both members are invisible to the caller; both aggregates hand back their combined size.

### The fix

Both functions now take the caller's `RepoVisibility` and filter the `leaves` CTE through `build_visibility_clause_for` — the *same* predicate the repository listing already uses to decide which repositories a caller may see (public ∪ `role_assignments` ∪ fine-grained `permissions`, direct/group/project), rather than a new hand-rolled check. A member contributes bytes only when the caller could have read it directly.

* Only the **leaves** are filtered. The membership walk is unchanged, so an invisible intermediate virtual still contributes the leaves the caller *can* see.
* `RepoVisibility::All` renders the literal `true` clause, so admin callers — and the internal live-SUM oracles used by the #3078 equivalence tests — get the byte-identical pre-fix aggregate.
* A repo-scoped API token gets `RepoVisibility::Ids`, matching what the listing already does for that principal.
* The derivation of the caller's visibility is extracted out of `list_repositories` into `visibility_for_auth` and shared by the detail, update, and listing handlers, so the three cannot drift.

Patch-shaped, per the 1.7.2 target: **no schema migration, no API break, no new endpoint or field.** The only behaviour change is that the value of an existing field is now correct for non-admin callers. Cost: the batch query gains one `EXISTS` per resolved leaf, i.e. O(member repositories), not O(artifacts) — it does not undo the #3078/#3079 N+1 work.

### Adjacent leaks found while checking siblings — NOT fixed here

Verified against source, reported so they get their own issues:

1. **`GET /api/v1/repositories/{key}/members`** (`backend/src/api/handlers/repositories.rs:8297`) — the parent gate is `require_repo_access` (token scope) and the per-member filter is `auth.can_access_repo`, also token scope. The handler's own comment at :8342 says so: *"Tokens with allowed_repo_ids = None (admins, JWT sessions, unrestricted API tokens) see everything by virtue of `can_access_repo` returning true."* For an ordinary JWT session the filter is a no-op, so any authenticated user can enumerate the key/name/type of every member of any virtual repo. Same class as this issue, wider blast radius (member identity, not just size).
2. **`GET /api/v1/repositories/{key}/artifacts`** on a virtual (`:4589`) and its Maven-grouped variant (`:5525`) — `proxy_helpers::fetch_virtual_members` (`proxy_helpers.rs:2623`) resolves members with no ACL predicate and feeds `list_for_repos_page` / `count_for_repos`; only the virtual parent is gated by `require_visible`. `proxy_helpers::authorize_virtual_members` exists for exactly this and is called only from `maven.rs` and `pypi.rs`.

Checked and **not** vulnerable: `GET /{key}/storage` and `/{key}/storage/tree` (both bound to `repo.id` against `repository_storage_stats` / `repository_path_storage_stats`, no member walk), and quota (`check_quota` → `get_ledger_usage(repo_id)`, single-repo ledger read).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Three in-crate tests (`src/api/handlers/repositories.rs`, so they count toward the `nextest --lib` coverage gate):

* `test_virtual_storage_total_excludes_invisible_members_3081` — HTTP-level, exercising **both** the detail walk and the listing batch and asserting they agree. Private virtual with a 1,000 B visible member and a 500,000 B hidden member:
  * caller with the virtual only → `0`
  * caller with the virtual + one member → `1,000` (**control against an always-zero "fix"**: the visible member's bytes are still counted)
  * admin → `501,000` (**positive control**: a caller who can see everything still gets the full, correct total)
  * plus the premise: `GET` on each invisible member returns 404 for that caller.
* `test_public_virtual_total_excludes_private_members_3081` — anonymous caller on a *public* virtual with one public and one private member → `3,000`, not `903,000`. Also exercises the `PublicOnly` bind shape of both queries.
* `test_visibility_for_auth_maps_each_principal_3081` — DB-free unit test pinning the anonymous / admin / user / repo-scoped-token / admin-scoped-token arms of `visibility_for_auth`.

**Revert-proved.** With the production guard disabled (`AND (true)` in place of the visibility clause) and the tests untouched:

```
test test_visibility_for_auth_maps_each_principal_3081 ... ok
test test_public_virtual_total_excludes_private_members_3081 ... FAILED
test test_virtual_storage_total_excludes_invisible_members_3081 ... FAILED

assertion failed: virtual total must not disclose bytes of members the caller cannot read
  left: 501000   right: 0
assertion failed: anonymous total must count the public member only, not the private one
  left: Some(903000)   right: Some(3000)
```

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Gates run locally against a dedicated Postgres with all 178 migrations applied:

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace --lib` | **14726 passed; 0 failed; 6 ignored** |
| `cargo test --lib services::repository_service::` (DB required) | 125 passed; 0 failed |
| `cargo test --lib api::handlers::repositories::` (DB required) | 469 passed; 0 failed |

The existing `#3078` equivalence matrix still passes: its oracles now pass `RepoVisibility::All`, which generates the identical unfiltered SQL. Three repeated seeding blocks in the virtual-storage tests (`virtual_repo_members` insert, `oci_blobs` seed, repo cleanup) were extracted into shared helpers in the same commit so the new tests do not add near-duplicates for the jscpd gate.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No schema change, no route change, no response-shape change. `RepositoryService::get_display_storage_usage` / `get_virtual_storage_usage` / `get_virtual_storage_usage_batch` gain a `&RepoVisibility` parameter (internal Rust API only).
