### PR TITLE
ci: run backend integration tests on backend-touching PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -966,6 +966,13 @@ jobs:
     # peak RSS.
     env:
       CARGO_INCREMENTAL: "0"
+      # This job carries no rust-cache (see the sccache note below), so it
+      # resolves and downloads the whole dependency graph from crates.io on
+      # every run — more registry exposure than any other Rust job here. Now
+      # that a failure blocks a PR rather than just reddening a `main` push,
+      # a transient registry hiccup costs a developer a rerun, so let cargo
+      # retry the fetch itself before the step fails.
+      CARGO_NET_RETRY: "10"
     services:
       postgres:
         # Use the GHCR mirror to avoid Docker Hub anonymous-pull rate limits.
@@ -984,6 +991,38 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Resolve and download the dependency graph in its own step, ahead of the
+      # test steps, with a retry.
+      #
+      # Why: on 2026-08-07 this job failed on `main` (run 31176621357) with
+      #   error: failed to select a version for the requirement `axum = "^0.7"`
+      #          (locked to 0.7.9)
+      #   candidate versions found which didn't match: 0.6.6, 0.6.5, ...
+      # i.e. cargo saw a stale/truncated crates.io index. No test ever ran.
+      # That was the only non-test failure of this job on `main` in the last
+      # 13 runs, and under this PR the same hiccup would red a developer's PR
+      # instead of a post-merge push.
+      #
+      # This retries the *resolution and download* only. It deliberately does
+      # NOT wrap `cargo test`: retrying the test steps would mask exactly the
+      # real regressions this gate exists to catch. A genuine dependency
+      # problem still fails after the last attempt.
+      #
+      # No `--locked`: the test steps below do not use it either, so adding it
+      # here would newly fail PRs with a legitimately-updated Cargo.lock.
+      - name: Fetch dependencies
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if cargo fetch; then
+              exit 0
+            fi
+            echo "cargo fetch failed (attempt ${attempt}/3) — retrying" >&2
+            sleep $(( attempt * 10 ))
+          done
+          echo "ERROR: cargo fetch failed after 3 attempts" >&2
+          exit 1
 
       # The integration suites under `backend/tests/` insert into real tables
       # (users, api_tokens, repositories, ...) via the SQLx pool. The service

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════
-  # DOCS-ONLY GATE
+  # DOCS-ONLY / BACKEND-CHANGE GATE
   # ════════════════════════════════════════════════════════════════════════════
 
   # Decides whether a PR touches anything beyond the docs paths that used to
@@ -57,6 +57,11 @@ jobs:
   # `code != 'false'` so an empty output also runs full CI. The file list
   # comes from the pulls/files API (server-side, same source GitHub's own
   # path filtering uses) — not from attacker-influenced checkout content.
+  #
+  # The same pass also classifies the PR as backend-touching or not (#3124).
+  # `backend` drives whether the integration suite runs on the PR; see
+  # `test-backend-integration` below. It is a strict subset of `code`: the
+  # docs arm is matched first, so `backend/README.md` is docs, not backend.
   changes:
     name: 🔍 Docs-Only Gate
     runs-on: ubuntu-latest
@@ -66,6 +71,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      backend: ${{ steps.filter.outputs.backend }}
     steps:
       - name: Determine whether non-docs files changed
         id: filter
@@ -74,25 +80,45 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ! files=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename'); then
             echo "PR file listing failed — failing open to full CI" >&2
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           code=false
+          backend=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
-            # Keep in sync with the `push` trigger's paths-ignore list above
-            # (CLAUDE.md is already covered by *.md).
+            # First arm: keep in sync with the `push` trigger's paths-ignore
+            # list above (CLAUDE.md is already covered by *.md).
+            #
+            # Second arm: anything that can change what the integration
+            # suites compile to, what schema they run against, or how the
+            # job itself is defined. Keep in sync with `detect-changes`'
+            # `backend` filter, minus docker/Dockerfile.backend (the
+            # integration job compiles with cargo, it does not build an
+            # image) and plus .github/workflows/ci.yml (so a change to this
+            # gate exercises the gate).
             case "$f" in
-              site/*|*.md|.beads/*|LICENSE) ;;
-              *) code=true ;;
+              site/*|*.md|.beads/*|LICENSE)
+                ;;
+              backend/*|Cargo.toml|Cargo.lock|.sqlx/*|.github/workflows/ci.yml)
+                code=true
+                backend=true
+                ;;
+              *)
+                code=true
+                ;;
             esac
           done <<< "$files"
           echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "backend=$backend" >> "$GITHUB_OUTPUT"
           echo "non-docs changes: $code"
+          echo "backend changes: $backend"
 
   # ════════════════════════════════════════════════════════════════════════════
   # RELEASE-BUMP GATE
@@ -900,14 +926,41 @@ jobs:
           path: lcov.info
 
   # ════════════════════════════════════════════════════════════════════════════
-  # TIER 2: INTEGRATION (Main Branch Push Only)
+  # TIER 2: INTEGRATION (main/release push + every backend-touching PR)
   # ════════════════════════════════════════════════════════════════════════════
 
+  # Until #3124 this job was gated to `main` / `release/*` pushes only, so it
+  # could not gate a pull request: a PR could break every integration test and
+  # still show all-green, with the breakage surfacing only after merge on a
+  # `main` push that blocks nothing and notifies nobody. That is exactly how
+  # #2905 shipped — its own CI shows `🔗 Backend Integration Tests` SKIPPING
+  # next to a green `✅ CI Complete` — and `main` stayed red for 11 days
+  # (#3118).
+  #
+  # The push arm is unchanged. The new arm runs the same suite, unmodified, on
+  # pull requests that touch backend code (`needs.changes.outputs.backend`).
+  # Non-backend PRs — web, docs, scripts, IaC — still skip it and pay nothing.
+  #
+  # Fails open to RUNNING: the PR arm tests `!= 'false'`, so if the `changes`
+  # job dies outright and the output is empty the suite runs anyway. The
+  # matching enforcement is in `ci-complete`, which fails closed: on a
+  # backend-touching PR a skipped integration job is a hard failure, not a
+  # pass.
   test-backend-integration:
     name: 🔗 Backend Integration Tests
     runs-on: ak-ci-runners
     timeout-minutes: 40
-    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [changes, release-bump]
+    if: >-
+      ${{ !cancelled()
+          && needs.release-bump.outputs.bump_only != 'true'
+          && (
+               (
+                 (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+                 && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+               )
+               || (github.event_name == 'pull_request' && needs.changes.outputs.backend != 'false')
+             ) }}
     # Disable incremental codegen (#1679): consistent with check-rust and the
     # other heavy Rust compile jobs. Useless in CI's clean checkout, inflates
     # peak RSS.
@@ -1337,6 +1390,7 @@ jobs:
           RESULT_BUILD_OPENSCAP: ${{ needs.build-openscap-image.result }}
           RESULT_SECURITY: ${{ needs.security-audit.result }}
           CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          BACKEND_CHANGED: ${{ needs.changes.outputs.backend }}
           BUMP_ONLY: ${{ needs.release-bump.outputs.bump_only }}
         run: |
           set -euo pipefail
@@ -1404,7 +1458,25 @@ jobs:
           require_success "security-audit" "$RESULT_SECURITY"
 
           allow_skip "smoke-e2e" "$RESULT_SMOKE"
-          allow_skip "integration-tests" "$RESULT_INTEGRATION"
+
+          # Integration tests are REQUIRED on a pull request that touches
+          # backend code (#3124). A skip there is precisely the hole that let
+          # #2905 merge green and leave `main` red for 11 days (#3118), so it
+          # must fail rather than pass. Fails closed: an empty BACKEND_CHANGED
+          # (the `changes` job itself died) counts as backend-touching, which
+          # matches the job's own fail-open-to-running condition.
+          #
+          # A skip still passes everywhere else: docs-only and version-bump-only
+          # PRs, PRs that touch no backend path, and pushes to branches other
+          # than main / release/*, none of which schedule the job.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" \
+                && "$docs_only" != "true" && "$bump_only" != "true" \
+                && "$BACKEND_CHANGED" != "false" ]]; then
+            require_success "integration-tests" "$RESULT_INTEGRATION"
+          else
+            allow_skip "integration-tests" "$RESULT_INTEGRATION"
+          fi
+
           allow_skip "build-backend-image" "$RESULT_BUILD_BACKEND"
           allow_skip "build-openscap-image" "$RESULT_BUILD_OPENSCAP"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,15 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --lib
 ```
 
-### Integration Tests (Tier 2) - Main & Release Branches Only
+### Integration Tests (Tier 2) - Main/Release Pushes & Backend PRs
 ```bash
 # Backend integration tests (requires PostgreSQL)
 cargo test --workspace
 ```
+CI runs this suite on pushes to `main` / `release/*` **and** on every pull
+request that touches `backend/**`, `Cargo.toml`, `Cargo.lock`, `.sqlx/**`, or
+`.github/workflows/ci.yml`. On such a PR a skipped integration job fails
+`✅ CI Complete` (#3124).
 
 ### Full E2E Tests (Tier 3) - Release/Manual Only
 ```bash


### PR DESCRIPTION
## Summary

`🔗 Backend Integration Tests` could not gate a pull request. It was scheduled only on pushes to `main` / `release/*`:

```yaml
# .github/workflows/ci.yml:910 (before)
if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
```

and `ci-complete` treated the resulting skip as a pass (`allow_skip "integration-tests"`). So a PR could break every integration test and still show all-green, with the breakage appearing only after merge on a `main` push whose failure blocks nothing and notifies nobody.

This PR:

1. **`changes`** (the existing docs-only gate) now also classifies the PR as backend-touching, from the same `pulls/files` listing it already fetches. `backend` is a strict subset of `code` — the docs arm matches first, so `backend/README.md` is docs, not backend. Backend paths are `backend/**`, `Cargo.toml`, `Cargo.lock`, `.sqlx/**`, and `.github/workflows/ci.yml` (so a change to this gate exercises the gate).
2. **`test-backend-integration`** keeps its main/release push arm byte-for-byte unchanged and gains a `pull_request` arm gated on `needs.changes.outputs.backend`. The suite, the service container, and every step are identical on both arms. It **fails open to running**: the PR arm tests `!= 'false'`, so if the `changes` job dies outright the suite runs anyway.
3. **`ci-complete`** **fails closed**: on a backend-touching PR a *skipped* integration job is now a hard failure rather than a pass. Everywhere else — docs-only PRs, version-bump-only release PRs, PRs touching no backend path, and pushes to branches other than `main`/`release/*` — a skip still passes.

`smoke-e2e` / `build-backend-image` are **also** effectively push-only (`detect-changes` is `if: github.event_name == 'push'`, despite its section header reading "CONTAINER BUILDS (PR only, ...)"). That is a separate hole with a much larger cost profile (a full image build per PR) and is deliberately **not** changed here; it wants its own issue.

## Cost analysis

Measured from the last 30 `push`-to-`main` CI runs via the Actions API — not estimated:

| Job | n | Mean duration |
|---|---|---|
| 🦀 Check Rust | 22 | 5.2 min |
| 🧪 Backend Unit Tests | 20 | 14.5 min |
| 📊 Code Coverage | 20 | 15.2 min |
| **🔗 Backend Integration Tests** | **21** | **~10 min** (10.3 success / 9.5 failure) |

Note this **corrects the estimate in #3124**, which put the job at "~115s". That is the test *execution* time; the job also compiles the integration test binaries from a clean checkout, and the real wall clock on `ak-ci-runners` is ~10 minutes.

**Wall-clock cost: ~0 added.** The job runs in parallel with the existing heavy jobs, and the PR critical path is already `max(5.2, 14.5, 15.2) ≈ 15.2 min` — longer than the ~10 min this job takes. A backend PR should finish in the same wall clock it does today, provided a runner slot is free.

**Runner cost: +~10 runner-minutes per backend PR run**, i.e. one more concurrent `ak-ci-runners` slot alongside the three heavy jobs already there. Peak concurrency observed across the last 40 CI runs is **11 simultaneous `ak-ci-runners` jobs**, so the fleet has headroom — but it is not free: per-job queue waits of up to 14.4 min (Check Rust) and 11.4 min (Coverage) already occur in that sample, so the fleet does saturate at times and this adds to the queue under load.

**The path filter is what keeps this affordable.** Of the last 54 merged PRs, **37 (69%)** touch `backend/**` / `Cargo.toml` / `Cargo.lock` / `.sqlx/**`; the other 31% (web, docs, scripts, IaC) skip the job entirely and pay nothing. Running the job unconditionally on every PR would be ~45% more runner-minutes than this for zero added signal.

Rejected alternatives: `merge_group` (no merge queue is enabled on this repo — a larger change); label opt-in `run-integration` (cheapest, but it relies on humans predicting which PRs are risky, and #2905 would not have been labelled).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The bug is in CI configuration, so the "test" is the gate itself. It is revert-proved below, and the `ci-complete` decision logic is exercised as a truth table.

### Evidence 1 — the gate fires on this very PR

This PR touches `.github/workflows/ci.yml`, which is in the backend path set, so `🔗 Backend Integration Tests` must run on this pull request. GitHub evaluates `pull_request` workflows from the head, so the new `if:` is the one in effect. See this PR's own checks — that is the live proof, and it is the check to look at before approving.

### Evidence 2 — it would have caught PR #2999

#2999 rewrote `execute_max_versions` in `lifecycle_service.rs`. Checks recorded at its original head **6ff1b253**:

```
skipped   🔗 Backend Integration Tests     <-- the job it was about to break
success   🧪 Backend Unit Tests
success   🦀 Check Rust
success   ✅ CI Complete
```

Running that head's own integration suite against a migrated Postgres — `cargo test --workspace --test lifecycle_policy_tests -- --ignored --test-threads=1`, exactly what the job runs:

```
running 22 tests
...
test test_max_versions_cascades_oci_tags ... FAILED

---- test_max_versions_cascades_oci_tags stdout ----
thread 'test_max_versions_cascades_oci_tags' (891843) panicked at backend/tests/lifecycle_policy_tests.rs:1331:5:
assertion `left == right` failed
  left: 3
 right: 2

test result: FAILED. 21 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.65s
```

The PR's own base — `a791799` (#2993), its merge base with `main` — is green on the same suite, so the red was introduced by the PR and not inherited:

```
running 22 tests
test test_max_versions_cascades_oci_tags ... ok
...
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.17s
```

Base green, head red. With this change that PR shows a red required check instead of a green one.

### Evidence 3 — the `ci-complete` gate, revert-proved

The `ci-complete` script was extracted from the workflow and executed under a matrix of job results. With this change:

```
backend PR, integration SKIPPED  (the #3124 hole)  backend=true  integ=skipped  -> FAIL (want FAIL)
backend PR, integration FAILED   (the #2999 case)  backend=true  integ=failure  -> FAIL (want FAIL)
backend PR, integration success                    backend=true  integ=success  -> PASS (want PASS)
non-backend PR, integration skipped                backend=false integ=skipped  -> PASS (want PASS)
docs-only PR, integration skipped                  backend=false integ=skipped  -> PASS (want PASS)
bump-only PR, integration skipped                  backend=true  integ=skipped  -> PASS (want PASS)
changes job died (backend empty), integ skipped    backend=      integ=skipped  -> FAIL (want FAIL)
push to main, integration success                  backend=true  integ=success  -> PASS (want PASS)
push to develop, integration skipped               backend=true  integ=skipped  -> PASS (want PASS)
```

All 9 match. Reverted to the script on `main`, the first case passes — the hole:

```
BEFORE fix: backend PR + integration skipped -> exit=0 (0 = green, i.e. the hole)
⏭️ integration-tests (skipped)
✅ **CI Passed**
```

### Evidence 4 — the suite is green on `main` today, so this does not immediately red-wall every PR

Turning on a gate that fails on arrival would be worse than leaving it off. The full job command list was run against `main` at `452b001` on a freshly migrated Postgres:

```
lifecycle_policy_tests               12 passed  0 failed
api_token_cache_flush_tests           8 passed  0 failed
grpc_sbom_tests                      13 passed  0 failed
search_reindex_tests                  7 passed  0 failed
scan_convert_to_reused_tests         23 passed  0 failed
stuck_scan_janitor_tests              1 passed  0 failed
virtual_members_atomicity_test        3 passed  0 failed
virtual_members_duplicate_test        5 passed  0 failed
oci_chunked_upload_cross_repo_tests   6 passed  0 failed
sso_oidc_login_callback_e2e_tests    13 passed  0 failed
sso_saml_acs_e2e_tests               16 passed  0 failed
cache_invalidation_fanout_tests       7 passed  0 failed
age_gate_tests                        5 passed  0 failed
scan_policy_validation_tests          4 passed  0 failed
                                    ---------
                                    123 passed  0 failed   (exit 0)
```

plus the job's second step, `incus_upload_tests::test_chunked_upload_cross_repo_session_rejected`: `1 passed; 0 failed`.

**Nothing is currently red.** Note this is a local run on a 20-core host, not `ak-ci-runners`; it does not rule out infrastructure flake on the fleet, only currently-failing tests.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `actionlint` reports 27 findings before and after this change, byte-identical (all pre-existing shellcheck warnings in the untouched `coverage` job); YAML parses; `ci-complete` truth table above
- [x] No regressions in existing tests — full integration suite green on `main` (Evidence 4)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Follow-ups deliberately not in this PR

- `smoke-e2e` / `build-backend-image` are push-only for the same structural reason (see Summary). Separate issue, separate cost argument.
- Option 3 in #3124 — alerting on a red `main` — is not addressed here. Gating PRs stops `main` going red on arrival; it does nothing about a `main` that is already red. Both are wanted.

Fixes #3124

## No branch-protection change needed

`main`'s required contexts are already:

```json
["🧪 Backend Unit Tests", "✅ CI Complete", "🦀 Check Rust"]
```

`✅ CI Complete` is required and gates on `test-backend-integration`, so the new enforcement flows through an existing required check. `🔗 Backend Integration Tests` does **not** need to be added to branch protection — and should not be, since it is legitimately skipped on non-backend PRs.
