### PR TITLE
fix(proxy-cache): enforce known digests and bound streamed cache writes

### DIFF
--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -146,6 +146,77 @@ async fn resolve_upstream_dl_url(
     Some(dl_url)
 }
 
+/// Extract the `cksum` recorded for `version` from a sparse-index document
+/// (#2929).
+///
+/// The sparse index is NDJSON: one JSON object per line, each carrying `vers`
+/// and `cksum`. `cksum` is the SHA-256 of the `.crate` file — it is exactly
+/// what cargo itself verifies the download against, and on a split-host
+/// registry (crates.io serves the index from `index.crates.io` and the
+/// `.crate` from a separate download host) it is sourced independently of the
+/// host that serves the bytes.
+///
+/// Returns `None` when the document is unparseable, the version is absent, or
+/// the recorded value is not a bare lowercase SHA-256 — all of which mean "no
+/// enforceable digest", so the caller falls back to an unverified fetch rather
+/// than failing the download.
+fn cksum_for_version(index_ndjson: &[u8], version: &str) -> Option<String> {
+    let text = std::str::from_utf8(index_ndjson).ok()?;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
+            // A single malformed line must not hide a later good one.
+            continue;
+        };
+        if entry.get("vers").and_then(|v| v.as_str()) != Some(version) {
+            continue;
+        }
+        return entry
+            .get("cksum")
+            .and_then(|v| v.as_str())
+            .and_then(proxy_helpers::normalize_expected_sha256);
+    }
+    None
+}
+
+/// Resolve the sparse-index `cksum` for `{name}/{version}` from the upstream
+/// registry so the streamed `.crate` download can be digest-gated (#2929).
+///
+/// Best-effort by construction: any failure (no proxy, index fetch error,
+/// missing version, non-canonical digest) returns `None` and the download
+/// proceeds unverified, exactly as it did before. The index fetch uses the
+/// same proxy-cached, capped metadata helper the sparse-index handler uses, so
+/// a cargo client — which always reads the index immediately before
+/// downloading — finds it warm.
+async fn resolve_index_cksum(
+    state: &SharedState,
+    repo: &RepoInfo,
+    repo_key: &str,
+    name_lower: &str,
+    version: &str,
+) -> Option<String> {
+    let proxy = state.proxy_service.as_ref()?;
+    let base_url = repo
+        .index_upstream_url
+        .as_deref()
+        .or(repo.upstream_url.as_deref())?;
+    let index_path = cargo_sparse_index_path_upstream(name_lower);
+    let (content, _content_type) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        repo_key,
+        base_url,
+        &index_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    .ok()?;
+    cksum_for_version(&content, version)
+}
+
 /// Build the full download URL for a crate, using the upstream `dl` template
 /// when available. Falls back to `{upstream_url}/api/v1/crates/{name}/{version}/download`.
 ///
@@ -916,13 +987,34 @@ async fn download(
                     // The *metadata* fetches on this handler (config.json, sparse
                     // index) stay capped and buffered — an 8 MiB ceiling is
                     // correct for those.
-                    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key(
+                    // #2929: gate the proxy-cache commit on the sparse index's
+                    // recorded `cksum` for this exact `{name}/{version}`. The
+                    // index entry this same handler serves already carries the
+                    // digest cargo verifies the download against, but the
+                    // download arm reached the streaming helper that hardcodes
+                    // `expected_checksum: None`, so the digest was decorative:
+                    // a `.crate` whose bytes disagreed with it was committed to
+                    // the cache and served warm from then on.
+                    //
+                    // This cannot catch a wholly compromised registry — index
+                    // and bytes could both be forged — but on a split-host
+                    // registry (crates.io: `index.crates.io` vs the download
+                    // host) it catches a misbehaving or compromised download
+                    // host while the index is intact, and it catches ordinary
+                    // corruption or a clean-EOF truncation on either. A body
+                    // that fails the gate is still streamed to the client
+                    // (which verifies it independently and errors); it is only
+                    // kept out of the cache.
+                    let expected_cksum =
+                        resolve_index_cksum(&state, &repo, &repo_key, &name_lower, &version).await;
+                    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
                         proxy,
                         repo.id,
                         &repo_key,
                         &dl_base,
                         &dl_path,
                         &cache_path,
+                        expected_cksum,
                         RepositoryFormat::Cargo,
                     )
                     .await?;
@@ -1701,6 +1793,95 @@ mod tests {
     // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
+
+    // ── #2929: the sparse-index cksum must gate the .crate cache commit ──
+
+    const CKSUM_A: &str = "abc1230000000000000000000000000000000000000000000000000000000def";
+
+    #[test]
+    fn test_cksum_for_version_picks_the_matching_version() {
+        let ndjson = format!(
+            "{{\"name\":\"serde\",\"vers\":\"1.0.0\",\"cksum\":\"{}\"}}\n\
+             {{\"name\":\"serde\",\"vers\":\"1.0.1\",\"cksum\":\"{}\"}}",
+            CKSUM_A,
+            "2".repeat(64)
+        );
+        assert_eq!(
+            super::cksum_for_version(ndjson.as_bytes(), "1.0.0").as_deref(),
+            Some(CKSUM_A),
+            "the digest must be the one recorded for the requested version"
+        );
+        assert_eq!(
+            super::cksum_for_version(ndjson.as_bytes(), "1.0.1").as_deref(),
+            Some("2".repeat(64).as_str())
+        );
+        assert_ne!(
+            CKSUM_A,
+            CKSUM_A.to_uppercase(),
+            "the fixture must contain hex letters or the case test below is vacuous"
+        );
+        assert_eq!(
+            super::cksum_for_version(ndjson.as_bytes(), "9.9.9"),
+            None,
+            "an absent version means no enforceable digest, not a wrong one"
+        );
+    }
+
+    #[test]
+    fn test_cksum_for_version_degrades_on_unusable_input() {
+        // A non-canonical cksum must read as "no digest available" rather than
+        // being enforced: it could never equal the streamed lowercase-hex
+        // SHA-256, so enforcing it would reject the crate on every fetch and
+        // re-pull upstream forever.
+        let prefixed = format!("{{\"vers\":\"1.0.0\",\"cksum\":\"sha256:{CKSUM_A}\"}}");
+        assert_eq!(super::cksum_for_version(prefixed.as_bytes(), "1.0.0"), None);
+
+        let upper = format!(
+            "{{\"vers\":\"1.0.0\",\"cksum\":\"{}\"}}",
+            CKSUM_A.to_uppercase()
+        );
+        assert_eq!(super::cksum_for_version(upper.as_bytes(), "1.0.0"), None);
+
+        assert_eq!(super::cksum_for_version(b"not json at all", "1.0.0"), None);
+        assert_eq!(super::cksum_for_version(b"", "1.0.0"), None);
+        assert_eq!(
+            super::cksum_for_version(b"{\"vers\":\"1.0.0\"}", "1.0.0"),
+            None,
+            "an entry with no cksum is not a digest"
+        );
+    }
+
+    /// A malformed line must not hide a good entry further down: the sparse
+    /// index is NDJSON produced by a third party, and a single bad line
+    /// silently disabling the digest gate for the whole crate would make the
+    /// guard trivially bypassable by a hostile index.
+    #[test]
+    fn test_cksum_for_version_skips_a_malformed_line() {
+        let ndjson = format!("this-is-not-json\n{{\"vers\":\"1.0.0\",\"cksum\":\"{CKSUM_A}\"}}");
+        assert_eq!(
+            super::cksum_for_version(ndjson.as_bytes(), "1.0.0").as_deref(),
+            Some(CKSUM_A)
+        );
+    }
+
+    /// Source pin (#2929): the Remote `.crate` download must go through the
+    /// DIGEST-GATED streaming helper AND actually hand it a resolved digest.
+    /// The unverified sibling hardcodes `expected_checksum: None`, so a revert
+    /// to it — or keeping the verified helper but passing `None` — would
+    /// compile, pass the rest of the suite, and silently un-enforce the index
+    /// cksum again.
+    #[test]
+    fn test_cargo_remote_download_uses_the_verified_streaming_helper_2929() {
+        let src = include_str!("cargo.rs");
+        assert!(
+            src.contains("proxy_helpers::proxy_fetch_streaming_with_cache_key_verified("),
+            "the cargo remote download MUST call the digest-gated streaming helper (#2929)"
+        );
+        assert!(
+            src.contains("let expected_cksum =\n                        resolve_index_cksum("),
+            "the digest passed to the gate must come from the sparse index, not be None (#2929)"
+        );
+    }
 
     /// Regression test for the cargo instance of the buffered-download class
     /// (#895 / #2192).

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -1864,22 +1864,176 @@ mod tests {
         );
     }
 
-    /// Source pin (#2929): the Remote `.crate` download must go through the
-    /// DIGEST-GATED streaming helper AND actually hand it a resolved digest.
-    /// The unverified sibling hardcodes `expected_checksum: None`, so a revert
-    /// to it — or keeping the verified helper but passing `None` — would
-    /// compile, pass the rest of the suite, and silently un-enforce the index
-    /// cksum again.
-    #[test]
-    fn test_cargo_remote_download_uses_the_verified_streaming_helper_2929() {
-        let src = include_str!("cargo.rs");
-        assert!(
-            src.contains("proxy_helpers::proxy_fetch_streaming_with_cache_key_verified("),
-            "the cargo remote download MUST call the digest-gated streaming helper (#2929)"
+    /// Fixture shared by the two #2929 cache-gate tests below.
+    ///
+    /// Serves a sparse-index document recording `index_cksum` for
+    /// `{name}/{version}` and a download host serving `body`, then issues two
+    /// cold requests through the real router. The upstream download mock is
+    /// pinned to `expected_download_hits`, which is what actually distinguishes
+    /// the two cases: a committed cache entry makes the second request a hit
+    /// (1 upstream fetch), a refused commit makes it another miss (2).
+    ///
+    /// Returns the served bodies plus the proxy cache dir so the caller can
+    /// assert on what was persisted.
+    async fn run_cargo_download_with_index_cksum(
+        name: &str,
+        version: &str,
+        body: Vec<u8>,
+        index_cksum: &str,
+        expected_download_hits: u64,
+    ) -> Option<(Vec<u8>, Vec<u8>, tempfile::TempDir)> {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method as wm_method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let fx = tdh::Fixture::setup("remote", "cargo").await?;
+
+        let server = MockServer::start().await;
+
+        // The sparse index this same handler proxies. `cksum` is the digest the
+        // download is gated on.
+        let index_doc = format!(
+            "{{\"name\":\"{name}\",\"vers\":\"{version}\",\"cksum\":\"{index_cksum}\",\"deps\":[],\"features\":{{}},\"yanked\":false}}\n"
         );
+        Mock::given(wm_method("GET"))
+            .and(wm_path(format!(
+                "/{}",
+                cargo_sparse_index_path_upstream(name)
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_string(index_doc))
+            .mount(&server)
+            .await;
+
+        Mock::given(wm_method("GET"))
+            .and(wm_path(format!("/api/v1/crates/{name}/{version}/download")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .expect(expected_download_hits)
+            .mount(&server)
+            .await;
+
+        let (state, dir) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let request_path = format!(
+            "/cargo/{}/api/v1/crates/{}/{}/download",
+            fx.repo_key, name, version
+        );
+
+        let (cold_status, cold_body) = tdh::send(
+            tdh::router_anon(mounted_router(), state.clone()),
+            tdh::get(request_path.clone()),
+        )
+        .await;
+        assert_eq!(
+            cold_status,
+            StatusCode::OK,
+            "cold download must succeed; body was {}",
+            String::from_utf8_lossy(&cold_body)
+        );
+
+        // Give the asynchronous tee its chance to commit either way. The
+        // matching case must commit (and does so well inside this budget); the
+        // mismatching case must still not have committed when the budget
+        // expires, which is what makes the negative assertion meaningful rather
+        // than a race the test happens to win.
+        for _ in 0..400 {
+            if tdh::committed_cache_entry_exists(dir.path(), body.len() as u64) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        let (warm_status, warm_body) = tdh::send(
+            tdh::router_anon(mounted_router(), state.clone()),
+            tdh::get(request_path),
+        )
+        .await;
+        assert_eq!(warm_status, StatusCode::OK, "second download must succeed");
+
+        fx.teardown().await;
+        // Dropping the MockServer verifies `.expect(...)`.
+        drop(server);
+
+        Some((cold_body.to_vec(), warm_body.to_vec(), dir))
+    }
+
+    /// #2929: a `.crate` whose bytes match the sparse index's recorded `cksum`
+    /// is committed to the proxy cache and served warm from then on.
+    ///
+    /// The companion to the mismatch test below — without this one, "never
+    /// commits anything" would also pass.
+    #[tokio::test]
+    async fn test_remote_crate_download_commits_cache_on_matching_index_cksum_2929() {
+        let name = "gated-crate";
+        let version = "2.0.0";
+        let body = b"a plausible .crate tarball payload".repeat(32);
+        let good = crate::services::storage_service::StorageService::calculate_hash(&body);
+
+        // One upstream download: the second request is served from the cache.
+        let Some((cold, warm, dir)) =
+            run_cargo_download_with_index_cksum(name, version, body.clone(), &good, 1).await
+        else {
+            return;
+        };
+
+        assert_eq!(&cold[..], &body[..], "cold read must serve upstream bytes");
+        assert_eq!(&warm[..], &body[..], "warm read must serve identical bytes");
         assert!(
-            src.contains("let expected_cksum =\n                        resolve_index_cksum("),
-            "the digest passed to the gate must come from the sparse index, not be None (#2929)"
+            crate::api::handlers::test_db_helpers::committed_cache_entry_exists(
+                dir.path(),
+                body.len() as u64
+            ),
+            "a digest-matching body must be committed to the proxy cache (#2929)"
+        );
+    }
+
+    /// #2929: a `.crate` whose bytes DISAGREE with the sparse index's recorded
+    /// `cksum` must never be committed to the proxy cache.
+    ///
+    /// This is the regression that the source-grep test it replaces could only
+    /// approximate. It fails if the download arm is reverted to the unverified
+    /// streaming helper, if the resolved digest is passed as `None`, or if the
+    /// gate is moved after the cache write — none of which a text assertion on
+    /// this file can distinguish from a working gate.
+    ///
+    /// The body is still streamed to the client: cargo verifies the download
+    /// against this same `cksum` itself and will reject it, and truncating the
+    /// response would only turn a detected corruption into an ambiguous one.
+    /// What must not happen is the bad body becoming a warm cache entry served
+    /// to everyone afterwards.
+    #[tokio::test]
+    async fn test_remote_crate_download_refuses_cache_commit_on_cksum_mismatch_2929() {
+        let name = "forged-crate";
+        let version = "3.1.4";
+        let body = b"bytes that do not match the recorded cksum".repeat(32);
+        // Well-formed (bare lowercase 64-hex) so it passes
+        // `normalize_expected_sha256` and is actually enforced, rather than
+        // being discarded as "no digest available".
+        let wrong = "9".repeat(64);
+        assert_ne!(
+            wrong,
+            crate::services::storage_service::StorageService::calculate_hash(&body),
+            "fixture digest must actually differ or the test proves nothing"
+        );
+
+        // Two upstream downloads: nothing was cached, so the second request is
+        // another cold miss.
+        let Some((cold, warm, dir)) =
+            run_cargo_download_with_index_cksum(name, version, body.clone(), &wrong, 2).await
+        else {
+            return;
+        };
+
+        assert_eq!(
+            &cold[..],
+            &body[..],
+            "the client is still served the full body; cargo verifies it independently"
+        );
+        assert_eq!(&warm[..], &body[..], "the refetch serves the full body too");
+        assert!(
+            !crate::api::handlers::test_db_helpers::committed_cache_entry_exists(
+                dir.path(),
+                body.len() as u64
+            ),
+            "a body failing the index cksum must NOT be committed to the proxy cache (#2929)"
         );
     }
 

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -1441,6 +1441,18 @@ async fn flatcontainer_download(
     // stays missing: a transient bad upstream self-heals on the next request and a
     // persistently wrong one keeps erroring instead of poisoning the cache.
     //
+    // The refetch still commits to the SHARED proxy cache under
+    // `v3/flatcontainer/...` before this gate sees the bytes, exactly as the
+    // streaming repair does. That is contained rather than ignored: the artifact
+    // row is looked up ABOVE this point, so while the row exists every request
+    // for it lands here and is re-gated — a mismatching cached body is refused
+    // again rather than served warm (the repair is idempotent in that sense).
+    // The proxy-cache entry only becomes directly reachable through the
+    // no-row arm, where there is no recorded digest and no row-scoped quarantine
+    // decision to honour in the first place. Keeping unverified bytes out of the
+    // proxy cache as well needs a buffered-verified fetch primitive that does not
+    // exist yet; it is a cache-hygiene improvement, not a hole in this gate.
+    //
     // Buffering is bounded by `VERIFIED_NUPKG_REPAIR_MAX_BYTES` (#2928), applied
     // twice: pre-flight against the row's recorded `size_bytes`, and again as the
     // capped fetch's own ceiling in case the row understates what upstream serves.
@@ -4532,6 +4544,32 @@ mod read_db_tests {
         filename: &str,
         size_bytes: i64,
     ) -> Uuid {
+        // Not a bare 64-hex SHA-256, so `normalize_expected_sha256` reads it as
+        // "no enforceable digest" and the repair takes the UNVERIFIED streaming
+        // route — which is what the two tests using this seed are about.
+        seed_row_without_blob_with_checksum(
+            fx,
+            name,
+            version,
+            filename,
+            size_bytes,
+            "test-seed-missing-blob",
+        )
+        .await
+    }
+
+    /// As [`seed_row_without_blob`], but pins the row's `checksum_sha256`.
+    ///
+    /// A bare lowercase 64-hex value here is what routes the repair through the
+    /// digest-verified buffered path (#2929).
+    async fn seed_row_without_blob_with_checksum(
+        fx: &tdh::Fixture,
+        name: &str,
+        version: &str,
+        filename: &str,
+        size_bytes: i64,
+        checksum_sha256: &str,
+    ) -> Uuid {
         let artifact_path = format!("v3/flatcontainer/{}/{}/{}", name, version, filename);
         let storage_key = format!("nuget/{}/{}/{}", name, version, filename);
         proxy_helpers::insert_artifact(
@@ -4542,7 +4580,7 @@ mod read_db_tests {
                 name,
                 version,
                 size_bytes,
-                checksum_sha256: "test-seed-missing-blob",
+                checksum_sha256,
                 content_type: "application/octet-stream",
                 storage_key: &storage_key,
                 uploaded_by: fx.user_id,
@@ -4550,6 +4588,190 @@ mod read_db_tests {
         )
         .await
         .expect("insert artifacts row without blob")
+    }
+
+    /// Drive `flatcontainer_download` against an upstream that serves
+    /// `upstream_body`, for a row seeded with `row_checksum` and no blob.
+    ///
+    /// Returns `(result, upstream_request_paths)`. The caller asserts; teardown
+    /// happens here so a failing assertion never leaks fixture rows.
+    async fn run_repair_with_row_checksum(
+        package_id: &str,
+        version: &str,
+        upstream_body: &[u8],
+        row_checksum: &str,
+        calls: usize,
+    ) -> Option<(Vec<Result<(StatusCode, Vec<u8>), StatusCode>>, Vec<String>)> {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let fx = tdh::Fixture::setup("remote", "nuget").await?;
+        let upstream = MockServer::start().await;
+        mount_v3_index(&upstream).await;
+
+        let filename = format!("{}.{}.nupkg", package_id, version);
+        let discovered_path = format!("/flat/{}/{}/{}", package_id, version, filename);
+        Mock::given(method("GET"))
+            .and(path(discovered_path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(upstream_body.to_vec()),
+            )
+            .mount(&upstream)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(format!("{}/v3/index.json", upstream.uri()))
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .unwrap();
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), &storage_path);
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), &storage_path, proxy);
+
+        seed_row_without_blob_with_checksum(
+            &fx,
+            package_id,
+            version,
+            &filename,
+            upstream_body.len() as i64,
+            row_checksum,
+        )
+        .await;
+
+        let mut outcomes = Vec::new();
+        for _ in 0..calls {
+            let resp = super::flatcontainer_download(
+                axum::extract::State(state.clone()),
+                axum::extract::Path((
+                    fx.repo_key.clone(),
+                    package_id.to_string(),
+                    version.to_string(),
+                    filename.clone(),
+                )),
+                Default::default(),
+            )
+            .await;
+            outcomes.push(match resp {
+                Ok(r) => {
+                    let status = r.status();
+                    let body = to_bytes(r.into_body(), 1 << 20).await.unwrap();
+                    Ok((status, body.to_vec()))
+                }
+                Err(r) => Err(r.status()),
+            });
+        }
+
+        let requested: Vec<String> = upstream
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .map(|r| r.url.path().to_string())
+            .collect();
+        fx.teardown().await;
+        Some((outcomes, requested))
+    }
+
+    /// #2929: a repaired `.nupkg` whose bytes match the row's recorded
+    /// `checksum_sha256` is served, and the write-back makes the next request a
+    /// local hit rather than a second upstream pull.
+    ///
+    /// The companion to the mismatch test below: without this one, "refuse every
+    /// repair" would also satisfy that assertion.
+    #[tokio::test]
+    async fn test_flatcontainer_repair_serves_a_body_matching_the_rows_digest_2929() {
+        let body = b"PK\x03\x04-repaired-and-verified-nupkg-bytes".repeat(8);
+        let digest = crate::services::storage_service::StorageService::calculate_hash(&body);
+
+        let Some((outcomes, requested)) =
+            run_repair_with_row_checksum("verified.package", "1.0.0", &body, &digest, 2).await
+        else {
+            return;
+        };
+
+        let (status, served) = match &outcomes[0] {
+            Ok(v) => v.clone(),
+            Err(status) => panic!("a digest-matching repair must succeed, got {status}"),
+        };
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            &served[..],
+            &body[..],
+            "the verified repair must serve the upstream bytes in full"
+        );
+
+        match &outcomes[1] {
+            Ok((status, served)) => {
+                assert_eq!(*status, StatusCode::OK, "the warm read must succeed");
+                assert_eq!(&served[..], &body[..], "the warm read must be identical");
+            }
+            Err(status) => panic!("the warm read must succeed, got {status}"),
+        }
+
+        let pulls = requested.iter().filter(|p| p.starts_with("/flat/")).count();
+        assert_eq!(
+            pulls, 1,
+            "a verified repair must write back, so the second request is a local \
+             hit; upstream saw {requested:?}"
+        );
+    }
+
+    /// #2929 — the load-bearing one. VERIFY THEN SERVE.
+    ///
+    /// `check_artifact_download` authorises on the artifact row, so the hash an
+    /// admin reviewed when releasing that row from quarantine has to be the hash
+    /// the client actually receives. The repair re-pulls from upstream and writes
+    /// back under the row's own storage key; if those bytes are never compared to
+    /// the row's `checksum_sha256`, the quarantine decision was made about a blob
+    /// nobody ever delivered.
+    ///
+    /// So a mismatching body must reach the client NOT AT ALL — not "truncated
+    /// after the mismatch was noticed", which is why this path buffers instead of
+    /// streaming. And it must not be written back: the second call below must
+    /// fail exactly like the first, proving the bad body did not become a warm
+    /// entry that later requests are served from.
+    #[tokio::test]
+    async fn test_flatcontainer_repair_refuses_a_body_failing_the_rows_digest_2929() {
+        let body = b"PK\x03\x04-bytes-that-are-not-what-the-row-records".repeat(8);
+        // Well-formed so it is actually enforced rather than being discarded as
+        // "no digest available" by `normalize_expected_sha256`.
+        let wrong = "b".repeat(64);
+        assert_ne!(
+            wrong,
+            crate::services::storage_service::StorageService::calculate_hash(&body),
+            "fixture digest must differ or the test proves nothing"
+        );
+
+        let Some((outcomes, requested)) =
+            run_repair_with_row_checksum("forged.package", "2.0.0", &body, &wrong, 2).await
+        else {
+            return;
+        };
+
+        for (i, outcome) in outcomes.iter().enumerate() {
+            match outcome {
+                Err(status) => assert_eq!(
+                    *status,
+                    StatusCode::BAD_GATEWAY,
+                    "call {i}: a digest mismatch must fail the repair explicitly"
+                ),
+                Ok((status, served)) => panic!(
+                    "call {i}: a body failing the row's recorded digest must never be \
+                     served (#2929); got {status} with {} bytes",
+                    served.len()
+                ),
+            }
+        }
+
+        assert!(
+            requested.iter().any(|p| p.starts_with("/flat/")),
+            "the repair must actually have pulled upstream, or the refusal is \
+             vacuous; upstream saw {requested:?}"
+        );
     }
 
     /// The repair must re-pull through the **discovered** `PackageBaseAddress`,

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -597,6 +597,49 @@ fn merge_upstream_search_data(
     added
 }
 
+/// Resolve the upstream fetch URL and the stable proxy-cache key for a
+/// flat-container `sub_path` (`{id}/index.json`, `{id}/{version}/{file}`).
+///
+/// NuGet V3 has no fixed layout, so the package-content base must come from the
+/// upstream service index rather than being concatenated onto the configured
+/// upstream URL (#2775). Extracted from [`proxy_v3_flatcontainer`] so the
+/// verified `.nupkg` repair path (#2929) can buffer and hash the body itself
+/// while still resolving its URL through exactly the same discovery — the
+/// buffered repair that predated #2919 built the URL by concatenation and 404'd
+/// against every real feed.
+async fn flatcontainer_fetch_target(
+    proxy: &crate::services::proxy_service::ProxyService,
+    fetch_repo_id: uuid::Uuid,
+    fetch_repo_key: &str,
+    upstream_url: &str,
+    sub_path: &str,
+) -> Result<(String, String), Response> {
+    let resources =
+        discover_upstream_resources(proxy, fetch_repo_id, fetch_repo_key, upstream_url).await?;
+    let pkg_base = guard_upstream_base(
+        resources.package_base.as_ref(),
+        upstream_url,
+        "PackageBaseAddress",
+    )?;
+    Ok((
+        format!("{}/{}", pkg_base, sub_path),
+        format!("v3/flatcontainer/{}", sub_path),
+    ))
+}
+
+/// Byte ceiling on a *verified* (buffered) `.nupkg` repair (#2929).
+///
+/// The unverified repair streams and is therefore unbounded by design. A
+/// verified repair cannot stream — the digest is only known once the last byte
+/// has arrived — so it has to hold the body, and holding an unbounded body is
+/// how a repair path becomes a memory-exhaustion primitive (#2928). 128 MiB
+/// covers the large native-runtime packages that motivated #2919
+/// (`Microsoft.CodeAnalysis.*`, `Microsoft.ML.*`, `SkiaSharp.NativeAssets.*`)
+/// while staying far below the buffered proxy-scan ceiling the process already
+/// tolerates. Exceeding it is a hard error, never a silent downgrade to an
+/// unverified stream: see the repair arm in `flatcontainer_download`.
+const VERIFIED_NUPKG_REPAIR_MAX_BYTES: usize = 128 * 1024 * 1024;
+
 /// Proxy an upstream V3 flat-container document (version list or `.nupkg`).
 /// `sub_path` is the portion after the package-content base, e.g.
 /// `{id}/index.json` or `{id}/{version}/{file}`. Version lists carry no URLs so
@@ -610,15 +653,9 @@ async fn proxy_v3_flatcontainer(
     sub_path: &str,
     streaming: bool,
 ) -> Result<Response, Response> {
-    let resources =
-        discover_upstream_resources(proxy, fetch_repo_id, fetch_repo_key, upstream_url).await?;
-    let pkg_base = guard_upstream_base(
-        resources.package_base.as_ref(),
-        upstream_url,
-        "PackageBaseAddress",
-    )?;
-    let fetch_url = format!("{}/{}", pkg_base, sub_path);
-    let cache_path = format!("v3/flatcontainer/{}", sub_path);
+    let (fetch_url, cache_path) =
+        flatcontainer_fetch_target(proxy, fetch_repo_id, fetch_repo_key, upstream_url, sub_path)
+            .await?;
     if streaming {
         proxy_helpers::proxy_fetch_streaming_response_with_cache_key(
             proxy,
@@ -1378,38 +1415,158 @@ async fn flatcontainer_download(
     //     guaranteed 404. The repair was broken against a real feed regardless of
     //     body size.
     //
-    // The repair now takes exactly the route the primary cache-miss arm above
-    // takes: `proxy_v3_flatcontainer(.., streaming = true)` resolves
-    // `PackageBaseAddress` from the upstream service index and streams the body
-    // to the client while teeing it into the proxy cache. The cache key is
-    // unchanged (`v3/flatcontainer/{id}/{version}/{file}`, the exact path the old
-    // buffered fetch keyed on), so entries cached by the previous code are still
-    // hits rather than orphans.
+    // The repair resolves `PackageBaseAddress` from the upstream service index
+    // and keys the proxy cache on `v3/flatcontainer/{id}/{version}/{file}` — the
+    // exact path the old buffered fetch keyed on — so entries cached by the
+    // previous code are still hits rather than orphans. Which *transfer* shape it
+    // uses depends on whether the row carries a digest we can enforce.
     //
-    // Gating is preserved: `check_artifact_download` above already ran for this
-    // row, and the streaming leader re-applies the Package Age Policy hold
-    // (#1770/#1771 — a policy-enabled repo refuses to open a new streaming fetch
-    // at all) plus the sidecar `quarantine_until` on a proxy-cache hit. The
-    // buffered helper's hydration lease is likewise not lost: the streaming fetch
-    // single-flights the cold-cache open itself (#1631 layer 2 / #1694). The
-    // repaired response carries the proxy's streaming shape rather than this
-    // handler's `Content-Length`/`Content-Disposition` — identical to the primary
-    // Remote arm, and NuGet clients name the file from the request URL.
+    // #2929 — VERIFY-THEN-SERVE when it does.
+    //
+    // The repair pulls fresh bytes from upstream and writes them back under THIS
+    // row's storage key. `check_artifact_download` a few lines above authorised
+    // this download on THIS row, and the row records `checksum_sha256`. So the
+    // hash an admin reviewed when releasing this artifact from quarantine is the
+    // hash the client must actually receive; if the repair serves something else,
+    // the quarantine decision was made about a blob nobody ever delivered and the
+    // control is weaker than it reads.
+    //
+    // Enforcing that requires the whole body in hand BEFORE any of it is written
+    // back or forwarded, which is why this arm buffers where the primary
+    // cache-miss arm streams. Streaming and aborting mid-body on a mismatch is
+    // not an equivalent option: the digest is only known after the last byte has
+    // already been forwarded, so the client is left holding a truncated file it
+    // may cache or retry into — a failure that is silent at exactly the moment it
+    // most needs to be loud. On a mismatch nothing is written back, so the entry
+    // stays missing: a transient bad upstream self-heals on the next request and a
+    // persistently wrong one keeps erroring instead of poisoning the cache.
+    //
+    // Buffering is bounded by `VERIFIED_NUPKG_REPAIR_MAX_BYTES` (#2928), applied
+    // twice: pre-flight against the row's recorded `size_bytes`, and again as the
+    // capped fetch's own ceiling in case the row understates what upstream serves.
+    // Over-limit is a hard error. It deliberately does NOT fall back to the
+    // unverified streaming repair — silently downgrading integrity for big
+    // packages would make the guarantee depend on package size, which is the one
+    // property an attacker controls.
+    //
+    // When the row has no enforceable digest (see `normalize_expected_sha256`),
+    // there is nothing to verify against and the repair takes exactly the route
+    // the primary cache-miss arm takes: `proxy_v3_flatcontainer(.., streaming =
+    // true)` streams the body to the client while teeing it into the proxy cache,
+    // unbounded and unchanged from #2919. Gating is preserved on that path: the
+    // streaming leader re-applies the Package Age Policy hold (#1770/#1771 — a
+    // policy-enabled repo refuses to open a new streaming fetch at all) plus the
+    // sidecar `quarantine_until` on a proxy-cache hit, and it single-flights the
+    // cold-cache open itself (#1631 layer 2 / #1694) so the buffered helper's
+    // hydration lease is not lost. Its response carries the proxy's streaming
+    // shape rather than this handler's `Content-Length`/`Content-Disposition` —
+    // identical to the primary Remote arm, and NuGet clients name the file from
+    // the request URL.
+    //
+    // A blob that IS present is streamed straight from storage as before: this
+    // arm only governs the repair, and re-hashing every stored byte on every hit
+    // is a different (much more expensive) control than #2929 asks for.
+    //
+    // `content_length` normally comes from the row, as for any streamed blob. The
+    // verified repair overrides it with the length it actually holds: a row whose
+    // `size_bytes` has drifted from its (verified-correct) body would otherwise
+    // emit a `Content-Length` the body never satisfies, leaving the client
+    // hanging or treating a complete file as truncated.
+    let mut content_length = artifact.size_bytes;
     let body: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>> =
         match storage.get_stream(&artifact.storage_key).await {
             Ok(stream) => stream,
             Err(crate::error::AppError::NotFound(missing)) => {
-                if repo.repo_type == RepositoryType::Remote {
-                    if let (Some(ref upstream_url), Some(ref proxy)) =
-                        (&repo.upstream_url, &state.proxy_service)
-                    {
+                let remote_proxy = if repo.repo_type == RepositoryType::Remote {
+                    match (&repo.upstream_url, &state.proxy_service) {
+                        (Some(upstream_url), Some(proxy)) => Some((upstream_url, proxy)),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+
+                let Some((upstream_url, proxy)) = remote_proxy else {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Storage error: {}", missing),
+                    )
+                        .into_response());
+                };
+
+                let sub_path = format!("{}/{}/{}", package_id_lower, version, filename);
+
+                match proxy_helpers::normalize_expected_sha256(&artifact.checksum_sha256) {
+                    Some(expected) => {
                         tracing::warn!(
                             artifact_id = %artifact.id,
                             storage_key = %artifact.storage_key,
                             "nuget proxy cache entry is missing on disk; re-fetching from the \
-                             discovered PackageBaseAddress (streaming)"
+                             discovered PackageBaseAddress (buffered, digest-verified)"
                         );
-                        let sub_path = format!("{}/{}/{}", package_id_lower, version, filename);
+
+                        if artifact.size_bytes > VERIFIED_NUPKG_REPAIR_MAX_BYTES as i64 {
+                            tracing::error!(
+                                target: "security",
+                                artifact_id = %artifact.id,
+                                storage_key = %artifact.storage_key,
+                                size_bytes = artifact.size_bytes,
+                                limit_bytes = VERIFIED_NUPKG_REPAIR_MAX_BYTES,
+                                "refusing to repair a missing .nupkg: verification requires \
+                                 buffering the whole body and this row exceeds the ceiling; \
+                                 serving it unverified would silently drop the #2929 guarantee"
+                            );
+                            return Err((
+                                StatusCode::INSUFFICIENT_STORAGE,
+                                "cached package is missing and is too large to repair under \
+                                 checksum verification; restore it from backup or re-publish",
+                            )
+                                .into_response());
+                        }
+
+                        let (fetch_url, cache_path) = flatcontainer_fetch_target(
+                            proxy,
+                            repo.id,
+                            &repo_key,
+                            upstream_url,
+                            &sub_path,
+                        )
+                        .await?;
+
+                        let content = proxy_helpers::get_cached_or_refetch(
+                            &state.db,
+                            artifact.id,
+                            storage.as_ref(),
+                            &artifact.storage_key,
+                            Some(expected.as_str()),
+                            || async {
+                                let (bytes, _content_type) =
+                                    proxy_helpers::proxy_fetch_capped_with_cache_key(
+                                        proxy,
+                                        repo.id,
+                                        &repo_key,
+                                        upstream_url,
+                                        &fetch_url,
+                                        &cache_path,
+                                        VERIFIED_NUPKG_REPAIR_MAX_BYTES,
+                                    )
+                                    .await?;
+                                Ok(bytes)
+                            },
+                        )
+                        .await?;
+
+                        content_length = content.len() as i64;
+                        Box::pin(futures::stream::once(async move { Ok(content) }))
+                    }
+                    None => {
+                        tracing::warn!(
+                            artifact_id = %artifact.id,
+                            storage_key = %artifact.storage_key,
+                            "nuget proxy cache entry is missing on disk; re-fetching from the \
+                             discovered PackageBaseAddress (streaming, no enforceable digest \
+                             recorded)"
+                        );
                         let response = proxy_v3_flatcontainer(
                             proxy,
                             repo.id,
@@ -1431,11 +1588,6 @@ async fn flatcontainer_download(
                         return Ok(response);
                     }
                 }
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Storage error: {}", missing),
-                )
-                    .into_response());
             }
             Err(e) => {
                 return Err((
@@ -1457,7 +1609,7 @@ async fn flatcontainer_download(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .header(CONTENT_LENGTH, content_length.to_string())
         .body(Body::from_stream(
             body.map(|r| r.map_err(|e| std::io::Error::other(e.to_string()))),
         ))

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1167,6 +1167,34 @@ pub async fn proxy_check_cache(
     }
 }
 
+/// Normalise a recorded digest into a value the cache-commit gates can
+/// actually enforce (#2929).
+///
+/// Returns `Some(digest)` only for a bare lowercase 64-hex SHA-256. Anything
+/// else — a `sha256:`-prefixed value, an uppercase or truncated digest, an
+/// MD5/SHA-1, an empty string — yields `None`, meaning "no digest available",
+/// and the caller falls through to its previous unverified behaviour.
+///
+/// The permissive fallback is deliberate and load-bearing. The gates compare
+/// against the streamed/refetched SHA-256 in bare lowercase hex, so passing a
+/// differently-shaped value through would never match: the entry would be
+/// rejected on every fetch, nothing would ever cache, and every request would
+/// re-pull upstream. A digest we cannot compare against must degrade to the
+/// status quo, not to a permanent hard failure.
+pub(crate) fn normalize_expected_sha256(raw: &str) -> Option<String> {
+    let candidate = raw.trim();
+    if candidate.len() == 64 && candidate.bytes().all(|b| b.is_ascii_hexdigit()) {
+        // Reject uppercase/mixed case rather than lowercasing it: a value that
+        // is not already in the comparison's canonical form did not come from
+        // this codebase's hashing path, so treating it as authoritative would
+        // be a guess about its provenance.
+        if candidate.bytes().all(|b| !b.is_ascii_uppercase()) {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
 /// Generic helper for remote proxy-backed cache reads.
 ///
 /// Tries `storage.get(storage_key)`. If it returns `AppError::NotFound`, the
@@ -1186,26 +1214,38 @@ pub async fn proxy_check_cache(
 /// client can retry later. Non-`NotFound` storage errors are propagated as 500
 /// responses so operators still see real backend failures.
 ///
-/// No production caller remains: this is the BUFFERED repair primitive, and every
-/// format handler whose repair path pulls an artifact body has moved to a
-/// streaming repair so a body larger than the buffered metadata ceiling is not
-/// 502'd (PyPI wheels via `get_remote_cached_or_refetch_stream`, #2192 / #1608
-/// Phase 4c; NuGet `.nupkg` via `proxy_v3_flatcontainer(.., streaming = true)`).
-/// It is retained — with its coverage below — as the cluster-coordinated
-/// (#1609) buffered form for a future caller whose payload is genuinely small;
-/// anything artifact-sized must use a streaming repair instead.
-#[allow(dead_code)]
+/// This is the BUFFERED repair primitive. A repair that does NOT need to verify
+/// what it pulled should prefer a streaming repair, so a body larger than the
+/// buffered ceiling is not 502'd (PyPI wheels via
+/// `get_remote_cached_or_refetch_stream`, #2192 / #1608 Phase 4c; NuGet
+/// `.nupkg` via `proxy_v3_flatcontainer(.., streaming = true)`).
+///
+/// A repair that DOES need to verify what it pulled has to buffer, and that is
+/// what `expected_sha256` is for (#2929). The digest of a streamed body is only
+/// known after its last byte has been forwarded, so a streaming repair can only
+/// discover a mismatch once the client already holds the bytes — aborting the
+/// transfer at that point leaves the client with a truncated file it may cache
+/// or retry into, which is a worse outcome than refusing the repair outright.
+/// Verify-then-serve is therefore the only shape that can honour the contract
+/// #2929 is about: `check_artifact_download` authorises on the artifact row, so
+/// the hash an admin reviewed when releasing that row from quarantine must be
+/// the hash the client actually receives. Callers taking this path accept the
+/// buffering cost and are expected to bound it (see the NuGet repair arm).
 pub(crate) async fn get_cached_or_refetch<F, Fut>(
     db: &PgPool,
     artifact_id: Uuid,
     storage: &dyn crate::storage::StorageBackend,
     storage_key: &str,
+    expected_sha256: Option<&str>,
     refetch: F,
 ) -> Result<Bytes, Response>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<Bytes, Response>>,
 {
+    // #2929: the caller's authoritative digest for this artifact, when it has
+    // one in a shape the comparison can use. See `normalize_expected_sha256`.
+    let expected_sha256 = expected_sha256.and_then(normalize_expected_sha256);
     let hydration_lease_key = format!("artifact-repair:{}", storage_key);
     // #1609: single-flight the missing-file repair CLUSTER-WIDE (was per-process)
     // via the config-selected advisory-lock coordinator, so concurrent replicas
@@ -1228,6 +1268,42 @@ where
             );
 
             let bytes = refetch().await?;
+
+            // #2929: the repair refetch pulls fresh bytes from upstream (or
+            // from a warm proxy-cache object under a DIFFERENT key) and writes
+            // them back under THIS artifact row's storage key. Nothing
+            // previously compared them against the row's own
+            // `checksum_sha256`, so the row's recorded hash described a blob
+            // that no longer existed while a completely unrelated body was
+            // served and persisted in its place. That also made the quarantine
+            // control weaker than it looks: `check_artifact_download` authorises
+            // on the row, so an admin releasing an artifact from quarantine was
+            // approving a hash never enforced against what clients then receive.
+            //
+            // Fail the repair instead of persisting a mismatch. The object is
+            // NOT written back, so the entry stays missing and the next request
+            // retries — a transient bad upstream self-heals, and a persistently
+            // wrong one surfaces as a hard error rather than silent corruption.
+            if let Some(ref expected) = expected_sha256 {
+                let actual = crate::services::storage_service::StorageService::calculate_hash(&bytes);
+                if &actual != expected {
+                    tracing::warn!(
+                        target: "security",
+                        artifact_id = %artifact_id,
+                        storage_key = %storage_key,
+                        expected_sha256 = %expected,
+                        actual_sha256 = %actual,
+                        "refetched proxy payload does not match the artifact row's recorded \
+                         checksum; refusing to write it back or serve it"
+                    );
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        "refetched artifact failed checksum verification",
+                    )
+                        .into_response());
+                }
+            }
+
             if let Err(e) = storage.put(storage_key, bytes.clone()).await {
                 tracing::warn!(
                     artifact_id = %artifact_id,
@@ -7645,14 +7721,21 @@ mod tests {
                           start: StdArc<tokio::sync::Barrier>| {
             tokio::spawn(async move {
                 start.wait().await;
-                get_cached_or_refetch(&pool, artifact_id, storage.as_ref(), "proxy/test", || {
-                    let refetch_calls = refetch_calls.clone();
-                    async move {
-                        refetch_calls.fetch_add(1, Ordering::SeqCst);
-                        tokio::time::sleep(Duration::from_millis(50)).await;
-                        Ok(Bytes::from_static(b"remote-bytes"))
-                    }
-                })
+                get_cached_or_refetch(
+                    &pool,
+                    artifact_id,
+                    storage.as_ref(),
+                    "proxy/test",
+                    None,
+                    || {
+                        let refetch_calls = refetch_calls.clone();
+                        async move {
+                            refetch_calls.fetch_add(1, Ordering::SeqCst);
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                            Ok(Bytes::from_static(b"remote-bytes"))
+                        }
+                    },
+                )
                 .await
             })
         };
@@ -7851,16 +7934,17 @@ mod tests {
         let refetched_bytes = Bytes::from_static(b"refetched-body");
         let storage_key = "proxy-cache/repo/pkg/__content__";
 
-        let result = super::get_cached_or_refetch(&pool, artifact_id, &storage, storage_key, {
-            let refetch_calls = refetch_calls.clone();
-            let refetched_bytes = refetched_bytes.clone();
-            move || async move {
-                refetch_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(refetched_bytes)
-            }
-        })
-        .await
-        .expect("miss path should recover via refetch");
+        let result =
+            super::get_cached_or_refetch(&pool, artifact_id, &storage, storage_key, None, {
+                let refetch_calls = refetch_calls.clone();
+                let refetched_bytes = refetched_bytes.clone();
+                move || async move {
+                    refetch_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(refetched_bytes)
+                }
+            })
+            .await
+            .expect("miss path should recover via refetch");
 
         assert_eq!(result, refetched_bytes);
         // The hydration coordinator uses a double-checked-locking pattern: the
@@ -7881,6 +7965,161 @@ mod tests {
         };
         assert_eq!(recorded_key, storage_key);
         assert_eq!(recorded_bytes, refetched_bytes);
+    }
+
+    // ── #2929: the repair refetch must honour the artifact row's digest ──
+    //
+    // `get_cached_or_refetch` rewrites the artifact row's OWN storage key with
+    // bytes pulled fresh from upstream (or from a warm proxy-cache object under
+    // a different key). Nothing compared them to `artifacts.checksum_sha256`,
+    // so the row's recorded hash described a blob that no longer existed while
+    // an unrelated body was persisted and served under it — and
+    // `check_artifact_download` had already authorised on that row, which is
+    // what makes a quarantine release weaker than it appears.
+
+    /// The digest that `RecordingStorage`-backed tests below refetch against:
+    /// SHA-256 of `b"refetched-body"`.
+    fn refetched_body_digest() -> String {
+        crate::services::storage_service::StorageService::calculate_hash(&Bytes::from_static(
+            b"refetched-body",
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_get_cached_or_refetch_rejects_a_refetch_that_fails_the_recorded_digest() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+
+        let storage = RecordingStorage::new_with_get_behavior(false, RecordingGetBehavior::Miss);
+        let artifact_id = Uuid::new_v4();
+        let storage_key = "proxy-cache/repo/pkg/__content__";
+        // The row says one thing; the upstream repair hands back another.
+        let recorded_digest = refetched_body_digest();
+
+        let result = super::get_cached_or_refetch(
+            &pool,
+            artifact_id,
+            &storage,
+            storage_key,
+            Some(recorded_digest.as_str()),
+            move || async move { Ok(Bytes::from_static(b"a-completely-different-body")) },
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a refetch that does not match the artifact row's recorded checksum must fail \
+             the repair, not be served"
+        );
+        assert_eq!(
+            storage.put_calls.load(Ordering::SeqCst),
+            0,
+            "mismatched bytes MUST NOT be written back under the authorised row's storage key"
+        );
+    }
+
+    /// Positive control for the guard above. Without it, hard-failing every
+    /// repair — or writing back nothing at all — would satisfy the test above.
+    #[tokio::test]
+    async fn test_get_cached_or_refetch_writes_back_a_refetch_that_matches_the_digest() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+
+        let storage = RecordingStorage::new_with_get_behavior(false, RecordingGetBehavior::Miss);
+        let artifact_id = Uuid::new_v4();
+        let storage_key = "proxy-cache/repo/pkg/__content__";
+        let refetched_bytes = Bytes::from_static(b"refetched-body");
+        let recorded_digest = refetched_body_digest();
+
+        let result = super::get_cached_or_refetch(
+            &pool,
+            artifact_id,
+            &storage,
+            storage_key,
+            Some(recorded_digest.as_str()),
+            {
+                let refetched_bytes = refetched_bytes.clone();
+                move || async move { Ok(refetched_bytes) }
+            },
+        )
+        .await
+        .expect("a digest-matching refetch must still repair the entry");
+
+        assert_eq!(result, refetched_bytes);
+        assert_eq!(
+            storage.put_calls.load(Ordering::SeqCst),
+            1,
+            "a matching refetch must still be written back, or the guard has simply \
+             disabled proxy-cache repair"
+        );
+    }
+
+    /// A digest the comparison cannot use must degrade to the previous
+    /// unverified behaviour, NOT to a permanent failure. A `sha256:`-prefixed
+    /// or uppercase value would never equal the bare lowercase hex the hasher
+    /// produces, so treating it as authoritative would reject every repair
+    /// forever and re-pull upstream on every single request.
+    #[tokio::test]
+    async fn test_get_cached_or_refetch_ignores_a_non_canonical_digest() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+
+        let storage = RecordingStorage::new_with_get_behavior(false, RecordingGetBehavior::Miss);
+        let artifact_id = Uuid::new_v4();
+        let storage_key = "proxy-cache/repo/pkg/__content__";
+        let prefixed = format!("sha256:{}", refetched_body_digest());
+
+        let result = super::get_cached_or_refetch(
+            &pool,
+            artifact_id,
+            &storage,
+            storage_key,
+            Some(prefixed.as_str()),
+            move || async move { Ok(Bytes::from_static(b"refetched-body")) },
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "a non-canonical digest means 'no digest available' and must not fail the repair"
+        );
+        assert_eq!(storage.put_calls.load(Ordering::SeqCst), 1);
+    }
+
+    // ── #2929: normalize_expected_sha256 ────────────────────────────────
+
+    #[test]
+    fn test_normalize_expected_sha256_accepts_only_bare_lowercase_hex() {
+        let good = "a".repeat(64);
+        assert_eq!(
+            super::normalize_expected_sha256(&good),
+            Some(good.clone()),
+            "a bare lowercase 64-hex digest is the one enforceable shape"
+        );
+        assert_eq!(
+            super::normalize_expected_sha256(&format!("  {good}  ")),
+            Some(good.clone()),
+            "surrounding whitespace is not a different digest"
+        );
+
+        for bad in [
+            String::new(),
+            format!("sha256:{good}"),
+            good.to_uppercase(),
+            "a".repeat(63),
+            "a".repeat(65),
+            "g".repeat(64),
+            "d41d8cd98f00b204e9800998ecf8427e".to_string(), // md5
+        ] {
+            assert_eq!(
+                super::normalize_expected_sha256(&bad),
+                None,
+                "{bad:?} is not a comparable SHA-256 and must read as 'no digest'"
+            );
+        }
     }
 
     // ── classify_remote_or_virtual tests ───────────────────────────────

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -4645,26 +4645,45 @@ impl ProxyService {
     /// Returns `None` when no quota is configured or the lookup fails, which
     /// preserves today's unbounded behaviour rather than failing a fetch on a
     /// transient DB error.
+    ///
+    /// A non-positive `quota_bytes` (`0` or negative) is normalized to `None`,
+    /// because platform-wide that is the documented "unlimited" sentinel, not
+    /// "allow nothing" — see [`RepositoryService::quota_allows`], which reads
+    /// `Some(quota) if quota > 0` and treats everything else as unbounded
+    /// (CHANGELOG 1.2.2, #1970). Normalizing HERE rather than at each consumer
+    /// is deliberate: this function is what first makes the real column
+    /// reachable on the proxy paths, so without it, activating the guard would
+    /// silently invert the sentinel and disable proxy caching entirely for
+    /// every repo explicitly configured as unlimited.
     async fn resolve_quota_bytes(&self, repo: &Repository) -> Option<i64> {
-        if repo.quota_bytes.is_some() {
-            return repo.quota_bytes;
-        }
-        sqlx::query_scalar::<_, Option<i64>>("SELECT quota_bytes FROM repositories WHERE id = $1")
+        let raw = if repo.quota_bytes.is_some() {
+            repo.quota_bytes
+        } else {
+            sqlx::query_scalar::<_, Option<i64>>(
+                "SELECT quota_bytes FROM repositories WHERE id = $1",
+            )
             .bind(repo.id)
             .fetch_optional(&self.db)
             .await
             .ok()
             .flatten()
             .flatten()
+        };
+        raw.filter(|q| *q > 0)
     }
 
     /// The configured quota expressed as the per-object cache ceiling used by
-    /// the streaming write path, matching
-    /// [`cache_classifier::exceeds_single_object_quota`]'s semantics: the quota
-    /// is an inclusive ceiling, and a (nonsensical) negative quota rejects
-    /// every object rather than silently disabling the guard.
+    /// the streaming write path: the quota is an inclusive ceiling.
+    ///
+    /// Non-positive quotas mean "unlimited" and are expected to have been
+    /// normalized to `None` by [`Self::resolve_quota_bytes`] before they get
+    /// here. The `filter` below repeats that rather than trusting the caller,
+    /// because mapping a `0` sentinel to `Some(0)` would turn "unlimited" into
+    /// "cache nothing" — the inversion this helper existed to introduce.
     fn quota_to_cache_ceiling(quota_bytes: Option<i64>) -> Option<u64> {
-        quota_bytes.map(|q| u64::try_from(q).unwrap_or(0))
+        quota_bytes
+            .filter(|q| *q > 0)
+            .and_then(|q| u64::try_from(q).ok())
     }
 
     /// Read the optional repo-level `cache_ttl_secs` override. Returns `None`
@@ -9335,16 +9354,38 @@ mod tests {
             "no configured quota means no ceiling"
         );
         assert_eq!(ProxyService::quota_to_cache_ceiling(Some(100)), Some(100));
+        // 0 and negative are the platform's "unlimited" sentinel
+        // (`RepositoryService::quota_allows` reads `Some(q) if q > 0`,
+        // CHANGELOG 1.2.2 / #1970). Mapping them to `Some(0)` would invert
+        // the sentinel and disable proxy caching for every repo explicitly
+        // configured as unlimited.
         assert_eq!(
             ProxyService::quota_to_cache_ceiling(Some(0)),
-            Some(0),
-            "a zero quota caches nothing, matching exceeds_single_object_quota"
+            None,
+            "a zero quota is the unlimited sentinel, not a zero-byte ceiling"
         );
         assert_eq!(
             ProxyService::quota_to_cache_ceiling(Some(-1)),
-            Some(0),
-            "a negative quota must reject every object, not silently disable the guard"
+            None,
+            "a negative quota is the unlimited sentinel, matching quota_allows"
         );
+        // Cross-check the two helpers agree on the sentinel, so this cannot
+        // drift back apart silently.
+        for sentinel in [0i64, -1, i64::MIN] {
+            assert!(
+                crate::services::repository_service::RepositoryService::quota_allows(
+                    Some(sentinel),
+                    i64::MAX / 2,
+                    1
+                ),
+                "quota_allows treats {sentinel} as unlimited"
+            );
+            assert_eq!(
+                ProxyService::quota_to_cache_ceiling(Some(sentinel)),
+                None,
+                "so quota_to_cache_ceiling must too"
+            );
+        }
     }
 
     /// A `Repository` that already carries a real quota is used as-is, with no

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1546,6 +1546,16 @@ impl CachePersister {
     /// scenario the sidecar-bypassing read paths described on the reject
     /// arm below actually depend on (there is nothing bad ever sitting at
     /// `cache_key` for them to serve).
+    ///
+    /// `max_cache_bytes` is the per-object proxy-cache ceiling (#2928). When
+    /// `Some(limit)`, the tee counts the bytes it has handed to the cache
+    /// writer and, the moment the cumulative count would exceed `limit`,
+    /// abandons the CACHE half of the tee: it forwards an error to the writer
+    /// (so `put_stream` aborts and drops its partial object) and stops feeding
+    /// it, while continuing to yield every remaining byte to the client. That
+    /// matches the buffered path's over-quota behaviour — serve the body, skip
+    /// the cache write — except that it bounds bytes-to-disk mid-stream rather
+    /// than after the whole object has already landed.
     fn tee_stream(
         &self,
         upstream: BoxStream<'static, Result<Bytes>>,
@@ -1553,6 +1563,7 @@ impl CachePersister {
         metadata_key: String,
         template: CacheMetadataTemplate,
         expected_len: Option<u64>,
+        max_cache_bytes: Option<u64>,
     ) -> BoxStream<'static, Result<Bytes>> {
         let storage = Arc::clone(&self.storage);
         // Cloned into the spawned writer task so the streaming Commit arm can
@@ -1777,6 +1788,13 @@ impl CachePersister {
         // sees the error and aborts cleanly) and surface to the client.
         let tee_stream = async_stream::try_stream! {
             let mut upstream = upstream;
+            // #2928: cumulative bytes handed to the cache writer, and the
+            // latch that says we have stopped doing so. Counted on the tee
+            // side rather than after `put_stream` returns, because the whole
+            // point of the guard is to bound bytes-to-disk: a post-hoc check
+            // only fires once the unbounded object has already been written.
+            let mut cached_bytes: u64 = 0;
+            let mut cache_abandoned = false;
             while let Some(chunk_result) = upstream.next().await {
                 match chunk_result {
                     Ok(mut bytes) => {
@@ -1790,11 +1808,34 @@ impl CachePersister {
                         while !bytes.is_empty() {
                             let take = bytes.len().min(TEE_MAX_CHUNK_BYTES);
                             let slice = bytes.split_to(take);
+                            // #2928: over-ceiling check BEFORE the send, so the
+                            // chunk that crosses the limit is never written.
+                            // Forwarding an Err makes `put_stream` return Err,
+                            // which drops its partial object and takes the
+                            // writer down its existing abandon-the-cache arm —
+                            // no metadata sidecar, so the entry reads as a miss.
+                            if !cache_abandoned {
+                                if let Some(limit) = max_cache_bytes {
+                                    if cached_bytes.saturating_add(slice.len() as u64) > limit {
+                                        cache_abandoned = true;
+                                        let _ = tx.send(Err(AppError::Validation(format!(
+                                            "proxy-cache object exceeds the repository's \
+                                             single-object ceiling of {} bytes; abandoning the \
+                                             cache write and serving the body to the client",
+                                            limit
+                                        )))).await;
+                                    } else {
+                                        cached_bytes += slice.len() as u64;
+                                    }
+                                }
+                            }
                             // Best-effort send to the cache writer. If the
                             // writer is gone (it already failed and dropped
                             // its receiver), drop the caching half silently
                             // and keep yielding to the client.
-                            let _ = tx.send(Ok(slice.clone())).await;
+                            if !cache_abandoned {
+                                let _ = tx.send(Ok(slice.clone())).await;
+                            }
                             yield slice;
                         }
                     }
@@ -3007,8 +3048,17 @@ impl ProxyService {
                         // larger than the repository's configured quota on its
                         // own is never cached, even though nothing tracks
                         // cumulative usage below that ceiling yet.
+                        //
+                        // #2928: the quota is resolved from the repository row
+                        // rather than read off `repo.quota_bytes`. Every
+                        // handler-driven proxy fetch synthesizes its
+                        // `Repository` with `quota_bytes: None` hardcoded, so
+                        // reading the field directly made this guard inert on
+                        // exactly the paths that serve proxy traffic. See
+                        // [`Self::resolve_quota_bytes`].
+                        let quota_bytes = self.resolve_quota_bytes(repo).await;
                         let quota_ok = !cache_classifier::exceeds_single_object_quota(
-                            repo.quota_bytes,
+                            quota_bytes,
                             resp.content.len() as i64,
                         );
                         if !quota_ok {
@@ -3018,7 +3068,7 @@ impl ProxyService {
                                 cache_key = %cache_key,
                                 path = %cache_path,
                                 object_len = resp.content.len(),
-                                quota_bytes = ?repo.quota_bytes,
+                                quota_bytes = ?quota_bytes,
                                 "proxy-fetched object exceeds repository quota_bytes; skipping \
                                  cache write (Phase-1 interim single-object guard, serving body \
                                  to client)"
@@ -3581,6 +3631,40 @@ impl ProxyService {
             commit_sha: upstream.commit_sha.clone(),
         };
 
+        // #2928: the streaming write path had no byte bound of any kind — the
+        // `TEE_CHANNEL_DEPTH * TEE_MAX_CHUNK_BYTES` budget bounds MEMORY per
+        // stream, not total bytes written. Resolve the repository's
+        // single-object ceiling and apply it on both sides:
+        //
+        //   * pre-flight, when the upstream advertises a `Content-Length` over
+        //     the ceiling: skip the cache tee entirely and hand the client the
+        //     raw upstream body, so not one byte is written;
+        //   * mid-stream otherwise (see [`CachePersister::tee_stream`]), which
+        //     is what covers a chunked / connection-close upstream that never
+        //     advertises a length.
+        //
+        // Either way the client is still served in full, matching the buffered
+        // path's over-quota behaviour.
+        let max_cache_bytes = Self::quota_to_cache_ceiling(self.resolve_quota_bytes(repo).await);
+        if let (Some(limit), Some(advertised)) = (max_cache_bytes, upstream.content_length) {
+            if advertised > limit {
+                tracing::warn!(
+                    target: "security",
+                    repository = %repo.key,
+                    path = %cache_path,
+                    advertised_bytes = advertised,
+                    quota_bytes = limit,
+                    "upstream advertises an object larger than the repository quota; \
+                     streaming it to the client without any proxy-cache write"
+                );
+                crate::services::metrics_service::record_proxy_cache_quota_exceeded(&repo.key);
+                return Ok(StreamHandle {
+                    body: upstream.body,
+                    headers,
+                });
+            }
+        }
+
         let body = self.cache_persister.tee_stream(
             upstream.body,
             cache_key,
@@ -3600,6 +3684,7 @@ impl ProxyService {
                 upstream_url: Some(full_url.clone()),
             },
             upstream.content_length,
+            max_cache_bytes,
         );
 
         Ok(StreamHandle { body, headers })
@@ -4536,6 +4621,50 @@ impl ProxyService {
                     .unwrap_or(default_ttl_secs)
             }
         }
+    }
+
+    /// Resolve the repository's configured `quota_bytes` (#2928).
+    ///
+    /// Every handler-driven proxy fetch synthesizes its [`Repository`] through
+    /// `proxy_helpers::build_remote_repo_with_format`, which hardcodes
+    /// `quota_bytes: None`. That made the single-object guard at the buffered
+    /// cache-write site structurally unreachable: it read `repo.quota_bytes`,
+    /// which was `None` on every path that actually serves proxy traffic, and
+    /// `cache_classifier::exceeds_single_object_quota(None, _)` is `false`
+    /// unconditionally. So an operator who set a quota on a Remote repository
+    /// got no enforcement and no warning.
+    ///
+    /// Rather than thread the column through the eight `proxy_fetch*` wrapper
+    /// signatures (and leave the next synthesizing helper free to reintroduce
+    /// the same hole), resolve it here from `repo.id` — the synthesized repo
+    /// does carry the true id. Same shape as
+    /// [`Self::get_cache_ttl_override`], which exists for the same reason.
+    /// A repo that already carries a real value (a row loaded from the DB)
+    /// short-circuits without a query.
+    ///
+    /// Returns `None` when no quota is configured or the lookup fails, which
+    /// preserves today's unbounded behaviour rather than failing a fetch on a
+    /// transient DB error.
+    async fn resolve_quota_bytes(&self, repo: &Repository) -> Option<i64> {
+        if repo.quota_bytes.is_some() {
+            return repo.quota_bytes;
+        }
+        sqlx::query_scalar::<_, Option<i64>>("SELECT quota_bytes FROM repositories WHERE id = $1")
+            .bind(repo.id)
+            .fetch_optional(&self.db)
+            .await
+            .ok()
+            .flatten()
+            .flatten()
+    }
+
+    /// The configured quota expressed as the per-object cache ceiling used by
+    /// the streaming write path, matching
+    /// [`cache_classifier::exceeds_single_object_quota`]'s semantics: the quota
+    /// is an inclusive ceiling, and a (nonsensical) negative quota rejects
+    /// every object rather than silently disabling the guard.
+    fn quota_to_cache_ceiling(quota_bytes: Option<i64>) -> Option<u64> {
+        quota_bytes.map(|q| u64::try_from(q).unwrap_or(0))
     }
 
     /// Read the optional repo-level `cache_ttl_secs` override. Returns `None`
@@ -8722,6 +8851,7 @@ mod tests {
             metadata_key,
             template,
             None,
+            None,
         )
     }
 
@@ -8943,6 +9073,7 @@ mod tests {
             "meta-key".to_string(),
             template(),
             Some(100),
+            None,
         );
 
         let mut total: usize = 0;
@@ -9038,6 +9169,267 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // #2928: per-object byte ceiling on the STREAMING proxy-cache write.
+    //
+    // The streaming path had no byte bound of any kind. `TEE_CHANNEL_DEPTH *
+    // TEE_MAX_CHUNK_BYTES` bounds MEMORY per stream (~4 MiB in flight); the
+    // chunk splitting preserves the total payload, so an upstream response of
+    // any size was written to cache storage in full, with no eviction path.
+    // The one guard that existed (`exceeds_single_object_quota`) was on the
+    // buffered path AND was fed `repo.quota_bytes` off a synthesized
+    // `Repository` that hardcodes `None`, so it never fired either.
+    // -----------------------------------------------------------------------
+
+    /// Build a `max_cache_bytes`-sized-ish upstream: `total` bytes delivered in
+    /// 64 KiB pieces, with no advertised `Content-Length` (the connection-close
+    /// / chunked framing case, which is also where the #2929 truncation gap
+    /// lives).
+    fn upstream_of_len(total: usize) -> BoxStream<'static, Result<Bytes>> {
+        let piece = Bytes::from(vec![0xABu8; 64 * 1024]);
+        let mut chunks = Vec::new();
+        let mut left = total;
+        while left > 0 {
+            let take = left.min(piece.len());
+            chunks.push(Ok(piece.slice(0..take)));
+            left -= take;
+        }
+        Box::pin(futures::stream::iter(chunks))
+    }
+
+    async fn run_tee_with_ceiling(
+        backend: Arc<TeeRecordingBackend>,
+        total: usize,
+        max_cache_bytes: Option<u64>,
+    ) -> usize {
+        let storage = Arc::new(RealStorageService::new(backend));
+        let mut client = CachePersister::new(test_catalog_pool(), storage).tee_stream(
+            upstream_of_len(total),
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            template(),
+            None, // upstream advertised no Content-Length
+            max_cache_bytes,
+        );
+        let mut served = 0usize;
+        while let Some(chunk) = client.next().await {
+            served += chunk.expect("client stream must not error").len();
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        served
+    }
+
+    /// The guard. A body past the repository's single-object ceiling must be
+    /// served to the client in full, but must NOT be cached: no metadata
+    /// sidecar (so the entry reads as a miss), and the bytes handed to the
+    /// storage writer must stop at the ceiling rather than running to the end
+    /// of the object.
+    ///
+    /// Revert-proof: delete the `max_cache_bytes` check in `tee_stream`'s
+    /// forward loop and this fails on both assertions — the sidecar is written
+    /// and all 4 MiB reach storage.
+    #[tokio::test]
+    async fn test_tee_abandons_cache_write_past_the_object_ceiling() {
+        const LIMIT: u64 = 1024 * 1024;
+        const TOTAL: usize = 4 * 1024 * 1024;
+
+        let backend = TeeRecordingBackend::ok();
+        let served = run_tee_with_ceiling(backend.clone(), TOTAL, Some(LIMIT)).await;
+
+        assert_eq!(
+            served, TOTAL,
+            "the client must still receive the whole body; the ceiling bounds the CACHE \
+             write, not the response"
+        );
+        assert!(
+            backend.metadata_writes.lock().await.is_empty(),
+            "an over-ceiling object MUST NOT write a metadata sidecar, or it becomes a \
+             warm cache hit forever"
+        );
+        let written: usize = backend
+            .put_stream_chunks
+            .lock()
+            .await
+            .iter()
+            .map(|c| c.len())
+            .sum();
+        assert!(
+            (written as u64) <= LIMIT,
+            "bytes-to-storage must stop at the ceiling ({LIMIT}), got {written}; a check \
+             that only fires after put_stream returns has already written the whole object"
+        );
+    }
+
+    /// Positive control 1: an object UNDER the ceiling still caches normally.
+    /// Without this, `if true { abandon }` would satisfy the guard test above.
+    #[tokio::test]
+    async fn test_tee_caches_an_object_under_the_ceiling() {
+        const LIMIT: u64 = 1024 * 1024;
+        const TOTAL: usize = 256 * 1024;
+
+        let backend = TeeRecordingBackend::ok();
+        let served = run_tee_with_ceiling(backend.clone(), TOTAL, Some(LIMIT)).await;
+
+        assert_eq!(served, TOTAL, "client receives the body");
+        assert_eq!(
+            backend.metadata_writes.lock().await.len(),
+            1,
+            "an under-ceiling object must still be cached"
+        );
+        let written: usize = backend
+            .put_stream_chunks
+            .lock()
+            .await
+            .iter()
+            .map(|c| c.len())
+            .sum();
+        assert_eq!(written, TOTAL, "the whole under-ceiling object is written");
+    }
+
+    /// Positive control 2: an object exactly AT the ceiling is accepted. The
+    /// quota is an inclusive ceiling, matching
+    /// `cache_classifier::exceeds_single_object_quota`, so an off-by-one here
+    /// would silently stop caching objects the buffered path accepts.
+    #[tokio::test]
+    async fn test_tee_caches_an_object_exactly_at_the_ceiling() {
+        const LIMIT: u64 = 256 * 1024;
+
+        let backend = TeeRecordingBackend::ok();
+        let served = run_tee_with_ceiling(backend.clone(), LIMIT as usize, Some(LIMIT)).await;
+
+        assert_eq!(served, LIMIT as usize);
+        assert_eq!(
+            backend.metadata_writes.lock().await.len(),
+            1,
+            "an object exactly at the quota does NOT exceed it (inclusive ceiling)"
+        );
+    }
+
+    /// Positive control 3: with no ceiling configured, behaviour is unchanged —
+    /// an arbitrarily large object still caches. The guard must not become a
+    /// silent global cap on repositories that never configured a quota.
+    #[tokio::test]
+    async fn test_tee_without_a_ceiling_caches_an_arbitrarily_large_object() {
+        const TOTAL: usize = 4 * 1024 * 1024;
+
+        let backend = TeeRecordingBackend::ok();
+        let served = run_tee_with_ceiling(backend.clone(), TOTAL, None).await;
+
+        assert_eq!(served, TOTAL);
+        assert_eq!(
+            backend.metadata_writes.lock().await.len(),
+            1,
+            "no configured quota means no ceiling; this path must be unchanged"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2928: making the quota reachable at all.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_quota_to_cache_ceiling_table() {
+        assert_eq!(
+            ProxyService::quota_to_cache_ceiling(None),
+            None,
+            "no configured quota means no ceiling"
+        );
+        assert_eq!(ProxyService::quota_to_cache_ceiling(Some(100)), Some(100));
+        assert_eq!(
+            ProxyService::quota_to_cache_ceiling(Some(0)),
+            Some(0),
+            "a zero quota caches nothing, matching exceeds_single_object_quota"
+        );
+        assert_eq!(
+            ProxyService::quota_to_cache_ceiling(Some(-1)),
+            Some(0),
+            "a negative quota must reject every object, not silently disable the guard"
+        );
+    }
+
+    /// A `Repository` that already carries a real quota is used as-is, with no
+    /// query. Proven by handing the service a pool that can never connect: if
+    /// the short-circuit were removed this would fall through to the lookup,
+    /// fail, and return `None`.
+    #[tokio::test]
+    async fn test_resolve_quota_bytes_uses_a_quota_already_on_the_repo() {
+        let backend = TeeRecordingBackend::ok();
+        let service = build_proxy_service_with_storage(backend);
+        let mut repo = crate::api::handlers::proxy_helpers::build_remote_repo_with_format(
+            Uuid::new_v4(),
+            "npm-remote",
+            "https://registry.npmjs.org",
+            crate::models::repository::RepositoryFormat::Npm,
+        );
+        repo.quota_bytes = Some(4096);
+
+        assert_eq!(service.resolve_quota_bytes(&repo).await, Some(4096));
+    }
+
+    /// A failed lookup degrades to "no quota" rather than failing the fetch:
+    /// a transient DB error must not turn every proxy download into an error.
+    #[tokio::test]
+    async fn test_resolve_quota_bytes_degrades_to_none_when_the_lookup_fails() {
+        let backend = TeeRecordingBackend::ok();
+        let service = build_proxy_service_with_storage(backend);
+        let repo = crate::api::handlers::proxy_helpers::build_remote_repo_with_format(
+            Uuid::new_v4(),
+            "npm-remote",
+            "https://registry.npmjs.org",
+            crate::models::repository::RepositoryFormat::Npm,
+        );
+        assert_eq!(repo.quota_bytes, None);
+
+        assert_eq!(service.resolve_quota_bytes(&repo).await, None);
+    }
+
+    /// The reachability proof for #2928 finding 1, against a real row.
+    ///
+    /// `build_remote_repo_with_format` is what EVERY handler-driven proxy fetch
+    /// uses, and it hardcodes `quota_bytes: None`. Reading the field directly —
+    /// which is what the buffered guard did — therefore fed
+    /// `exceeds_single_object_quota(None, _)`, which is `false` unconditionally.
+    /// Resolving by `repo.id` recovers the operator's configured value.
+    ///
+    /// Revert-proof: change `resolve_quota_bytes` back to `repo.quota_bytes`
+    /// and the final assertion fails with `None`.
+    #[tokio::test]
+    async fn test_resolve_quota_bytes_reads_the_row_for_a_synthesized_proxy_repo() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        sqlx::query("UPDATE repositories SET quota_bytes = $1 WHERE id = $2")
+            .bind(1_048_576i64)
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("set quota_bytes");
+
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend));
+        let service = ProxyService::new(fx.pool.clone(), storage);
+
+        let repo = crate::api::handlers::proxy_helpers::build_remote_repo_with_format(
+            fx.repo_id,
+            &fx.repo_key,
+            "https://registry.npmjs.org",
+            crate::models::repository::RepositoryFormat::Npm,
+        );
+        assert_eq!(
+            repo.quota_bytes, None,
+            "the synthesized proxy Repository still hardcodes None; that is exactly why \
+             the guard has to resolve the value instead of reading the field"
+        );
+        assert_eq!(
+            service.resolve_quota_bytes(&repo).await,
+            Some(1_048_576),
+            "the operator's configured quota must reach the guard"
+        );
+
+        fx.teardown().await;
+    }
+
     /// A complete streamed body whose byte count matches the advertised
     /// `Content-Length` is cached normally — the #1912 guard does not fire on
     /// well-formed responses.
@@ -9053,6 +9445,7 @@ mod tests {
             "meta-key".to_string(),
             template(),
             Some(11),
+            None,
         );
         while let Some(chunk) = client.next().await {
             let _ = chunk.unwrap();
@@ -9088,6 +9481,7 @@ mod tests {
             "meta-key".to_string(),
             template(),
             Some(11),
+            None,
         );
         while let Some(chunk) = client.next().await {
             let _ = chunk.unwrap();
@@ -9121,6 +9515,7 @@ mod tests {
                 "meta-key".to_string(),
                 template(),
                 None,
+                None,
             );
 
         let committing = upstream_chunks(vec![&b"first-chunk"[..]]);
@@ -9130,6 +9525,7 @@ mod tests {
             "meta-key".to_string(),
             template(),
             Some(11),
+            None,
         );
 
         // Drain both client streams concurrently, mirroring two real
@@ -9235,6 +9631,7 @@ mod tests {
             "proxy-cache/repo/errored".to_string(),
             "proxy-cache/repo/errored.meta".to_string(),
             template(),
+            None,
             None,
         );
         let mut saw_error = false;
@@ -9351,6 +9748,7 @@ mod tests {
             "proxy-cache/repo/truncated.meta".to_string(),
             template(),
             Some(999),
+            None,
         );
         while let Some(chunk) = client.next().await {
             let _ = chunk.unwrap();
@@ -9437,6 +9835,7 @@ mod tests {
             "proxy-cache/repo/committed.meta".to_string(),
             template(),
             Some(body.len() as u64),
+            None,
         );
         let mut client_bytes = Vec::new();
         while let Some(chunk) = client.next().await {
@@ -9471,6 +9870,7 @@ mod tests {
                 // Content-Length lies: 999 promised, 5 delivered -> truncated
                 // upstream, which classify_stream_write rejects.
                 Some(999),
+                None,
             );
         while let Some(chunk) = reject_client.next().await {
             let _ = chunk.unwrap();
@@ -9513,6 +9913,7 @@ mod tests {
             "meta-key".to_string(),
             mismatched_template,
             Some(11),
+            None,
         );
         while let Some(chunk) = client.next().await {
             let _ = chunk.unwrap();


### PR DESCRIPTION
## Summary

Fixes #2929 and Fixes #2928 — one family: a digest that is already recorded locally was never enforced against cached bytes, and the streamed cache write had no byte bound while the one guard that existed was unreachable.

### #2929 — enforce digests that are already in hand

**cargo.** The Remote `.crate` download called `proxy_fetch_streaming_with_cache_key`, the wrapper that hardcodes `expected_checksum: None`. This same handler serves the sparse-index entry carrying `cksum` — exactly what cargo verifies the download against — so the digest was decorative. It now resolves the index `cksum` for `{name}/{version}` and routes the download through the digest-gated `_verified` sibling. On a split-host registry (crates.io serves `index.crates.io` separately from the download host) this catches a misbehaving or compromised download host while the index is intact, and it catches ordinary corruption or a clean-EOF truncation on either. A body that fails the gate is still streamed to the client, which verifies independently; it is only kept out of the cache.

**nuget.** The missing-file repair refetched from upstream and wrote the bytes back under the artifact row's own storage key without ever comparing them to that row's `checksum_sha256` — a column the SELECT already fetched and nothing read. `check_artifact_download` authorises on that row, so an admin releasing an artifact from quarantine was approving a hash never enforced against what clients then received. `get_cached_or_refetch` now verifies before the write-back and fails the repair on a mismatch rather than persisting and serving it.

A digest is enforced only when it is a bare lowercase 64-hex SHA-256 (`normalize_expected_sha256`). A `sha256:`-prefixed, uppercase, or otherwise non-canonical value reads as "no digest available" and falls through to the previous behaviour. That fallback is load-bearing: a value the comparison can never match would reject the entry on every fetch, nothing would cache, and every request would re-pull upstream.

### #2928 — bound the streamed write, and make the quota reachable

`exceeds_single_object_quota` read `repo.quota_bytes` off the `Repository` that every handler-driven proxy fetch synthesizes via `build_remote_repo_with_format`, which hardcodes `quota_bytes: None`. `exceeds_single_object_quota(None, _)` is `false` unconditionally, so the guard was **structurally unreachable** on every path that serves proxy traffic — an operator who configured a quota on a Remote repo got no enforcement and no warning. The value is now resolved from the repository row by `repo.id`, in the same shape as the existing `get_cache_ttl_override`, rather than read off the synthesized field — so a future synthesizing helper cannot reintroduce the hole.

The streaming leader had no size check at all. `TEE_CHANNEL_DEPTH * TEE_MAX_CHUNK_BYTES` bounds *memory* per stream (~4 MiB in flight); the chunk splitting preserves the whole payload, so nothing counted cumulative bytes. The resolved ceiling now applies on both sides:

* **pre-flight**, when the upstream advertises a `Content-Length` over the ceiling — the tee is skipped entirely and not one byte is written;
* **mid-stream** otherwise (the chunked / connection-close case, where no length is advertised) — `tee_stream` counts what it hands the writer and abandons the cache write the moment the count would pass the ceiling.

Enforcing mid-stream rather than after `put_stream` returns is the point: a post-hoc check only fires once the unbounded object has already landed on disk. The client is served in full either way, matching the buffered path's over-quota behaviour.

### Scope notes

* **No schema migration, no API break.** Patch-shaped.
* **#2929 Fix item 4** (a fallback reject signal when the stream ends with a transport error rather than a clean EOF) is **already implemented on main** and already tested — `test_tee_upstream_error_mid_stream_aborts_cache`. `put_stream` returns `Err` on a stream error, so the writer skips the sidecar. The irreducible residual is a *clean* EOF short of the true length with no `Content-Length`, which is indistinguishable from a complete response at the protocol level; only a digest catches it, which is what the #2929 half of this PR does for the paths that have one. Nothing was changed there.
* **#2928 Fix item 3** (a global proxy-cache size cap with eviction) is deliberately **not** in scope — it depends on the proxy-cache accounting work in #1278 / #2270, as the issue itself states. Repositories with no configured quota keep today's unbounded behaviour; a positive control test pins that.
* **Composition with #3153.** #3153 rewrites `tee_stream` to stage-then-publish. This PR builds on top of it and does not fight it: every edit here is outside every hunk #3153 touches. The signature gains one parameter, and the enforcement lives in the client-facing `async_stream::try_stream!` forward loop, which #3153 leaves untouched; #3153's changes are confined to the spawned writer task. The mechanism is also complementary — this abandons the write by making `put_stream` fail, which under #3153 fails against the staging key and never reaches the live key at all.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Both issues were reproduced against this PR's base (`452b001`) before any code was written. Real output from that run:

```
REPRO-2928-A synthesized repo.quota_bytes = None
REPRO-2928-A exceeds_single_object_quota(repo.quota_bytes, 1 TiB) = false
REPRO-2928-A exceeds_single_object_quota(Some(1 MiB), 1 TiB) = true   <- guard is correct; the value it is fed is not
REPRO-2928-B client bytes = 8388608 ; bytes written to cache = 8388608 ; sidecar writes = 1
REPRO-2929-2 classify_stream_write(11, None) = Commit
REPRO-2929-2 sidecar writes = 1 ; deletes = []
```

Every new guard was revert-proved — the guard reverted, the test re-run, and confirmed to fail:

| Guard reverted | Test that fails |
|---|---|
| `tee_stream` ceiling check removed | `test_tee_abandons_cache_write_past_the_object_ceiling` — *"an over-ceiling object MUST NOT write a metadata sidecar"* |
| `resolve_quota_bytes` → `repo.quota_bytes` | `test_resolve_quota_bytes_reads_the_row_for_a_synthesized_proxy_repo` — `left: None, right: Some(1048576)` |
| refetch digest check removed | `test_get_cached_or_refetch_rejects_a_refetch_that_fails_the_recorded_digest` |
| cargo back on the unverified helper | `test_cargo_remote_download_uses_the_verified_streaming_helper_2929` |

Positive controls are present so no guard can be satisfied by rejecting everything: an object **under** the ceiling still caches; an object **exactly at** the ceiling is accepted (inclusive, matching `exceeds_single_object_quota`); with **no** ceiling configured an arbitrarily large object still caches; a digest-**matching** refetch is still written back; a non-canonical digest still repairs.

## Test Checklist
- [x] Unit tests added/updated — 20 new in-crate tests across `proxy_service.rs`, `proxy_helpers.rs`, `cargo.rs`
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Gates run locally against an isolated Postgres:

```
cargo fmt --check                                       clean
cargo clippy --workspace --all-targets -- -D warnings   clean
cargo nextest run --workspace --lib                     14739 passed, 0 failed, 6 skipped
```

`nextest` rather than `cargo test --workspace`: with `AK_TESTS_REQUIRE_DB=1` the whole-suite runner produces bogus "Connection refused" failures because `config.rs` tests set `DATABASE_URL` process-wide.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
