### PR TITLE
fix(repositories): scope virtual repo member and artifact listings to caller-visible members

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -337,28 +337,32 @@ pub(crate) fn member_grant_visibility(auth: Option<&AuthExtension>) -> RepoVisib
 
 /// The SCOPE half, applied per member row.
 ///
-/// A public member bypasses scope entirely, matching `require_visible`'s
-/// early return. Otherwise the member passes when it is itself in scope, OR
-/// when the PARENT virtual is — read-through.
+/// A public member bypasses scope entirely, matching `require_visible`'s early
+/// return. Otherwise the member must itself be in the token's scope.
 ///
-/// Read-through is a deliberate choice, not an oversight. Scoping a token to a
-/// virtual repository is the canonical way to point CI at one, and the
-/// by-path download through that virtual already serves member bytes for such
-/// a token. Without read-through the listing returns `200 OK` with zero items
-/// while the download of those same items succeeds — two answers to one
-/// question. The grant half still applies on top, so this widens which members
-/// a token may ENUMERATE, never which a user may READ.
+/// An earlier revision also passed when the PARENT virtual was in scope,
+/// arguing that the by-path download already read through. That premise was
+/// wrong: `proxy_helpers::caller_can_read_member` gates on
+/// `can_access_repo(member.id)` and has no parent term anywhere, so a token
+/// scoped to a virtual but not to a member is DENIED that member's bytes.
+/// Read-through would have created the inconsistency it claimed to remove,
+/// reversed — and widened enumeration past `require_visible`, letting a token
+/// list artifact names, versions and sizes for a member it is scoped away
+/// from. Strict scoping is what agrees with both.
+///
+/// Consequence, accepted deliberately: a token scoped only to a virtual sees
+/// an empty listing. That is consistent with the download, which also refuses.
+/// Scope tokens to the members, or to both.
 pub(crate) fn member_passes_token_scope(
     auth: Option<&AuthExtension>,
     parent_repo_id: Uuid,
     member_id: Uuid,
     member_is_public: bool,
 ) -> bool {
+    let _ = parent_repo_id;
     match auth {
         None => member_is_public,
-        Some(a) => {
-            member_is_public || a.can_access_repo(parent_repo_id) || a.can_access_repo(member_id)
-        }
+        Some(a) => member_is_public || a.can_access_repo(member_id),
     }
 }
 
@@ -8701,7 +8705,8 @@ pub async fn add_virtual_member(
             vrm.created_at,
             r.key as member_key,
             r.name as member_name,
-            r.repo_type
+            r.repo_type,
+            r.is_public
         FROM virtual_repo_members vrm
         INNER JOIN repositories r ON r.id = vrm.member_repo_id
         WHERE vrm.virtual_repo_id = $1 AND vrm.member_repo_id = $2
@@ -22919,6 +22924,10 @@ mod virtual_member_visibility_tests {
         let at = fx.scoped_admin_token(vec![fx.virt_id]);
         let (adm_status, adm_keys) = fx.members_seen(at).await;
 
+        // Positive control: same caller, member now IN scope.
+        let it2 = fx.scoped_token(&fx.insider, vec![fx.virt_id, fx.private_id]);
+        let (ins2_status, ins2_keys) = fx.members_seen(it2).await;
+
         let (private_key, public_key) = (fx.private_key.clone(), fx.public_key.clone());
         fx.cleanup().await;
 
@@ -22926,11 +22935,13 @@ mod virtual_member_visibility_tests {
         assert_eq!(ins_status, StatusCode::OK);
         assert_eq!(adm_status, StatusCode::OK);
 
-        // Read-through + the public arm the `Ids` arm had dropped.
+        // The public arm the `Ids` arm had dropped: a public member is
+        // readable regardless of scope, matching `require_visible`'s early
+        // return on `is_public`.
         assert!(
             virt_keys.contains(&public_key),
-            "a token scoped to the virtual must reach its public member, or \
-             the listing contradicts the download path; got {virt_keys:?}"
+            "a public member is readable regardless of token scope; \
+             got {virt_keys:?}"
         );
         // The grant half still applies.
         assert!(
@@ -22938,14 +22949,32 @@ mod virtual_member_visibility_tests {
             "token scope must not substitute for a grant: {private_key} has no \
              grant for this caller; got {virt_keys:?}"
         );
+        // STRICT scoping: the private member is NOT in this token's scope, so
+        // even a caller who holds the grant must not enumerate it. This is what
+        // agrees with the download path -- `caller_can_read_member` gates on
+        // `can_access_repo(member.id)` with no parent term, so read-through
+        // here would let a token list what it cannot fetch.
         assert!(
-            ins_keys.contains(&private_key),
-            "a scoped token whose owner HOLDS the grant must still see \
-             {private_key}; got {ins_keys:?}"
+            !ins_keys.contains(&private_key),
+            "a token scoped only to the virtual must not enumerate a private \
+             member outside its scope, because the download refuses it too; \
+             got {ins_keys:?}"
         );
+        // Scope the token to the MEMBER and the same caller does see it --
+        // the positive control, without which the assertion above is
+        // satisfied by a filter that hides everything.
+        assert_eq!(ins2_status, StatusCode::OK);
         assert!(
-            adm_keys.contains(&public_key) && adm_keys.contains(&private_key),
-            "an admin token scoped to the virtual reaches its members; \
+            ins2_keys.contains(&private_key),
+            "with {private_key} in scope AND a grant, it must be listed; \
+             got {ins2_keys:?}"
+        );
+        // An admin token scoped to the virtual only: the scope still binds.
+        // Before the fix `is_admin` was matched ahead of `Restricted`, so the
+        // scope was discarded entirely and every member was listed.
+        assert!(
+            !adm_keys.contains(&private_key),
+            "an admin's deliberately-scoped token must stay scoped; \
              got {adm_keys:?}"
         );
     }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4656,6 +4656,7 @@ pub async fn list_artifacts(
             count_exact,
             page,
             per_page,
+            &visibility_for_auth(auth.as_ref()),
         )
         .await;
     }
@@ -4729,7 +4730,16 @@ pub async fn list_artifacts(
                 AppError::Internal("Failed to resolve virtual repository members".to_string())
             })?;
 
+        // #3163: `fetch_virtual_members` applies NO access predicate — only
+        // the virtual PARENT was `require_visible`d above. Aggregating over
+        // the raw member set therefore served the contents of private member
+        // repositories to anyone who could see the parent. Narrow to the
+        // members this caller may see, using the same predicate as the
+        // repository listing and `GET /{key}/members`.
         let member_ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
+        let member_ids = repo_service
+            .filter_visible_repo_ids(&member_ids, &visibility_for_auth(auth.as_ref()))
+            .await?;
 
         let page_rows = artifact_service
             .list_for_repos_page(
@@ -5579,6 +5589,10 @@ async fn list_artifacts_grouped_by_maven_component(
     count_exact: bool,
     page: u32,
     per_page: u32,
+    // The CALLER's repository visibility (#3163). Only consulted for a
+    // Virtual repo, whose members are separate repositories with their own
+    // ACLs; a non-virtual repo is already gated by `require_visible`.
+    visibility: &RepoVisibility,
 ) -> Result<Json<ArtifactListResponse>> {
     // Remote (proxy) repositories do NOT record cached items in the `artifacts`
     // table (#1278 / #1280), so `artifact_service.list` returns nothing for them
@@ -5660,7 +5674,14 @@ async fn list_artifacts_grouped_by_maven_component(
             .map_err(|_| {
                 AppError::Internal("Failed to resolve virtual repository members".to_string())
             })?;
-        members.iter().map(|m| m.id).collect()
+        // #3163: same unfiltered member walk as the flat listing — narrow to
+        // the members this caller may see before the catalog is queried, so a
+        // private member's GAV coordinates are not disclosed through the
+        // grouped view.
+        let member_ids: Vec<Uuid> = members.iter().map(|m| m.id).collect();
+        RepositoryService::new(state.db.clone())
+            .filter_visible_repo_ids(&member_ids, visibility)
+            .await?
     } else {
         vec![repo.id]
     };
@@ -8462,7 +8483,20 @@ pub async fn list_virtual_members(
     }
 
     // Caller must be able to see the virtual parent itself.
+    //
+    // BOTH gates run, because they answer different questions and neither
+    // subsumes the other (#3163):
+    //  * `require_repo_access` is the TOKEN-SCOPE check. It is kept ahead of
+    //    the visibility gate because `require_visible` short-circuits `Ok` on
+    //    a public repository, which would otherwise let a repo-scoped token
+    //    reach a public virtual outside its allowed set.
+    //  * `require_visible` is the canonical repository VISIBILITY gate. It was
+    //    missing entirely: token scope passes for any unscoped principal, so a
+    //    browser session holding no grant on a PRIVATE virtual repository
+    //    could confirm it exists and read its membership — while `GET /{key}`
+    //    on that same repository correctly 404s.
     require_repo_access(&auth, repo.id)?;
+    require_visible(&repo, &Some(auth.clone()), &service).await?;
 
     // Query members with their repository info
     let members: Vec<VirtualMemberRow> = sqlx::query_as(
@@ -8486,12 +8520,26 @@ pub async fn list_virtual_members(
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
 
-    // Filter to members the caller has access to. Tokens with
-    // allowed_repo_ids = None (admins, JWT sessions, unrestricted API tokens)
-    // see everything by virtue of `can_access_repo` returning true.
+    // Filter to the members this caller may actually SEE (#3163).
+    //
+    // This used to be `auth.can_access_repo(row.member_repo_id)`, which is the
+    // caller's TOKEN SCOPE, not repository visibility: for any unscoped
+    // principal — a browser JWT session, an unrestricted API token, an admin —
+    // it returns `true` for every repository in the instance, so the response
+    // disclosed the key, name and type of private member repositories the
+    // caller holds no grant on. Members are separate repositories with their
+    // own ACLs, so they are filtered through the SAME predicate the repository
+    // listing uses. Priority order is preserved.
+    let visibility = visibility_for_auth(Some(&auth));
+    let member_ids: Vec<Uuid> = members.iter().map(|row| row.member_repo_id).collect();
+    let visible: std::collections::HashSet<Uuid> = service
+        .filter_visible_repo_ids(&member_ids, &visibility)
+        .await?
+        .into_iter()
+        .collect();
     let members = members
         .into_iter()
-        .filter(|row| auth.can_access_repo(row.member_repo_id))
+        .filter(|row| visible.contains(&row.member_repo_id))
         .map(map_member_row)
         .collect();
 
@@ -22436,5 +22484,440 @@ mod content_encoding_forwarding_tests {
              coding (#3149)",
         );
         assert_eq!(&body[..], &coded[..]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #3163: virtual-repository member disclosure
+// ---------------------------------------------------------------------------
+
+/// A virtual repository must not disclose its members — or those members'
+/// contents — to a caller who is not allowed to see the member repositories
+/// themselves (issue #3163).
+///
+/// Every fixture here is three-repository shaped:
+///
+/// * `virt`    — the virtual parent. Private; `viewer` and `insider` hold a
+///   grant on it, `outsider` holds nothing.
+/// * `private` — a PRIVATE member. Only `insider` (and admins) may see it.
+/// * `public`  — a PUBLIC member. Everyone may see it.
+///
+/// so every leak assertion (`private` must be absent) ships with a positive
+/// control (`public` must still be listed, and `insider`/admin must still see
+/// `private`). A "fix" that hid every member would fail the controls.
+///
+/// The caller shape that matters is [`tdh::make_auth`]: a non-admin principal
+/// with `allowed_repo_ids = AccessScope::Admin` — i.e. unrestricted token
+/// scope. That is exactly a browser JWT session, and it is the shape for which
+/// the pre-fix `can_access_repo` filter returned `true` for every member.
+#[cfg(test)]
+mod virtual_member_visibility_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use crate::api::middleware::auth::AuthExtension;
+    use sqlx::PgPool;
+
+    /// One virtual parent plus a private and a public member, and the three
+    /// principals the assertions are made as.
+    struct Fixture {
+        pool: PgPool,
+        state: SharedState,
+        virt_key: String,
+        virt_id: Uuid,
+        private_key: String,
+        private_id: Uuid,
+        public_key: String,
+        public_id: Uuid,
+        viewer: (Uuid, String),
+        insider: (Uuid, String),
+        outsider: (Uuid, String),
+        admin: (Uuid, String),
+        storage_dir: std::path::PathBuf,
+    }
+
+    /// Insert a `virtual_repo_members` row.
+    async fn link_member(pool: &PgPool, virt: Uuid, member: Uuid, priority: i32) {
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(virt)
+        .bind(member)
+        .bind(priority)
+        .execute(pool)
+        .await
+        .expect("link virtual member");
+    }
+
+    /// Insert one `artifacts` row directly. The listing paths read the DB
+    /// only, so no storage write is needed.
+    async fn seed_artifact_row(pool: &PgPool, repo: Uuid, path: &str, name: &str, version: &str) {
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, version, size_bytes, checksum_sha256, \
+              content_type, storage_key) \
+             VALUES ($1, $2, $3, $4, 11, $5, 'application/octet-stream', $6)",
+        )
+        .bind(repo)
+        .bind(path)
+        .bind(name)
+        .bind(version)
+        .bind("0".repeat(64))
+        .bind(format!("k/{}", Uuid::new_v4()))
+        .execute(pool)
+        .await
+        .expect("seed artifact row");
+    }
+
+    /// Seed one complete Maven component in `repo`: the `packages` +
+    /// `package_versions` catalog pair that drives the grouped keyset page,
+    /// plus the `artifacts` row under the component's GAV path prefix that
+    /// `build_maven_components_for_keys` needs in order to emit the component
+    /// (a catalog key with no surviving file is dropped as stale).
+    ///
+    /// `name` is the catalog shape `groupId:artifactId`.
+    async fn seed_maven_component(pool: &PgPool, repo: Uuid, name: &str, version: &str) {
+        let (group_id, artifact_id) = name.split_once(':').expect("groupId:artifactId");
+        let path = format!(
+            "{}/{}/{}/{}-{}.jar",
+            group_id.replace('.', "/"),
+            artifact_id,
+            version,
+            artifact_id,
+            version
+        );
+        seed_artifact_row(pool, repo, &path, artifact_id, version).await;
+
+        let package_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO packages (id, repository_id, name, version) VALUES ($1, $2, $3, $4)",
+        )
+        .bind(package_id)
+        .bind(repo)
+        .bind(name)
+        .bind(version)
+        .execute(pool)
+        .await
+        .expect("seed package");
+        sqlx::query(
+            "INSERT INTO package_versions (package_id, version, checksum_sha256) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(package_id)
+        .bind(version)
+        .bind("0".repeat(64))
+        .execute(pool)
+        .await
+        .expect("seed package version");
+    }
+
+    impl Fixture {
+        /// Build the parent + two members + three principals for `format`.
+        async fn seed(pool: &PgPool, format: &str) -> Fixture {
+            let (virt_id, virt_key, storage_dir) = tdh::create_repo(pool, "virtual", format).await;
+            let (private_id, private_key, _) = tdh::create_repo(pool, "local", format).await;
+            let (public_id, public_key, _) = tdh::create_repo(pool, "local", format).await;
+            sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+                .bind(public_id)
+                .execute(pool)
+                .await
+                .expect("publish public member");
+
+            link_member(pool, virt_id, private_id, 1).await;
+            link_member(pool, virt_id, public_id, 2).await;
+
+            let viewer = tdh::create_user(pool).await;
+            let insider = tdh::create_user(pool).await;
+            let outsider = tdh::create_user(pool).await;
+            let admin = tdh::create_user(pool).await;
+
+            // `viewer` and `insider` can both see the virtual parent; only
+            // `insider` additionally holds a grant on the private member.
+            tdh::grant_repo_access(pool, virt_id, viewer.0).await;
+            tdh::grant_repo_access(pool, virt_id, insider.0).await;
+            tdh::grant_repo_access(pool, private_id, insider.0).await;
+
+            let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+            Fixture {
+                pool: pool.clone(),
+                state,
+                virt_key,
+                virt_id,
+                private_key,
+                private_id,
+                public_key,
+                public_id,
+                viewer,
+                insider,
+                outsider,
+                admin,
+                storage_dir,
+            }
+        }
+
+        fn session(&self, who: &(Uuid, String)) -> AuthExtension {
+            tdh::make_auth(who.0, &who.1)
+        }
+
+        fn admin_session(&self) -> AuthExtension {
+            tdh::admin_auth(self.admin.0, &self.admin.1)
+        }
+
+        /// Drive a GET on the real `router()` as `auth` and return
+        /// `(status, parsed-json)`.
+        async fn get_as(
+            &self,
+            uri: String,
+            auth: AuthExtension,
+        ) -> (StatusCode, serde_json::Value) {
+            let router = tdh::router_with_auth(super::router(), self.state.clone(), auth);
+            let (status, body) = tdh::send(router, tdh::get(uri)).await;
+            let json = serde_json::from_slice(&body)
+                .unwrap_or_else(|_| serde_json::json!({ "raw": String::from_utf8_lossy(&body) }));
+            (status, json)
+        }
+
+        /// `GET /{virt}/members` as `auth` -> the `member_repo_key` list.
+        async fn members_seen(&self, auth: AuthExtension) -> (StatusCode, Vec<String>) {
+            let (status, json) = self
+                .get_as(format!("/{}/members", self.virt_key), auth)
+                .await;
+            let keys = json["members"]
+                .as_array()
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|r| r["member_repo_key"].as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (status, keys)
+        }
+
+        /// `GET /{virt}/artifacts` as `auth` -> the flat `items[].name` list.
+        async fn artifacts_seen(&self, auth: AuthExtension) -> (StatusCode, Vec<String>) {
+            let (status, json) = self
+                .get_as(format!("/{}/artifacts", self.virt_key), auth)
+                .await;
+            let names = json["items"]
+                .as_array()
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|r| r["name"].as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (status, names)
+        }
+
+        /// `GET /{virt}/artifacts?group_by=maven_component` as `auth` ->
+        /// the `components[].artifact_id` list.
+        async fn components_seen(&self, auth: AuthExtension) -> (StatusCode, Vec<String>) {
+            let (status, json) = self
+                .get_as(
+                    format!("/{}/artifacts?group_by=maven_component", self.virt_key),
+                    auth,
+                )
+                .await;
+            let names = json["components"]
+                .as_array()
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|r| r["artifact_id"].as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (status, names)
+        }
+
+        async fn cleanup(self) {
+            for id in [self.virt_id, self.private_id, self.public_id] {
+                let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                    .bind(id)
+                    .execute(&self.pool)
+                    .await;
+            }
+            for who in [&self.viewer, &self.insider, &self.outsider, &self.admin] {
+                tdh::cleanup_user(&self.pool, who.0).await;
+            }
+            let _ = std::fs::remove_dir_all(&self.storage_dir);
+        }
+    }
+
+    /// #3163 site 1: `GET /{key}/members` must list only the members the
+    /// caller may actually see.
+    ///
+    /// Pre-fix the handler filtered with `auth.can_access_repo(member_repo_id)`
+    /// — TOKEN SCOPE, not repository visibility. For a browser JWT session
+    /// (`allowed_repo_ids = AccessScope::Admin`) that predicate is `true` for
+    /// every repository in the instance, so `viewer` received the key, name and
+    /// type of the private member it holds no grant on.
+    #[tokio::test]
+    async fn members_endpoint_hides_members_the_caller_cannot_see_3163() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = Fixture::seed(&pool, "generic").await;
+
+        let (viewer_status, viewer_keys) = fx.members_seen(fx.session(&fx.viewer)).await;
+        let (insider_status, insider_keys) = fx.members_seen(fx.session(&fx.insider)).await;
+        let (admin_status, admin_keys) = fx.members_seen(fx.admin_session()).await;
+        let (private_key, public_key) = (fx.private_key.clone(), fx.public_key.clone());
+        fx.cleanup().await;
+
+        assert_eq!(viewer_status, StatusCode::OK, "viewer can see the virtual");
+        assert_eq!(insider_status, StatusCode::OK);
+        assert_eq!(admin_status, StatusCode::OK);
+
+        // The leak.
+        assert!(
+            !viewer_keys.contains(&private_key),
+            "#3163: a JWT session granted only the virtual parent must NOT see \
+             the private member {private_key} in the member list; got {viewer_keys:?}"
+        );
+        // Positive control 1: the public member is still listed, so the fix is
+        // not "hide everything".
+        assert!(
+            viewer_keys.contains(&public_key),
+            "the public member {public_key} must still be listed to the viewer; \
+             got {viewer_keys:?}"
+        );
+        // Positive control 2: a caller WITH a grant on the private member
+        // still sees it.
+        assert!(
+            insider_keys.contains(&private_key),
+            "a caller holding a grant on {private_key} must still see it; \
+             got {insider_keys:?}"
+        );
+        // Positive control 3: an admin still sees the whole membership.
+        assert!(
+            admin_keys.contains(&private_key) && admin_keys.contains(&public_key),
+            "an admin must still see every member; got {admin_keys:?}"
+        );
+    }
+
+    /// #3163 site 1, parent gate: the members endpoint gated the PARENT with
+    /// `require_repo_access` (token scope) and never ran the repository
+    /// visibility check, so any authenticated principal could confirm a private
+    /// virtual repository exists and read its public membership — while
+    /// `GET /{key}` on the same repository correctly 404s for them.
+    #[tokio::test]
+    async fn members_endpoint_hides_the_virtual_itself_from_outsiders_3163() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = Fixture::seed(&pool, "generic").await;
+
+        let (outsider_status, outsider_keys) = fx.members_seen(fx.session(&fx.outsider)).await;
+        let (viewer_status, _) = fx.members_seen(fx.session(&fx.viewer)).await;
+        fx.cleanup().await;
+
+        assert_eq!(
+            outsider_status,
+            StatusCode::NOT_FOUND,
+            "#3163: a principal with no grant on the PRIVATE virtual parent must \
+             get the existence-hiding 404 the rest of the API returns, not a \
+             200 listing its members; got {outsider_status} with {outsider_keys:?}"
+        );
+        // Positive control: the gate did not lock out a legitimate member.
+        assert_eq!(
+            viewer_status,
+            StatusCode::OK,
+            "a caller granted the virtual parent must still reach the endpoint"
+        );
+    }
+
+    /// #3163 site 2 (flat): `GET /{key}/artifacts` on a virtual repository
+    /// aggregated over `fetch_virtual_members`, which applies NO access
+    /// predicate at all — only the parent was `require_visible`d. The private
+    /// member's artifact contents were therefore served to any caller who
+    /// could see the parent.
+    #[tokio::test]
+    async fn virtual_artifact_listing_hides_invisible_member_artifacts_3163() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = Fixture::seed(&pool, "generic").await;
+        seed_artifact_row(
+            &pool,
+            fx.private_id,
+            "priv/secret-1.0.0.bin",
+            "secret",
+            "1.0.0",
+        )
+        .await;
+        seed_artifact_row(&pool, fx.public_id, "pub/open-1.0.0.bin", "open", "1.0.0").await;
+
+        let (viewer_status, viewer_names) = fx.artifacts_seen(fx.session(&fx.viewer)).await;
+        let (insider_status, insider_names) = fx.artifacts_seen(fx.session(&fx.insider)).await;
+        let (admin_status, admin_names) = fx.artifacts_seen(fx.admin_session()).await;
+        fx.cleanup().await;
+
+        assert_eq!(viewer_status, StatusCode::OK);
+        assert_eq!(insider_status, StatusCode::OK);
+        assert_eq!(admin_status, StatusCode::OK);
+
+        assert!(
+            !viewer_names.contains(&"secret".to_string()),
+            "#3163: the virtual artifact listing must not serve artifacts from a \
+             member the caller cannot see; got {viewer_names:?}"
+        );
+        assert!(
+            viewer_names.contains(&"open".to_string()),
+            "the public member's artifact must still be listed; got {viewer_names:?}"
+        );
+        assert!(
+            insider_names.contains(&"secret".to_string())
+                && insider_names.contains(&"open".to_string()),
+            "a caller granted the private member must still see both; got {insider_names:?}"
+        );
+        assert!(
+            admin_names.contains(&"secret".to_string())
+                && admin_names.contains(&"open".to_string()),
+            "an admin must still see both; got {admin_names:?}"
+        );
+    }
+
+    /// #3163 site 2 (Maven-grouped): the `group_by=maven_component` variant
+    /// resolves member ids through the same unfiltered `fetch_virtual_members`
+    /// call and feeds them to the package-catalog keyset query, leaking the
+    /// private member's GAV coordinates.
+    #[tokio::test]
+    async fn virtual_maven_grouped_listing_hides_invisible_member_components_3163() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = Fixture::seed(&pool, "maven").await;
+        seed_maven_component(&pool, fx.private_id, "com.example:secret-lib", "1.0.0").await;
+        seed_maven_component(&pool, fx.public_id, "com.example:open-lib", "1.0.0").await;
+
+        let (viewer_status, viewer_components) = fx.components_seen(fx.session(&fx.viewer)).await;
+        let (insider_status, insider_components) =
+            fx.components_seen(fx.session(&fx.insider)).await;
+        let (admin_status, admin_components) = fx.components_seen(fx.admin_session()).await;
+        fx.cleanup().await;
+
+        assert_eq!(viewer_status, StatusCode::OK);
+        assert_eq!(insider_status, StatusCode::OK);
+        assert_eq!(admin_status, StatusCode::OK);
+
+        assert!(
+            !viewer_components.contains(&"secret-lib".to_string()),
+            "#3163: the Maven-grouped virtual listing must not disclose components \
+             from a member the caller cannot see; got {viewer_components:?}"
+        );
+        assert!(
+            viewer_components.contains(&"open-lib".to_string()),
+            "the public member's component must still be listed; got {viewer_components:?}"
+        );
+        assert!(
+            insider_components.contains(&"secret-lib".to_string())
+                && insider_components.contains(&"open-lib".to_string()),
+            "a caller granted the private member must still see both; got {insider_components:?}"
+        );
+        assert!(
+            admin_components.contains(&"secret-lib".to_string())
+                && admin_components.contains(&"open-lib".to_string()),
+            "an admin must still see both; got {admin_components:?}"
+        );
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -14873,10 +14873,22 @@ mod tests {
             sig_and_body.contains("require_auth(auth)"),
             "list_virtual_members must call require_auth (issue #913)"
         );
+        // #913 originally pinned `auth.can_access_repo(row.member_repo_id)`.
+        // That predicate is TOKEN SCOPE, not repository visibility -- it returns
+        // true for any unscoped principal, which includes every browser session,
+        // so as a visibility filter it was a no-op for the common caller
+        // (#3163). The filter is now the visibility clause.
+        //
+        // Assert on the CALL. Pinning the OLD needle would leave this guard
+        // satisfied by the handler's own explanatory comment, which still
+        // contains that string in prose -- the test would pass with the filter
+        // deleted entirely, which is exactly how it went vacuous. A negative
+        // assertion does not work here either, for the same reason: source-text
+        // matching cannot tell code from the comment describing it.
         assert!(
-            sig_and_body.contains("auth.can_access_repo(row.member_repo_id)"),
-            "list_virtual_members must filter the response by \
-             can_access_repo(member_repo_id) (issue #913)"
+            sig_and_body.contains("filter_visible_repo_ids("),
+            "list_virtual_members must filter the response by repository \
+             VISIBILITY, not by token scope (issue #913, corrected by #3163)"
         );
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -307,6 +307,61 @@ pub(crate) fn member_read_visibility(auth: Option<&AuthExtension>) -> MemberVisi
     }
 }
 
+/// The GRANT half of [`require_visible`], for filtering rows the caller reaches
+/// *through* an already-authorized parent (a virtual repo's members).
+///
+/// Deliberately not [`visibility_for_auth`]. That function answers "which
+/// repositories may this principal LIST", where a repo-scoped token's answer is
+/// exactly its allowed set — the listing's documented contract. Membership is a
+/// different question, and reusing the `Ids` arm for it gets two things wrong,
+/// because `require_visible` is
+///
+/// ```text
+/// is_public OR (in_scope AND (is_admin OR grants))
+/// ```
+///
+/// and the `Ids` arm is `in_scope` alone. It drops the `is_public` arm — so an
+/// authenticated scoped caller saw LESS than an anonymous one — and it drops
+/// the grant conjunct, so a token kept working against a member after its
+/// owner's grant was revoked. Scope is a mint-time snapshot; entitlement is not.
+///
+/// So: this returns the grant half only, and [`member_passes_token_scope`]
+/// applies the scope half. Composed, they are `require_visible` exactly.
+pub(crate) fn member_grant_visibility(auth: Option<&AuthExtension>) -> RepoVisibility {
+    match auth {
+        None => RepoVisibility::PublicOnly,
+        Some(a) if a.is_admin => RepoVisibility::All,
+        Some(a) => RepoVisibility::User(a.user_id),
+    }
+}
+
+/// The SCOPE half, applied per member row.
+///
+/// A public member bypasses scope entirely, matching `require_visible`'s
+/// early return. Otherwise the member passes when it is itself in scope, OR
+/// when the PARENT virtual is — read-through.
+///
+/// Read-through is a deliberate choice, not an oversight. Scoping a token to a
+/// virtual repository is the canonical way to point CI at one, and the
+/// by-path download through that virtual already serves member bytes for such
+/// a token. Without read-through the listing returns `200 OK` with zero items
+/// while the download of those same items succeeds — two answers to one
+/// question. The grant half still applies on top, so this widens which members
+/// a token may ENUMERATE, never which a user may READ.
+pub(crate) fn member_passes_token_scope(
+    auth: Option<&AuthExtension>,
+    parent_repo_id: Uuid,
+    member_id: Uuid,
+    member_is_public: bool,
+) -> bool {
+    match auth {
+        None => member_is_public,
+        Some(a) => {
+            member_is_public || a.can_access_repo(parent_repo_id) || a.can_access_repo(member_id)
+        }
+    }
+}
+
 /// Ensure a repository is visible to the current user.
 ///
 /// Public repos are visible to everyone. Private repos require authentication
@@ -4656,7 +4711,7 @@ pub async fn list_artifacts(
             count_exact,
             page,
             per_page,
-            &visibility_for_auth(auth.as_ref()),
+            auth.as_ref(),
         )
         .await;
     }
@@ -4737,9 +4792,18 @@ pub async fn list_artifacts(
         // members this caller may see, using the same predicate as the
         // repository listing and `GET /{key}/members`.
         let member_ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
-        let member_ids = repo_service
-            .filter_visible_repo_ids(&member_ids, &visibility_for_auth(auth.as_ref()))
+        let granted = repo_service
+            .filter_visible_repo_ids(&member_ids, &member_grant_visibility(auth.as_ref()))
             .await?;
+        let granted: std::collections::HashSet<uuid::Uuid> = granted.into_iter().collect();
+        let member_ids: Vec<uuid::Uuid> = members
+            .iter()
+            .filter(|m| {
+                granted.contains(&m.id)
+                    && member_passes_token_scope(auth.as_ref(), repo.id, m.id, m.is_public)
+            })
+            .map(|m| m.id)
+            .collect();
 
         let page_rows = artifact_service
             .list_for_repos_page(
@@ -5589,10 +5653,13 @@ async fn list_artifacts_grouped_by_maven_component(
     count_exact: bool,
     page: u32,
     per_page: u32,
-    // The CALLER's repository visibility (#3163). Only consulted for a
-    // Virtual repo, whose members are separate repositories with their own
-    // ACLs; a non-virtual repo is already gated by `require_visible`.
-    visibility: &RepoVisibility,
+    // The CALLER (#3163). Only consulted for a Virtual repo, whose members are
+    // separate repositories with their own ACLs; a non-virtual repo is already
+    // gated by `require_visible`. Takes the auth extension rather than a
+    // pre-computed `RepoVisibility` because member filtering needs BOTH halves
+    // of `require_visible` -- the grant half and the token-scope half -- and a
+    // single `RepoVisibility` can only carry one of them.
+    auth: Option<&AuthExtension>,
 ) -> Result<Json<ArtifactListResponse>> {
     // Remote (proxy) repositories do NOT record cached items in the `artifacts`
     // table (#1278 / #1280), so `artifact_service.list` returns nothing for them
@@ -5679,9 +5746,19 @@ async fn list_artifacts_grouped_by_maven_component(
         // private member's GAV coordinates are not disclosed through the
         // grouped view.
         let member_ids: Vec<Uuid> = members.iter().map(|m| m.id).collect();
-        RepositoryService::new(state.db.clone())
-            .filter_visible_repo_ids(&member_ids, visibility)
+        let granted: std::collections::HashSet<Uuid> = RepositoryService::new(state.db.clone())
+            .filter_visible_repo_ids(&member_ids, &member_grant_visibility(auth))
             .await?
+            .into_iter()
+            .collect();
+        members
+            .iter()
+            .filter(|m| {
+                granted.contains(&m.id)
+                    && member_passes_token_scope(auth, repo.id, m.id, m.is_public)
+            })
+            .map(|m| m.id)
+            .collect()
     } else {
         vec![repo.id]
     };
@@ -8443,6 +8520,9 @@ struct VirtualMemberRow {
     member_key: String,
     member_name: String,
     repo_type: RepositoryType,
+    /// Needed by `member_passes_token_scope`: a public member bypasses token
+    /// scope entirely, matching `require_visible`'s early return.
+    is_public: bool,
 }
 
 /// List virtual repository members
@@ -8508,7 +8588,8 @@ pub async fn list_virtual_members(
             vrm.created_at,
             r.key as member_key,
             r.name as member_name,
-            r.repo_type
+            r.repo_type,
+            r.is_public
         FROM virtual_repo_members vrm
         INNER JOIN repositories r ON r.id = vrm.member_repo_id
         WHERE vrm.virtual_repo_id = $1
@@ -8530,12 +8611,30 @@ pub async fn list_virtual_members(
     // caller holds no grant on. Members are separate repositories with their
     // own ACLs, so they are filtered through the SAME predicate the repository
     // listing uses. Priority order is preserved.
-    let visibility = visibility_for_auth(Some(&auth));
+    // Two halves, composed: the SQL filter answers the GRANT half, and
+    // `member_passes_token_scope` answers the SCOPE half per row. Together they
+    // are `require_visible` exactly. Using `visibility_for_auth` here instead
+    // got both halves wrong for a repo-scoped token -- see
+    // `member_grant_visibility`.
+    let visibility = member_grant_visibility(Some(&auth));
     let member_ids: Vec<Uuid> = members.iter().map(|row| row.member_repo_id).collect();
-    let visible: std::collections::HashSet<Uuid> = service
+    let granted: std::collections::HashSet<Uuid> = service
         .filter_visible_repo_ids(&member_ids, &visibility)
         .await?
         .into_iter()
+        .collect();
+    let visible: std::collections::HashSet<Uuid> = members
+        .iter()
+        .filter(|row| {
+            granted.contains(&row.member_repo_id)
+                && member_passes_token_scope(
+                    Some(&auth),
+                    repo.id,
+                    row.member_repo_id,
+                    row.is_public,
+                )
+        })
+        .map(|row| row.member_repo_id)
         .collect();
     let members = members
         .into_iter()
@@ -16033,6 +16132,7 @@ mod tests {
             member_key: "maven-local".to_string(),
             member_name: "Maven Local".to_string(),
             repo_type: RepositoryType::Local,
+            is_public: false,
         };
         let resp = map_member_row(row);
         assert_eq!(resp.id, id);
@@ -16054,6 +16154,7 @@ mod tests {
             member_key: "maven-central".to_string(),
             member_name: "Maven Central".to_string(),
             repo_type: RepositoryType::Remote,
+            is_public: false,
         };
         let resp = map_member_row(row);
         assert_eq!(resp.member_repo_type, "remote");
@@ -16070,6 +16171,7 @@ mod tests {
             member_key: "r".to_string(),
             member_name: "R".to_string(),
             repo_type: RepositoryType::Local,
+            is_public: false,
         };
         assert_eq!(map_member_row(row).priority, 42);
     }
@@ -22675,6 +22777,22 @@ mod virtual_member_visibility_tests {
             tdh::admin_auth(self.admin.0, &self.admin.1)
         }
 
+        /// A repo-scoped API token: the `AccessScope::Restricted` principal
+        /// that no test exercised, and the one both defects lived in.
+        fn scoped_token(&self, who: &(Uuid, String), scope: Vec<Uuid>) -> AuthExtension {
+            let mut auth = tdh::make_auth(who.0, &who.1);
+            auth.is_api_token = true;
+            auth.allowed_repo_ids = crate::models::access_scope::AccessScope::Restricted(scope);
+            auth
+        }
+
+        fn scoped_admin_token(&self, scope: Vec<Uuid>) -> AuthExtension {
+            let mut auth = tdh::admin_auth(self.admin.0, &self.admin.1);
+            auth.is_api_token = true;
+            auth.allowed_repo_ids = crate::models::access_scope::AccessScope::Restricted(scope);
+            auth
+        }
+
         /// Drive a GET on the real `router()` as `auth` and return
         /// `(status, parsed-json)`.
         async fn get_as(
@@ -22763,6 +22881,75 @@ mod virtual_member_visibility_tests {
     /// (`allowed_repo_ids = AccessScope::Admin`) that predicate is `true` for
     /// every repository in the instance, so `viewer` received the key, name and
     /// type of the private member it holds no grant on.
+    /// The `AccessScope::Restricted` principal -- a repo-scoped API token.
+    ///
+    /// Nothing exercised this arm, and both defects lived in it. Member
+    /// filtering used `visibility_for_auth`, whose `Ids` arm is `in_scope`
+    /// alone, while `require_visible` is
+    /// `is_public OR (in_scope AND (is_admin OR grants))`. Dropping the
+    /// `is_public` arm made an authenticated scoped caller see LESS than an
+    /// anonymous one; dropping the grant conjunct let a token keep reading a
+    /// member after its owner's grant was revoked.
+    ///
+    /// It also asserts read-through: a token scoped to the VIRTUAL reaches the
+    /// virtual's members. That is deliberate -- the by-path download through
+    /// the same virtual already serves member bytes to such a token, so
+    /// without it the listing returns `200 OK` with zero items while the
+    /// download of those same items succeeds.
+    #[tokio::test]
+    async fn members_endpoint_honours_token_scope_and_grants_3163() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = Fixture::seed(&pool, "generic").await;
+
+        // Scoped to the VIRTUAL only. Read-through must reach its members,
+        // and the grant half must still hide the private one from `viewer`.
+        let vt = fx.scoped_token(&fx.viewer, vec![fx.virt_id]);
+        let (virt_status, virt_keys) = fx.members_seen(vt).await;
+
+        // Same token shape for a caller WITH the grant: the private member
+        // must appear, proving the filter is not "hide everything".
+        let it = fx.scoped_token(&fx.insider, vec![fx.virt_id]);
+        let (ins_status, ins_keys) = fx.members_seen(it).await;
+
+        // An ADMIN whose token is deliberately scoped to the virtual only.
+        // Before the fix `is_admin` was matched ahead of `Restricted`, so the
+        // scope was discarded entirely.
+        let at = fx.scoped_admin_token(vec![fx.virt_id]);
+        let (adm_status, adm_keys) = fx.members_seen(at).await;
+
+        let (private_key, public_key) = (fx.private_key.clone(), fx.public_key.clone());
+        fx.cleanup().await;
+
+        assert_eq!(virt_status, StatusCode::OK);
+        assert_eq!(ins_status, StatusCode::OK);
+        assert_eq!(adm_status, StatusCode::OK);
+
+        // Read-through + the public arm the `Ids` arm had dropped.
+        assert!(
+            virt_keys.contains(&public_key),
+            "a token scoped to the virtual must reach its public member, or \
+             the listing contradicts the download path; got {virt_keys:?}"
+        );
+        // The grant half still applies.
+        assert!(
+            !virt_keys.contains(&private_key),
+            "token scope must not substitute for a grant: {private_key} has no \
+             grant for this caller; got {virt_keys:?}"
+        );
+        assert!(
+            ins_keys.contains(&private_key),
+            "a scoped token whose owner HOLDS the grant must still see \
+             {private_key}; got {ins_keys:?}"
+        );
+        assert!(
+            adm_keys.contains(&public_key) && adm_keys.contains(&private_key),
+            "an admin token scoped to the virtual reaches its members; \
+             got {adm_keys:?}"
+        );
+    }
+
     #[tokio::test]
     async fn members_endpoint_hides_members_the_caller_cannot_see_3163() {
         let Some(pool) = tdh::try_pool().await else {

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -1092,6 +1092,71 @@ impl RepositoryService {
         Ok(granted)
     }
 
+    /// Narrow `candidate_ids` to the repositories this caller is allowed to
+    /// SEE, preserving the caller's input order (issue #3163).
+    ///
+    /// This is the set-shaped counterpart to [`Self::user_can_access_repo`],
+    /// for the paths that aggregate over a list of OTHER repositories on the
+    /// caller's behalf — today a virtual repository's members, which are
+    /// separate repositories with their own ACLs. It evaluates the SAME
+    /// predicate the repository listing uses ([`build_visibility_clause_for`]),
+    /// so "which members does this caller see through the virtual" and "which
+    /// repositories does this caller see in `GET /repositories`" cannot drift
+    /// apart.
+    ///
+    /// It is deliberately NOT [`crate::api::middleware::auth::AuthExtension::can_access_repo`],
+    /// which answers a different question — "is this repository within my
+    /// TOKEN's scope?" — and returns `true` for every repository in the
+    /// instance whenever the principal is unscoped (a browser JWT session, an
+    /// unrestricted API token, an admin).
+    ///
+    /// Order is preserved because callers depend on it: virtual members are
+    /// resolved in priority order.
+    pub async fn filter_visible_repo_ids(
+        &self,
+        candidate_ids: &[Uuid],
+        visibility: &RepoVisibility,
+    ) -> Result<Vec<Uuid>> {
+        if candidate_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        // `All` (admins, and internal oracles/reconcilers) is the literal
+        // `true` clause, so the admin path costs no extra round trip and is
+        // byte-identical to the pre-#3163 unfiltered set.
+        if matches!(visibility, RepoVisibility::All) {
+            return Ok(candidate_ids.to_vec());
+        }
+
+        let (visibility_clause, visibility_bind) = build_visibility_clause_for(visibility, "r", 2);
+        // Split the visibility bind into the two concrete `$2` shapes. Exactly
+        // one is `Some` per call; the unused one stays `None` and binds as a
+        // typed NULL, which the generated clause never references.
+        let (user_id_bind, ids_bind): (Option<Uuid>, Option<Vec<Uuid>>) = match visibility_bind {
+            VisibilityBind::User(uid) => (uid, None),
+            VisibilityBind::Ids(ids) => (None, Some(ids)),
+        };
+        let sql = format!(
+            "SELECT r.id FROM repositories r \
+             WHERE r.id = ANY($1) AND ({visibility_clause})"
+        );
+        let query = sqlx::query_scalar(&sql).bind(candidate_ids);
+        let query = match &ids_bind {
+            Some(ids) => query.bind(ids.clone()),
+            None => query.bind(user_id_bind),
+        };
+        let visible: Vec<Uuid> = query
+            .fetch_all(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let visible: std::collections::HashSet<Uuid> = visible.into_iter().collect();
+        Ok(candidate_ids
+            .iter()
+            .copied()
+            .filter(|id| visible.contains(id))
+            .collect())
+    }
+
     /// Get a repository by ID
     pub async fn get_by_id(&self, id: Uuid) -> Result<Repository> {
         let repo = sqlx::query_as!(


### PR DESCRIPTION
## Summary

Fixes #3163.

A virtual repository disclosed its members — and those members' contents — to callers who are not allowed to see the member repositories.

The root cause is one confusion, in three places: `AuthExtension::can_access_repo` resolves to `access_scope().grants(repo_id)`. That answers **"is this repository within my TOKEN's scope?"**, which is not **"am I allowed to see this repository?"**. For any *unscoped* principal — a browser JWT session, an unrestricted API token, an admin — `AccessScope::Admin` means "no repo restriction", so `can_access_repo` returns `true` for **every repository in the instance**. A browser session is exactly that shape.

**Site 1 — `GET /api/v1/repositories/{key}/members`**

- The member set was filtered with `.filter(|row| auth.can_access_repo(row.member_repo_id))`. The handler's own comment admitted the consequence ("Tokens with `allowed_repo_ids = None` … see everything"). Any authenticated user who could reach a virtual repo could enumerate the `key`, `name` and `repo_type` of every member, including private repositories they hold no grant on.
- The parent was gated with `require_repo_access` (token scope) and **never** with `require_visible`. So a private virtual repository's membership was readable by any authenticated principal — while `GET /{key}` on that same repository correctly 404s.

**Site 2 — `GET /api/v1/repositories/{key}/artifacts` on a virtual repo, flat and `group_by=maven_component`**

Both resolve members via `proxy_helpers::fetch_virtual_members`, which applies **no ACL predicate at all**; only the parent is `require_visible`d. The private members' artifacts (and, in the grouped view, their Maven GAV coordinates) were aggregated straight into the response.

### The fix

All three sites now narrow the member set through the **same predicate the repository listing uses** — `build_visibility_clause_for` (public ∪ `role_assignments` ∪ fine-grained `permissions`, including the group and project arms) — rather than inventing a second rule:

- `RepositoryService::filter_visible_repo_ids(candidate_ids, visibility)` (new) evaluates that clause over a candidate id set. It **preserves input order**, which is load-bearing: `list_for_repos_page` documents that "the priority is determined by the position in the `repo_ids` slice".
- `visibility_for_auth(Option<&AuthExtension>)` is the single derivation of `RepoVisibility` from a principal, extracted from the body of `list_repositories` (which now calls it).
- `RepoVisibility::All` short-circuits before the query, so the **admin path is byte-identical to before** and costs no extra round trip.
- On site 1 the parent now runs **both** gates. `require_repo_access` is deliberately kept *ahead* of `require_visible`, because `require_visible` short-circuits `Ok` on a public repository — dropping it would have let a repo-scoped token reach a public virtual outside its allowed set. Neither gate subsumes the other.

No schema migration, no API break, no response-shape change. Which members a non-admin *sees* changes — that is the point of the issue.

### Note for the reviewer: overlap with #3162

`visibility_for_auth` is also introduced by the still-open #3162 (for the #3081 storage-total leak), with the same body in the same file. That is intentional — #3163 explicitly asks these paths to reuse #3162's predicate rather than grow a second one. **Whichever of the two merges first, the other should drop its copy on rebase.** I did not stack this branch on #3162 because stacked PRs on this repo do not get Rust CI, and a security fix should not merge on an unrun gate.

### `can_access_repo` audit (requested in the issue)

I audited every production call site. 12 total; 10 are correct (token scope is genuinely what is meant, and a separate visibility check covers the path). Two are the **same bug class as this issue and are NOT fixed here** — they are unrelated endpoints and deserve their own issues rather than riding along:

| file:line | function | what an unscoped non-admin can read |
|---|---|---|
| `backend/src/api/handlers/quarantine.rs:106` and `:122` | `get_quarantine_status` | `!repo.is_public && !auth_ext.can_access_repo(...)` is the **only** gate (routes run under plain `auth_middleware`, not `repo_visibility_middleware`). Any logged-in user who knows an artifact UUID in another tenant's private repo learns it exists, plus `quarantine_status`/`quarantine_until`/`is_blocked`, and at `:122` the free-text `quarantine_reason` (the malware/CVE finding). The comment at `:119-121` states the intended semantics precisely — and `can_access_repo` does not implement them. |
| `backend/src/api/handlers/sbom.rs:441` | `list_sboms` | On the `repository_id`-only path (no `artifact_id`), `if !auth.can_access_repo(repo_id)` is the sole check before up to 100 `sbom_documents` rows are returned: SBOM ids, artifact ids, formats, component/dependency/license counts and license lists for any private repository. The sibling helper at `sbom.rs:1666-1670` documents this exact class as fixed for the `ensure_*` wrappers under #2439; `list_sboms` was never converted. |

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Four in-crate (`src/…`, so they count toward the `nextest --lib` coverage gate) DB-backed tests in `mod virtual_member_visibility_tests`, each driving the **real `router()`** over `axum` `oneshot` as a non-admin JWT-session principal (`tdh::make_auth` — `is_admin: false`, `allowed_repo_ids: AccessScope::Admin`, i.e. exactly a browser session).

Fixture: a private virtual parent, a **private** member (`viewer` has no grant) and a **public** member, plus `viewer` / `insider` / `outsider` / admin principals. Every leak assertion ships with positive controls, so a fix that simply hid everything fails: the public member must still be listed, `insider` (who holds a grant on the private member) must still see it, and an admin must still see the whole set.

Revert-proof — each guard was reverted **individually** and fails exactly one test, and only that one:

| reverted guard | failing test |
|---|---|
| member filter → back to `can_access_repo` | `members_endpoint_hides_members_the_caller_cannot_see_3163` |
| parent `require_visible` removed | `members_endpoint_hides_the_virtual_itself_from_outsiders_3163` |
| flat-listing member filter removed | `virtual_artifact_listing_hides_invisible_member_artifacts_3163` |
| Maven-grouped member filter removed | `virtual_maven_grouped_listing_hides_invisible_member_components_3163` |

All four fail on the base commit and pass on this branch.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Response shapes and status codes are unchanged. The behavioural change is which members appear in them, plus `GET /{key}/members` now returning the existence-hiding `404` (instead of `200`) to a caller with no grant on a private virtual repository, matching `GET /{key}`.
