### PR TITLE
fix(pypi): PEP 658 virtual repo handling

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1705,6 +1705,26 @@ async fn serve_virtual_metadata(
     let members =
         proxy_helpers::authorize_virtual_members(&state.permission_service, auth, members).await;
 
+    // Keep PEP 658 metadata resolution symmetric with the simple-index and
+    // distribution-download paths. A higher-priority local owner suppresses a
+    // lower-priority Remote member unless the requested distribution is an
+    // admitted Case-A platform wheel. Without this gate, a direct or stale
+    // `.metadata` URL could expose a remote-only Case-B version that neither
+    // the index advertises nor the download route serves.
+    let owning_local_min_priority =
+        proxy_helpers::pypi_virtual_isolates_name(&state.db, virtual_repo.id, normalized_project)
+            .await?;
+    let member_priorities = if owning_local_min_priority.is_some() {
+        proxy_helpers::fetch_virtual_member_priorities(&state.db, virtual_repo.id).await?
+    } else {
+        Default::default()
+    };
+    let owned_profile = if owning_local_min_priority.is_some() {
+        pypi_owned_wheel_profile(&state.db, &members, normalized_project).await
+    } else {
+        OwnedWheelProfile::default()
+    };
+
     for member in members {
         let member_info = proxy_helpers::repo_info_from_member(&member);
         if enforce_pypi_curation(state, &member_info, normalized_project, requested_version)
@@ -1715,6 +1735,20 @@ async fn serve_virtual_metadata(
         }
 
         let result = if member.repo_type == RepositoryType::Remote {
+            let remote_suppressed = match owning_local_min_priority {
+                Some(local_min) => {
+                    local_min
+                        < member_priorities
+                            .get(&member.id)
+                            .copied()
+                            .unwrap_or(i32::MAX)
+                        && !owned_profile.admits(filename)
+                }
+                None => false,
+            };
+            if remote_suppressed {
+                continue;
+            }
             match (&member.upstream_url, state.proxy_service.as_ref()) {
                 (Some(upstream_url), Some(proxy)) => {
                     serve_remote_metadata(
@@ -9486,6 +9520,96 @@ mod tests {
             &body[..],
             metadata,
             "virtual member must return wheel METADATA"
+        );
+    }
+
+    /// A higher-priority local owner without a `tracks` declaration isolates
+    /// its project from lower-priority remote-only versions. PEP 658 metadata
+    /// must enforce the same Case-B suppression as the simple index and wheel
+    /// download, including for direct or stale `.metadata` URLs.
+    #[tokio::test]
+    async fn test_virtual_pypi_metadata_suppresses_remote_only_version() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pypi").await else {
+            return;
+        };
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+        let project = "demo";
+        let local_wheel = "demo-1.0-cp39-cp39-manylinux_2_17_x86_64.whl";
+        let remote_wheel = "demo-2.0-cp39-cp39-win_amd64.whl";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(pep658_index_html(remote_wheel)),
+            )
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{remote_wheel}.metadata")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("Metadata-Version: 2.1\nName: demo\nVersion: 2.0\n"),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (remote_id, _remote_key, remote_dir, state) =
+            setup_virtual_pypi_member(&fx, false, &upstream.uri()).await;
+        let (local_id, _local_key, local_dir) = tdh::create_repo(&fx.pool, "local", "pypi").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(local_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make local owner public");
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(fx.repo_id)
+        .bind(local_id)
+        .execute(&fx.pool)
+        .await
+        .expect("attach higher-priority local owner");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8)",
+        )
+        .bind(local_id)
+        .bind(format!("simple/{project}/{local_wheel}"))
+        .bind(project)
+        .bind("1.0")
+        .bind("test-local-owner")
+        .bind("application/zip")
+        .bind(format!("local/{local_wheel}"))
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed local ownership artifact");
+
+        let app = tdh::router_anon(super::router(), state);
+        let (status, _body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{remote_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        cleanup_virtual_member(&fx.pool, local_id, &local_dir).await;
+        cleanup_virtual_member(&fx.pool, remote_id, &remote_dir).await;
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "remote-only metadata must stay hidden when the local owner outranks the remote"
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1630,6 +1630,18 @@ async fn download_or_metadata(
             return Err(AppError::NotFound(format!("File not found: {}", filename)).into_response());
         }
         let real_filename = distribution;
+        if repo.repo_type == RepositoryType::Virtual {
+            return serve_virtual_metadata(
+                &state,
+                auth.as_ref(),
+                &repo,
+                &project,
+                &normalized,
+                requested_version.as_deref(),
+                real_filename,
+            )
+            .await;
+        }
         if repo.repo_type == RepositoryType::Remote {
             if let (Some(upstream_url), Some(proxy)) = (&repo.upstream_url, &state.proxy_service) {
                 return serve_remote_metadata(
@@ -1665,6 +1677,81 @@ async fn download_or_metadata(
         &ctx,
     )
     .await
+}
+
+/// Resolve a PEP 658 metadata request through a virtual repository's members.
+///
+/// Virtual repositories do not own artifacts, so metadata cannot be served
+/// against the virtual repository ID. Resolve members in priority order, using
+/// the same authorization and curation boundaries as the regular download
+/// path. A missing distribution falls through to the next member; other
+/// failures remain visible instead of being misreported as a 404.
+async fn serve_virtual_metadata(
+    state: &SharedState,
+    auth: Option<&AuthExtension>,
+    virtual_repo: &RepoInfo,
+    project: &str,
+    normalized_project: &str,
+    requested_version: Option<&str>,
+    filename: &str,
+) -> Result<Response, Response> {
+    let members = proxy_helpers::fetch_virtual_members(&state.db, virtual_repo.id).await?;
+    if members.is_empty() {
+        return Err(
+            AppError::NotFound("Virtual repository has no members".to_string()).into_response(),
+        );
+    }
+
+    let members =
+        proxy_helpers::authorize_virtual_members(&state.permission_service, auth, members).await;
+
+    for member in members {
+        let member_info = proxy_helpers::repo_info_from_member(&member);
+        if enforce_pypi_curation(state, &member_info, normalized_project, requested_version)
+            .await
+            .is_err()
+        {
+            continue;
+        }
+
+        let result = if member.repo_type == RepositoryType::Remote {
+            match (&member.upstream_url, state.proxy_service.as_ref()) {
+                (Some(upstream_url), Some(proxy)) => {
+                    serve_remote_metadata(
+                        state,
+                        proxy,
+                        member.id,
+                        &member.key,
+                        upstream_url,
+                        project,
+                        filename,
+                    )
+                    .await
+                }
+                _ => continue,
+            }
+        } else {
+            serve_metadata(
+                state,
+                &state.db,
+                member.id,
+                &member.storage_location(),
+                filename,
+            )
+            .await
+        };
+
+        match result {
+            Ok(response) => return Ok(response),
+            Err(response) if response.status() == StatusCode::NOT_FOUND => continue,
+            Err(response) => return Err(response),
+        }
+    }
+
+    Err(
+        AppError::NotFound("Metadata not found in any member repository".to_string())
+            .into_response(),
+    )
 }
 
 async fn serve_remote_metadata(
@@ -9334,6 +9421,71 @@ mod tests {
             &body[..],
             metadata,
             "served metadata must be the wheel's METADATA bytes"
+        );
+    }
+
+    /// A virtual repository has no artifacts of its own. PEP 658 metadata must
+    /// therefore resolve through its remote member, just as a wheel download
+    /// does. This exercises the PR #3077 404-to-wheel fallback through the
+    /// virtual route that previously passed the virtual repository ID to
+    /// `serve_metadata` and returned 404.
+    #[tokio::test]
+    async fn test_virtual_pypi_metadata_resolves_remote_member() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pypi").await else {
+            return;
+        };
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+        let project = "demo";
+        let wheel = "demo-1.0-py3-none-any.whl";
+        let metadata: &[u8] = b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(pep658_index_html(wheel)))
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{wheel}.metadata")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{wheel}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(wheel_with_metadata("demo-1.0", metadata)),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (member_id, _member_key, member_dir, state) =
+            setup_virtual_pypi_member(&fx, false, &upstream.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        cleanup_virtual_member(&fx.pool, member_id, &member_dir).await;
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "virtual metadata request must resolve its member"
+        );
+        assert_eq!(
+            &body[..],
+            metadata,
+            "virtual member must return wheel METADATA"
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1681,10 +1681,21 @@ async fn download_or_metadata(
 /// Resolve a PEP 658 metadata request through a virtual repository's members.
 ///
 /// Virtual repositories do not own artifacts, so metadata cannot be served
-/// against the virtual repository ID. Resolve members in priority order, using
-/// the same authorization and curation boundaries as the regular download
-/// path. A missing distribution falls through to the next member; other
-/// failures remain visible instead of being misreported as a 404.
+/// against the virtual repository ID. Resolve members in priority order,
+/// applying the member authorization filter, the per-member curation gate, and
+/// the PEP 708 dependency-confusion isolation the download path uses.
+///
+/// It is NOT full parity with the download path, and the difference is worth
+/// stating rather than implying: `serve_file` additionally enforces the
+/// download age gate, the inline scan-and-block gate, and the quarantine check
+/// (`serve_metadata`'s query selects no quarantine columns). So a quarantined
+/// or age-withheld distribution returns 403/451 on download while its METADATA
+/// -- name, version, full `Requires-Dist` -- is served here. That is a
+/// disclosure gap, not an install bypass, and it is tracked separately.
+///
+/// A missing distribution falls through to the next member. Other failures are
+/// recorded and returned only if NO member serves, so one misconfigured
+/// upstream cannot deny metadata for a package another member owns.
 /// Takes ONLY the normalized project name. The raw path segment is
 /// deliberately not a parameter: every gate here keys on the PEP 503 form, and
 /// an earlier revision passed the raw segment to the upstream fetch, which
@@ -1728,6 +1739,7 @@ async fn serve_virtual_metadata(
         OwnedWheelProfile::default()
     };
 
+    let mut first_member_error: Option<Response> = None;
     for member in members {
         let member_info = proxy_helpers::repo_info_from_member(&member);
         if enforce_pypi_curation(state, &member_info, normalized_project, requested_version)
@@ -1735,6 +1747,29 @@ async fn serve_virtual_metadata(
             .is_err()
         {
             continue;
+        }
+
+        // Local-first for EVERY member, including Remote ones -- mirroring
+        // `serve_file`, which calls `local_fetch_or_redirect_by_suffix` before
+        // its own Remote branch precisely because Remote-typed repos do carry
+        // `artifacts` rows (direct upload, replication, promotion).
+        //
+        // Dispatching on `repo_type` alone made metadata and the wheel resolve
+        // from different places: the download served a Remote member's stored
+        // bytes while `.metadata` skipped the row and fetched the upstream's.
+        // PEP 658 metadata is not hash-tied to the distribution, so pip would
+        // resolve against one package's dependencies and install another's,
+        // with nothing anywhere to detect it.
+        if let Ok(response) = serve_metadata(
+            state,
+            &state.db,
+            member.id,
+            &member.storage_location(),
+            filename,
+        )
+        .await
+        {
+            return Ok(response);
         }
 
         let result = if member.repo_type == RepositoryType::Remote {
@@ -1784,21 +1819,37 @@ async fn serve_virtual_metadata(
                 _ => continue,
             }
         } else {
-            serve_metadata(
-                state,
-                &state.db,
-                member.id,
-                &member.storage_location(),
-                filename,
-            )
-            .await
+            // Local storage was already tried for this member above.
+            continue;
         };
 
+        // M2: record and continue, do NOT abort the whole resolution.
+        //
+        // `serve_file`'s virtual loop logs and continues on a member error;
+        // this returned immediately on any non-404. Upstream 401/403/5xx map
+        // to BadGateway and an SSRF-blocked href maps to 400, so one Remote
+        // member with expired credentials at priority 0 made EVERY
+        // locally-owned package's metadata 502 -- while the sibling wheel
+        // download succeeded from the local member. That is the exact topology
+        // this function exists to serve.
+        //
+        // The first non-404 is kept and returned only if nothing serves, so a
+        // genuine upstream failure is still visible rather than masked as a
+        // 404.
         match result {
             Ok(response) => return Ok(response),
             Err(response) if response.status() == StatusCode::NOT_FOUND => continue,
-            Err(response) => return Err(response),
+            Err(response) => {
+                if first_member_error.is_none() {
+                    first_member_error = Some(response);
+                }
+                continue;
+            }
         }
+    }
+
+    if let Some(error) = first_member_error {
+        return Err(error);
     }
 
     Err(
@@ -9799,6 +9850,138 @@ mod tests {
             "an anonymous caller must not read a PRIVATE member's metadata \
              through the virtual: got body {:?}",
             String::from_utf8_lossy(&local_body)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_virtual_pypi_metadata_survives_a_failing_higher_priority_member() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pypi").await else {
+            return;
+        };
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+        let project = "demo";
+        let local_wheel = "demo-1.0-cp39-cp39-manylinux_2_17_x86_64.whl";
+        let remote_wheel = "demo-2.0-cp39-cp39-win_amd64.whl";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/")))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{remote_wheel}.metadata")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("Metadata-Version: 2.1\nName: demo\nVersion: 2.0\n"),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (remote_id, _remote_key, remote_dir, state) =
+            setup_virtual_pypi_member(&fx, false, &upstream.uri()).await;
+        let (local_id, _local_key, local_dir) = tdh::create_repo(&fx.pool, "local", "pypi").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(local_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make local owner public");
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 10)",
+        )
+        .bind(fx.repo_id)
+        .bind(local_id)
+        .execute(&fx.pool)
+        .await
+        .expect("attach LOWER-priority local owner (remote outranks it)");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8)",
+        )
+        .bind(local_id)
+        .bind(format!("simple/{project}/{local_wheel}"))
+        .bind(project)
+        .bind("1.0")
+        .bind("test-local-owner")
+        .bind("application/zip")
+        .bind(format!("local/{local_wheel}"))
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed local ownership artifact");
+
+        // Write the local owner's wheel to its storage so the local branch can
+        // actually resolve. Without this the local member is only ever a miss,
+        // and the 404 below cannot distinguish "the guard suppressed the
+        // remote" from "nothing resolved at all".
+        let local_wheel_path = local_dir.join("local");
+        std::fs::create_dir_all(&local_wheel_path).expect("local storage dir");
+        std::fs::write(
+            local_wheel_path.join(local_wheel),
+            wheel_with_metadata(
+                "demo-1.0",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n",
+            ),
+        )
+        .expect("seed local wheel bytes");
+
+        let app = tdh::router_anon(super::router(), state.clone());
+        let (status, _body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{remote_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        // POSITIVE CONTROL. The local owner's own wheel must resolve through
+        // the virtual. This is the half that fails on `main`: pre-fix, a
+        // virtual `.metadata` request falls through to
+        // `serve_metadata(repo.id)` against a repo that owns no artifacts, so
+        // EVERYTHING 404s -- which silently satisfies the negative assertion
+        // above. Without this control the suppression test is green on `main`
+        // and carries no information about whether the fix shipped.
+        let app = tdh::router_anon(super::router(), state);
+        let (local_status, local_body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{local_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        cleanup_virtual_member(&fx.pool, local_id, &local_dir).await;
+        cleanup_virtual_member(&fx.pool, remote_id, &remote_dir).await;
+        fx.teardown().await;
+
+        let _ = status;
+        // `serve_virtual_metadata` is a NEW way to read member content through
+        // a virtual repo, so the member filter is load-bearing here rather
+        // than inherited. Deleting `authorize_virtual_members` leaves every
+        // other test in this module green.
+        // The remote outranks the local owner and returns 500. Previously any
+        // non-404 aborted the whole loop, so a misconfigured or briefly-down
+        // upstream made EVERY locally-owned package's metadata 502 -- while
+        // the sibling wheel download succeeded, because `serve_file`'s loop
+        // logs and continues. Resolution must reach the local member.
+        assert_eq!(
+            local_status,
+            StatusCode::OK,
+            "a failing higher-priority member must not deny metadata for a \
+             package a lower-priority member owns: got body {:?}",
+            String::from_utf8_lossy(&local_body)
+        );
+        assert!(
+            String::from_utf8_lossy(&local_body).contains("Version: 1.0"),
+            "and the body must be the local member's"
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1635,7 +1635,6 @@ async fn download_or_metadata(
                 &state,
                 auth.as_ref(),
                 &repo,
-                &project,
                 &normalized,
                 requested_version.as_deref(),
                 real_filename,
@@ -1686,11 +1685,15 @@ async fn download_or_metadata(
 /// the same authorization and curation boundaries as the regular download
 /// path. A missing distribution falls through to the next member; other
 /// failures remain visible instead of being misreported as a 404.
+/// Takes ONLY the normalized project name. The raw path segment is
+/// deliberately not a parameter: every gate here keys on the PEP 503 form, and
+/// an earlier revision passed the raw segment to the upstream fetch, which
+/// re-normalizes with a DIFFERENT function. Not having the raw name in scope
+/// is what stops that from being reintroduced.
 async fn serve_virtual_metadata(
     state: &SharedState,
     auth: Option<&AuthExtension>,
     virtual_repo: &RepoInfo,
-    project: &str,
     normalized_project: &str,
     requested_version: Option<&str>,
     filename: &str,
@@ -1757,7 +1760,23 @@ async fn serve_virtual_metadata(
                         member.id,
                         &member.key,
                         upstream_url,
-                        project,
+                        // The NORMALIZED name, not the raw path segment.
+                        //
+                        // Every gate above keys on `normalized_project`
+                        // (`normalize_pep503`), but the upstream fetch
+                        // re-normalizes with `PypiHandler::normalize_name`,
+                        // and the two disagree: `normalize_pep503` silently
+                        // DROPS any character outside [A-Za-z0-9._-] without
+                        // marking a separator, while `normalize_name` maps
+                        // every non-alphanumeric to '-'. So "acme sdk" clears
+                        // the gate as "acmesdk" -- owned by nobody -- and then
+                        // fetches "acme-sdk", which is precisely the private
+                        // package the gate exists to protect.
+                        //
+                        // `normalize_name` is idempotent on PEP 503 output, so
+                        // passing the normalized name keeps the policy string
+                        // and the fetch string identical.
+                        normalized_project,
                         filename,
                     )
                     .await
@@ -9610,6 +9629,114 @@ mod tests {
             status,
             StatusCode::NOT_FOUND,
             "remote-only metadata must stay hidden when the local owner outranks the remote"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_virtual_pypi_metadata_isolation_survives_a_divergent_project_spelling() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pypi").await else {
+            return;
+        };
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+        let project = "acme-sdk";
+        let local_wheel = "acme_sdk-1.0-cp39-cp39-manylinux_2_17_x86_64.whl";
+        let remote_wheel = "acme_sdk-9.9.9-py3-none-any.whl";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(pep658_index_html(remote_wheel)),
+            )
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{remote_wheel}.metadata")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("Metadata-Version: 2.1\nName: acme-sdk\nVersion: 9.9.9\n"),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (remote_id, _remote_key, remote_dir, state) =
+            setup_virtual_pypi_member(&fx, false, &upstream.uri()).await;
+        let (local_id, _local_key, local_dir) = tdh::create_repo(&fx.pool, "local", "pypi").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(local_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make local owner public");
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(fx.repo_id)
+        .bind(local_id)
+        .execute(&fx.pool)
+        .await
+        .expect("attach higher-priority local owner");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8)",
+        )
+        .bind(local_id)
+        .bind(format!("simple/{project}/{local_wheel}"))
+        .bind(project)
+        .bind("1.0")
+        .bind("test-local-owner")
+        .bind("application/zip")
+        .bind(format!("local/{local_wheel}"))
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed local ownership artifact");
+
+        let app = tdh::router_anon(super::router(), state);
+        let (status, _body) = tdh::send(
+            app,
+            // Same request, but the project segment is spelled with a
+            // character that the two normalizers disagree about. axum
+            // percent-decodes the segment, so the handler sees "demo x".
+            //
+            // `normalize_pep503` (the gate) DROPS any character outside
+            // [A-Za-z0-9._-] without marking a separator, so it yields
+            // "demox" and no local owner is found. `PypiHandler::normalize_name`
+            // (the upstream fetch) maps every non-alphanumeric to '-', so it
+            // yields "demo-x" and asks upstream for a different project than
+            // the one the gate cleared.
+            // "acme sdk" -- one space. axum percent-decodes it.
+            //
+            // `normalize_pep503` (the GATE) drops any character outside
+            // [A-Za-z0-9._-] without marking a separator  -> "acmesdk",
+            // which no local member owns, so nothing is suppressed.
+            // `PypiHandler::normalize_name` (the upstream FETCH) maps every
+            // non-alphanumeric to '-'                      -> "acme-sdk",
+            // which is exactly the private package the gate was supposed to
+            // protect. The upstream mock below answers on that spelling, the
+            // way public PyPI would for an attacker-published shadow.
+            tdh::get(format!(
+                "/{}/simple/acme%20sdk/{remote_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        cleanup_virtual_member(&fx.pool, local_id, &local_dir).await;
+        cleanup_virtual_member(&fx.pool, remote_id, &remote_dir).await;
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "isolation must not depend on how the client spells the project. If the \
+             string used for the policy check differs from the string used to fetch, \
+             one percent-encoded character turns the dependency-confusion gate off."
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -9611,11 +9611,43 @@ mod tests {
         .await
         .expect("seed local ownership artifact");
 
-        let app = tdh::router_anon(super::router(), state);
+        // Write the local owner's wheel to its storage so the local branch can
+        // actually resolve. Without this the local member is only ever a miss,
+        // and the 404 below cannot distinguish "the guard suppressed the
+        // remote" from "nothing resolved at all".
+        let local_wheel_path = local_dir.join("local");
+        std::fs::create_dir_all(&local_wheel_path).expect("local storage dir");
+        std::fs::write(
+            local_wheel_path.join(local_wheel),
+            wheel_with_metadata(
+                "demo-1.0",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n",
+            ),
+        )
+        .expect("seed local wheel bytes");
+
+        let app = tdh::router_anon(super::router(), state.clone());
         let (status, _body) = tdh::send(
             app,
             tdh::get(format!(
                 "/{}/simple/{project}/{remote_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        // POSITIVE CONTROL. The local owner's own wheel must resolve through
+        // the virtual. This is the half that fails on `main`: pre-fix, a
+        // virtual `.metadata` request falls through to
+        // `serve_metadata(repo.id)` against a repo that owns no artifacts, so
+        // EVERYTHING 404s -- which silently satisfies the negative assertion
+        // above. Without this control the suppression test is green on `main`
+        // and carries no information about whether the fix shipped.
+        let app = tdh::router_anon(super::router(), state);
+        let (local_status, local_body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{local_wheel}.metadata",
                 fx.repo_key
             )),
         )
@@ -9629,6 +9661,144 @@ mod tests {
             status,
             StatusCode::NOT_FOUND,
             "remote-only metadata must stay hidden when the local owner outranks the remote"
+        );
+        assert_eq!(
+            local_status,
+            StatusCode::OK,
+            "the local owner's own wheel must still resolve through the virtual"
+        );
+        assert!(
+            String::from_utf8_lossy(&local_body).contains("Version: 1.0"),
+            "the served metadata must come from the LOCAL member's wheel, not \
+             the remote's -- got {:?}",
+            String::from_utf8_lossy(&local_body)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_virtual_pypi_metadata_does_not_leak_a_private_member_to_anon() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pypi").await else {
+            return;
+        };
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+        let project = "demo";
+        let local_wheel = "demo-1.0-cp39-cp39-manylinux_2_17_x86_64.whl";
+        let remote_wheel = "demo-2.0-cp39-cp39-win_amd64.whl";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{project}/")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(pep658_index_html(remote_wheel)),
+            )
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{remote_wheel}.metadata")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("Metadata-Version: 2.1\nName: demo\nVersion: 2.0\n"),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (remote_id, _remote_key, remote_dir, state) =
+            setup_virtual_pypi_member(&fx, false, &upstream.uri()).await;
+        let (local_id, _local_key, local_dir) = tdh::create_repo(&fx.pool, "local", "pypi").await;
+        // PRIVATE, unlike the sibling fixture. An anonymous caller must not
+        // be able to read this member's content through the virtual.
+        sqlx::query("UPDATE repositories SET is_public = false WHERE id = $1")
+            .bind(local_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make local owner private");
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(fx.repo_id)
+        .bind(local_id)
+        .execute(&fx.pool)
+        .await
+        .expect("attach higher-priority local owner");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8)",
+        )
+        .bind(local_id)
+        .bind(format!("simple/{project}/{local_wheel}"))
+        .bind(project)
+        .bind("1.0")
+        .bind("test-local-owner")
+        .bind("application/zip")
+        .bind(format!("local/{local_wheel}"))
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed local ownership artifact");
+
+        // Write the local owner's wheel to its storage so the local branch can
+        // actually resolve. Without this the local member is only ever a miss,
+        // and the 404 below cannot distinguish "the guard suppressed the
+        // remote" from "nothing resolved at all".
+        let local_wheel_path = local_dir.join("local");
+        std::fs::create_dir_all(&local_wheel_path).expect("local storage dir");
+        std::fs::write(
+            local_wheel_path.join(local_wheel),
+            wheel_with_metadata(
+                "demo-1.0",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n",
+            ),
+        )
+        .expect("seed local wheel bytes");
+
+        let app = tdh::router_anon(super::router(), state.clone());
+        let (status, _body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{remote_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        // POSITIVE CONTROL. The local owner's own wheel must resolve through
+        // the virtual. This is the half that fails on `main`: pre-fix, a
+        // virtual `.metadata` request falls through to
+        // `serve_metadata(repo.id)` against a repo that owns no artifacts, so
+        // EVERYTHING 404s -- which silently satisfies the negative assertion
+        // above. Without this control the suppression test is green on `main`
+        // and carries no information about whether the fix shipped.
+        let app = tdh::router_anon(super::router(), state);
+        let (local_status, local_body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{project}/{local_wheel}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        cleanup_virtual_member(&fx.pool, local_id, &local_dir).await;
+        cleanup_virtual_member(&fx.pool, remote_id, &remote_dir).await;
+        fx.teardown().await;
+
+        let _ = status;
+        // `serve_virtual_metadata` is a NEW way to read member content through
+        // a virtual repo, so the member filter is load-bearing here rather
+        // than inherited. Deleting `authorize_virtual_members` leaves every
+        // other test in this module green.
+        assert_ne!(
+            local_status,
+            StatusCode::OK,
+            "an anonymous caller must not read a PRIVATE member's metadata \
+             through the virtual: got body {:?}",
+            String::from_utf8_lossy(&local_body)
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1649,7 +1649,12 @@ async fn download_or_metadata(
                     repo.id,
                     &repo.key,
                     upstream_url,
-                    &project,
+                    // NORMALIZED, exactly as the virtual arm above. This
+                    // branch was left on the raw segment when the virtual one
+                    // was fixed, so a curation block on a direct Remote repo
+                    // was still evadable by spelling: the gate saw "acmesdk"
+                    // and the fetch resolved "acme-sdk".
+                    &normalized,
                     real_filename,
                 )
                 .await;
@@ -1760,7 +1765,7 @@ async fn serve_virtual_metadata(
         // PEP 658 metadata is not hash-tied to the distribution, so pip would
         // resolve against one package's dependencies and install another's,
         // with nothing anywhere to detect it.
-        if let Ok(response) = serve_metadata(
+        match serve_metadata(
             state,
             &state.db,
             member.id,
@@ -1769,7 +1774,20 @@ async fn serve_virtual_metadata(
         )
         .await
         {
-            return Ok(response);
+            Ok(response) => return Ok(response),
+            Err(response) if response.status() == StatusCode::NOT_FOUND => {}
+            // A non-404 here is a storage or DB fault, or a 503 from the
+            // decode-permit fast-fail -- not "this member does not have it".
+            // Swallowing it would fall through to a lower-priority REMOTE
+            // member and serve the upstream's metadata for a distribution this
+            // member holds locally, which is exactly the bytes-mismatch the
+            // local-first ordering exists to prevent, reappearing under load.
+            Err(response) => {
+                if first_member_error.is_none() {
+                    first_member_error = Some(response);
+                }
+                continue;
+            }
         }
 
         let result = if member.repo_type == RepositoryType::Remote {

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -842,6 +842,13 @@ mod tests {
         body_finished_rx
             .await
             .expect("server finished response body");
+        // The loopback write has completed, but client-side socket readiness is
+        // delivered by the OS in wall-clock time. Leaving Tokio paused here can
+        // auto-advance straight to reqwest's read deadline before that readiness
+        // event arrives. Resume real time for the final body read. Any accidental
+        // total deadline shorter than the 20-second jump is already expired and
+        // is still observed when reqwest next polls the body.
+        tokio::time::resume();
 
         assert_eq!(request.await.expect("request task").as_ref(), b"OK");
         server.await.expect("server task");

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -777,6 +777,7 @@ mod tests {
             .await
             .expect("bind test server");
         let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (body_finished_tx, body_finished_rx) = tokio::sync::oneshot::channel::<()>();
 
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.expect("accept request");
@@ -797,6 +798,7 @@ mod tests {
                 .expect("write first byte");
             tokio::time::sleep(Duration::from_secs(20)).await;
             socket.write_all(b"K").await.expect("write second byte");
+            body_finished_tx.send(()).expect("signal body finished");
         });
 
         // Serialize the client build against `test_configured_proxy_host_is_
@@ -833,6 +835,13 @@ mod tests {
             .expect("request task reached response headers");
         tokio::time::pause();
         tokio::time::advance(Duration::from_secs(20)).await;
+        // `advance` makes the server's sleep ready but does not guarantee the
+        // server task runs before the request task. Wait for the second byte to
+        // be written so Tokio cannot auto-advance to the client's 30-second
+        // read-inactivity timeout first under a heavily loaded full test run.
+        body_finished_rx
+            .await
+            .expect("server finished response body");
 
         assert_eq!(request.await.expect("request task").as_ref(), b"OK");
         server.await.expect("server task");


### PR DESCRIPTION
## Summary
Closes #3175 - extends #3077 to virtual repos.

For full-disclosure, I'm no rust programmer, so this was AI assisted with additional review by codex.

#3077 fixed PEP 658 metadata routing for remote repositories. Virtual repositories still queried metadata against the virtual repository itself, which owns no artifacts, resulting in a 404.

New logic:
- Resolves metadata through authorized virtual members in priority order.
- Preserves remote `.metadata` fetching and wheel-extraction fallback.
- Applies the same priority-aware dependency-confusion isolation used by simple indexes and artifact downloads.
- Allows remote platform-specific wheels for locally owned versions when they support a platform not available locally, while blocking remote-only versions and competing builds.
- Stabilizes the large-object timeout test by separating virtual timeout advancement from wall-clock socket readiness.

## Regression test (required for `fix/*` PRs)
<!--
Hardening Core (https://github.com/orgs/artifact-keeper/projects/2) requires
every bug-fix PR to land with a regression test that fails on `main` and
passes on this PR. Choose one that fits the bug:
  - unit test (closest to the buggy logic)
  - integration test (requires DB/storage/etc.)
  - end-to-end test in artifact-keeper-test (exercises the user flow)

For non-fix PRs (feat/, chore/, docs/, ci/, refactor/) check N/A.
Reviewers should not approve fix/* PRs without a checked box.
-->
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Regression coverage verifies:
- Metadata resolves through a virtual repository’s remote member.
- A remote metadata 404 falls back to extracting metadata from the wheel.
- Remote-only metadata remains hidden when a higher-priority local member owns the project.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
