### PR TITLE
fix(maven): spare a checksum sidecar whenever its base object is spared

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3966,6 +3966,31 @@ async fn purge_storage_object_keys(
 /// (#3156). Once this repository's attribution rows CASCADE away with it, that
 /// other repository becomes the key's sole read-path owner -- of bytes the
 /// delete has already destroyed.
+///
+/// Each of those two guards is then run a SECOND time against the
+/// sidecar-stripped key, which is what makes the invariant hold:
+///
+/// > a checksum/signature sidecar is spared whenever its BASE object is spared.
+///
+/// Without that, the guards tested only the candidate key verbatim, and
+/// *nothing ever references a sidecar by name* -- a parent's `files[]` lists
+/// the companion, not the companion's `.sha1`. So both guards always missed on
+/// a sidecar, and a miss in a `NOT EXISTS` means DELETE: `<companion>.sha1` was
+/// collected for purge even while `<companion>` itself was correctly spared
+/// (#3160, #3188). The GC sweep has carried the equivalent arms since #2668;
+/// this path never grew them. #3159 made the gap newly reachable -- before it
+/// the companion was purged too, so the sidecar was the lesser half of a larger
+/// loss; after it the companion survives and the sidecar alone is destroyed,
+/// leaving another repository serving an artifact whose checksum 404s (a
+/// warning under Maven's default `checksumPolicy=warn`, a hard build failure
+/// under `checksumPolicy=fail` and under Gradle dependency verification).
+///
+/// The sidecar arms mirror the verbatim guards *exactly* apart from the
+/// stripped key -- same joins, same `<> $1` scoping, and likewise no
+/// `is_deleted` test. That symmetry is load-bearing rather than incidental: any
+/// condition present on a sidecar arm but absent from the guard it shadows
+/// re-creates this same bug for the rows it excludes, by letting a base be
+/// spared while its sidecar is collected.
 async fn collect_repo_maven_flat_keys(state: &SharedState, repo_id: Uuid) -> Vec<String> {
     let sql = format!(
         "SELECT o.storage_key \
@@ -3985,10 +4010,33 @@ async fn collect_repo_maven_flat_keys(state: &SharedState, repo_id: Uuid) -> Vec
                WHERE pa.repository_id <> $1 \
                  AND pr.storage_backend = o.storage_backend \
                  AND {files_match} \
+           ) \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM artifacts sb \
+               JOIN repositories srb ON srb.id = sb.repository_id \
+               WHERE {is_sidecar} \
+                 AND sb.storage_key = {base_key} \
+                 AND sb.repository_id <> $1 \
+                 AND srb.storage_backend = o.storage_backend \
+           ) \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM artifact_metadata sam \
+               JOIN artifacts spa ON spa.id = sam.artifact_id \
+               JOIN repositories spr ON spr.id = spa.repository_id \
+               WHERE {is_sidecar} \
+                 AND spa.repository_id <> $1 \
+                 AND spr.storage_backend = o.storage_backend \
+                 AND {sidecar_files_match} \
            )",
         files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
             "am.metadata->'files'",
             "o.storage_key",
+        ),
+        is_sidecar = crate::services::maven_flat_attribution::is_sidecar_key_sql("o.storage_key"),
+        base_key = crate::services::maven_flat_attribution::sidecar_base_key_sql("o.storage_key"),
+        sidecar_files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
+            "sam.metadata->'files'",
+            &crate::services::maven_flat_attribution::sidecar_base_key_sql("o.storage_key"),
         ),
     );
     sqlx::query_scalar(&sql)
@@ -21215,6 +21263,124 @@ mod apt_validation_tests {
             collected.contains(&orphan_key),
             "positive control: a key no parent references must still be \
              collected for purge; collected: {collected:?}"
+        );
+    }
+
+    /// Seed a live `artifacts` row (no `files[]` metadata) at `storage_key`,
+    /// so it can anchor its own key against the verbatim guard.
+    async fn seed_flat_artifact_row(pool: &sqlx::PgPool, repo_id: Uuid, storage_key: &str) {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO artifacts \
+                 (id, repository_id, path, name, size_bytes, checksum_sha256, \
+                  content_type, storage_key, is_deleted) \
+             VALUES ($1, $2, $3, $3, 1, repeat('0', 64), \
+                     'application/java-archive', $4, false)",
+        )
+        .bind(id)
+        .bind(repo_id)
+        .bind(format!("p/{id}.jar"))
+        .bind(storage_key)
+        .execute(pool)
+        .await
+        .expect("seed flat artifact row");
+    }
+
+    /// #3160 / #3188: a checksum or signature sidecar must be spared whenever
+    /// its BASE object is spared.
+    ///
+    /// Both pre-existing guards test the candidate key *verbatim*, and nothing
+    /// ever references a sidecar by name -- a parent's `files[]` lists the
+    /// companion, not the companion's `.sha1`. So both guards always missed on
+    /// a sidecar, and a miss in a `NOT EXISTS` means DELETE: deleting this
+    /// repository destroyed `<companion>.sha1` while another repository was
+    /// still serving `<companion>`.
+    ///
+    /// Both anchoring layers are exercised, because the fix adds a sidecar arm
+    /// to each: a base anchored by a parent's `files[]` entry, and a base
+    /// anchored by a live `artifacts` row. `.asc` is included because
+    /// migrations 163 and 170 step (3') both backfill `.asc` attribution rows
+    /// -- it is a real inhabitant of this table, and the GC predicate's regex
+    /// omits it.
+    ///
+    /// TWO positive controls keep the fix honest: a genuinely unreferenced
+    /// base, and a genuinely unreferenced *sidecar*. Without the latter a fix
+    /// that spared every key ending in `.sha1` would pass.
+    #[tokio::test]
+    async fn collect_repo_maven_flat_keys_spares_sidecar_of_spared_base_3160() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (owner_repo, _, dir) = tdh::create_repo(&pool, "local", "maven").await;
+        let (other_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let uid = Uuid::new_v4().simple().to_string();
+
+        // Base 1: spared by the files[] guard (camelCase, as #3159 fixed).
+        let pom_key = format!("maven/gav3160/{uid}/demo-1.0.0.pom");
+        // Base 2: spared by the live-artifacts-row guard.
+        let jar_key = format!("maven/gav3160/{uid}/sibling-1.0.0.jar");
+        // Positive controls: nothing references either of these.
+        let orphan_key = format!("maven/gav3160/{uid}/gone-9.9.9.pom");
+        let orphan_sidecar_key = format!("{orphan_key}.sha1");
+
+        seed_flat_parent(
+            &pool,
+            other_repo,
+            &format!("maven/gav3160/{uid}/demo-1.0.0.jar"),
+            "storageKey",
+            &pom_key,
+        )
+        .await;
+        seed_flat_artifact_row(&pool, other_repo, &jar_key).await;
+
+        // The repository being deleted holds the claims for every base and
+        // every sidecar -- exactly the pairs migration 170 step (3') creates.
+        let pom_sidecars: Vec<String> = [".sha1", ".md5", ".sha256", ".sha512", ".asc"]
+            .iter()
+            .map(|s| format!("{pom_key}{s}"))
+            .collect();
+        let jar_sidecar = format!("{jar_key}.sha1");
+        for key in pom_sidecars.iter().map(String::as_str).chain([
+            jar_sidecar.as_str(),
+            &orphan_key,
+            &orphan_sidecar_key,
+        ]) {
+            seed_flat_claim(&pool, owner_repo, key).await;
+        }
+
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let collected = collect_repo_maven_flat_keys(&state, owner_repo).await;
+
+        tdh::cleanup(&pool, other_repo, Uuid::nil()).await;
+        tdh::cleanup(&pool, owner_repo, Uuid::nil()).await;
+
+        for sidecar in &pom_sidecars {
+            assert!(
+                !collected.contains(sidecar),
+                "the sidecar of a base another repository's live parent lists in \
+                 files[] must NOT be purged by this repository's delete -- that \
+                 leaves the other repository serving an artifact whose checksum \
+                 404s (#3160/#3188); collected: {collected:?}"
+            );
+        }
+        assert!(
+            !collected.contains(&jar_sidecar),
+            "the sidecar of a base anchored by another repository's live \
+             artifacts row must NOT be purged either (#3160/#3188); \
+             collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&orphan_key),
+            "positive control: a base no repository references must still be \
+             collected for purge; collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&orphan_sidecar_key),
+            "positive control: a sidecar whose BASE is itself unreferenced is a \
+             genuine orphan and must still be collected -- otherwise sparing \
+             every sidecar unconditionally would pass this test; \
+             collected: {collected:?}"
         );
     }
 }

--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -99,6 +99,66 @@ pub(crate) fn metadata_files_name_key_sql(files_expr: &str, key_expr: &str) -> S
     )
 }
 
+/// Sidecar suffixes a *delete guard* must strip before asking whether the
+/// object's BASE is still referenced (#3160/#3188).
+///
+/// Nothing ever references a sidecar by name: a parent artifact's `files[]`
+/// lists the companion, never the companion's `.sha1`. So a guard that tests
+/// the sidecar key verbatim always misses -- and in a `NOT EXISTS` guard a
+/// miss means DELETE. A sidecar is referenced exactly when its base is, which
+/// is why every such guard has to be run a second time against the stripped
+/// key.
+///
+/// The read path in this module has always known this: [`strip_checksum_suffix`]
+/// resolves a sidecar's owner from its base via [`CHECKSUM_SUFFIXES`]. This list
+/// must stay a superset of that one, or a sidecar the read path still serves
+/// (because its base resolves an owner) is one the delete path treats as
+/// unreferenced and purges -- the same read-path / delete-guard disagreement
+/// that produced #3156.
+///
+/// This is deliberately **not** `storage_gc_service::MAVEN_SIDECAR_SUFFIXES`,
+/// which serves a different and opposite purpose: that list *derives keys to
+/// delete* when GC reclaims a base object, so adding a suffix to it widens
+/// deletion. This list only ever *spares*, so it is the union of every suffix
+/// any path can produce -- the four GC derives, plus `.asc`, which migrations
+/// 163 and 170 step (3') both backfill into `maven_flat_object_owner`
+/// (`VALUES ('.sha1'), ('.md5'), ('.sha256'), ('.asc')`) and which the GC
+/// predicate's own regex omits. Erring wide is the safe direction here:
+/// a suffix listed in error spares an object that a later GC pass will
+/// reclaim anyway, while a suffix missing destroys a served one.
+pub(crate) const GUARDED_SIDECAR_SUFFIXES: [&str; 5] =
+    [".md5", ".sha1", ".sha256", ".sha512", ".asc"];
+
+/// The `(md5|sha1|...)` regex alternation built from
+/// [`GUARDED_SIDECAR_SUFFIXES`], so the SQL and the list cannot drift.
+fn guarded_sidecar_alternation() -> String {
+    GUARDED_SIDECAR_SUFFIXES
+        .iter()
+        .map(|s| s.trim_start_matches('.'))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// SQL predicate: does `key_expr` name a checksum/signature sidecar?
+///
+/// Pairs with [`sidecar_base_key_sql`]: a guard arm is only meaningful for
+/// keys that actually are sidecars, and without this test `regexp_replace`
+/// returns the key unchanged, so the arm would degenerate into a duplicate of
+/// the verbatim guard it is meant to complement.
+pub(crate) fn is_sidecar_key_sql(key_expr: &str) -> String {
+    let alt = guarded_sidecar_alternation();
+    format!(r"{key_expr} ~ '\.({alt})$'")
+}
+
+/// SQL expression stripping a [`GUARDED_SIDECAR_SUFFIXES`] suffix off
+/// `key_expr`, yielding the base object key the sidecar belongs to. Keys that
+/// are not sidecars come back unchanged -- always gate on
+/// [`is_sidecar_key_sql`].
+pub(crate) fn sidecar_base_key_sql(key_expr: &str) -> String {
+    let alt = guarded_sidecar_alternation();
+    format!(r"regexp_replace({key_expr}, '\.({alt})$', '')")
+}
+
 /// Distinct owning repositories of a live parent artifact whose metadata
 /// `files[]` array lists this key (legacy GAV-grouped uploads whose companion
 /// files have no row of their own), restricted to repositories on `$2`. LIMIT 2
@@ -524,6 +584,82 @@ mod tests {
             "rendered fragment changed; every caller (read path + three delete \
              guards) depends on this exact shape -- update deliberately, and \
              keep the two branches OR-ed"
+        );
+    }
+
+    /// The guard suffix list must stay a SUPERSET of the list GC derives
+    /// sidecar keys to delete from (#3160/#3188).
+    ///
+    /// The two lists point in opposite directions. `MAVEN_SIDECAR_SUFFIXES`
+    /// widens *deletion*: a suffix added there makes GC reclaim that sidecar
+    /// class. `GUARDED_SIDECAR_SUFFIXES` widens *sparing*. So a suffix that GC
+    /// deletes but no guard strips is a key that gets purged while its base is
+    /// still served — the #3160 bug, re-created one suffix at a time. `.asc`
+    /// is the standing example in the other direction: migrations 163 and 170
+    /// step (3') backfill `.asc` attribution rows, so it must be guarded even
+    /// though GC never derives it.
+    #[test]
+    fn guarded_sidecar_suffixes_are_a_superset_of_the_gc_derived_list() {
+        for suffix in crate::services::storage_gc_service::MAVEN_SIDECAR_SUFFIXES {
+            assert!(
+                GUARDED_SIDECAR_SUFFIXES.contains(&suffix),
+                "{suffix} is derived for deletion by GC but not stripped by the \
+                 delete guards: its base could be spared while it is purged"
+            );
+        }
+        // ...and a superset of the READ path's own list. This is the tighter
+        // constraint, and the one that states the bug exactly:
+        // `strip_checksum_suffix` already resolves a sidecar's owner from its
+        // BASE, so the read path has always known sidecars inherit base
+        // ownership. A suffix the read path resolves but the delete guard does
+        // not strip is precisely a sidecar that stays *served* (its base
+        // resolves an owner) while the delete path treats it as unreferenced
+        // and purges it -- the #3160/#3188 shape, and the same read-path /
+        // delete-guard disagreement as #3156.
+        for suffix in CHECKSUM_SUFFIXES {
+            assert!(
+                GUARDED_SIDECAR_SUFFIXES.contains(&suffix),
+                "{suffix} is resolved to its base by the read path \
+                 (strip_checksum_suffix) but not stripped by the delete guards: \
+                 the object stays served while the delete path purges it"
+            );
+        }
+        assert!(
+            GUARDED_SIDECAR_SUFFIXES.contains(&".asc"),
+            "migrations 163 and 170 step (3') backfill `.asc` attribution rows, \
+             so `.asc` sidecars must be guarded against their base"
+        );
+    }
+
+    /// Both sidecar helpers must be built from [`GUARDED_SIDECAR_SUFFIXES`] and
+    /// anchor at end-of-string. An unanchored or hand-edited alternation would
+    /// silently stop matching a suffix class, and in a `NOT EXISTS` guard a key
+    /// that stops matching is a key that gets DELETED.
+    ///
+    /// This is the only check on the sidecar guards that runs WITHOUT a
+    /// database — `collect_repo_maven_flat_keys_spares_sidecar_of_spared_base_3160`
+    /// skips silently when `DATABASE_URL` is unset.
+    #[test]
+    fn sidecar_helpers_render_every_guarded_suffix_anchored() {
+        let base = sidecar_base_key_sql("o.storage_key");
+        let is_sidecar = is_sidecar_key_sql("o.storage_key");
+        for suffix in GUARDED_SIDECAR_SUFFIXES {
+            let bare = suffix.trim_start_matches('.');
+            assert!(base.contains(bare), "{suffix} missing from {base}");
+            assert!(
+                is_sidecar.contains(bare),
+                "{suffix} missing from {is_sidecar}"
+            );
+        }
+        assert_eq!(
+            base, r"regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512|asc)$', '')",
+            "rendered base-key expression changed; the repository-delete sidecar \
+             guards depend on this exact shape"
+        );
+        assert_eq!(
+            is_sidecar, r"o.storage_key ~ '\.(md5|sha1|sha256|sha512|asc)$'",
+            "rendered sidecar test changed; without the `$` anchor a key merely \
+             CONTAINING a suffix would be treated as a sidecar"
         );
     }
 

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -174,7 +174,7 @@ const MAVEN_FLAT_KEY_PREFIX: &str = "maven/";
 /// artifacts-driven orphan sweep, which is exactly why GC used to leave
 /// `.md5`/`.sha1` files behind after their base artifact was reclaimed
 /// (#2668). GC derives these keys from the base key when reclaiming it.
-const MAVEN_SIDECAR_SUFFIXES: [&str; 4] = [".md5", ".sha1", ".sha256", ".sha512"];
+pub(crate) const MAVEN_SIDECAR_SUFFIXES: [&str; 4] = [".md5", ".sha1", ".sha256", ".sha512"];
 
 /// Upper bound on flat-object attribution rows examined per GC pass.
 const ORPHAN_MAVEN_FLAT_SCAN_LIMIT: i64 = 1000;


### PR DESCRIPTION
## Summary

Fixes #3160.
Fixes #3188.

`collect_repo_maven_flat_keys` — the purge list built before a repository delete —
carried two `NOT EXISTS` guards, and **both tested the candidate key verbatim**.
Nothing ever references a checksum or signature sidecar *by name*: a parent artifact's
`files[]` lists the companion, never the companion's `.sha1`. So both guards always
missed on a sidecar, and in a `NOT EXISTS` guard **a miss means DELETE**.

Deleting repository A therefore destroyed `<companion>.sha1` while repository B's live
parent artifact was still serving `<companion>`. B is left publishing an artifact whose
checksum sidecar 404s:

- Maven's default `checksumPolicy=warn` — logs a warning, build proceeds. Survivable.
- `checksumPolicy=fail` — **hard build failure** for every consumer of that artifact.
- Gradle dependency verification — **hard failure**; a missing checksum is a
  verification failure, not a soft miss.

The GC sweep has had the equivalent arms since #2668
(`ORPHAN_MAVEN_FLAT_PREDICATE_SQL` guards 4 and 5). The repository-delete path never
grew them.

Cloud backends only (S3/GCS/Azure), where the flat `maven/{path}` key space is shared
and `maven_flat_object_owner` attribution rows exist. Filesystem backends isolate each
repository's key space and are unaffected.

### One root cause, one PR

#3160 and #3188 are the same defect in the same function, filed twice from two passes
over #3159 — #3160 from that PR's post-fix output, #3188 while finishing it. #3188 is a
strict superset: #3160 describes the missing sidecar arm on the `files[]` guard, #3188
establishes that **both** guards lack one and adds the reproduction, the
`checksumPolicy` impact, and the `.asc` question. Both prescribe the identical fix —
port the GC predicate's sidecar arms and reuse `metadata_files_name_key_sql`. One
change closes both, so splitting would mean two PRs editing the same SQL literal.

## Fix

Each existing guard is run a **second time** against the sidecar-stripped key,
establishing the invariant:

> a sidecar is spared whenever its BASE object is spared.

The new arms mirror the guards they shadow *exactly* apart from the stripped key —
same joins, same `<> $1` scoping, and likewise no `is_deleted` test. That symmetry is
load-bearing, not incidental: any condition present on a sidecar arm but absent from
the guard it shadows re-creates this same bug for the rows it excludes, by letting a
base be spared while its sidecar is collected.

These are anti-joins, so every arm added only ever **spares more**. Nothing here
narrows an existing guard — narrowing is the data-loss direction. In particular the
guards are still not scoped by `am.format`: migration 170 backfills attribution from
any `artifact_metadata` row naming a `maven/%` key, filtering on the key prefix and not
on format, so format-scoping would desynchronize the guard from the backfill.

### The read path already knew this

Worth stating plainly, because it is the sharpest form of the bug:
`maven_flat_attribution::strip_checksum_suffix` — the **read** path — has always
resolved a sidecar's owner from its *base* key, via

```rust
const CHECKSUM_SUFFIXES: [&str; 4] = [".sha1", ".md5", ".sha256", ".asc"];
```

So the read path serves `<companion>.sha1` on the strength of `<companion>`'s
ownership, while the delete guard asked whether anything referenced
`<companion>.sha1` by name and concluded nothing did. Read path and delete guard
disagreeing about the same key is exactly the #3156 shape, one layer down. A test now
pins `GUARDED_SIDECAR_SUFFIXES` as a superset of `CHECKSUM_SUFFIXES`, so a suffix the
read path resolves can never again be one the delete path fails to guard.

### `.asc` is covered — and is a real inhabitant of this table

#3188 asks whether `.asc` needs the same treatment. It does, on two independent
grounds. `CHECKSUM_SUFFIXES` above already resolves it on the read path. And
migrations 163 and 170 step (3') both backfill sidecar rows with
`CROSS JOIN (VALUES ('.sha1'), ('.md5'), ('.sha256'), ('.asc'))` — so `.asc` rows are
in `maven_flat_object_owner` and were being collected for purge — while the GC
predicate's regex covers `md5|sha1|sha256|sha512` and omits `.asc` entirely. The
lists were already asymmetric in both directions (`.sha512` is in the GC regex but is
neither backfilled nor resolved by the read path).

The new guard list is therefore the **union**, and deliberately a separate constant
from `storage_gc_service::MAVEN_SIDECAR_SUFFIXES`:

```rust
pub(crate) const GUARDED_SIDECAR_SUFFIXES: [&str; 5] =
    [".md5", ".sha1", ".sha256", ".sha512", ".asc"];
```

The two lists point in **opposite directions**. `MAVEN_SIDECAR_SUFFIXES` derives keys
*to delete* when GC reclaims a base, so adding a suffix there widens deletion.
`GUARDED_SIDECAR_SUFFIXES` only ever spares, so erring wide is the safe direction: a
suffix listed in error spares an object a later GC pass reclaims anyway, while a
suffix missing destroys a served one. A test pins the superset relationship so a
suffix cannot be added to GC's list without being guarded.

### Follow-up, not fixed here

The GC predicate's own regex still omits `.asc`, so the sweep will reclaim an `.asc`
sidecar whose base is live — the same bug class on the other path, and the second
instance #3188 predicted. It is not fixed here because `MAVEN_SIDECAR_SUFFIXES` serves
that dual derive-and-guard role, and splitting the two roles is a real change to the
GC deletion set rather than a one-line widening. Filed separately.

## Reproduced first

Isolated `postgres:16-alpine`, all 192 migrations applied, seeded per #3188: two
`s3`-backed repositories, B holding a live parent artifact whose `files[]` names
`demo-1.0.0.pom` under camelCase `storageKey`, A owning the attribution rows for that
`.pom` and its sidecars. Running the predicate **as merged in #3159**:

```
=== collect_repo_maven_flat_keys(repo A) -- predicate AS MERGED IN #3159 ===
                   storage_key
--------------------------------------------------
 maven/com/example/demo/1.0.0/demo-1.0.0.pom.asc
 maven/com/example/demo/1.0.0/demo-1.0.0.pom.sha1
 maven/com/example/gone/9.9.9/gone-9.9.9.pom
 maven/com/example/gone/9.9.9/gone-9.9.9.pom.sha1
(4 rows)
```

`demo-1.0.0.pom` is spared (#3159 working as intended); its `.sha1` and `.asc` are
collected and would be deleted from storage. With the sidecar-base guards, same seed:

```
=== collect_repo_maven_flat_keys(repo A) -- predicate WITH THE #3160/#3188 SIDECAR-BASE GUARDS ===
                   storage_key
--------------------------------------------------
 maven/com/example/gone/9.9.9/gone-9.9.9.pom
 maven/com/example/gone/9.9.9/gone-9.9.9.pom.sha1
(2 rows)
```

The spared base's sidecars are spared with it, and the genuine orphan **and its own
sidecar** are still collected — the fix does not simply spare everything.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

All in-crate (`src/... mod tests`) so they count toward the `nextest --lib` coverage
gate:

- `repositories.rs` `collect_repo_maven_flat_keys_spares_sidecar_of_spared_base_3160`
  — DB-backed. Exercises **both** anchoring layers, because the fix adds an arm to
  each: a base anchored by a parent's `files[]` entry, and a base anchored by a live
  `artifacts` row. Covers all five guarded suffixes.
- `maven_flat_attribution.rs` `guarded_sidecar_suffixes_are_a_superset_of_the_gc_derived_list`
  — pins the guard list against **both** the GC derive list and the read path's
  `CHECKSUM_SUFFIXES`
- `maven_flat_attribution.rs` `sidecar_helpers_render_every_guarded_suffix_anchored`

**Two positive controls.** A genuinely unreferenced base, *and* a genuinely
unreferenced sidecar. The second is the one that matters: without it, a "fix" that
spared every key ending in `.sha1` would pass, and the whole point of this predicate is
that it must still reclaim real orphans.

The DB-free helper tests exist because both DB-backed tests here skip silently when
`DATABASE_URL` is unset — the suffix list and the `$`-anchored rendering are pinned
where a database is not required.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — the DB-backed `--lib` test
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Run against an isolated Postgres 16 with `AK_TESTS_REQUIRE_DB=1`, so a skipped DB test
fails loudly instead of reporting a false green.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No schema migration and no `sqlx::query!` macro (the predicate is composed at runtime
and run through `query_scalar`), so no `.sqlx` regeneration. Patch-shaped, targeting
1.7.2.

## Relationship to #3159

**Stacked on #3159, no conflict.** This branches from
`fix/maven-flat-delete-guards-accept-camelcase` and targets it, so the two do not
collide on the SQL literal they both touch. Merge #3159 first; this retargets to `main`
automatically.

The dependency is real rather than a convenience: this fix reuses
`metadata_files_name_key_sql`, the shared fragment #3159 introduces, which is what both
issues prescribe so the sidecar arm cannot drift from the guard it shadows. #3159 also
makes the bug newly reachable — before it the companion was purged too, so losing the
sidecar was the lesser half of a larger loss; after it the companion survives and the
sidecar alone is destroyed.
