### PR TITLE
fix(proxy): forward upstream Content-Encoding on the buffered scanned serve paths (npm, PyPI, NuGet flat-container)

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -3451,13 +3451,24 @@ fn npm_synthetic_artifact(
 /// Build a buffered 200 response for scanned npm tarball bytes. `pending`
 /// selects the loud `X-AK-Scan: pending` header for the fail-open
 /// serve-before-verdict path so a served-unscanned byte is observable.
+///
+/// `content_encoding` is the coding the UPSTREAM declared on these exact bytes,
+/// forwarded verbatim (#3184). This builder previously did not take the
+/// parameter at all, so a scan-enabled npm proxy served a coded tarball with no
+/// coding declared and a `Content-Length` describing the CODED length — #3149,
+/// left live on this arm when #3176 fixed the streaming sibling beside it.
+/// Note the transfer coding is distinct from the `.tgz` gzip that is part of the
+/// tarball format itself: a `Content-Encoding` here is an EXTRA layer the client
+/// must strip before it sees a tarball at all. Pass `None` when the upstream
+/// sent no coding, so the header stays absent rather than being manufactured.
 fn build_scanned_tarball_response(
     filename: &str,
     bytes: Bytes,
+    content_encoding: Option<&str>,
     digest: &str,
     pending: bool,
 ) -> Response {
-    Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, NPM_TARBALL_CONTENT_TYPE)
         .header(
@@ -3466,9 +3477,11 @@ fn build_scanned_tarball_response(
         )
         .header(CONTENT_LENGTH, bytes.len().to_string())
         .header("X-AK-Scan", if pending { "pending" } else { "clean" })
-        .header("X-NPM-Tarball-SHA256", digest)
-        .body(Body::from(bytes))
-        .unwrap()
+        .header("X-NPM-Tarball-SHA256", digest);
+    if let Some(enc) = content_encoding {
+        builder = builder.header(CONTENT_ENCODING, enc);
+    }
+    builder.body(Body::from(bytes)).unwrap()
 }
 
 /// Inline scan-and-block for an npm proxy tarball download (#3003).
@@ -3504,7 +3517,11 @@ async fn serve_scanned_npm_tarball(
         upstream_url,
         RepositoryFormat::Npm,
     );
-    let bytes = match proxy
+    // The upstream content-type is discarded on purpose (the tarball type is
+    // fixed by the format), but the upstream CODING is not: this arm forwards
+    // the buffered body verbatim, so it must declare what the bytes are coded
+    // with or reproduce #3149 (#3184).
+    let (bytes, content_encoding) = match proxy
         .fetch_artifact_with_cache_path_capped(
             &remote_repo,
             fetch_path,
@@ -3513,7 +3530,7 @@ async fn serve_scanned_npm_tarball(
         )
         .await
     {
-        Ok((bytes, _upstream_content_type)) => bytes,
+        Ok((bytes, _upstream_content_type, content_encoding)) => (bytes, content_encoding),
         Err(e) if proxy_helpers::is_over_cap_error(&e) => {
             // Over the byte cap: never buffer unbounded (#895 OOM).
             return match crate::services::proxy_scan_service::decide_inconclusive(action) {
@@ -3628,7 +3645,11 @@ async fn serve_scanned_npm_tarball(
         proxy_helpers::ProxyScanServeOutcome::Serve { pending } => {
             proxy_helpers::record_proxy_download(state, repo_id, repo_key, fetch_path, ctx).await;
             Ok(build_scanned_tarball_response(
-                filename, bytes, &digest, pending,
+                filename,
+                bytes,
+                content_encoding.as_deref(),
+                &digest,
+                pending,
             ))
         }
     }
@@ -9096,6 +9117,100 @@ mod tests {
         assert_eq!(npm_package_name_from_artifact_path("lodash/4.17.21"), None);
         assert_eq!(npm_package_name_from_artifact_path(""), None);
         assert_eq!(npm_package_name_from_artifact_path("//file.tgz"), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // #3184: the buffered scan-on-proxy tarball serve must forward the
+    // UPSTREAM's Content-Encoding.
+    //
+    // Fixtures are `deflate`, never gzip. A gzip fixture cannot distinguish
+    // "forwards the upstream coding" from "hardcodes gzip" -- which is how
+    // #3176's fourteen tests stayed green under exactly that mutation. It
+    // matters doubly here: a `.tgz` is gzip by format, so a gzip fixture would
+    // also be indistinguishable from the tarball's own inner compression.
+    // -----------------------------------------------------------------------
+
+    /// Positive: a deflate-coded upstream tarball is served with
+    /// `Content-Encoding: deflate`.
+    ///
+    /// Fails if the builder hardcodes `"gzip"`, and fails if the builder drops
+    /// the coding -- the #3184 bug, which was structural here because this
+    /// builder did not even take the parameter.
+    #[test]
+    fn test_build_scanned_tarball_response_forwards_upstream_deflate_coding() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let (_plain, coded) = tdh::coded_fixture("deflate", b"tarball-payload-");
+        let bytes = Bytes::from(coded.clone());
+
+        let resp =
+            build_scanned_tarball_response("pkg-1.0.0.tgz", bytes, Some("deflate"), "d", false);
+
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_ENCODING).as_deref(),
+            Some("deflate"),
+            "buffered scanned tarball serve must declare the UPSTREAM's coding; \
+             `gzip` here means the value is hardcoded, `None` means #3184 is live"
+        );
+        // Content-Length is the CODED length, only correct once declared.
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_LENGTH).as_deref(),
+            Some(coded.len().to_string().as_str())
+        );
+    }
+
+    /// Negative control: an UNCODED upstream tarball must not have a coding
+    /// manufactured for it. Fails if the header is emitted unconditionally.
+    ///
+    /// The plain `.tgz` case is the overwhelmingly common one -- npm registries
+    /// serve tarballs uncoded -- so an unconditional header would break the
+    /// default path rather than an edge case.
+    #[test]
+    fn test_build_scanned_tarball_response_omits_coding_when_upstream_uncoded() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let resp = build_scanned_tarball_response(
+            "pkg-1.0.0.tgz",
+            Bytes::from_static(b"\x1f\x8b plain tgz bytes"),
+            None,
+            "d",
+            false,
+        );
+
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_ENCODING),
+            None,
+            "an uncoded upstream must be served with NO Content-Encoding; \
+             manufacturing one makes npm try to decode a raw tarball"
+        );
+    }
+
+    /// End-to-end on the bytes: decode the served body with the coding the
+    /// response declares and compare to the plaintext. Also asserts the proxy
+    /// does NOT decode on the client's behalf -- the wire bytes stay coded.
+    #[tokio::test]
+    async fn test_build_scanned_tarball_response_body_decodes_under_declared_coding() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let (plain, coded) = tdh::coded_fixture("deflate", b"decodable-tarball-");
+
+        let resp = build_scanned_tarball_response(
+            "pkg-1.0.0.tgz",
+            Bytes::from(coded.clone()),
+            Some("deflate"),
+            "d",
+            true,
+        );
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_ENCODING).as_deref(),
+            Some("deflate")
+        );
+
+        let (status, body, _headers) = tdh::collect_response(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.as_ref(), coded.as_slice());
+        assert_eq!(
+            tdh::inflate_deflate(&body),
+            plain,
+            "body must decode under the coding the response declares"
+        );
     }
 }
 

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -13,7 +13,7 @@
 
 use axum::body::Body;
 use axum::extract::{Path, Query, RawQuery, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, put};
@@ -632,24 +632,30 @@ async fn proxy_v3_flatcontainer(
         )
         .await
     } else {
-        let (content, content_type) = proxy_helpers::proxy_fetch_capped_with_cache_key(
-            proxy,
-            fetch_repo_id,
-            fetch_repo_key,
-            upstream_url,
-            &fetch_url,
-            &cache_path,
-            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-        )
-        .await?;
-        Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header(
-                CONTENT_TYPE,
-                content_type.unwrap_or_else(|| "application/json".to_string()),
+        // Unlike the registration / search / OData arms, this one serves the
+        // upstream body VERBATIM (a version list carries no URLs, so nothing is
+        // rewritten). That makes it the one NuGet caller that has to forward the
+        // upstream coding, hence the `_encoded` variant — surfaced by the #3184
+        // widening of `fetch_artifact_with_cache_path_capped`.
+        let (content, content_type, content_encoding) =
+            proxy_helpers::proxy_fetch_capped_with_cache_key_encoded(
+                proxy,
+                fetch_repo_id,
+                fetch_repo_key,
+                upstream_url,
+                &fetch_url,
+                &cache_path,
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
             )
-            .body(Body::from(content))
-            .unwrap())
+            .await?;
+        let mut builder = Response::builder().status(StatusCode::OK).header(
+            CONTENT_TYPE,
+            content_type.unwrap_or_else(|| "application/json".to_string()),
+        );
+        if let Some(enc) = content_encoding.as_deref() {
+            builder = builder.header(CONTENT_ENCODING, enc);
+        }
+        Ok(builder.body(Body::from(content)).unwrap())
     }
 }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1384,6 +1384,14 @@ pub async fn proxy_fetch_capped_anonymous(
 
 /// Byte-ceiling-bounded sibling of [`proxy_fetch_with_cache_key`] (#1608 Phase
 /// 4b / #2181). See [`proxy_fetch_capped`] for the `max` semantics.
+///
+/// DROPS the upstream `Content-Encoding`. That is correct only for callers that
+/// PARSE or REWRITE the buffered body (the NuGet service-index / registration /
+/// search / OData arms all `from_utf8_lossy` + rewrite before serving), because
+/// the bytes they emit are not the bytes that arrived and the upstream coding no
+/// longer describes them. A caller that forwards the buffered body VERBATIM must
+/// use [`proxy_fetch_capped_with_cache_key_encoded`] instead, or it reproduces
+/// #3149 — coded bytes served with no coding declared.
 pub async fn proxy_fetch_capped_with_cache_key(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -1393,6 +1401,31 @@ pub async fn proxy_fetch_capped_with_cache_key(
     cache_path: &str,
     max: usize,
 ) -> Result<(Bytes, Option<String>), Response> {
+    let (content, content_type, _encoding) = proxy_fetch_capped_with_cache_key_encoded(
+        proxy_service,
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        cache_path,
+        max,
+    )
+    .await?;
+    Ok((content, content_type))
+}
+
+/// As [`proxy_fetch_capped_with_cache_key`], but also reports the upstream
+/// `Content-Encoding` so a caller that passes the buffered body through
+/// untouched can declare the coding it is actually serving (#3184).
+pub async fn proxy_fetch_capped_with_cache_key_encoded(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>, Option<String>), Response> {
     with_proxy_repo(
         repo_id,
         repo_key,

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3172,10 +3172,20 @@ fn pypi_synthetic_artifact(
 /// Build a buffered 200 response for scanned bytes. `pending` adds the loud
 /// `X-AK-Scan: pending` header for the fail-open serve-before-verdict path so a
 /// served-unscanned byte is observable (kills the #1274 silent gap).
+///
+/// `content_encoding` is the coding the UPSTREAM declared on these exact bytes,
+/// forwarded verbatim (#3184). The proxy no longer lets reqwest decode upstream
+/// bodies, so a coded wheel arrives here still coded and `bytes.len()` — which
+/// feeds `Content-Length` — is the CODED length. Serving that without declaring
+/// the coding is #3149: pip receives compressed data labelled as identity and
+/// fails to unpack it. Pass `None` when the upstream sent no coding; the header
+/// must then be ABSENT rather than manufactured, or every uncoded serve is
+/// mislabelled instead.
 fn build_scanned_file_response(
     filename: &str,
     bytes: Bytes,
     content_type: Option<String>,
+    content_encoding: Option<&str>,
     digest: Option<&str>,
     pending: bool,
 ) -> Response {
@@ -3189,6 +3199,9 @@ fn build_scanned_file_response(
         )
         .header(CONTENT_LENGTH, bytes.len().to_string())
         .header("X-AK-Scan", if pending { "pending" } else { "clean" });
+    if let Some(enc) = content_encoding {
+        builder = builder.header(CONTENT_ENCODING, enc);
+    }
     if let Some(d) = digest {
         builder = builder.header("X-PyPI-File-SHA256", d);
     }
@@ -3234,7 +3247,11 @@ async fn serve_scanned_pypi_file(
         &target.fetch_base,
         RepositoryFormat::Pypi,
     );
-    let (bytes, content_type) = match proxy
+    // `content_encoding` is the coding these exact bytes arrived under. It has
+    // to travel with them to `build_scanned_file_response` below: this arm
+    // forwards the buffered body VERBATIM, so dropping the coding here is the
+    // #3149 bug (#3184).
+    let (bytes, content_type, content_encoding) = match proxy
         .fetch_artifact_with_cache_path_capped(
             &repo,
             &target.fetch_path,
@@ -3243,7 +3260,7 @@ async fn serve_scanned_pypi_file(
         )
         .await
     {
-        Ok(pair) => pair,
+        Ok(triple) => triple,
         Err(e) if is_over_cap_error(&e) => {
             // Over the byte cap: never buffer unbounded (#895 OOM).
             return match crate::services::proxy_scan_service::decide_inconclusive(action) {
@@ -3346,6 +3363,7 @@ async fn serve_scanned_pypi_file(
                 filename,
                 bytes,
                 content_type,
+                content_encoding.as_deref(),
                 Some(&digest),
                 pending,
             ))
@@ -10953,6 +10971,7 @@ mod tests {
             "pkg-1.0-py3-none-any.whl",
             bytes.clone(),
             Some("application/x-custom".to_string()),
+            None,
             Some(&digest),
             false,
         );
@@ -10984,7 +11003,7 @@ mod tests {
 
         // Pending serve (fail-open before a verdict): loud header, and the
         // content type falls back to the filename-derived default.
-        let resp = build_scanned_file_response("pkg-1.0.tar.gz", bytes, None, None, true);
+        let resp = build_scanned_file_response("pkg-1.0.tar.gz", bytes, None, None, None, true);
         assert_eq!(
             resp.headers().get("X-AK-Scan").unwrap().to_str().unwrap(),
             "pending"
@@ -10994,6 +11013,112 @@ mod tests {
             "application/gzip"
         );
         assert!(resp.headers().get("X-PyPI-File-SHA256").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // #3184: the buffered scan-on-proxy serve path must forward the UPSTREAM's
+    // Content-Encoding.
+    //
+    // Every fixture below is `deflate`, never gzip. #3176 shipped fourteen
+    // tests that all stayed green when the forwarded value was replaced by a
+    // hardcoded `"gzip"` literal, because every fixture WAS gzip -- they pinned
+    // "a coding is declared", not "the upstream's coding is declared". A
+    // gzip-only fixture cannot tell the two apart; deflate can.
+    // -----------------------------------------------------------------------
+
+    /// Positive: a deflate-coded upstream body is served with
+    /// `Content-Encoding: deflate`, not with some other coding and not bare.
+    ///
+    /// Fails if the builder hardcodes `"gzip"` (asserts `deflate`), and fails
+    /// if the builder drops the coding (asserts the header is present) -- the
+    /// #3184 bug itself.
+    #[test]
+    fn test_build_scanned_file_response_forwards_upstream_deflate_coding() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let (_plain, coded) = tdh::coded_fixture("deflate", b"wheel-payload-");
+        let bytes = Bytes::from(coded.clone());
+        let digest = sha256_hex(&bytes);
+
+        let resp = build_scanned_file_response(
+            "pkg-1.0-py3-none-any.whl",
+            bytes.clone(),
+            None,
+            Some("deflate"),
+            Some(&digest),
+            false,
+        );
+
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_ENCODING).as_deref(),
+            Some("deflate"),
+            "buffered scanned serve must declare the UPSTREAM's coding; \
+             `gzip` here means the value is hardcoded, `None` means #3184 is live"
+        );
+        // Content-Length describes the CODED bytes, which is only correct
+        // once the coding is declared alongside it.
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_LENGTH).as_deref(),
+            Some(coded.len().to_string().as_str())
+        );
+    }
+
+    /// Negative control: an UNCODED upstream must not have a coding
+    /// manufactured for it. Fails if the header is emitted unconditionally.
+    #[test]
+    fn test_build_scanned_file_response_omits_coding_when_upstream_uncoded() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let bytes = Bytes::from_static(b"PK\x03\x04plain-wheel-bytes");
+        let digest = sha256_hex(&bytes);
+
+        let resp = build_scanned_file_response(
+            "pkg-1.0-py3-none-any.whl",
+            bytes,
+            None,
+            None,
+            Some(&digest),
+            false,
+        );
+
+        assert_eq!(
+            tdh::header_str(resp.headers(), CONTENT_ENCODING),
+            None,
+            "an uncoded upstream must be served with NO Content-Encoding; \
+             manufacturing one mislabels every plain wheel"
+        );
+    }
+
+    /// End-to-end on the bytes, not just the header: decode the served body
+    /// with the coding the response declares and compare to the plaintext.
+    ///
+    /// This is the assertion a client actually makes. A response whose declared
+    /// coding does not match its bytes fails here even if the header is
+    /// non-empty, which is exactly what a hardcoded `"gzip"` produces.
+    #[tokio::test]
+    async fn test_build_scanned_file_response_body_decodes_under_declared_coding() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let (plain, coded) = tdh::coded_fixture("deflate", b"decodable-wheel-");
+        let resp = build_scanned_file_response(
+            "pkg-1.0-py3-none-any.whl",
+            Bytes::from(coded.clone()),
+            None,
+            Some("deflate"),
+            None,
+            true,
+        );
+
+        let declared = tdh::header_str(resp.headers(), CONTENT_ENCODING);
+        assert_eq!(declared.as_deref(), Some("deflate"));
+
+        let (status, body, _headers) = tdh::collect_response(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        // The proxy must not decode on the client's behalf either: the wire
+        // bytes are the coded ones.
+        assert_eq!(body.as_ref(), coded.as_slice());
+        assert_eq!(
+            tdh::inflate_deflate(&body),
+            plain,
+            "body must decode under the coding the response declares"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1483,18 +1483,17 @@ pub async fn rewire_remote_proxy(
 }
 
 // ---------------------------------------------------------------------------
-// #3149: Content-Encoding forwarding fixtures.
+// #3149 / #3184: Content-Encoding forwarding fixtures.
 // ---------------------------------------------------------------------------
 
-/// Build a gzip-coded body for the #3149 `Content-Encoding`-forwarding tests,
-/// returning `(plain, coded)`.
+/// Build a body coded with `encoding`, returning `(plain, coded)`.
 ///
 /// Shared across the npm / PyPI / OCI / generic-repository / cargo arms so the
-/// five suites do not each carry their own copy of the encoder block (the
-/// jscpd duplication gate scores changed files). The payload is deliberately
-/// repetitive so gzip actually shrinks it: the caller asserts `coded != plain`,
-/// without which a "forwarding" test could pass while proving nothing.
-/// Build a body coded with `encoding`, returning `(plain, coded)`.
+/// suites do not each carry their own copy of the encoder block (the jscpd
+/// duplication gate scores changed files). The payload is deliberately
+/// repetitive so the coding actually shrinks it: the caller asserts
+/// `coded != plain`, without which a "forwarding" test could pass while
+/// proving nothing.
 ///
 /// Exists because every #3149 fixture was gzip and every assertion was
 /// `== Some("gzip")`, so replacing the forwarded value with a hardcoded
@@ -1545,6 +1544,13 @@ pub fn inflate_deflate(coded: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Build a gzip-coded body, returning `(plain, coded)`.
+///
+/// Retained for the arms that assert GET/HEAD header parity, where the point
+/// of the test is that two builders agree with each other rather than which
+/// coding is in play. Prefer [`coded_fixture`] with a NON-gzip coding for
+/// anything asserting that the UPSTREAM's coding is what gets forwarded: a
+/// gzip fixture cannot tell that apart from a hardcoded `"gzip"`.
 pub fn gzip_fixture(seed: &[u8]) -> (Vec<u8>, Vec<u8>) {
     use flate2::write::GzEncoder;
     use flate2::Compression;

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2634,19 +2634,28 @@ impl ProxyService {
 
     /// Byte-ceiling-aware sibling of
     /// [`Self::fetch_artifact_with_cache_path`] (#1608 Phase 4b / #2181).
+    ///
+    /// Returns a [`CachedBody`] — `(body, content_type, content_encoding)` —
+    /// rather than the `(body, content_type)` pair it used to (#3184). The
+    /// coding was previously dropped right here, which is why the buffered
+    /// scan-on-proxy serve paths for npm and PyPI could not forward it even
+    /// after #3176 fixed their streaming siblings: the value never reached
+    /// them. Widening in place rather than adding a `_with_encoding` sibling is
+    /// deliberate — it breaks every caller at compile time and forces each one
+    /// to state whether it forwards the bytes verbatim (must declare the
+    /// coding) or parses/transforms them (must drop it), instead of letting a
+    /// new caller silently reintroduce #3149.
     pub async fn fetch_artifact_with_cache_path_capped(
         &self,
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
         max: usize,
-    ) -> Result<(Bytes, Option<String>)> {
-        let (content, content_type, _encoding) = self
-            .fetch_artifact_with_cache_path_and_accept_capped(
-                repo, fetch_path, cache_path, None, max,
-            )
-            .await?;
-        Ok((content, content_type))
+    ) -> Result<CachedBody> {
+        self.fetch_artifact_with_cache_path_and_accept_capped(
+            repo, fetch_path, cache_path, None, max,
+        )
+        .await
     }
 
     /// Variant of [`Self::fetch_artifact`] that forwards a client-supplied


### PR DESCRIPTION
Fixes #3184

## What was still broken

#3176 fixed the *streaming* builders. The two **buffered** proxied-serve builders were left behind, so on any repository with `scan_on_proxy` enabled the original #3149 symptom was still live end to end:

- `build_scanned_file_response` (`pypi.rs`) — `pip install` gets a coded body labelled as identity
- `build_scanned_tarball_response` (`npm.rs`) — same on the `npm install` tarball path; it did not even take the parameter

Both set `Content-Length` from `bytes.len()`, which is the **coded** length. That is only a correct pair of headers once the coding is declared alongside it.

## Why they couldn't just be patched

The coding never reached them. It was discarded one level up, in the signature of the primitive itself:

```rust
let (content, content_type, _encoding) = self.fetch_artifact_with_cache_path_and_accept_capped(...)
```

So `fetch_artifact_with_cache_path_capped` now returns `CachedBody` — `(body, content_type, content_encoding)`.

Widening it **in place**, rather than adding a `_with_encoding` sibling next to it, is deliberate. It breaks every caller at compile time and forces each one to state which of the two things it is: a caller that forwards the buffered bytes **verbatim** (must declare the coding) or one that **parses or rewrites** them (must drop it). A sibling would have let the next caller silently reintroduce #3149, which is exactly how this bug outlived #3176.

## The widening found a third live instance

`fetch_artifact_with_cache_path_capped` has three direct callers. Two are the builders above. The third is `proxy_helpers::proxy_fetch_capped_with_cache_key`, which fans out to five NuGet call sites:

| Call site | Does what with the body | Coding |
| --- | --- | --- |
| `discover_upstream_resources` | parses as JSON | drop (correct) |
| `proxy_v3_registration` | `from_utf8_lossy` + URL rewrite | drop (correct) |
| V3 search | `from_utf8_lossy` + rewrite + parse | drop (correct) |
| V2 OData feed | `from_utf8_lossy` + rewrite | drop (correct) |
| **`proxy_v3_flatcontainer` (buffered arm)** | **serves verbatim** | **was dropping it — same bug** |

Dropping the coding on the four rewriting arms is right: the bytes they emit are not the bytes that arrived, so the upstream coding no longer describes them. The flat-container version-list arm carries no URLs and therefore needs no rewriting, which is precisely why it forwards its body untouched — and why it needed the coding. It now uses a new `proxy_fetch_capped_with_cache_key_encoded`; the dropping wrapper documents why its remaining callers may drop.

## Tests: deflate, never gzip

Per the issue, every fixture here is **`deflate`**. #3176 shipped fourteen tests that all stayed green when the forwarded value was replaced by a hardcoded `"gzip"` literal, because every fixture *was* gzip — they pinned "a coding is declared", not "the **upstream's** coding is declared". A gzip fixture cannot tell those apart. On the npm side it is worse still: a `.tgz` is gzip by format, so a gzip fixture is also indistinguishable from the tarball's own inner compression.

Each builder gets three tests:

- **positive** — deflate upstream ⇒ served `Content-Encoding: deflate`
- **negative control** — uncoded upstream ⇒ **no** `Content-Encoding` header
- **decode** — inflates the served body and compares to the plaintext, and asserts the proxy did not decode on the client's behalf

`tdh::coded_fixture` / `tdh::inflate_deflate` / `header_str` / `collect_response` were added to `test_db_helpers.rs` (they live on #3176's branch, not on `main`).

### Mutation-proven, not eyeballed

| Mutation | Result |
| --- | --- |
| Hardcode `"gzip"` in both builders | **4 fail** (both positives + both decode tests): `left: Some("gzip") / right: Some("deflate")` |
| Emit the header unconditionally | **2 fail** (both negative controls): `left: Some("gzip") / right: None` |
| Drop the coding — the bug as shipped | **4 fail** (both positives + both decode tests): `left: None / right: Some("deflate")` |

Clean state restored and re-verified green after each.

## Gates (run locally — CI fleet is down)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --lib -- pypi npm proxy_service` with `AK_TESTS_REQUIRE_DB=1` — **1101 passed, 0 failed**
- No `sqlx::query!` macro added, so no `.sqlx` regeneration. `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` unset verified anyway — clean.

## Notes for the reviewer

- **#3176 is still open.** This branch is cut from `main`, so it does not contain the streaming fixes. Both PRs append to the end of `test_db_helpers.rs` and both add `coded_fixture` / `inflate_deflate`; expect a conflict there whichever merges second. The helper text is copied verbatim from #3176 so the resolution is "keep one copy".
- **`serve_remote_metadata` (PEP 658 `.metadata`) is NOT in this PR** — filed separately as #3193. It needs a *different* primitive widened (`fetch_upstream_direct_with_link`, whose third tuple element is the `Link` header, not the coding, and which is shared with OCI tag pagination), and its wheel-extraction fallback arm has a distinct **decode-before-parse** bug rather than a forward-the-header one. Bundling them would put two different remediations behind one title.
