### PR TITLE
fix(backup): never report success when artifact bytes are missing (#3170, #3171)

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -473,10 +473,17 @@ pub async fn execute_backup(
     Extension(_auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<BackupResponse>> {
-    let storage = Arc::new(StorageService::from_config(&state.config).await?);
+    // Two distinct handles, deliberately (#3171):
+    //  * `archive_root` is the prefix-less handle backup ARCHIVES have always
+    //    been written to/read from; it must stay prefix-less or existing
+    //    archives become unreachable.
+    //  * `source` reads ARTIFACT BYTES and must carry the configured
+    //    `S3_PREFIX`, because that is where primary storage wrote them.
+    let archive_root = Arc::new(StorageService::from_config(&state.config).await?);
     let archive_storage =
-        StorageService::backup_archive_from_config(&state.config, &storage).await?;
-    let service = BackupService::with_archive_storage(state.db.clone(), storage, archive_storage);
+        StorageService::backup_archive_from_config(&state.config, &archive_root).await?;
+    let source = Arc::new(StorageService::artifact_source_from_config(&state.config).await?);
+    let service = BackupService::with_archive_storage(state.db.clone(), source, archive_storage);
 
     let backup = service.execute(id).await?;
 
@@ -531,14 +538,18 @@ pub async fn restore_backup(
     Path(id): Path<Uuid>,
     Json(payload): Json<RestoreRequest>,
 ) -> Result<Json<RestoreResponse>> {
-    let storage = Arc::new(
+    // As in `execute_backup`: archives keep the prefix-less handle, artifact
+    // bytes are restored through the prefixed artifact-source handle so they
+    // land at the keys the rest of the system reads them from (#3171).
+    let archive_root = Arc::new(
         StorageService::from_config(&state.config)
             .await
             .map_err(|e: AppError| e)?,
     );
     let archive_storage =
-        StorageService::backup_archive_from_config(&state.config, &storage).await?;
-    let service = BackupService::with_archive_storage(state.db.clone(), storage, archive_storage);
+        StorageService::backup_archive_from_config(&state.config, &archive_root).await?;
+    let source = Arc::new(StorageService::artifact_source_from_config(&state.config).await?);
+    let service = BackupService::with_archive_storage(state.db.clone(), source, archive_storage);
 
     let options = RestoreOptions {
         restore_database: payload.restore_database.unwrap_or(true),

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -77,9 +77,66 @@ pub struct BackupManifest {
     pub backup_type: BackupType,
     pub created_at: DateTime<Utc>,
     pub database_tables: Vec<String>,
+    /// Number of artifact objects whose bytes were successfully read and are
+    /// present in the archive.
     pub artifact_count: i64,
+    /// Number of enumerated artifact objects whose bytes could **not** be read
+    /// and are therefore absent from the archive (#3170).
+    ///
+    /// Recorded so an existing archive can be audited without re-running the
+    /// backup, and so [`BackupService::restore`] can refuse to present an
+    /// incomplete archive as a clean restore. Defaults to `0` when absent so
+    /// archives written before this field existed still deserialize.
+    #[serde(default)]
+    pub artifacts_unreadable: i64,
     pub total_size_bytes: i64,
     pub checksum: String,
+}
+
+/// Metadata key that opts a backup in to completing despite unreadable
+/// artifact bytes (#3170).
+///
+/// Absent/false — the default — means a backup that cannot read an artifact's
+/// bytes FAILS. Partial backups remain possible, but only as an explicit
+/// operator choice, never as a silent default.
+const ALLOW_PARTIAL_ARTIFACTS_KEY: &str = "allow_partial_artifacts";
+
+/// Whether the backup's metadata opts in to a partial (best-effort) archive.
+fn allow_partial_artifacts(metadata: Option<&serde_json::Value>) -> bool {
+    metadata
+        .and_then(|m| m.get(ALLOW_PARTIAL_ARTIFACTS_KEY))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Build the operator-facing message for a backup that could not read every
+/// artifact's bytes (#3170).
+///
+/// Names the affected keys (capped, with an overflow count) so the job's
+/// `error_message` is actionable without trawling logs.
+fn unreadable_artifacts_message(unreadable: &[(String, String)]) -> String {
+    const MAX_LISTED: usize = 5;
+    let listed = unreadable
+        .iter()
+        .take(MAX_LISTED)
+        .map(|(key, err)| format!("{key} ({err})"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    let overflow = unreadable.len().saturating_sub(MAX_LISTED);
+    let suffix = if overflow > 0 {
+        format!(" and {overflow} more")
+    } else {
+        String::new()
+    };
+    format!(
+        "backup is missing artifact content: {} artifact object(s) could not be read: {}{}. \
+         The archive does NOT contain these bytes. Set `{}` in the backup metadata to accept \
+         a partial archive deliberately.",
+        unreadable.len(),
+        listed,
+        suffix,
+        ALLOW_PARTIAL_ARTIFACTS_KEY
+    )
 }
 
 /// Request to create a backup
@@ -601,14 +658,28 @@ impl BackupService {
         let storage_keys = self
             .artifact_storage_keys(repository_filter.as_deref(), since_filter)
             .await?;
+        // Read each artifact's bytes, tracking failures rather than discarding
+        // them (#3170). A read that fails means the archive will not contain
+        // that artifact's content; that must never be invisible.
         let mut artifact_data: Vec<(String, Vec<u8>)> = Vec::new();
+        let mut unreadable: Vec<(String, String)> = Vec::new();
         for key in storage_keys {
-            if let Ok(content) = self.storage.get(&key).await {
-                artifact_data.push((key, content.to_vec()));
+            match self.storage.get(&key).await {
+                Ok(content) => artifact_data.push((key, content.to_vec())),
+                Err(e) => {
+                    tracing::warn!(
+                        backup_id = %backup_id,
+                        storage_key = %key,
+                        error = %e,
+                        "backup could not read artifact bytes; the archive will not contain this object"
+                    );
+                    unreadable.push((key, e.to_string()));
+                }
             }
         }
 
-        // Build manifest
+        // Build manifest. Both counts are recorded so an archive can be audited
+        // after the fact without re-running the backup (#3170).
         let manifest = BackupManifest {
             version: "1.0".to_string(),
             backup_id,
@@ -616,6 +687,7 @@ impl BackupService {
             created_at: Utc::now(),
             database_tables: table_names.iter().map(|s| s.to_string()).collect(),
             artifact_count: artifact_data.len() as i64,
+            artifacts_unreadable: unreadable.len() as i64,
             total_size_bytes: 0,     // Will be actual size in final backup
             checksum: String::new(), // Will be computed after archive is complete
         };
@@ -658,6 +730,27 @@ impl BackupService {
         .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // A backup that could not read every artifact's bytes must not present
+        // as a clean success (#3170). The archive and its manifest are written
+        // first, deliberately: the partial data plus the recorded miss count is
+        // strictly more useful to an operator than discarding both, and the
+        // manifest is what lets `restore` refuse the archive later. The job
+        // itself then fails, so the failure is visible at the moment it happens
+        // rather than at restore time when there is no recourse.
+        if !unreadable.is_empty() {
+            let message = unreadable_artifacts_message(&unreadable);
+            if allow_partial_artifacts(backup.metadata.as_ref()) {
+                tracing::warn!(
+                    backup_id = %backup_id,
+                    unreadable = unreadable.len(),
+                    "{}", message
+                );
+            } else {
+                tracing::error!(backup_id = %backup_id, "{}", message);
+                return Err(AppError::Internal(message));
+            }
+        }
 
         self.get_by_id(backup_id).await
     }
@@ -851,6 +944,23 @@ impl BackupService {
             errors: Vec::new(),
         };
 
+        // An archive whose manifest records unreadable artifacts is known to be
+        // missing content. Surface that as a restore error so the restore can
+        // never report `errors=[]` over an incomplete archive (#3170). This is
+        // the second half of the honesty guarantee: the backup fails loudly at
+        // capture time, and if a partial archive was deliberately opted in to,
+        // the restore still refuses to call it clean.
+        if let Some(manifest) = Self::read_manifest(&entries) {
+            if manifest.artifacts_unreadable > 0 {
+                result.errors.push(format!(
+                    "archive is incomplete: its manifest records {} artifact object(s) that were \
+                     unreadable at backup time and are absent from this archive (backup {}). \
+                     {} artifact object(s) were captured.",
+                    manifest.artifacts_unreadable, manifest.backup_id, manifest.artifact_count
+                ));
+            }
+        }
+
         // Restore database tables in dependency order
         if options.restore_database {
             let table_order = [
@@ -934,6 +1044,19 @@ impl BackupService {
         }
 
         Ok(result)
+    }
+
+    /// Parse `manifest.json` out of already-extracted archive entries.
+    ///
+    /// Returns `None` when the archive has no manifest or it does not parse —
+    /// both are tolerated so a malformed manifest never blocks an otherwise
+    /// usable restore. Archives written before #3170 simply report
+    /// `artifacts_unreadable = 0` via the field's serde default.
+    fn read_manifest(entries: &[(std::path::PathBuf, Vec<u8>)]) -> Option<BackupManifest> {
+        entries
+            .iter()
+            .find(|(path, _)| path.file_name().and_then(|n| n.to_str()) == Some("manifest.json"))
+            .and_then(|(_, content)| serde_json::from_slice::<BackupManifest>(content).ok())
     }
 
     /// Extract all entries from a tar.gz archive synchronously.
@@ -1341,6 +1464,7 @@ mod tests {
             created_at: Utc::now(),
             database_tables: vec!["users".to_string(), "artifacts".to_string()],
             artifact_count: 42,
+            artifacts_unreadable: 0,
             total_size_bytes: 1024 * 1024,
             checksum: "abc123".to_string(),
         };
@@ -1353,6 +1477,7 @@ mod tests {
         assert_eq!(deserialized.backup_type, BackupType::Full);
         assert_eq!(deserialized.database_tables.len(), 2);
         assert_eq!(deserialized.artifact_count, 42);
+        assert_eq!(deserialized.artifacts_unreadable, 0);
         assert_eq!(deserialized.total_size_bytes, 1024 * 1024);
         assert_eq!(deserialized.checksum, "abc123");
     }
@@ -2183,5 +2308,225 @@ mod tests {
             .execute(&pool)
             .await;
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // #3170: a backup that cannot read an artifact's bytes must not report a
+    // clean success. Historically the collect loop was
+    //
+    //     if let Ok(content) = self.storage.get(&key).await { ... }
+    //
+    // so a failed read was discarded entirely: not counted, not logged, not in
+    // the manifest, not in the job status. The job reported `completed` with
+    // `artifact_count=0` and the restore reported `errors=[]` while restoring
+    // nothing — an operator got no signal at any point that the archive held
+    // no content. These tests assert on honesty (the miss is surfaced), not on
+    // any particular storage-path resolution, so they keep passing after the
+    // #2863 root-resolution fix lands.
+    // -----------------------------------------------------------------------
+
+    /// Build a backup service whose primary storage is an **empty** directory,
+    /// so every artifact key enumerated from the database is unreadable. This
+    /// is the in-process stand-in for the real-world condition in #3170/#3171:
+    /// the row says the bytes exist, the handle the backup reads through
+    /// cannot find them.
+    fn service_with_empty_storage(pool: PgPool) -> (BackupService, std::path::PathBuf) {
+        use crate::services::storage_service::FilesystemBackend;
+        let dir = std::env::temp_dir().join(format!("bk-3170-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp storage dir");
+        let backend = Arc::new(FilesystemBackend::new(dir.clone()));
+        let storage = Arc::new(StorageService::new(backend));
+        (BackupService::new(pool, storage), dir)
+    }
+
+    fn full_backup_of(repo_id: Uuid) -> CreateBackupRequest {
+        CreateBackupRequest {
+            backup_type: BackupType::Full,
+            repository_ids: Some(vec![repo_id]),
+            exclude_repository_ids: None,
+            since: None,
+            created_by: None,
+            name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn backup_with_unreadable_artifact_bytes_does_not_report_success() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _key, repo_dir) = tdh::create_repo(&pool, "local", "generic").await;
+
+        // One artifact row whose bytes are NOT present at the resolved root.
+        let missing_key = insert_artifact_at(&pool, repo_id, "unreadable", Utc::now()).await;
+
+        let (service, storage_dir) = service_with_empty_storage(pool.clone());
+        let backup = service
+            .create(full_backup_of(repo_id))
+            .await
+            .expect("create backup job");
+
+        let result = service.execute(backup.id).await;
+
+        // The core assertion: the job must NOT succeed while the archive is
+        // missing artifact content.
+        assert!(
+            result.is_err(),
+            "backup whose artifact bytes are unreadable must not report success"
+        );
+
+        let row = service
+            .get_by_id(backup.id)
+            .await
+            .expect("reload backup row");
+        assert_ne!(
+            row.status,
+            BackupStatus::Completed,
+            "a backup missing artifact content must not present as completed"
+        );
+        let message = row.error_message.unwrap_or_default();
+        assert!(
+            message.contains(&missing_key),
+            "the unreadable key must be named in the job error; got {message:?}"
+        );
+
+        // A failed backup is not restorable, so the missing bytes can never be
+        // silently "restored" as a clean run.
+        let restore = service
+            .restore(
+                backup.id,
+                RestoreOptions {
+                    restore_database: false,
+                    restore_artifacts: true,
+                    target_repository_id: None,
+                },
+            )
+            .await;
+        assert!(
+            restore.is_err(),
+            "restore must refuse an archive whose backup did not complete cleanly"
+        );
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&repo_dir);
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    #[tokio::test]
+    async fn opt_in_partial_backup_records_misses_and_restore_refuses_them() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _key, repo_dir) = tdh::create_repo(&pool, "local", "generic").await;
+        let missing_key = insert_artifact_at(&pool, repo_id, "unreadable", Utc::now()).await;
+
+        let (service, storage_dir) = service_with_empty_storage(pool.clone());
+        let backup = service
+            .create(full_backup_of(repo_id))
+            .await
+            .expect("create backup job");
+
+        // Operators who genuinely want a best-effort archive opt in explicitly.
+        sqlx::query("UPDATE backups SET metadata = metadata || $2::jsonb WHERE id = $1")
+            .bind(backup.id)
+            .bind(serde_json::json!({ "allow_partial_artifacts": true }))
+            .execute(&pool)
+            .await
+            .expect("set allow_partial_artifacts");
+
+        service
+            .execute(backup.id)
+            .await
+            .expect("opt-in partial backup completes");
+
+        let row = service
+            .get_by_id(backup.id)
+            .await
+            .expect("reload backup row");
+        assert_eq!(
+            row.status,
+            BackupStatus::Completed,
+            "an explicitly opted-in partial backup may complete"
+        );
+
+        // ...but the archive must record the miss so it can be audited without
+        // re-running, and so the restore path can refuse it.
+        let manifest = read_manifest_from_backup(&service, &row).await;
+        assert_eq!(
+            manifest.artifacts_unreadable, 1,
+            "the manifest must record the unreadable artifact"
+        );
+        assert_eq!(
+            manifest.artifact_count, 0,
+            "the unreadable artifact must not be counted as captured"
+        );
+
+        let restore = service
+            .restore(
+                backup.id,
+                RestoreOptions {
+                    restore_database: false,
+                    restore_artifacts: true,
+                    target_repository_id: None,
+                },
+            )
+            .await
+            .expect("restore of a partial archive runs");
+        assert!(
+            restore
+                .errors
+                .iter()
+                .any(|e| e.contains("unreadable") || e.contains(&missing_key)),
+            "restore must not report errors=[] for an archive with recorded misses; got {:?}",
+            restore.errors
+        );
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&repo_dir);
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// Pull `backup/manifest.json` back out of a written archive.
+    async fn read_manifest_from_backup(service: &BackupService, row: &Backup) -> BackupManifest {
+        let path = row.storage_path.as_ref().expect("archive path");
+        let bytes = service
+            .archive_storage
+            .get(path)
+            .await
+            .expect("archive readable");
+        let entries = BackupService::extract_entries(&bytes).expect("extract archive");
+        let (_, content) = entries
+            .iter()
+            .find(|(p, _)| p.to_string_lossy().contains("manifest.json"))
+            .expect("archive contains a manifest");
+        serde_json::from_slice(content).expect("manifest parses")
+    }
+
+    #[test]
+    fn manifest_without_unreadable_field_defaults_to_zero() {
+        // Archives written before #3170 have no `artifacts_unreadable` key;
+        // they must still deserialize (as 0) so old backups stay auditable.
+        let legacy = serde_json::json!({
+            "version": "1.0",
+            "backup_id": Uuid::nil(),
+            "backup_type": "full",
+            "created_at": "2026-01-01T00:00:00Z",
+            "database_tables": ["users"],
+            "artifact_count": 3,
+            "total_size_bytes": 0,
+            "checksum": ""
+        });
+        let manifest: BackupManifest =
+            serde_json::from_value(legacy).expect("legacy manifest deserializes");
+        assert_eq!(manifest.artifacts_unreadable, 0);
+        assert_eq!(manifest.artifact_count, 3);
     }
 }

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -1217,7 +1217,9 @@ async fn execute_due_backup_schedules(db: &PgPool, config: &Config) -> crate::er
         return Ok(());
     }
 
-    let storage = match StorageService::from_config(config).await {
+    // Handle that reads ARTIFACT BYTES: must carry the configured `S3_PREFIX`
+    // so it resolves the keys primary storage wrote artifacts under (#3171).
+    let storage = match StorageService::artifact_source_from_config(config).await {
         Ok(s) => Arc::new(s),
         Err(e) => {
             tracing::error!(
@@ -1228,18 +1230,32 @@ async fn execute_due_backup_schedules(db: &PgPool, config: &Config) -> crate::er
         }
     };
 
-    // Route backup archives to a dedicated bucket when BACKUP_S3_BUCKET is set
-    // (#2507); otherwise this is a clone of the primary storage handle.
-    let archive_storage = match StorageService::backup_archive_from_config(config, &storage).await {
-        Ok(s) => s,
+    // Handle that backup ARCHIVES live on. Kept prefix-less (the historical
+    // layout) so archives written before #3171 stay reachable.
+    let archive_root = match StorageService::from_config(config).await {
+        Ok(s) => Arc::new(s),
         Err(e) => {
             tracing::error!(
-                "Failed to create backup archive storage for scheduled backups: {}",
+                "Failed to create archive storage service for scheduled backups: {}",
                 e
             );
             return Err(e);
         }
     };
+
+    // Route backup archives to a dedicated bucket when BACKUP_S3_BUCKET is set
+    // (#2507); otherwise this is a clone of the prefix-less archive handle.
+    let archive_storage =
+        match StorageService::backup_archive_from_config(config, &archive_root).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to create backup archive storage for scheduled backups: {}",
+                    e
+                );
+                return Err(e);
+            }
+        };
 
     for due_schedule in &due_schedules {
         let claimed = match claim_backup_schedule_run(

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -475,8 +475,9 @@ macro_rules! impl_storage_wrapper {
 ///
 /// Forwards the facade `StorageBackend` trait — including `supports_redirect`
 /// and `get_presigned_url` — to the inner S3 backend, so the single facade
-/// handle carries presign capability (built with `prefix = None` for the
-/// proxy cache; #1555).
+/// handle carries presign capability. The inner backend's key prefix is set by
+/// the [`StorageRole`] the handle was built for (`prefix = None` for the proxy
+/// cache, #1555; the configured `S3_PREFIX` for artifact bytes, #3171).
 pub struct S3BackendWrapper {
     inner: Arc<crate::storage::s3::S3Backend>,
 }
@@ -502,8 +503,11 @@ pub struct StorageService {
     /// parallel side-channel field, so no call site can silently get a
     /// non-presigning handle.
     ///
-    /// For S3 the inner backend is built with `prefix = None` so the signed
-    /// key matches the no-prefix layout the proxy cache writes.
+    /// For S3 the inner backend's key prefix depends on the [`StorageRole`]
+    /// the handle was built for: `ProxyCache` forces `prefix = None` so the
+    /// signed key matches the no-prefix layout the proxy cache writes (#1555),
+    /// while `ArtifactSource` keeps the configured `S3_PREFIX` so artifact
+    /// bytes are read at the key primary storage wrote them under (#3171).
     backend: Arc<dyn StorageBackend>,
 }
 
@@ -522,9 +526,71 @@ pub fn backend_supports_proxy_cache(storage_backend: &str) -> bool {
     matches!(storage_backend, "filesystem" | "s3" | "gcs")
 }
 
+/// What a [`StorageService`] handle is being built to address.
+///
+/// The two roles differ in exactly one thing — S3 key-prefix policy — and that
+/// difference is load-bearing in both directions, which is why it is named
+/// here instead of being an unlabelled line inside one constructor (#3171):
+///
+/// * [`StorageRole::ProxyCache`] must force `prefix = None`. Proxy-cache
+///   content lives at the bucket root (`proxy-cache/...`), not under
+///   `S3_PREFIX`, so a presigned key must carry no prefix (#1555).
+/// * [`StorageRole::ArtifactSource`] must keep the configured `S3_PREFIX`,
+///   because that is where primary storage actually wrote the artifact bytes.
+///
+/// Reusing the prefix-less proxy-cache handle to read artifact bytes was the
+/// #3171 bug: backup looked for `<storage_key>` while the bytes lived at
+/// `<S3_PREFIX>/<storage_key>`, so it missed every object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageRole {
+    /// Cache facade for remote/proxy repositories. Content is anchored at the
+    /// bucket root, so the key prefix is deliberately forced off (#1555).
+    ProxyCache,
+    /// Artifact bytes for hosted repositories, laid out exactly as primary
+    /// storage writes them — including `S3_PREFIX` (#3171).
+    ArtifactSource,
+}
+
+impl StorageRole {
+    /// Apply this role's S3 key-prefix policy to an env-derived config.
+    ///
+    /// Only the S3 backend has a key prefix; filesystem and GCS resolve keys
+    /// identically for both roles, so this is the whole of the divergence.
+    pub fn apply_s3_prefix_policy(self, config: &mut crate::storage::s3::S3Config) {
+        match self {
+            // Proxy-cache content is anchored at the bucket root (#1555).
+            StorageRole::ProxyCache => config.prefix = None,
+            // Artifact bytes keep the prefix primary storage wrote them under
+            // (#3171); leaving `from_env`'s value untouched is the fix.
+            StorageRole::ArtifactSource => {}
+        }
+    }
+}
+
 impl StorageService {
-    /// Create storage service from config
+    /// Create the proxy-cache storage service from config.
+    ///
+    /// Equivalent to [`StorageService::from_config_for_role`] with
+    /// [`StorageRole::ProxyCache`]. Every historical caller of this function
+    /// wants the prefix-less proxy-cache handle, so its behavior is unchanged.
+    /// Callers that need to read or write **artifact bytes** must use
+    /// [`StorageService::artifact_source_from_config`] instead (#3171).
     pub async fn from_config(config: &Config) -> Result<Self> {
+        Self::from_config_for_role(config, StorageRole::ProxyCache).await
+    }
+
+    /// Build the storage handle used to read and write **artifact bytes**,
+    /// laid out exactly as primary storage wrote them (#3171).
+    ///
+    /// This is what the backup source path and the artifact-restore path must
+    /// use. It differs from [`StorageService::from_config`] only on S3, where
+    /// it preserves the configured `S3_PREFIX` rather than forcing it off.
+    pub async fn artifact_source_from_config(config: &Config) -> Result<Self> {
+        Self::from_config_for_role(config, StorageRole::ArtifactSource).await
+    }
+
+    /// Create storage service from config for an explicit [`StorageRole`].
+    pub async fn from_config_for_role(config: &Config, role: StorageRole) -> Result<Self> {
         let backend: Arc<dyn StorageBackend> = match config.storage_backend.as_str() {
             "filesystem" => {
                 let path = PathBuf::from(&config.storage_path);
@@ -532,17 +598,18 @@ impl StorageService {
                 Arc::new(FilesystemBackend::new(path))
             }
             "s3" => {
-                // Build the proxy-cache S3 backend from the SAME env-derived
-                // config the primary storage uses (redirect_downloads, presign
-                // creds, CloudFront, path_format, TLS, pool tuning), then force
-                // the key prefix to None. Proxy-cache content lives at the
-                // bucket root (`proxy-cache/...`), not under S3_PREFIX, so the
-                // signed key must carry no prefix. Reusing from_env() (instead
-                // of S3Config::new, which hardcodes redirect_downloads=false and
-                // no presign creds) is what makes presigning actually fire on
-                // this handle (#1555).
+                // Build the S3 backend from the SAME env-derived config the
+                // primary storage uses (redirect_downloads, presign creds,
+                // CloudFront, path_format, TLS, pool tuning). Reusing
+                // from_env() (instead of S3Config::new, which hardcodes
+                // redirect_downloads=false and no presign creds) is what makes
+                // presigning actually fire on this handle (#1555).
+                //
+                // The key-prefix policy is the one thing that depends on what
+                // the handle is for, so it is delegated to the role (#3171):
+                // ProxyCache forces the prefix off, ArtifactSource keeps it.
                 let mut s3_config = crate::storage::s3::S3Config::from_env()?;
-                s3_config.prefix = None;
+                role.apply_s3_prefix_policy(&mut s3_config);
                 let inner = Arc::new(crate::storage::s3::S3Backend::new(s3_config).await?);
                 Arc::new(S3BackendWrapper { inner })
             }
@@ -1627,5 +1694,99 @@ mod tests {
             bytes_written: 42,
         };
         assert_ne!(r1, r3);
+    }
+
+    // -----------------------------------------------------------------------
+    // #3171: the handle a backup reads artifact bytes through must resolve the
+    // SAME object key the artifact was written under.
+    //
+    // Primary storage (main.rs) builds its S3 backend from `S3Config::from_env`
+    // and keeps `S3_PREFIX`, so hosted artifacts live at
+    // `<S3_PREFIX>/<storage_key>`. `StorageService::from_config` deliberately
+    // forces `prefix = None` because the proxy cache it was written for keeps
+    // content at the bucket root (#1555) — correct for that role. The bug was
+    // reusing that prefix-less handle for backup, which then looked for
+    // `<storage_key>`, missed every object, and (because of #3170) still
+    // reported `completed`.
+    // -----------------------------------------------------------------------
+
+    static S3_ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+    fn s3_env_lock() -> &'static std::sync::Mutex<()> {
+        S3_ENV_LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[test]
+    fn artifact_source_role_reads_the_prefix_artifacts_were_written_under() {
+        let _guard = s3_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+        let orig_bucket = std::env::var("S3_BUCKET").ok();
+        let orig_prefix = std::env::var("S3_PREFIX").ok();
+        std::env::set_var("S3_BUCKET", "ak-artifacts");
+        std::env::set_var("S3_PREFIX", "team-a/registry");
+
+        // What primary storage (main.rs) writes artifact bytes through.
+        let primary = crate::storage::s3::S3Config::from_env().expect("primary config");
+        assert_eq!(
+            primary.prefix.as_deref(),
+            Some("team-a/registry"),
+            "sanity: primary storage keeps S3_PREFIX"
+        );
+
+        // What the backup source handle reads through: must match primary.
+        let mut source = crate::storage::s3::S3Config::from_env().expect("source config");
+        StorageRole::ArtifactSource.apply_s3_prefix_policy(&mut source);
+        assert_eq!(
+            source.prefix, primary.prefix,
+            "backup must read artifact bytes at the key they were written under; \
+             a prefix-less handle looks at <storage_key> while the bytes live at \
+             <S3_PREFIX>/<storage_key> and every object is missed (#3171)"
+        );
+
+        // ...while the proxy-cache role keeps forcing the prefix off (#1555).
+        let mut proxy = crate::storage::s3::S3Config::from_env().expect("proxy config");
+        StorageRole::ProxyCache.apply_s3_prefix_policy(&mut proxy);
+        assert_eq!(
+            proxy.prefix, None,
+            "#1555 regression guard: proxy-cache content stays at the bucket root"
+        );
+        assert_ne!(
+            proxy.prefix, source.prefix,
+            "the two roles must genuinely differ when S3_PREFIX is set"
+        );
+
+        let restore = |name: &str, val: Option<String>| match val {
+            Some(v) => std::env::set_var(name, v),
+            None => std::env::remove_var(name),
+        };
+        restore("S3_BUCKET", orig_bucket);
+        restore("S3_PREFIX", orig_prefix);
+    }
+
+    #[test]
+    fn storage_roles_agree_when_no_s3_prefix_is_configured() {
+        // Deployments without S3_PREFIX are explicitly listed as unaffected in
+        // #3171: both roles resolve identical keys, so the fix is a no-op there.
+        let _guard = s3_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+        let orig_bucket = std::env::var("S3_BUCKET").ok();
+        let orig_prefix = std::env::var("S3_PREFIX").ok();
+        std::env::set_var("S3_BUCKET", "ak-artifacts");
+        std::env::remove_var("S3_PREFIX");
+
+        let mut source = crate::storage::s3::S3Config::from_env().expect("source config");
+        StorageRole::ArtifactSource.apply_s3_prefix_policy(&mut source);
+        let mut proxy = crate::storage::s3::S3Config::from_env().expect("proxy config");
+        StorageRole::ProxyCache.apply_s3_prefix_policy(&mut proxy);
+
+        assert_eq!(source.prefix, None);
+        assert_eq!(proxy.prefix, None);
+
+        let restore = |name: &str, val: Option<String>| match val {
+            Some(v) => std::env::set_var(name, v),
+            None => std::env::remove_var(name),
+        };
+        restore("S3_BUCKET", orig_bucket);
+        restore("S3_PREFIX", orig_prefix);
     }
 }


### PR DESCRIPTION
## Summary

Two bugs in the same subsystem — the path a backup reads artifact bytes through — that combine into the worst failure a backup can have: reporting `completed` while the archive contains no artifact content. A backup that fails loudly is an incident; a backup that reports success and is empty is discovered only at restore time, when there is no recourse.

Both are fixed here in one PR because they are the same failure class on one code path, they are causally coupled (#3171's data loss is invisible *only* because of #3170's silent discard), and the fix touches the same call sites — splitting them would produce two PRs that conflict on `execute_backup`/`restore_backup`.

Fixes #3170
Fixes #3171

## #3170 — silent discard

`backup_service.rs` collected artifact bytes with:

```rust
for key in storage_keys {
    if let Ok(content) = self.storage.get(&key).await {
        artifact_data.push((key, content.to_vec()));
    }
}
```

A failed read was discarded: not counted, not logged, not in the manifest, not in the job status. The job reported `completed` with `artifact_count=0` and the restore reported `errors=[]`.

**Semantics chosen: fail loudly by default, partial only as an explicit opt-in.**

- Every read failure is logged at `warn` with the key and the underlying error.
- `BackupManifest` gains `artifacts_unreadable` alongside `artifact_count`, so an existing archive can be audited without re-running the backup. The field is `#[serde(default)]`, so archives written before this change still deserialize.
- If any object could not be read, the job **fails** with an error message naming the affected keys. Partial backups remain possible via `allow_partial_artifacts` in the backup metadata — an explicit operator choice, never the silent default.
- The archive and manifest are still written before the job fails. That is deliberate: the partial data plus a recorded miss count is strictly more useful than discarding both, and the manifest is what lets the restore path refuse the archive later.
- `restore` now reads the manifest and records an error when it declares unreadable artifacts, so a restore can never report `errors=[]` over a known-incomplete archive. (A *failed* backup is already unrestorable, since `restore` requires `Completed`.)

## #3171 — S3_PREFIX dropped on the backup handle

`StorageService::from_config` forces `prefix = None`. That is correct for what it was written for: proxy-cache content lives at the bucket root, not under `S3_PREFIX`, so a presigned proxy-cache key must carry no prefix (#1555). The bug was reusing that same prefix-less handle for backup, where the keys being read *are* prefixed — so backup looked for `<storage_key>` while the bytes live at `<S3_PREFIX>/<storage_key>`, missed every object, and (because of #3170) still reported `completed`.

The prefix policy is now selected by an explicit, documented `StorageRole` instead of being an unlabelled line inside one constructor:

- `StorageRole::ProxyCache` — forces `prefix = None` (#1555 behaviour, unchanged; every existing `from_config` caller gets this).
- `StorageRole::ArtifactSource` — keeps the configured `S3_PREFIX`, exposed as `StorageService::artifact_source_from_config`.

`execute_backup`, `restore_backup`, and the scheduled-backup path now read/write **artifact bytes** through the artifact-source handle.

**Backup archives deliberately keep the prefix-less handle.** `archive_storage` defaulted to a clone of the source handle, so naively swapping it would have relocated archives to `<S3_PREFIX>/backups/...` and made every existing archive unreachable. The two handles are now built separately at each call site, with a comment saying why.

Deployments with no `S3_PREFIX` are unaffected — both roles resolve identical keys, which is covered by a test.

## Tests

Reproduced before any production change:

- `backup_with_unreadable_artifact_bytes_does_not_report_success` — DB-backed, end to end: an artifact row whose bytes are absent from the resolved root. Asserts `execute` errors, the job status is not `Completed`, the unreadable key is named in the job error, and the archive is not restorable. **Fails on `origin/main`** with `backup whose artifact bytes are unreadable must not report success`.
- `opt_in_partial_backup_records_misses_and_restore_refuses_them` — the opt-in path still completes, but the manifest records `artifacts_unreadable=1` / `artifact_count=0` and the restore does not report `errors=[]`.
- `manifest_without_unreadable_field_defaults_to_zero` — pre-#3170 archives still deserialize.
- `artifact_source_role_reads_the_prefix_artifacts_were_written_under` — the backup source handle resolves the same prefix primary storage wrote artifacts under, while the proxy-cache role still forces it off (#1555 regression guard).
- `storage_roles_agree_when_no_s3_prefix_is_configured` — no-prefix deployments are a no-op.

Each production change was reverted independently and the corresponding tests fail again; restoring the fix makes them pass. The assertions are on honesty (the miss is surfaced), not on any particular path resolution, so they keep passing after #2863's root-resolution fix lands.

## Gates (run locally — the self-hosted CI fleet is down)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --lib` for `services::backup_service::`, `services::storage_service::`, `services::scheduler_service::`, `api::handlers::admin::` — 210 passed, 0 failed, with `AK_TESTS_REQUIRE_DB=1`
- No `sqlx::query!`/`query_as!`/`query_scalar!` macros added, so no `.sqlx` re-prepare is needed. Verified with `SQLX_OFFLINE=true cargo build --lib --tests` and `DATABASE_URL` unset.

## Deliberately out of scope

- **#2863** — backup resolving bytes from the deployment-wide storage root rather than the per-repo one. That needs an archive-format change and is correctly milestoned 1.8.0. This PR does not repair the mismatch; it converts an undetectable failure into a detectable one.
- **OCI blobs** — they live in `oci_blobs`, not `artifacts`, so `artifact_storage_keys` never enumerates them. They are missing from every archive for a third, independent reason that needs its own issue.
- **No `completed_with_errors` status.** `backup_status` is a Postgres enum, so a new variant needs a migration. Failing the job plus recording the count in the manifest delivers the same operator signal without a schema change in a patch release.
