### PR TITLE
fix(pypi): validate project names per PEP 508 and make the normalizer divergence unrepresentable

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -37,6 +37,7 @@ use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
 use crate::error::AppError;
 use crate::formats::pypi::PypiHandler;
+use crate::formats::pypi_name::NormalizedProjectName;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::age_gate_service::AgeGateService;
 use crate::services::upstream_metadata::metadata_http_client;
@@ -61,6 +62,62 @@ pub fn router() -> Router<SharedState> {
             "/:repo_key/simple/:project/:filename",
             get(download_or_metadata),
         )
+}
+
+// ---------------------------------------------------------------------------
+// PEP 508 project-name validation (the routed edge)
+// ---------------------------------------------------------------------------
+
+/// Validate a `:project` path segment against PEP 508 and return it in PEP 503
+/// canonical form, or a 404.
+///
+/// This is the ONLY way a routed project segment enters the PyPI handlers, and
+/// it runs before any curation gate, any DB lookup and any upstream fetch.
+///
+/// # Why validate rather than coerce
+///
+/// PEP 503 defines normalization as exactly `re.sub(r"[-_.]+", "-",
+/// name).lower()` and says nothing about any other character, because it
+/// presupposes a name that is already valid. PEP 508 supplies that
+/// precondition: a name matches `^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$`
+/// (case-insensitive). `acme sdk` is therefore not a project name and has no
+/// correct normalization — which is precisely why our two coercions could
+/// disagree about it ([`normalize_pep503`] drops the space to `acmesdk`,
+/// [`PypiHandler::normalize_name`] turns it into `acme-sdk`), letting a client
+/// clear a gate under one name and be served another package's bytes (#3077,
+/// #3179, #3183). See [`crate::formats::pypi_name`].
+///
+/// # Why 404
+///
+/// Measured against the reference implementation, not inferred: pypi.org
+/// returns `404` for `/simple/acme%20sdk/`, `/simple/acme!sdk/`,
+/// `/simple/_leading/` and `/simple/trailing-/`, and `301`s a *valid* but
+/// non-canonical name (`/simple/Django/`, `/simple/zope.interface/`) to its
+/// canonical URL. A name that cannot exist has no route, so 404 — not 400 — is
+/// the behaviour clients already handle.
+///
+/// # Why the body is "Invalid project name" and does not echo the segment
+///
+/// Two reasons, and both are load-bearing.
+///
+/// *It does not repeat the input.* Reflecting an unvalidated segment would hand
+/// back the very characters [`normalize_pep503`] exists to strip, and a 404 that
+/// repeats its input is a reflection sink. The rejected name is only logged.
+///
+/// *It is not "Package not found".* An absent-but-valid project already 404s
+/// with that message, so reusing it would make a validation rejection and an
+/// ordinary lookup miss indistinguishable -- to an operator debugging a broken
+/// `pip install`, and to the tests that have to prove this change does not
+/// over-reject. Distinct wording is what lets a test assert *which* 404 it got.
+#[allow(clippy::result_large_err)]
+fn parse_project_segment(project: &str) -> Result<NormalizedProjectName, Response> {
+    NormalizedProjectName::parse(project).ok_or_else(|| {
+        debug!(
+            "rejecting PyPI project segment that is not a PEP 508 name (len {})",
+            project.len()
+        );
+        AppError::NotFound("Invalid project name".to_string()).into_response()
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -686,13 +743,16 @@ async fn simple_project(
     headers: HeaderMap,
 ) -> Result<Response, Response> {
     let repo = resolve_pypi_repo(&state.db, &repo_key).await?;
-    let normalized = normalize_pep503(&project);
+    // PEP 508 validation FIRST (#3186), before the curation gate, the local
+    // lookup and any upstream fetch. An invalid segment is not a project name,
+    // so there is nothing to gate and nothing to fetch.
+    let normalized = parse_project_segment(&project)?;
 
     // Curation gate (#2912): block a curation-ruled package
     // before doing any local lookup or upstream fetch for it. The index request
     // names only a project, so version-constrained rules do not apply here — they
     // are enforced on the download path, which knows the version.
-    enforce_pypi_curation(&state, &repo, &normalized, None).await?;
+    enforce_pypi_curation(&state, &repo, normalized.as_str(), None).await?;
 
     // PEP 691 content negotiation also governs the proxy path: a JSON client
     // must get the upstream's JSON representation (which carries PEP 700
@@ -718,7 +778,7 @@ async fn simple_project(
         ORDER BY a.created_at DESC
         "#,
         repo.id,
-        normalized
+        normalized.as_str()
     )
     .fetch_all(&state.db)
     .await
@@ -783,13 +843,13 @@ async fn simple_project(
                 // HTML and fall through to the HTML rewrite below.
                 if wants_json && ct.contains("json") {
                     if let Some(json) =
-                        rewrite_upstream_simple_json(&content, &repo_key, &normalized)
+                        rewrite_upstream_simple_json(&content, &repo_key, normalized.as_str())
                     {
                         let json = filter_pypi_simple_json_response(
                             &state,
                             &repo,
                             &effective_upstream,
-                            &normalized,
+                            normalized.as_str(),
                             json,
                         )
                         .await;
@@ -805,12 +865,12 @@ async fn simple_project(
                 // Rewrite absolute download URLs to route through our proxy.
                 if ct.contains("text/html") {
                     let html = String::from_utf8_lossy(&content);
-                    let rewritten = rewrite_upstream_urls(&html, &repo_key, &normalized);
+                    let rewritten = rewrite_upstream_urls(&html, &repo_key, normalized.as_str());
                     let rewritten = filter_pypi_simple_html_response(
                         &state,
                         &repo,
                         &effective_upstream,
-                        &normalized,
+                        normalized.as_str(),
                         rewritten,
                     )
                     .await;
@@ -826,13 +886,14 @@ async fn simple_project(
                 // bytes, which carry un-rewritten offsite download URLs.
                 return match sniff_simple_index(&content) {
                     SniffedSimpleIndex::Json => {
-                        match rewrite_upstream_simple_json(&content, &repo_key, &normalized) {
+                        match rewrite_upstream_simple_json(&content, &repo_key, normalized.as_str())
+                        {
                             Some(json) => {
                                 let json = filter_pypi_simple_json_response(
                                     &state,
                                     &repo,
                                     &effective_upstream,
-                                    &normalized,
+                                    normalized.as_str(),
                                     json,
                                 )
                                 .await;
@@ -847,12 +908,13 @@ async fn simple_project(
                     }
                     SniffedSimpleIndex::Html => {
                         let html = String::from_utf8_lossy(&content);
-                        let rewritten = rewrite_upstream_urls(&html, &repo_key, &normalized);
+                        let rewritten =
+                            rewrite_upstream_urls(&html, &repo_key, normalized.as_str());
                         let rewritten = filter_pypi_simple_html_response(
                             &state,
                             &repo,
                             &effective_upstream,
-                            &normalized,
+                            normalized.as_str(),
                             rewritten,
                         )
                         .await;
@@ -890,7 +952,8 @@ async fn simple_project(
             // The download path makes the same per-member decision, keeping
             // index and download consistent.
             let owning_local_min_priority =
-                proxy_helpers::pypi_virtual_isolates_name(&state.db, repo.id, &normalized).await?;
+                proxy_helpers::pypi_virtual_isolates_name(&state.db, repo.id, normalized.as_str())
+                    .await?;
             let member_priorities = if owning_local_min_priority.is_some() {
                 proxy_helpers::fetch_virtual_member_priorities(&state.db, repo.id).await?
             } else {
@@ -930,7 +993,7 @@ async fn simple_project(
         ORDER BY a.created_at DESC
         "#,
                     member.id,
-                    normalized
+                    normalized.as_str()
                 )
                 .fetch_all(&state.db)
                 .await
@@ -1024,7 +1087,7 @@ async fn simple_project(
                 // block suppresses this member's contribution rather than failing
                 // the whole listing, exactly as the age gate filters it.
                 let member_info = proxy_helpers::repo_info_from_member(member);
-                if enforce_pypi_curation(&state, &member_info, &normalized, None)
+                if enforce_pypi_curation(&state, &member_info, normalized.as_str(), None)
                     .await
                     .is_err()
                 {
@@ -1075,7 +1138,7 @@ async fn simple_project(
                                 &state,
                                 &member_info,
                                 &effective_upstream,
-                                &normalized,
+                                normalized.as_str(),
                                 String::from_utf8_lossy(&content).into_owned(),
                             )
                             .await;
@@ -1085,7 +1148,7 @@ async fn simple_project(
                                 &state,
                                 &member_info,
                                 &effective_upstream,
-                                &normalized,
+                                normalized.as_str(),
                                 String::from_utf8_lossy(&content).into_owned(),
                             )
                             .await;
@@ -1104,7 +1167,7 @@ async fn simple_project(
                                 &content,
                                 &owned_profile,
                                 &repo_key,
-                                &normalized,
+                                normalized.as_str(),
                             )
                         } else {
                             content
@@ -1127,7 +1190,8 @@ async fn simple_project(
                 .filter(|m| matches!(m.repo_type, RepositoryType::Local | RepositoryType::Staging))
                 .map(|m| m.id)
                 .collect();
-            let tracks = pypi_project_tracks_for(&state.db, &local_member_ids, &normalized).await;
+            let tracks =
+                pypi_project_tracks_for(&state.db, &local_member_ids, normalized.as_str()).await;
 
             // Render the union.
             match (local_artifacts.is_empty(), remote_response) {
@@ -1141,7 +1205,7 @@ async fn simple_project(
                     return build_simple_project_response(
                         &headers,
                         &repo_key,
-                        &normalized,
+                        normalized.as_str(),
                         &local_artifacts,
                         &tracks,
                     );
@@ -1165,11 +1229,11 @@ async fn simple_project(
                                 let merged = merge_local_into_remote_simple_json(
                                     &content,
                                     &repo_key,
-                                    &normalized,
+                                    normalized.as_str(),
                                     &local_artifacts,
                                     &tracks,
                                 )
-                                .unwrap_or_else(|| empty_pep691_listing(&normalized));
+                                .unwrap_or_else(|| empty_pep691_listing(normalized.as_str()));
                                 Ok(cacheable_response(
                                     merged.into_bytes(),
                                     PEP691_JSON_CONTENT_TYPE,
@@ -1182,7 +1246,7 @@ async fn simple_project(
                                 let merged = merge_local_into_remote_simple_html(
                                     &String::from_utf8_lossy(&content),
                                     &repo_key,
-                                    &normalized,
+                                    normalized.as_str(),
                                     &local_artifacts,
                                     &tracks,
                                 );
@@ -1196,13 +1260,13 @@ async fn simple_project(
                             // listing, never raw upstream bytes.
                             SniffedSimpleIndex::Binary => {
                                 let merged = merge_local_into_remote_simple_json(
-                                    empty_pep691_listing(&normalized).as_bytes(),
+                                    empty_pep691_listing(normalized.as_str()).as_bytes(),
                                     &repo_key,
-                                    &normalized,
+                                    normalized.as_str(),
                                     &local_artifacts,
                                     &tracks,
                                 )
-                                .unwrap_or_else(|| empty_pep691_listing(&normalized));
+                                .unwrap_or_else(|| empty_pep691_listing(normalized.as_str()));
                                 Ok(cacheable_response(
                                     merged.into_bytes(),
                                     PEP691_JSON_CONTENT_TYPE,
@@ -1220,7 +1284,7 @@ async fn simple_project(
                         if let Some(json) = merge_local_into_remote_simple_json(
                             &content,
                             &repo_key,
-                            &normalized,
+                            normalized.as_str(),
                             &local_artifacts,
                             &tracks,
                         ) {
@@ -1235,11 +1299,12 @@ async fn simple_project(
 
                     if ct.contains("text/html") {
                         let html = String::from_utf8_lossy(&content);
-                        let rewritten = rewrite_upstream_urls(&html, &repo_key, &normalized);
+                        let rewritten =
+                            rewrite_upstream_urls(&html, &repo_key, normalized.as_str());
                         let merged = merge_local_into_remote_simple_html(
                             &rewritten,
                             &repo_key,
-                            &normalized,
+                            normalized.as_str(),
                             &local_artifacts,
                             &tracks,
                         );
@@ -1258,7 +1323,7 @@ async fn simple_project(
                             match merge_local_into_remote_simple_json(
                                 &content,
                                 &repo_key,
-                                &normalized,
+                                normalized.as_str(),
                                 &local_artifacts,
                                 &tracks,
                             ) {
@@ -1272,11 +1337,12 @@ async fn simple_project(
                         }
                         SniffedSimpleIndex::Html => {
                             let html = String::from_utf8_lossy(&content);
-                            let rewritten = rewrite_upstream_urls(&html, &repo_key, &normalized);
+                            let rewritten =
+                                rewrite_upstream_urls(&html, &repo_key, normalized.as_str());
                             let merged = merge_local_into_remote_simple_html(
                                 &rewritten,
                                 &repo_key,
-                                &normalized,
+                                normalized.as_str(),
                                 &local_artifacts,
                                 &tracks,
                             );
@@ -1295,8 +1361,14 @@ async fn simple_project(
         return Err(AppError::NotFound("Package not found".to_string()).into_response());
     }
 
-    let tracks = pypi_project_tracks_for(&state.db, &[repo.id], &normalized).await;
-    build_simple_project_response(&headers, &repo_key, &normalized, &simple_artifacts, &tracks)
+    let tracks = pypi_project_tracks_for(&state.db, &[repo.id], normalized.as_str()).await;
+    build_simple_project_response(
+        &headers,
+        &repo_key,
+        normalized.as_str(),
+        &simple_artifacts,
+        &tracks,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1608,10 +1680,19 @@ async fn download_or_metadata(
     // the gate must evaluate exactly the distribution the serve path resolves,
     // or a suffix shape that parses to a different (or no) version slips past a
     // version-constrained rule and is then served anyway.
-    let normalized = normalize_pep503(&project);
+    // PEP 508 validation FIRST (#3186). This covers BOTH branches below --
+    // the PEP 658 `.metadata` resource and the regular distribution download --
+    // because both are reached through this one route.
+    let normalized = parse_project_segment(&project)?;
     let distribution = pypi_distribution_filename(&filename);
     let requested_version = version_from_pypi_filename(distribution);
-    enforce_pypi_curation(&state, &repo, &normalized, requested_version.as_deref()).await?;
+    enforce_pypi_curation(
+        &state,
+        &repo,
+        normalized.as_str(),
+        requested_version.as_deref(),
+    )
+    .await?;
 
     // PEP 658: serve metadata from the remote upstream when possible. If the
     // upstream advertises metadata but returns 404, fall back to extracting it
@@ -1654,6 +1735,9 @@ async fn download_or_metadata(
                     // was fixed, so a curation block on a direct Remote repo
                     // was still evadable by spelling: the gate saw "acmesdk"
                     // and the fetch resolved "acme-sdk".
+                    // The VALIDATED, normalized name -- not the raw segment.
+                    // This is #3179's fix, now enforced by the type system:
+                    // `serve_remote_metadata` no longer accepts a `&str`.
                     &normalized,
                     real_filename,
                 )
@@ -1685,6 +1769,10 @@ async fn download_or_metadata(
     // `normalize_name` is idempotent on `normalize_pep503` output (see
     // `test_normalize_name_is_idempotent_on_pep503_output`), so upstream URLs
     // and proxy-cache keys are byte-identical for every well-formed name.
+    // The VALIDATED, normalized name -- not the raw segment. This is #3183's
+    // fix, now enforced by the type system: `serve_file` no longer accepts a
+    // `&str`, so the gates it runs and the upstream fetch it performs cannot
+    // key on different strings.
     serve_file(
         &state,
         &repo,
@@ -1724,7 +1812,7 @@ async fn serve_virtual_metadata(
     state: &SharedState,
     auth: Option<&AuthExtension>,
     virtual_repo: &RepoInfo,
-    normalized_project: &str,
+    normalized_project: &NormalizedProjectName,
     requested_version: Option<&str>,
     filename: &str,
 ) -> Result<Response, Response> {
@@ -1744,16 +1832,19 @@ async fn serve_virtual_metadata(
     // admitted Case-A platform wheel. Without this gate, a direct or stale
     // `.metadata` URL could expose a remote-only Case-B version that neither
     // the index advertises nor the download route serves.
-    let owning_local_min_priority =
-        proxy_helpers::pypi_virtual_isolates_name(&state.db, virtual_repo.id, normalized_project)
-            .await?;
+    let owning_local_min_priority = proxy_helpers::pypi_virtual_isolates_name(
+        &state.db,
+        virtual_repo.id,
+        normalized_project.as_str(),
+    )
+    .await?;
     let member_priorities = if owning_local_min_priority.is_some() {
         proxy_helpers::fetch_virtual_member_priorities(&state.db, virtual_repo.id).await?
     } else {
         Default::default()
     };
     let owned_profile = if owning_local_min_priority.is_some() {
-        pypi_owned_wheel_profile(&state.db, &members, normalized_project).await
+        pypi_owned_wheel_profile(&state.db, &members, normalized_project.as_str()).await
     } else {
         OwnedWheelProfile::default()
     };
@@ -1761,9 +1852,14 @@ async fn serve_virtual_metadata(
     let mut first_member_error: Option<Response> = None;
     for member in members {
         let member_info = proxy_helpers::repo_info_from_member(&member);
-        if enforce_pypi_curation(state, &member_info, normalized_project, requested_version)
-            .await
-            .is_err()
+        if enforce_pypi_curation(
+            state,
+            &member_info,
+            normalized_project.as_str(),
+            requested_version,
+        )
+        .await
+        .is_err()
         {
             continue;
         }
@@ -1889,14 +1985,18 @@ async fn serve_virtual_metadata(
             .into_response(),
     )
 }
-
+/// Serve a PEP 658 `.metadata` resource from a remote upstream.
+///
+/// `project` is a [`NormalizedProjectName`] (#3186), so the string this fetches
+/// with is by construction the same string the curation gate in
+/// `download_or_metadata` evaluated.
 async fn serve_remote_metadata(
     state: &SharedState,
     proxy: &crate::services::proxy_service::ProxyService,
     repo_id: uuid::Uuid,
     repo_key: &str,
     upstream_url: &str,
-    project: &str,
+    project: &NormalizedProjectName,
     filename: &str,
 ) -> Result<Response, Response> {
     let index_path = fetch_pypi_upstream_index_path(&state.db, repo_id).await;
@@ -1985,8 +2085,15 @@ fn pypi_lkg_filename_from_artifact_path(artifact_path: &str) -> String {
         .to_string()
 }
 
-fn build_pypi_proxy_cache_path(normalized_project: &str, filename: &str) -> String {
-    format!("simple/{}/{}", normalized_project, filename)
+/// Build the stable proxy-cache key for a proxied PyPI distribution.
+///
+/// Takes a [`NormalizedProjectName`], not a `&str` (#3186): the cache key is a
+/// *name-keyed* store, so if this could be called with a raw segment then two
+/// spellings of one request could address two different cache entries -- or,
+/// worse, one spelling could address the entry another package's bytes were
+/// written under. The newtype makes that unrepresentable.
+fn build_pypi_proxy_cache_path(project: &NormalizedProjectName, filename: &str) -> String {
+    format!("simple/{}/{}", project.as_str(), filename)
 }
 
 /// Apply the age-gate listing filter to a rewritten PEP 691 JSON simple
@@ -2176,7 +2283,7 @@ async fn enforce_pypi_download_age_gate(
     state: &SharedState,
     repo: &RepoInfo,
     repo_key: &str,
-    project: &str,
+    project: &NormalizedProjectName,
     filename: &str,
 ) -> Result<Option<Response>, Response> {
     let (upstream_url, proxy) = match (&repo.upstream_url, &state.proxy_service) {
@@ -2184,13 +2291,16 @@ async fn enforce_pypi_download_age_gate(
         _ => return Ok(None),
     };
 
-    let lkg_filename = match apply_pypi_download_age_gate(state, repo, project, filename).await? {
-        Some(lkg) => lkg,
-        None => return Ok(None),
-    };
+    let lkg_filename =
+        match apply_pypi_download_age_gate(state, repo, project.as_str(), filename).await? {
+            Some(lkg) => lkg,
+            None => return Ok(None),
+        };
 
-    let normalized = PypiHandler::normalize_name(project);
-    let lkg_cache_path = build_pypi_proxy_cache_path(&normalized, &lkg_filename);
+    // The gate above and this cache key are now the SAME string by
+    // construction (#3186); they used to be `project` and
+    // `PypiHandler::normalize_name(project)` respectively.
+    let lkg_cache_path = build_pypi_proxy_cache_path(project, &lkg_filename);
     // #1555 ordering holds on the LKG fallback too: presigned redirect on a
     // fresh cache hit BEFORE the streaming cache check, so a cached LKG wheel is
     // not streamed through the backend.
@@ -2237,11 +2347,17 @@ async fn enforce_pypi_download_age_gate(
 /// into a '-'. Passing the raw segment therefore let a client check one name
 /// and download another. Not having the raw name in scope is what stops that
 /// from being reintroduced.
+/// `project` is a [`NormalizedProjectName`] (#3186). Every gate on this path --
+/// the PEP 708 dependency-confusion isolation, the per-member curation gate,
+/// the download age gate and the inline scan gate -- keys on the PEP 503 form,
+/// while the upstream fetch and the proxy-cache key are built from the same
+/// value. Because the parameter is not a `&str`, "gate one name, fetch another"
+/// is no longer expressible here.
 async fn serve_file(
     state: &SharedState,
     repo: &RepoInfo,
     repo_key: &str,
-    normalized_project: &str,
+    project: &NormalizedProjectName,
     filename: &str,
     auth: Option<&AuthExtension>,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
@@ -2274,14 +2390,9 @@ async fn serve_file(
                     // Enforce the download age gate before any proxy fetch, and
                     // serve the last-known-good wheel if the requested version is
                     // withheld. Shared with the local-`artifacts`-hit branch below.
-                    if let Some(resp) = enforce_pypi_download_age_gate(
-                        state,
-                        repo,
-                        repo_key,
-                        normalized_project,
-                        filename,
-                    )
-                    .await?
+                    if let Some(resp) =
+                        enforce_pypi_download_age_gate(state, repo, repo_key, project, filename)
+                            .await?
                     {
                         return Ok(resp);
                     }
@@ -2312,7 +2423,7 @@ async fn serve_file(
                             repo.id,
                             repo_key,
                             upstream_url,
-                            normalized_project,
+                            project,
                             filename,
                             action,
                             ctx,
@@ -2326,11 +2437,10 @@ async fn serve_file(
                     // already cached from a previous request. Streamed straight
                     // from storage (#895): buffering cached multi-hundred-MiB
                     // wheels per request OOM-killed memory-constrained pods.
-                    // Already PEP 503 normalized by the caller;
-                    // `PypiHandler::normalize_name` is the identity on that
-                    // form, so this is the same cache key it always was.
-                    let local_cache_path =
-                        build_pypi_proxy_cache_path(normalized_project, filename);
+                    // `project` is already canonical, so this is the same
+                    // cache key it always was for a well-formed name -- but it
+                    // can no longer be a DIFFERENT one for a malformed name.
+                    let local_cache_path = build_pypi_proxy_cache_path(project, filename);
 
                     // #1555: redirect to a presigned URL on a fresh cache hit
                     // before falling back to streaming.
@@ -2372,7 +2482,7 @@ async fn serve_file(
                         repo.id,
                         repo_key,
                         upstream_url,
-                        normalized_project,
+                        project,
                         filename,
                         &index_path,
                         RepositoryFormat::Pypi,
@@ -2446,12 +2556,9 @@ async fn serve_file(
                 // member at equal or higher priority than the owning local
                 // still serves, mirroring the simple-index decision above so
                 // every version the index lists is downloadable.
-                let owning_local_min_priority = proxy_helpers::pypi_virtual_isolates_name(
-                    &state.db,
-                    repo.id,
-                    normalized_project,
-                )
-                .await?;
+                let owning_local_min_priority =
+                    proxy_helpers::pypi_virtual_isolates_name(&state.db, repo.id, project.as_str())
+                        .await?;
                 let member_priorities = if owning_local_min_priority.is_some() {
                     proxy_helpers::fetch_virtual_member_priorities(&state.db, repo.id).await?
                 } else {
@@ -2467,7 +2574,7 @@ async fn serve_file(
                 // symmetric: every distribution the index lists is downloadable
                 // and every one it hides 404s here.
                 let owned_profile = if owning_local_min_priority.is_some() {
-                    pypi_owned_wheel_profile(&state.db, &members, normalized_project).await
+                    pypi_owned_wheel_profile(&state.db, &members, project.as_str()).await
                 } else {
                     OwnedWheelProfile::default()
                 };
@@ -2492,7 +2599,7 @@ async fn serve_file(
                     if enforce_pypi_curation(
                         state,
                         &member_info,
-                        normalized_project,
+                        project.as_str(),
                         version_from_pypi_filename(filename).as_deref(),
                     )
                     .await
@@ -2505,7 +2612,7 @@ async fn serve_file(
                         state,
                         &member_info,
                         &member.key,
-                        normalized_project,
+                        project,
                         filename,
                     )
                     .await?
@@ -2594,7 +2701,7 @@ async fn serve_file(
                                     member.id,
                                     &member.key,
                                     upstream_url,
-                                    normalized_project,
+                                    project,
                                     filename,
                                     action,
                                     ctx,
@@ -2623,12 +2730,8 @@ async fn serve_file(
                             // direct Remote path). This avoids re-fetching the
                             // simple index from upstream when the file is already
                             // cached from a previous request through this member.
-                            // Already PEP 503 normalized by the caller;
-                            // `PypiHandler::normalize_name` is the identity on
-                            // that form, so this is the same cache key it
-                            // always was for a well-formed name.
-                            let local_cache_path =
-                                build_pypi_proxy_cache_path(normalized_project, filename);
+                            // Already canonical; see the direct-remote arm.
+                            let local_cache_path = build_pypi_proxy_cache_path(project, filename);
 
                             // #1555: redirect to a presigned URL on a fresh
                             // cache hit before falling back to streaming.
@@ -2663,7 +2766,7 @@ async fn serve_file(
                                 member.id,
                                 &member.key,
                                 upstream_url,
-                                normalized_project,
+                                project,
                                 filename,
                                 &member_index_path,
                                 member.format.clone(),
@@ -2703,8 +2806,7 @@ async fn serve_file(
     // young local artifact.
     if repo.repo_type == RepositoryType::Remote {
         if let Some(resp) =
-            enforce_pypi_download_age_gate(state, repo, repo_key, normalized_project, filename)
-                .await?
+            enforce_pypi_download_age_gate(state, repo, repo_key, project, filename).await?
         {
             return Ok(resp);
         }
@@ -2736,7 +2838,7 @@ async fn serve_file(
                         repo.id,
                         repo_key,
                         upstream_url,
-                        normalized_project,
+                        project,
                         filename,
                         &index_path,
                         RepositoryFormat::Pypi,
@@ -2945,16 +3047,27 @@ struct PypiRemoteFetchTarget {
 /// The index fetch stays buffered by design: simple-index pages are small
 /// HTML documents that must be parsed in-process. Only the package file
 /// itself (potentially hundreds of MiB) needs the streaming path.
+///
+/// `project` is a [`NormalizedProjectName`], not a `&str` (#3186). This is the
+/// single place a route-derived project name becomes an OUTBOUND upstream URL,
+/// so it is the exact boundary the newtype exists to guard: the gates upstream
+/// of here key on the PEP 503 form, and a raw segment reaching this function
+/// re-normalized differently is what produced #3077, #3179 and #3183. A `&str`
+/// no longer compiles here, so a fourth path cannot reintroduce it.
 async fn resolve_pypi_remote_fetch_target(
     proxy: &crate::services::proxy_service::ProxyService,
     repo_id: uuid::Uuid,
     repo_key: &str,
     upstream_url: &str,
-    project: &str,
+    project: &NormalizedProjectName,
     filename: &str,
     index_path: &str,
 ) -> Result<PypiRemoteFetchTarget, Response> {
-    let normalized = PypiHandler::normalize_name(project);
+    // `PypiHandler::normalize_name` is the identity on canonical input (see
+    // `pypi_name::tests::legacy_fetch_normalizer_is_identity_on_canonical_form`),
+    // so this is retained only to keep the produced URLs byte-identical to what
+    // they were before, and can be dropped once nothing else calls it.
+    let normalized = PypiHandler::normalize_name(project.as_str());
 
     // Build the upstream index URL using the configured index_path.
     // When `index_path` is "simple" (the default), the existing /simple-dedup
@@ -3087,7 +3200,7 @@ async fn fetch_from_pypi_remote_streaming(
     repo_id: uuid::Uuid,
     repo_key: &str,
     upstream_url: &str,
-    project: &str,
+    project: &NormalizedProjectName,
     filename: &str,
     index_path: &str,
     format: RepositoryFormat,
@@ -3258,7 +3371,7 @@ async fn serve_scanned_pypi_file(
     repo_id: uuid::Uuid,
     repo_key: &str,
     upstream_url: &str,
-    project: &str,
+    project: &NormalizedProjectName,
     filename: &str,
     action: crate::services::proxy_scan_service::ProxyScanAction,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
@@ -3364,7 +3477,11 @@ async fn serve_scanned_pypi_file(
         Some(version) => proxy_helpers::ProxyScanIdentity::Established(
             crate::services::scanner_service::ExpectedComponent::new(
                 crate::services::scanner_service::ComponentEcosystem::Python,
-                project,
+                // The canonical name. The scan gate grades a component by
+                // name+version, so before #3186 it could grade `acme sdk`
+                // while the fetch resolved `acme-sdk` -- the same divergence,
+                // in the component identity the verdict is keyed on.
+                project.as_str(),
                 &version,
             ),
         ),
@@ -4565,6 +4682,18 @@ mod tests {
     use crate::api::handlers::proxy_helpers::scan_blocked_response;
     use sha2::{Digest, Sha256};
 
+    /// Build a [`NormalizedProjectName`] for a test fixture (#3186).
+    ///
+    /// Panics on an invalid name on purpose: a fixture that cannot produce one
+    /// is not exercising a real request, because `download_or_metadata` and
+    /// `simple_project` reject such a segment with 404 before they ever reach
+    /// the function under test. The rejection itself is covered end-to-end by
+    /// the route-level tests, not here.
+    fn proj(name: &str) -> NormalizedProjectName {
+        NormalizedProjectName::parse(name)
+            .unwrap_or_else(|| panic!("test fixture project name is not PEP 508-valid: {name:?}"))
+    }
+
     #[test]
     fn metadata_filename_uses_distribution_version_for_curation() {
         let wheel = "demo-1.2.3-py3-none-any.whl";
@@ -4678,8 +4807,461 @@ mod tests {
     #[test]
     fn build_pypi_proxy_cache_path_format() {
         assert_eq!(
-            build_pypi_proxy_cache_path("requests", "requests-2.31.0.tar.gz"),
+            build_pypi_proxy_cache_path(&proj("requests"), "requests-2.31.0.tar.gz"),
             "simple/requests/requests-2.31.0.tar.gz"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3186 -- PEP 508 project-name validation at the routed edge
+    // -----------------------------------------------------------------------
+
+    /// The exact body `parse_project_segment` produces on rejection. Asserted
+    /// literally so a route test cannot confuse a validation 404 with an
+    /// ordinary "Package not found" / "File not found" 404 -- which is the
+    /// failure mode that would let an over-rejecting fix look like it passes.
+    const PROJECT_REJECTED_MESSAGE: &str = "Invalid project name";
+
+    /// PEP 508-valid names, weighted towards the unusual-but-legal.
+    ///
+    /// Over-rejection here does not break one request, it takes the entire
+    /// PyPI surface offline, so this list matters more than the rejection list.
+    fn valid_route_names() -> Vec<&'static str> {
+        vec![
+            "a",
+            "A",
+            "z",
+            "0",
+            "9",
+            "123",
+            "2024",
+            "ab",
+            "a1",
+            "1a",
+            "a-b",
+            "a_b",
+            "a.b",
+            "a.b-c_d",
+            "a__b",
+            "a--b",
+            "a._-b",
+            "MyPackage",
+            "Django",
+            "PyYAML",
+            "Jinja2",
+            "zope.interface",
+            "ruamel.yaml",
+            "backports.ssl_match_hostname",
+            "acme-sdk",
+            "requests",
+        ]
+    }
+
+    /// Names that fail `^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$`, paired with
+    /// their percent-encoded URI form so they can be sent over a real route.
+    fn invalid_route_names() -> Vec<(&'static str, &'static str)> {
+        vec![
+            // The motivating case (#3077 / #3179 / #3183): a space is where
+            // `normalize_pep503` ("acmesdk") and `PypiHandler::normalize_name`
+            // ("acme-sdk") disagree, so the gate and the fetch saw different
+            // packages.
+            ("acme sdk", "acme%20sdk"),
+            ("acme+sdk", "acme%2Bsdk"),
+            ("acme!sdk", "acme%21sdk"),
+            ("acme@sdk", "acme%40sdk"),
+            ("acme:sdk", "acme%3Asdk"),
+            ("acme#sdk", "acme%23sdk"),
+            // Leading / trailing separators: PEP 508 requires an alphanumeric
+            // at both ends.
+            ("_leading", "_leading"),
+            ("-leading", "-leading"),
+            (".leading", ".leading"),
+            ("trailing_", "trailing_"),
+            ("trailing-", "trailing-"),
+            ("trailing.", "trailing."),
+            ("-", "-"),
+            ("---", "---"),
+            // Non-ASCII, including the Kelvin sign that a `(?i)[A-Z]` class
+            // would have accepted under Unicode case folding.
+            ("acmeésdk", "acme%C3%A9sdk"),
+            ("acme\u{212A}sdk", "acme%E2%84%AAsdk"),
+            // A newline: Rust's `$` matches before a trailing newline, which is
+            // why the pattern is anchored with `\z`.
+            ("acme-sdk\n", "acme-sdk%0A"),
+            ("acme\tsdk", "acme%09sdk"),
+            // The stored-XSS payload `normalize_pep503`'s character dropping
+            // exists to neutralize. Rejecting it outright is strictly stronger
+            // than sanitizing it -- and the sanitizer is left untouched.
+            ("<script>", "%3Cscript%3E"),
+        ]
+    }
+
+    /// Pure, exhaustive over-rejection guard.
+    ///
+    /// Runs without a database so it can never be skipped, and covers far more
+    /// names than the route tests below can afford to.
+    #[test]
+    fn parse_project_segment_accepts_valid_and_rejects_invalid() {
+        for name in valid_route_names() {
+            let parsed = parse_project_segment(name);
+            assert!(
+                parsed.is_ok(),
+                "PEP 508-valid name must be accepted, got a rejection: {name:?}"
+            );
+        }
+
+        for (raw, _encoded) in invalid_route_names() {
+            match parse_project_segment(raw) {
+                Ok(accepted) => panic!(
+                    "PEP 508-invalid name {raw:?} was accepted and normalized to {accepted:?}"
+                ),
+                Err(response) => assert_eq!(
+                    response.status(),
+                    StatusCode::NOT_FOUND,
+                    "rejection must be 404 (pypi.org has no route for an invalid name): {raw:?}"
+                ),
+            }
+        }
+    }
+
+    /// Validation must not change the answer for any name that HAS one: on the
+    /// PEP 508-valid domain the accepted form equals `normalize_pep503`, which
+    /// is what every existing gate keys on.
+    #[test]
+    fn accepted_names_normalize_exactly_as_the_gate_does() {
+        for name in valid_route_names() {
+            let accepted = parse_project_segment(name).expect("valid");
+            assert_eq!(
+                accepted.as_str(),
+                normalize_pep503(name),
+                "validation changed the canonical form of {name:?}"
+            );
+        }
+    }
+
+    /// Every PyPI route that takes a `:project` segment must reject a name that
+    /// is not a PEP 508 name, with 404, on all three shapes: the simple index,
+    /// the distribution download, and the PEP 658 `.metadata` resource.
+    #[tokio::test]
+    async fn pep508_invalid_project_segment_is_404_on_every_pypi_route() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let wheel = "pkg-1.0.0-py3-none-any.whl";
+        let mut failures: Vec<String> = Vec::new();
+
+        for (raw, encoded) in invalid_route_names() {
+            for (route, uri) in [
+                (
+                    "simple index",
+                    format!("/{}/simple/{encoded}/", fx.repo_key),
+                ),
+                (
+                    "download",
+                    format!("/{}/simple/{encoded}/{wheel}", fx.repo_key),
+                ),
+                (
+                    "PEP 658 metadata",
+                    format!("/{}/simple/{encoded}/{wheel}.metadata", fx.repo_key),
+                ),
+            ] {
+                let app = fx.router_with_auth(super::router());
+                let (status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+                let body = String::from_utf8_lossy(&body).into_owned();
+
+                if status != StatusCode::NOT_FOUND {
+                    failures.push(format!(
+                        "{route} {uri} (name {raw:?}): expected 404, got {status}; body {body}"
+                    ));
+                } else if !body.contains(PROJECT_REJECTED_MESSAGE) {
+                    // A 404 alone is not proof: an unknown-but-valid package
+                    // also 404s on these routes. The rejection message is what
+                    // shows validation -- not a lookup miss -- produced it.
+                    failures.push(format!(
+                        "{route} {uri} (name {raw:?}): 404 but not from validation; body {body}"
+                    ));
+                }
+            }
+        }
+
+        fx.teardown().await;
+
+        assert!(
+            failures.is_empty(),
+            "PEP 508-invalid project segments were not rejected:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    /// Groups of PEP 508-valid spellings that PEP 503 says name the SAME
+    /// project, keyed by their canonical form.
+    ///
+    /// One upload per group, then a read back under every spelling in it. That
+    /// covers acceptance (no spelling is rejected) and correctness (every
+    /// spelling resolves to the one project) in a single pass, and it makes the
+    /// case-folding and separator-collapsing rules of PEP 503 executable rather
+    /// than asserted only against a helper.
+    fn valid_name_groups() -> Vec<(&'static str, Vec<&'static str>)> {
+        vec![
+            // Single character: the first branch of the PEP 508 alternation,
+            // and the shape an off-by-one in the pattern breaks first.
+            ("a", vec!["a", "A"]),
+            ("z", vec!["z", "Z"]),
+            // Digits only.
+            ("0", vec!["0"]),
+            ("123", vec!["123"]),
+            ("2024", vec!["2024"]),
+            // Two characters: the second branch with an empty middle.
+            ("ab", vec!["ab", "AB", "Ab"]),
+            ("a1", vec!["a1"]),
+            ("1a", vec!["1a"]),
+            // Every separator, and every run of separators, collapses to one
+            // '-' per PEP 503's `re.sub(r"[-_.]+", "-", name)`.
+            (
+                "a-b",
+                vec!["a-b", "a_b", "a.b", "a__b", "a--b", "a._-b", "A-B"],
+            ),
+            ("a-b-c-d", vec!["a.b-c_d", "a-b-c-d", "A.B-C_D"]),
+            // Mixed case lowercases.
+            ("mypackage", vec!["MyPackage", "mypackage", "MYPACKAGE"]),
+            ("django", vec!["Django"]),
+            ("pyyaml", vec!["PyYAML"]),
+            ("jinja2", vec!["Jinja2"]),
+            // Real-world dotted names.
+            ("zope-interface", vec!["zope.interface", "zope-interface"]),
+            ("ruamel-yaml", vec!["ruamel.yaml"]),
+            (
+                "backports-ssl-match-hostname",
+                vec!["backports.ssl_match_hostname"],
+            ),
+            ("acme-sdk", vec!["acme-sdk", "acme_sdk", "ACME-SDK"]),
+            ("requests", vec!["requests"]),
+        ]
+    }
+
+    /// The positive control, and the one that matters more than the rejection
+    /// tests: a name that IS a PEP 508 name must still work end to end.
+    ///
+    /// This deliberately does NOT settle for "did not return the validation
+    /// 404". It uploads a real distribution under each name and reads it back
+    /// from the simple index, so the assertion is a 200 that LISTS THE WHEEL --
+    /// something an over-rejecting validator cannot produce, and something a
+    /// wrongly-normalizing one cannot produce either.
+    ///
+    /// An earlier revision asserted "an unknown valid project returns 200 with
+    /// an empty index". That was simply false -- a local repo 404s "Package not
+    /// found" for an absent project -- and the test caught it. Recorded because
+    /// the false version would have passed while proving nothing.
+    #[tokio::test]
+    async fn valid_project_names_round_trip_upload_to_index() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let mut failures: Vec<String> = Vec::new();
+
+        for (canonical, spellings) in valid_name_groups() {
+            let upload_name = spellings[0];
+            // Wheel filenames use '_' where the project name uses a separator.
+            let filename = format!(
+                "{}-1.0.0-py3-none-any.whl",
+                upload_name.replace(['.', '-'], "_")
+            );
+            let (content_type, body) = pypi_upload_multipart(
+                upload_name,
+                "1.0.0",
+                &filename,
+                b"fake-wheel-bytes",
+                "pep508 positive control",
+                ">=3.8",
+            );
+            let app = fx.router_with_auth(super::router());
+            let (upload_status, upload_body) = tdh::send(
+                app,
+                tdh::post(format!("/{}/", fx.repo_key), &content_type, body),
+            )
+            .await;
+            if upload_status != StatusCode::OK {
+                failures.push(format!(
+                    "upload of valid name {upload_name:?} failed with {upload_status}; body {}",
+                    String::from_utf8_lossy(&upload_body)
+                ));
+                continue;
+            }
+
+            for spelling in &spellings {
+                let uri = format!("/{}/simple/{spelling}/", fx.repo_key);
+                let app = fx.router_with_auth(super::router());
+                let (status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+                let body = String::from_utf8_lossy(&body).into_owned();
+                if status != StatusCode::OK {
+                    failures.push(format!(
+                        "index {uri}: spelling {spelling:?} of canonical {canonical:?} \
+                         must serve 200, got {status}; body {body}"
+                    ));
+                } else if !body.contains(&filename) {
+                    failures.push(format!(
+                        "index {uri}: spelling {spelling:?} served 200 but did not list \
+                         {filename} -- it resolved to the wrong project; body {body}"
+                    ));
+                }
+            }
+        }
+
+        fx.teardown().await;
+
+        assert!(
+            failures.is_empty(),
+            "PEP 508-valid project names did not work -- over-rejection here breaks \
+             all real pip traffic:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    /// The download and PEP 658 metadata routes 404 for an absent file whether
+    /// or not validation ran, so they get their own targeted assertion: a valid
+    /// name must never produce the *validation* 404 on either of them.
+    #[tokio::test]
+    async fn valid_names_are_not_rejected_on_download_or_metadata_routes() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let wheel = "pkg-1.0.0-py3-none-any.whl";
+        let mut failures: Vec<String> = Vec::new();
+
+        for (_canonical, spellings) in valid_name_groups() {
+            for name in spellings {
+                for (route, uri) in [
+                    (
+                        "download",
+                        format!("/{}/simple/{name}/{wheel}", fx.repo_key),
+                    ),
+                    (
+                        "PEP 658 metadata",
+                        format!("/{}/simple/{name}/{wheel}.metadata", fx.repo_key),
+                    ),
+                ] {
+                    let app = fx.router_with_auth(super::router());
+                    let (_status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+                    let body = String::from_utf8_lossy(&body).into_owned();
+                    if body.contains(PROJECT_REJECTED_MESSAGE) {
+                        failures.push(format!(
+                            "{route} {uri}: valid name {name:?} was rejected by name validation"
+                        ));
+                    }
+                }
+            }
+        }
+
+        fx.teardown().await;
+
+        assert!(
+            failures.is_empty(),
+            "PEP 508-valid names were rejected on a serve route:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    /// Rejection must happen BEFORE any upstream fetch, not merely before the
+    /// response is written.
+    ///
+    /// Differential, so it cannot pass vacuously: the same mock upstream is hit
+    /// with a valid name and an invalid one. The valid name must reach it (which
+    /// proves the proxy wiring is live) and the invalid name must not (which
+    /// proves validation short-circuits ahead of the fetch). Without the
+    /// control, "upstream saw nothing" would also be satisfied by a broken
+    /// fixture.
+    #[tokio::test]
+    async fn invalid_project_segment_never_reaches_the_upstream() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::any;
+        use wiremock::{Mock, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&upstream)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(upstream.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("point the fixture repo at the mock upstream");
+
+        let proxy = tdh::build_proxy_service_with_fs(
+            fx.pool.clone(),
+            fx.storage_dir.to_str().expect("storage dir"),
+        );
+        let state = tdh::build_state_with_proxy(
+            fx.pool.clone(),
+            fx.storage_dir.to_str().expect("storage dir"),
+            proxy,
+        );
+
+        let wheel = "pkg-1.0.0-py3-none-any.whl";
+
+        // Invalid name first, so the count below cannot be polluted by the
+        // control request.
+        let app = tdh::router_anon(super::router(), state.clone());
+        let (invalid_status, invalid_body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/simple/acme%20sdk/{wheel}", fx.repo_key)),
+        )
+        .await;
+        let after_invalid = upstream
+            .received_requests()
+            .await
+            .expect("mock upstream records requests")
+            .len();
+
+        // Control: a valid name on the same repo MUST reach the upstream.
+        let app = tdh::router_anon(super::router(), state.clone());
+        let (_control_status, _control_body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/simple/acme-sdk/{wheel}", fx.repo_key)),
+        )
+        .await;
+        let after_control = upstream
+            .received_requests()
+            .await
+            .expect("mock upstream records requests")
+            .len();
+
+        fx.teardown().await;
+
+        assert_eq!(
+            invalid_status,
+            StatusCode::NOT_FOUND,
+            "invalid name must 404; body: {}",
+            String::from_utf8_lossy(&invalid_body)
+        );
+        assert!(
+            String::from_utf8_lossy(&invalid_body).contains(PROJECT_REJECTED_MESSAGE),
+            "the 404 must come from name validation; body: {}",
+            String::from_utf8_lossy(&invalid_body)
+        );
+        assert_eq!(
+            after_invalid, 0,
+            "an invalid project name made {after_invalid} upstream request(s); \
+             validation must short-circuit before ANY fetch"
+        );
+        assert!(
+            after_control > 0,
+            "control failed: a VALID name made no upstream request either, so the \
+             zero-request assertion above proves nothing"
         );
     }
 
@@ -6973,7 +7555,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -7132,7 +7714,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -7349,7 +7931,7 @@ mod tests {
             &state,
             &virtual_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -7410,7 +7992,7 @@ mod tests {
             &state,
             &virtual_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -7463,7 +8045,7 @@ mod tests {
             &state,
             &virtual_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -9420,7 +10002,7 @@ mod tests {
             repo_id,
             "pypi-remote",
             &server.uri(),
-            "numpy",
+            &proj("numpy"),
             "numpy-2.0.0-py3-none-any.whl",
             "simple",
             RepositoryFormat::Pypi,
@@ -11514,7 +12096,7 @@ mod tests {
             &state,
             &virtual_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -11587,7 +12169,7 @@ mod tests {
             &state,
             &virtual_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -11639,7 +12221,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -11687,7 +12269,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -11777,7 +12359,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -11864,7 +12446,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -11994,7 +12576,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -12078,7 +12660,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -12169,7 +12751,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -12254,7 +12836,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),
@@ -12340,7 +12922,7 @@ mod tests {
             &state,
             &repo_info,
             &fx.repo_key,
-            project,
+            &proj(project),
             filename,
             None,
             &Default::default(),

--- a/backend/src/formats/mod.rs
+++ b/backend/src/formats/mod.rs
@@ -32,6 +32,7 @@ pub mod protobuf;
 pub mod r#pub;
 pub mod puppet;
 pub mod pypi;
+pub mod pypi_name;
 pub mod rpm;
 pub mod rubygems;
 pub mod sbt;

--- a/backend/src/formats/pypi_name.rs
+++ b/backend/src/formats/pypi_name.rs
@@ -1,0 +1,419 @@
+//! Validated, normalized PyPI project names (PEP 508 + PEP 503).
+//!
+//! # Why this module exists
+//!
+//! Artifact Keeper carried *two* PyPI name coercions and *zero* validation:
+//!
+//! * [`crate::api::handlers::pypi::normalize_pep503`] — the policy/gate form.
+//!   It DROPS every character outside `[A-Za-z0-9._-]` without marking a
+//!   separator. That drop is a deliberate stored-XSS boundary (#1377) and is
+//!   correct as a *sanitizer*.
+//! * [`crate::formats::pypi::PypiHandler::normalize_name`] — the fetch/cache-key
+//!   form. It maps every non-alphanumeric character to `-`.
+//!
+//! On any character outside `[A-Za-z0-9._-]` the two disagree. `acme sdk`
+//! becomes `acmesdk` for the gate and `acme-sdk` for the fetch, so a client
+//! could clear a curation / dependency-confusion gate under one name and be
+//! served a different package's bytes. That divergence has been re-introduced
+//! three separate times (#3077, #3179, #3183), each time as a silent security
+//! bug rather than a compile error.
+//!
+//! # The spec position
+//!
+//! **PEP 503** ("Simple Repository API", *Normalized Names*) defines
+//! normalization as exactly:
+//!
+//! ```text
+//! re.sub(r"[-_.]+", "-", name).lower()
+//! ```
+//!
+//! That is the whole rule. It collapses runs of `-`, `_` and `.` into a single
+//! `-` and lowercases. It says nothing about any other character — not because
+//! other characters are permitted, but because the rule presupposes a name that
+//! is already valid.
+//!
+//! **PEP 508** ("Dependency specification for Python Software Packages",
+//! *Names*) supplies that missing precondition:
+//!
+//! > The format of a name is:
+//! >
+//! > ```text
+//! > ^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
+//! > ```
+//! >
+//! > with `re.IGNORECASE`.
+//!
+//! So `acme sdk` is not a project name at all, and there is no correct
+//! normalization for it — it is outside the input domain of PEP 503's rule.
+//! Two coercions disagreeing about an input that has no correct answer is the
+//! expected outcome, not an implementation slip.
+//!
+//! # What this module does
+//!
+//! [`NormalizedProjectName`] can only be constructed from a name that satisfies
+//! the PEP 508 pattern, and it stores the PEP 503 normalized form. Because the
+//! fetch and cache-key helpers take `&NormalizedProjectName` rather than
+//! `&str`, a raw path segment cannot reach them: a fourth code path that
+//! reaches for the wrong coercion now fails to compile instead of shipping a
+//! silent gate bypass.
+//!
+//! # The invariant that makes this a *removal* of the divergence
+//!
+//! For every PEP 508-valid name, all three functions — PEP 503's reference
+//! `re.sub`, `normalize_pep503`, and `PypiHandler::normalize_name` — agree
+//! byte for byte. A valid name draws only on `[A-Za-z0-9._-]`, so
+//! `normalize_pep503` never drops anything, and it begins and ends with an
+//! alphanumeric, so neither the leading-separator skip nor the trailing-hyphen
+//! pop fires. Validation therefore does not paper over the divergence; it
+//! eliminates the inputs on which a divergence can exist. That equivalence is
+//! asserted directly in `tests::all_three_normalizers_agree_on_every_valid_name`.
+//!
+//! This module deliberately does NOT weaken `normalize_pep503`. Its character
+//! dropping remains the XSS boundary for names scraped out of upstream HTML,
+//! which are not route input and are not validated here.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// PEP 508 *Names*: `^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$` with
+/// `re.IGNORECASE`.
+///
+/// Written with an explicit `[A-Za-z0-9]` class rather than the `(?i)` flag so
+/// the accepted alphabet is ASCII and visible at the call site. A `(?i)`
+/// `[A-Z]` in Rust's `regex` crate would additionally match the Kelvin sign
+/// (U+212A) and the dotless/long variants under Unicode case folding, which
+/// would let non-ASCII names through the very check that exists to exclude
+/// them.
+///
+/// `\A`/`\z` rather than `^`/`$`: in Rust's `regex`, `$` also matches before a
+/// trailing `\n`, so `^...$` would accept `"acme-sdk\n"` — a name carrying a
+/// header-injection newline into every downstream URL.
+static PEP508_NAME_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\A([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])\z")
+        .expect("PEP 508 name pattern is a valid regex")
+});
+
+/// Does `name` satisfy the PEP 508 project-name pattern?
+///
+/// This is the *unnormalized* check: `Django`, `zope.interface` and
+/// `a.b-c_d` are all valid names, they simply are not canonical ones.
+pub fn is_valid_project_name(name: &str) -> bool {
+    PEP508_NAME_RE.is_match(name)
+}
+
+/// A PyPI project name that has been validated against PEP 508 and stored in
+/// PEP 503 canonical form.
+///
+/// The inner `String` is private and there is no `From<String>`, no
+/// `Deref<Target = str>` and no public constructor other than [`Self::parse`],
+/// so the only way to obtain one is to pass validation. That is the whole
+/// point: helpers that fetch from an upstream or build a proxy-cache key take
+/// `&NormalizedProjectName`, which makes "gate on one string, fetch with
+/// another" unrepresentable rather than merely currently-fixed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NormalizedProjectName(String);
+
+impl NormalizedProjectName {
+    /// Validate `raw` against PEP 508 and normalize it per PEP 503.
+    ///
+    /// Returns `None` for anything outside the PEP 508 alphabet — an empty
+    /// segment, a leading or trailing `-`/`_`/`.`, whitespace, a control
+    /// character, a path separator, or any non-ASCII character. Callers on a
+    /// routed path must turn `None` into a 404: pypi.org has no route for a
+    /// name that cannot exist, and returns 404 for exactly these inputs.
+    pub fn parse(raw: &str) -> Option<Self> {
+        if !is_valid_project_name(raw) {
+            return None;
+        }
+        Some(Self(normalize_valid(raw)))
+    }
+
+    /// The PEP 503 canonical form.
+    ///
+    /// The single, explicit way out of the newtype. There is deliberately no
+    /// `Deref<Target = str>`, no `AsRef<str>` and no `Into<String>`: any of
+    /// those would let the canonical name be passed where a `&str` is expected
+    /// through inference alone, which is exactly the implicitness this type
+    /// exists to remove. Every unwrap should be visible at the call site.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for NormalizedProjectName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// PEP 503 normalization, `re.sub(r"[-_.]+", "-", name).lower()`, applied to a
+/// name already known to satisfy PEP 508.
+///
+/// Private on purpose. Exposing it would recreate exactly the hazard this
+/// module removes: a third bare `&str` -> `String` name coercion for a future
+/// code path to pick by accident.
+fn normalize_valid(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut in_separator_run = false;
+    for c in name.chars() {
+        if c == '-' || c == '_' || c == '.' {
+            if !in_separator_run {
+                out.push('-');
+                in_separator_run = true;
+            }
+        } else {
+            out.push(c.to_ascii_lowercase());
+            in_separator_run = false;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::handlers::pypi::normalize_pep503;
+    use crate::formats::pypi::PypiHandler;
+
+    // -- PEP 508 acceptance -------------------------------------------------
+
+    /// Every one of these satisfies
+    /// `^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$`, so every one MUST be
+    /// accepted. Over-rejection here does not fail one request, it takes the
+    /// whole PyPI surface offline, so this list is deliberately weighted
+    /// towards the unusual-but-legal.
+    fn valid_names() -> Vec<&'static str> {
+        vec![
+            // Single character - the first alternation branch, and the only
+            // shape for which the pattern's second branch cannot match.
+            "a",
+            "A",
+            "0",
+            "9",
+            // Digits only.
+            "123",
+            "2024",
+            // Two characters: the second branch with an empty middle.
+            "ab",
+            "a1",
+            "1a",
+            // Every separator the alphabet allows, interior.
+            "a.b-c_d",
+            "a-b",
+            "a_b",
+            "a.b",
+            // Runs of separators are legal input (PEP 503 collapses them).
+            "a__b",
+            "a--b",
+            "a._-b",
+            // Mixed case.
+            "MyPackage",
+            "Django",
+            "PyYAML",
+            "Jinja2",
+            // Real-world names with dots.
+            "zope.interface",
+            "ruamel.yaml",
+            "backports.ssl_match_hostname",
+            // Already canonical.
+            "acme-sdk",
+            "requests",
+            // Long-ish and separator-dense but legal.
+            "a-b-c-d-e-f-g-h",
+        ]
+    }
+
+    /// None of these satisfies the PEP 508 pattern, so none is a project name
+    /// and none has a correct normalization.
+    fn invalid_names() -> Vec<&'static str> {
+        vec![
+            // Empty.
+            "",
+            // The motivating case: a space is outside the alphabet, and it is
+            // exactly where the two legacy coercions disagreed.
+            "acme sdk",
+            " acme-sdk",
+            "acme-sdk ",
+            // Other out-of-alphabet characters.
+            "acme!sdk",
+            "acme@sdk",
+            "acme/sdk",
+            "acme\\sdk",
+            "acme:sdk",
+            "acme+sdk",
+            "acme%20sdk",
+            "acme#sdk",
+            // Non-ASCII, including the Kelvin-sign / case-folding trap the
+            // explicit ASCII class exists to exclude.
+            "acmeésdk",
+            "acme\u{212A}sdk",
+            "пакет",
+            // Control characters and newlines: `$` in Rust regex matches
+            // before a trailing newline, which is why the pattern uses `\z`.
+            "acme-sdk\n",
+            "acme-sdk\r\n",
+            "acme\tsdk",
+            "acme\0sdk",
+            // Leading / trailing separators - the pattern requires an
+            // alphanumeric at both ends.
+            "_leading",
+            "-leading",
+            ".leading",
+            "trailing_",
+            "trailing-",
+            "trailing.",
+            // Separator only.
+            "-",
+            "_",
+            ".",
+            "---",
+            // Path traversal shapes, which the alphabet excludes for free.
+            "..",
+            "../etc/passwd",
+            "a/../b",
+            // The XSS payload the sanitizer boundary exists for. It is not a
+            // name; rejecting it is strictly stronger than sanitizing it.
+            "<script>alert(1)</script>",
+        ]
+    }
+
+    #[test]
+    fn accepts_every_valid_name() {
+        for name in valid_names() {
+            assert!(
+                NormalizedProjectName::parse(name).is_some(),
+                "PEP 508-valid name was rejected: {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_every_invalid_name() {
+        for name in invalid_names() {
+            assert!(
+                NormalizedProjectName::parse(name).is_none(),
+                "PEP 508-invalid name was accepted: {name:?}"
+            );
+        }
+    }
+
+    // -- PEP 503 normalization ----------------------------------------------
+
+    #[test]
+    fn normalizes_per_pep503() {
+        let cases = [
+            ("MyPackage", "mypackage"),
+            ("my_package", "my-package"),
+            ("my.package", "my-package"),
+            ("My_Package.Name", "my-package-name"),
+            ("my__package", "my-package"),
+            ("my-package", "my-package"),
+            ("a.b-c_d", "a-b-c-d"),
+            ("a._-b", "a-b"),
+            ("zope.interface", "zope-interface"),
+            (
+                "backports.ssl_match_hostname",
+                "backports-ssl-match-hostname",
+            ),
+            ("Jinja2", "jinja2"),
+            ("a", "a"),
+            ("123", "123"),
+        ];
+        for (input, expected) in cases {
+            let parsed = NormalizedProjectName::parse(input)
+                .unwrap_or_else(|| panic!("{input:?} should be valid"));
+            assert_eq!(parsed.as_str(), expected, "input {input:?}");
+        }
+    }
+
+    /// PEP 503 normalization is idempotent, so a canonical name round-trips.
+    #[test]
+    fn normalization_is_idempotent() {
+        for name in valid_names() {
+            let once = NormalizedProjectName::parse(name).expect("valid");
+            let twice = NormalizedProjectName::parse(once.as_str())
+                .expect("PEP 503 output must itself be a valid PEP 508 name");
+            assert_eq!(once, twice, "not idempotent for {name:?}");
+        }
+    }
+
+    /// The load-bearing claim of this whole change.
+    ///
+    /// On the PEP 508-valid domain the two legacy coercions and the newtype all
+    /// produce the same string, so validating at the edge does not change the
+    /// answer for any name that has one — it only removes the inputs for which
+    /// the two answers differed. If this ever fails, validation alone is no
+    /// longer sufficient and the divergence is back.
+    #[test]
+    fn all_three_normalizers_agree_on_every_valid_name() {
+        for name in valid_names() {
+            let newtype = NormalizedProjectName::parse(name).expect("valid");
+            assert_eq!(
+                newtype.as_str(),
+                normalize_pep503(name),
+                "newtype vs normalize_pep503 disagree on {name:?}"
+            );
+            assert_eq!(
+                newtype.as_str(),
+                PypiHandler::normalize_name(name),
+                "newtype vs PypiHandler::normalize_name disagree on {name:?}"
+            );
+        }
+    }
+
+    /// `PypiHandler::normalize_name` is the identity on canonical output, which
+    /// is what lets the fetch helpers keep calling it without changing any URL
+    /// or cache key for a well-formed name.
+    #[test]
+    fn legacy_fetch_normalizer_is_identity_on_canonical_form() {
+        for name in valid_names() {
+            let canonical = NormalizedProjectName::parse(name).expect("valid");
+            assert_eq!(
+                PypiHandler::normalize_name(canonical.as_str()),
+                canonical.as_str(),
+                "normalize_name is not the identity on canonical {canonical}"
+            );
+        }
+    }
+
+    /// The exact divergence from the issue, pinned so the motivation cannot be
+    /// lost: on `acme sdk` the two legacy coercions really do differ, and the
+    /// newtype refuses the input rather than picking a winner.
+    #[test]
+    fn documents_the_divergence_the_newtype_removes() {
+        assert_eq!(normalize_pep503("acme sdk"), "acmesdk");
+        assert_eq!(PypiHandler::normalize_name("acme sdk"), "acme-sdk");
+        assert_ne!(
+            normalize_pep503("acme sdk"),
+            PypiHandler::normalize_name("acme sdk")
+        );
+        assert!(NormalizedProjectName::parse("acme sdk").is_none());
+    }
+
+    /// The canonical form never carries a character that could break out of a
+    /// URL path segment, an HTML attribute, or a storage key.
+    #[test]
+    fn canonical_form_is_url_and_html_safe() {
+        for name in valid_names() {
+            let canonical = NormalizedProjectName::parse(name).expect("valid");
+            assert!(
+                canonical
+                    .as_str()
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "canonical form {canonical} contains an unexpected character"
+            );
+        }
+    }
+
+    /// A single-character name is the shape most likely to be broken by an
+    /// off-by-one in the pattern, and `a` is a real package on pypi.org.
+    #[test]
+    fn single_character_names_survive() {
+        for name in ["a", "z", "A", "Z", "0", "9"] {
+            let parsed = NormalizedProjectName::parse(name)
+                .unwrap_or_else(|| panic!("single character {name:?} must be valid"));
+            assert_eq!(parsed.as_str(), name.to_ascii_lowercase());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3186

## The problem is not that the two normalizers disagree — it's that the input has no correct answer

We carry two PyPI name coercions and zero validation:

| input | `normalize_pep503` (gate) | `PypiHandler::normalize_name` (fetch) |
|---|---|---|
| `acme-sdk` | `acme-sdk` | `acme-sdk` |
| `acme sdk` | `acmesdk` | `acme-sdk` |

So `acme sdk` clears a curation / PEP 708 dependency-confusion gate as `acmesdk` — owned by nobody, blocked by nobody — and then fetches `acme-sdk`, which is the private package the gate exists to protect.

Every fix so far has been *"make both sides use the same coercion."* That works, and it is fragile by construction: any third code path needing a project name has to know which of the two helpers is blessed, and picking wrong is a silent security bug rather than a compile error. That has happened three times — #3077 (suffix stripping), #3179 (metadata), #3183 (download).

## Why the spec says there is nothing to keep in sync

**PEP 503**, *Simple Repository API — Normalized Names*, defines normalization as exactly:

```python
re.sub(r"[-_.]+", "-", name).lower()
```

That is the whole rule. It collapses runs of `-`, `_`, `.` and lowercases. It says nothing about any other character — not because other characters are permitted, but because the rule **presupposes a name that is already valid**.

**PEP 508**, *Dependency specification for Python Software Packages — Names*, supplies that missing precondition:

> The format of a name is:
>
> ```
> ^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
> ```
>
> with `re.IGNORECASE`.

So `acme sdk` is **not a project name**, and there is no correct normalization for it — it is outside the input domain of PEP 503's rule. Two coercions disagreeing about an input that has no correct answer is the expected outcome, not an implementation slip.

## What changed

**1. Reject a `:project` segment failing the PEP 508 pattern with 404, before any gate, DB lookup or upstream fetch.**

Applies to every route that takes a project segment: the simple index, the distribution download, and the PEP 658 `.metadata` resource.

**404 is measured against the reference implementation, not inferred.** pypi.org:

| request | response |
|---|---|
| `/simple/acme%20sdk/` | **404** |
| `/simple/acme!sdk/` | **404** |
| `/simple/_leading/` | **404** |
| `/simple/trailing-/` | **404** |
| `/simple/Django/` | 301 → `/simple/django/` |
| `/simple/zope.interface/` | 301 → `/simple/zope-interface/` |

A name that cannot exist has no route, so 404 — not 400 — is the behaviour clients already handle. (The 301-to-canonical for *valid* non-canonical names is a separate question; we serve those directly, unchanged by this PR.)

**2. A `NormalizedProjectName` newtype** (`backend/src/formats/pypi_name.rs`), constructible only from a validated name and holding the PEP 503 canonical form.

The fetch and cache-key helpers now take `&NormalizedProjectName` instead of `&str`:

- `resolve_pypi_remote_fetch_target` — the single place a route-derived name becomes an outbound upstream URL
- `build_pypi_proxy_cache_path` — the proxy-cache key
- and the chain above them: `serve_file`, `serve_remote_metadata`, `enforce_pypi_download_age_gate`, `serve_scanned_pypi_file`

A raw path segment cannot reach them. A fourth code path that reaches for the wrong coercion now **fails to compile** instead of shipping a silent gate bypass.

There is deliberately **no `Deref<Target = str>`, no `AsRef<str>`, no `Into<String>`** — any of those would let the canonical name flow into a `&str` position through inference alone, which is exactly the implicitness the type exists to remove. Every unwrap is a visible `.as_str()`.

**3. `normalize_pep503` is NOT weakened.** Its character dropping remains the stored-XSS boundary (#1377) for names scraped out of upstream simple-index HTML — which are not route input and are not validated here. Its body is byte-for-byte unchanged.

### Why validation *removes* the divergence rather than papering over it

On the PEP 508-valid domain, all three functions — PEP 503's reference `re.sub`, `normalize_pep503`, and `PypiHandler::normalize_name` — agree byte for byte. A valid name draws only on `[A-Za-z0-9._-]`, so nothing is ever dropped; and it begins and ends with an alphanumeric, so neither the leading-separator skip nor the trailing-hyphen pop fires.

Validation therefore does not change the answer for any name that *has* one. It eliminates the inputs on which a divergence can exist. That equivalence is asserted directly (`all_three_normalizers_agree_on_every_valid_name`, `accepted_names_normalize_exactly_as_the_gate_does`), so if it ever stops holding, the tests say so rather than a user finding out.

### Also fixed in passing

`serve_scanned_pypi_file` built the inline scan gate's `ExpectedComponent` from the **raw** segment, so a scan verdict could be keyed on `acme sdk` while the fetch resolved `acme-sdk` — the same divergence, in the component identity the verdict is looked up by.

### On the error body

The rejection body is `"Invalid project name"`.

- It **does not echo the segment**. Reflecting an unvalidated name would hand back the very characters `normalize_pep503` exists to strip, and a 404 that repeats its input is a reflection sink. The rejected name is only logged.
- It is **deliberately distinct from `"Package not found"`**, which an absent-but-valid project already returns. Reusing that string would make a validation rejection and an ordinary lookup miss indistinguishable — to an operator debugging a broken `pip install`, and to the tests that have to prove this change does not over-reject.

## Tests

Over-rejection is the dangerous failure mode here: a fix that rejects too much does not break one request, it takes the whole PyPI surface offline. So the positive controls carry more weight than the rejection tests.

| test | proves | DB |
|---|---|---|
| `parse_project_segment_accepts_valid_and_rejects_invalid` | exhaustive over-rejection guard: 26 valid names accepted, 19 invalid rejected with 404 | no |
| `accepted_names_normalize_exactly_as_the_gate_does` | validation does not change the canonical form of any valid name | no |
| `pep508_invalid_project_segment_is_404_on_every_pypi_route` | rejection on **all three** routes — simple index, download, `.metadata` | yes |
| `valid_project_names_round_trip_upload_to_index` | **the real positive control** | yes |
| `valid_names_are_not_rejected_on_download_or_metadata_routes` | 33 spellings never hit the validator on the serve routes | yes |
| `invalid_project_segment_never_reaches_the_upstream` | rejection happens **before any fetch** | yes |

Two of those deserve elaboration:

**`valid_project_names_round_trip_upload_to_index`** does not settle for "did not return the validation 404". It uploads a real distribution under 20 canonical names across 33 spellings, then reads each back from the simple index and asserts a **200 that lists the wheel** — something an over-rejecting validator cannot produce, and that a wrongly-normalizing one cannot produce either. Spellings are grouped by canonical form (`a-b` ← `a-b`, `a_b`, `a.b`, `a__b`, `a--b`, `a._-b`, `A-B`), so PEP 503's collapsing and case-folding rules are executable, not merely asserted against a helper.

An earlier revision of this test asserted "an unknown-but-valid project returns 200 with an empty index." That was simply false — a local repo 404s `"Package not found"` — and the test caught it. Noted in the source, because the false version would have passed while proving nothing.

**`invalid_project_segment_never_reaches_the_upstream`** is differential so it cannot pass vacuously: the same mock upstream is hit with an invalid name and a valid one. The invalid name must produce **zero** upstream requests; the valid one must produce at least one. Without that control, "upstream saw nothing" would also be satisfied by a broken fixture.

Coverage includes single characters (`a`, `A`, `0`, `9`), digits-only (`123`, `2024`), `a.b-c_d`, mixed case (`MyPackage`, `Django`, `PyYAML`), and real dotted names (`zope.interface`, `backports.ssl_match_hostname`).

Two details the pattern is anchored against, both covered:

- `\A`/`\z` rather than `^`/`$` — in Rust's `regex`, `$` also matches before a trailing `\n`, so `^...$` would accept `"acme-sdk\n"`, a name carrying a newline into every downstream URL.
- an explicit `[A-Za-z0-9]` class rather than the `(?i)` flag — a `(?i)[A-Z]` would additionally match the Kelvin sign (U+212A) under Unicode case folding, letting a non-ASCII name through the check that exists to exclude it.

### Revert-proof

Validation removed (`parse_project_segment` restored to coerce-then-accept), full `-- pypi` run:

```
---- api::handlers::pypi::tests::parse_project_segment_accepts_valid_and_rejects_invalid stdout ----
panicked at backend/src/api/handlers/pypi.rs:4649:33:
PEP 508-invalid name "acme sdk" was accepted and normalized to NormalizedProjectName("acmesdk")

---- api::handlers::pypi::tests::pep508_invalid_project_segment_is_404_on_every_pypi_route stdout ----
panicked at backend/src/api/handlers/pypi.rs:4726:9:
PEP 508-invalid project segments were not rejected:
simple index .../simple/acme%20sdk/ (name "acme sdk"): 404 but not from validation; body {"code":"NOT_FOUND","message":"Package not found"}
download .../simple/acme%20sdk/pkg-1.0.0-py3-none-any.whl (name "acme sdk"): 404 but not from validation; body {"code":"NOT_FOUND","message":"File not found"}
PEP 658 metadata .../simple/acme%20sdk/pkg-1.0.0-py3-none-any.whl.metadata (name "acme sdk"): 404 but not from validation; body {"code":"NOT_FOUND","message":"File not found"}
[... 54 more lines, all 19 invalid names × 3 routes ...]

---- api::handlers::pypi::tests::invalid_project_segment_never_reaches_the_upstream stdout ----
panicked at backend/src/api/handlers/pypi.rs:4985:9:
the 404 must come from name validation; body: Artifact not found upstream

failures:
    api::handlers::pypi::tests::invalid_project_segment_never_reaches_the_upstream
    api::handlers::pypi::tests::parse_project_segment_accepts_valid_and_rejects_invalid
    api::handlers::pypi::tests::pep508_invalid_project_segment_is_404_on_every_pypi_route

test result: FAILED. 380 passed; 3 failed; 0 ignored; 0 measured; 14395 filtered out
```

The three rejection tests fail; **both positive controls still pass**, which is the point — they are genuine controls, not tautologies that only hold because the fix is present.

## Compatibility

A behaviour change for clients currently sending invalid names — but those clients are already getting *arbitrary* results depending on which helper a given route happens to use, so there is no coherent behaviour to preserve. pip normalizes before requesting, so real traffic is unaffected; and every 301-to-canonical name pypi.org accepts (`Django`, `zope.interface`) is accepted here too.

**Out of scope:** the twine upload path (`POST /{repo}/`) takes its project name from a multipart form field, not a path segment, and is left unvalidated by this PR. Worth a follow-up — a package published under a name that fails PEP 508 would now be unreachable through the simple index — but it is a different input channel with a different correct status code (400, not 404), and mixing it in would put an upload-rejection behaviour change inside a read-path security fix.

## Relationship to #3179 and #3190 — please read before merging

These three PRs are **complementary, not competing**, and they overlap textually.

- **#3179** (metadata) and **#3190** (download) thread the already-normalized name through the fetch helpers. That fixes the *valid-but-non-canonical* case: `Django` vs `django`, which validation alone does **not** fix, because `Django` is a perfectly legal PEP 508 name.
- **This PR** removes the *invalid* inputs entirely — the only inputs on which the two coercions actually disagree — and makes the threading enforced by the type system rather than by review.

Neither subsumes the other. Both should land.

**Deliberately not duplicated:** the 11 simple-index call sites in `simple_project` (`rewrite_upstream_urls`, `filter_pypi_simple_json_response`, `filter_pypi_simple_html_response`) still receive `&project` on this branch. Those are #3190's contribution and merge cleanly here.

### Conflicts this PR creates

Measured by trial merge against both PR heads (`13b81c4` / `c5b023a`), both in `backend/src/api/handlers/pypi.rs` only:

**vs #3179 — 2 hunks, both trivial.**
1. The `serve_remote_metadata` call in `download_or_metadata`: both branches change `&project` → `&normalized`. Same edit, adjacent comments. Take either comment, or both.
2. Doc-comment adjacency where #3179 inserts `serve_virtual_metadata`. Keep #3179's new function and change its `normalized_project: &str` parameter to `project: &NormalizedProjectName`, then `.as_str()` at its gate call sites — the same mechanical change this PR applies to `serve_file`. Its doc comment ("Not having the raw name in scope is what stops that from being reintroduced") then becomes literally enforced.

**vs #3190 — 8 hunks, all the same shape.** Every one is "#3190 renames `project: &str` → `normalized_project: &str`; this PR retypes it to `project: &NormalizedProjectName`". Resolve by **taking this branch's side in all 8** — the newtype form is strictly stronger and subsumes the rename. Affected: `serve_file`'s signature and doc comment, the two `build_pypi_proxy_cache_path` call sites, `pypi_virtual_isolates_name`, `pypi_owned_wheel_profile`, `enforce_pypi_curation`, and the `serve_file` call in `download_or_metadata`.

**Suggested merge order:** #3179 → #3190 → this PR, resolving as above. This PR is the one that should rebase, since it is the one whose whole purpose is to make the other two's invariant mechanical.

## Verification

CI fleet is down; all gates run locally against a disposable Postgres 16.

| gate | result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --lib -- pypi` (`AK_TESTS_REQUIRE_DB=1`) | **383 passed, 0 failed** |
| `cargo test --lib` (full suite) | **14772 passed, 0 failed, 6 ignored** |
| `SQLX_OFFLINE=true cargo build --lib --tests`, `DATABASE_URL` unset | clean |

No `sqlx::query!` query text changed — only a bind *argument* (`normalized` → `normalized.as_str()`), which does not affect the `.sqlx` cache key. `.sqlx/` is unmodified, and the offline build above confirms it.

Two unrelated pre-existing flakes surfaced during full-suite runs under load and passed in isolation and on re-run: `test_fetch_from_pypi_remote_streaming_fallback_path` and `oci_v2::...::remote_blob_streams_large_layer_and_warms_cache`. Both are cache-commit timing (`wait_for_cache_commit`), neither touches name handling.
