### PR TITLE
fix(security): gate quarantine status and SBOM listing on repository visibility, not token scope

### DIFF
--- a/backend/src/api/handlers/quarantine.rs
+++ b/backend/src/api/handlers/quarantine.rs
@@ -98,14 +98,28 @@ pub async fn get_quarantine_status(
     // Fetch quarantine status along with the artifact's repository to check visibility
     let row = quarantine_service::get_status_with_repo(&state.db, artifact_id).await?;
 
-    // Check that the user has access to the artifact's repository.
-    // For private repos, unauthenticated or unauthorized users get 404.
-    let repo_service =
-        crate::services::repository_service::RepositoryService::new(state.db.clone());
-    let repo = repo_service.get_by_id(row.repository_id).await?;
-    if !repo.is_public && !auth_ext.can_access_repo(row.repository_id) {
-        return Err(AppError::NotFound("Artifact not found".to_string()));
-    }
+    // EXISTENCE gate: the caller must be able to SEE the artifact's repository.
+    //
+    // This used to be `!repo.is_public && !auth_ext.can_access_repo(...)`.
+    // `can_access_repo` is the caller's TOKEN SCOPE — it resolves to
+    // `access_scope().grants(repo_id)`, and `AccessScope::Admin` grants
+    // unconditionally — so for every browser JWT session and every unscoped API
+    // token it returned `true` for EVERY repository in the instance. As a
+    // visibility gate it was inert for the most common caller, and any
+    // authenticated user holding an artifact UUID could confirm the existence
+    // of another tenant's private artifact (#3174).
+    //
+    // `require_repo_id_visible` is the canonical predicate,
+    // `is_public OR (in_scope AND (is_admin OR grants))`, and it collapses
+    // "repository row is gone" into the same existence-hiding 404 rather than
+    // surfacing a "Repository '<key>' not found" message that would name it.
+    crate::api::handlers::repositories::require_repo_id_visible(
+        &state.db,
+        &auth_ext,
+        row.repository_id,
+        "Artifact not found",
+    )
+    .await?;
 
     let now = chrono::Utc::now();
     let is_blocked = quarantine_service::check_download_allowed(
@@ -115,11 +129,33 @@ pub async fn get_quarantine_status(
     )
     .is_err();
 
-    // The reason is per-artifact security detail, so it goes only to callers who
-    // hold the repository. `can_access_repo` is unrestricted for admin scope, so
-    // this covers admins and scoped users who genuinely hold the repo, and excludes
-    // an authenticated caller who merely happens to be able to read a public one.
-    let quarantine_reason = if auth_ext.can_access_repo(row.repository_id) {
+    // REASON gate, deliberately STRICTER than the existence gate above.
+    //
+    // The reason is per-artifact security detail — the policy name, finding
+    // counts and free-text admin incident notes behind the hold. #2912 keeps it
+    // off the blocked-download 403 for exactly that reason, because that path is
+    // reachable anonymously on a public repository. So it goes ONLY to callers
+    // who genuinely HOLD the repository: the `is_public` arm of the visibility
+    // predicate is dropped, leaving `in_scope AND (is_admin OR grants)`. A
+    // caller who can see the artifact only because its repository happens to be
+    // public does not get the finding text.
+    //
+    // That is precisely what the comment here claimed before #3174 — "excludes
+    // an authenticated caller who merely happens to be able to read a public
+    // one". The code did not implement it. Testing `can_access_repo` alone
+    // tested TOKEN SCOPE, which is unconditionally `true` for `AccessScope::
+    // Admin` — every browser JWT session, every unscoped API token — so the
+    // field was handed to any authenticated caller on any repository. The
+    // comment is why the gate survived review; the predicate is now spelled out
+    // instead of delegated to a name that means something else.
+    let repo_service =
+        crate::services::repository_service::RepositoryService::new(state.db.clone());
+    let holds_repository = auth_ext.can_access_repo(row.repository_id)
+        && (auth_ext.is_admin
+            || repo_service
+                .user_can_access_repo(row.repository_id, auth_ext.user_id)
+                .await?);
+    let quarantine_reason = if holds_repository {
         row.quarantine_reason
     } else {
         None
@@ -676,6 +712,147 @@ mod tests {
             reason.as_deref(),
             Some("malicious maintainer takeover"),
             "the rejection reason must replace the earlier quarantine reason"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3174: `can_access_repo` is TOKEN SCOPE, not repository visibility.
+    // -----------------------------------------------------------------------
+
+    /// Flip the fixture repository's `is_public` flag.
+    async fn set_repo_public(fx: &tdh::Fixture, public: bool) {
+        sqlx::query("UPDATE repositories SET is_public = $1 WHERE id = $2")
+            .bind(public)
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("set is_public");
+    }
+
+    /// `GET /{artifact_id}` as `auth`, decoded.
+    async fn status_as(
+        fx: &tdh::Fixture,
+        auth: crate::api::middleware::auth::AuthExtension,
+        artifact_id: Uuid,
+    ) -> (StatusCode, serde_json::Value) {
+        let app = tdh::router_with_auth(router(), fx.state.clone(), auth);
+        let (status, body) = tdh::send(app, tdh::get(format!("/{artifact_id}"))).await;
+        let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+        (status, json)
+    }
+
+    /// A private repository's quarantine status must not be readable by an
+    /// authenticated caller who holds no grant on it (#3174).
+    ///
+    /// The caller shape that matters is [`tdh::make_auth`]: a non-admin with
+    /// `allowed_repo_ids = AccessScope::Admin`, i.e. unrestricted token scope.
+    /// That is exactly a browser JWT session, and it is the shape for which the
+    /// pre-fix `can_access_repo` gate returned `true` for every repository in
+    /// the instance — so the endpoint disclosed existence, hold status, and the
+    /// free-text `quarantine_reason` (the malware / CVE finding) cross-tenant.
+    ///
+    /// Both positive controls run against the SAME fixture and the SAME
+    /// artifact, so a "fix" that denied everyone would fail here.
+    #[tokio::test]
+    async fn test_status_private_repo_denies_non_member_but_not_holders() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let reason = "Policy 'cve-gate': 2 findings at or above high";
+        let artifact_id = seed_artifact(&fx, Some("quarantined"), None, Some(reason)).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+
+        // NEGATIVE: authenticated, unrestricted scope, no grant on the repo.
+        let (out_status, out_json) =
+            status_as(&fx, tdh::make_auth(outsider, &outname), artifact_id).await;
+        // POSITIVE CONTROL 1: the fixture user holds a developer grant.
+        let (member_status, member_json) =
+            status_as(&fx, tdh::make_auth(fx.user_id, &fx.username), artifact_id).await;
+        // POSITIVE CONTROL 2: a global admin.
+        let (admin_status, admin_json) =
+            status_as(&fx, tdh::admin_auth(fx.user_id, &fx.username), artifact_id).await;
+
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+
+        assert_eq!(
+            out_status,
+            StatusCode::NOT_FOUND,
+            "a non-member must not learn that a private repo's artifact exists; got {out_json}"
+        );
+        assert!(
+            out_json.get("quarantine_reason").is_none(),
+            "the security finding must not be disclosed to a non-member: {out_json}"
+        );
+
+        assert_eq!(
+            member_status,
+            StatusCode::OK,
+            "member must still read status"
+        );
+        assert_eq!(member_json["quarantine_status"], "quarantined");
+        assert_eq!(member_json["quarantine_reason"], reason);
+
+        assert_eq!(admin_status, StatusCode::OK, "admin must still read status");
+        assert_eq!(admin_json["quarantine_reason"], reason);
+    }
+
+    /// On a PUBLIC repository the existence gate opens — anyone may see that
+    /// the artifact is held — but `quarantine_reason` is per-artifact security
+    /// detail and stays with callers who actually HOLD the repository (#3174).
+    ///
+    /// This is the behavior the pre-fix comment claimed ("excludes an
+    /// authenticated caller who merely happens to be able to read a public
+    /// one") and did not implement: `can_access_repo` is `true` for every
+    /// unscoped principal, so the reason went to everyone.
+    ///
+    /// The member and admin controls are in the same fixture, so hiding the
+    /// reason unconditionally would fail.
+    #[tokio::test]
+    async fn test_status_public_repo_reason_only_to_repo_holders() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        set_repo_public(&fx, true).await;
+        let reason = "Policy 'malware-gate': eicar signature match";
+        let artifact_id = seed_artifact(&fx, Some("quarantined"), None, Some(reason)).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+
+        // NEGATIVE: reads the public repo fine, but holds no grant on it.
+        let (out_status, out_json) =
+            status_as(&fx, tdh::make_auth(outsider, &outname), artifact_id).await;
+        // POSITIVE CONTROL 1: grant holder.
+        let (member_status, member_json) =
+            status_as(&fx, tdh::make_auth(fx.user_id, &fx.username), artifact_id).await;
+        // POSITIVE CONTROL 2: admin.
+        let (admin_status, admin_json) =
+            status_as(&fx, tdh::admin_auth(fx.user_id, &fx.username), artifact_id).await;
+
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+
+        assert_eq!(
+            out_status,
+            StatusCode::OK,
+            "a public repo's hold STATUS stays readable: {out_json}"
+        );
+        assert_eq!(out_json["quarantine_status"], "quarantined");
+        assert_eq!(out_json["is_blocked"], true);
+        assert!(
+            out_json.get("quarantine_reason").is_none(),
+            "the finding text must not reach a caller who merely reads a public \
+             repo: {out_json}"
+        );
+
+        assert_eq!(member_status, StatusCode::OK);
+        assert_eq!(
+            member_json["quarantine_reason"], reason,
+            "a grant holder must still receive the reason"
+        );
+        assert_eq!(admin_status, StatusCode::OK);
+        assert_eq!(
+            admin_json["quarantine_reason"], reason,
+            "an admin must still receive the reason"
         );
     }
 }

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -437,10 +437,17 @@ async fn list_sboms(
     if let Some(artifact_id) = query.artifact_id {
         ensure_artifact_repo_access(&state.db, &auth, artifact_id).await?;
     }
+    // #3174: this branch used to gate on `auth.can_access_repo(repo_id)` alone.
+    // That is the caller's TOKEN SCOPE, not repository visibility: it resolves
+    // to `access_scope().grants(repo_id)`, which `AccessScope::Admin` satisfies
+    // unconditionally, so for a browser JWT session or any unscoped API token it
+    // was `true` for every repository in the instance. It was the ONLY check
+    // before up to 100 `sbom_documents` rows were returned — a private
+    // repository's whole dependency inventory — while the `artifact_id` branch
+    // one line above already routed through the proper helper. Both branches now
+    // apply the same predicate.
     if let Some(repo_id) = query.repository_id {
-        if !auth.can_access_repo(repo_id) {
-            return Err(AppError::NotFound("Repository not found".into()));
-        }
+        ensure_repo_visibility(&state.db, &auth, repo_id).await?;
     }
     let service = SbomService::new(state.db.clone());
 
@@ -1692,6 +1699,26 @@ async fn require_repo_visibility(
         }
     }
     Ok(())
+}
+
+/// Resolve `repository_id → (id, is_public)` and apply
+/// [`require_repo_visibility`] (#3174).
+///
+/// The repository-scoped sibling of [`ensure_artifact_repo_access`], for the
+/// paths that are handed a bare `repository_id`. A repository id that does not
+/// resolve yields the same existence-hiding 404 as one the caller may not see.
+async fn ensure_repo_visibility(
+    db: &sqlx::PgPool,
+    auth: &AuthExtension,
+    repo_id: Uuid,
+) -> Result<()> {
+    let repo: Option<(Uuid, bool)> =
+        sqlx::query_as("SELECT r.id, r.is_public FROM repositories r WHERE r.id = $1")
+            .bind(repo_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+    require_repo_visibility(db, auth, repo, "Repository not found").await
 }
 
 /// Resolve `artifact_id → (repository_id, is_public)` and apply
@@ -3767,5 +3794,114 @@ mod tests {
             .await;
         tdh::cleanup_user(&fx.pool, outsider).await;
         fx.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #3174: `list_sboms`'s `repository_id` branch gated on `can_access_repo`,
+    // which is TOKEN SCOPE, not repository visibility.
+    // -----------------------------------------------------------------------
+
+    /// `GET /sbom?repository_id=…` as `auth`.
+    async fn list_sboms_by_repo(
+        fx: &crate::api::handlers::test_db_helpers::Fixture,
+        auth: AuthExtension,
+        repo_id: Uuid,
+    ) -> Result<Json<Vec<SbomResponse>>> {
+        super::list_sboms(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(auth),
+            axum::extract::Query(ListSbomsQuery {
+                artifact_id: None,
+                repository_id: Some(repo_id),
+                format: None,
+            }),
+        )
+        .await
+    }
+
+    /// A private repository's SBOM listing — its full dependency inventory —
+    /// must not be readable by an authenticated caller holding no grant on it
+    /// (#3174).
+    ///
+    /// The `artifact_id` branch one line above already routed through
+    /// `ensure_artifact_repo_access`; the `repository_id` branch did not, and
+    /// `can_access_repo` returns `true` for any unscoped principal — every
+    /// browser JWT session — so it was the sole gate and it was inert.
+    ///
+    /// Both positive controls read the SAME seeded document in the SAME
+    /// fixture, so denying everyone would fail.
+    #[tokio::test]
+    async fn test_list_sboms_by_repository_id_private_denies_non_member_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let sbom_id = seed_sbom_for_handler(&fx.pool, artifact_id, fx.repo_id, "cyclonedx").await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+
+        // NEGATIVE: unrestricted token scope, no grant on the private repo.
+        let denied = list_sboms_by_repo(&fx, tdh::make_auth(outsider, &outname), fx.repo_id).await;
+        // POSITIVE CONTROL 1: the fixture user holds a developer grant.
+        let member =
+            list_sboms_by_repo(&fx, tdh::make_auth(fx.user_id, &fx.username), fx.repo_id).await;
+        // POSITIVE CONTROL 2: a global admin.
+        let admin =
+            list_sboms_by_repo(&fx, tdh::admin_auth(fx.user_id, &fx.username), fx.repo_id).await;
+
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+
+        assert!(
+            matches!(denied, Err(AppError::NotFound(_))),
+            "a non-member listing a private repo's SBOMs must get an \
+             existence-hiding 404, got {:?}",
+            denied.map(|j| j.0.len())
+        );
+
+        let member = member.expect("member must still list").0;
+        assert!(
+            member.iter().any(|s| s.id == sbom_id),
+            "grant holder must still see the repository's SBOM"
+        );
+        let admin = admin.expect("admin must still list").0;
+        assert!(
+            admin.iter().any(|s| s.id == sbom_id),
+            "admin must still see the repository's SBOM"
+        );
+    }
+
+    /// A PUBLIC repository's SBOM listing stays open to any authenticated
+    /// caller — the visibility predicate's `is_public` arm. Guards the fix
+    /// against over-denial (#3174).
+    #[tokio::test]
+    async fn test_list_sboms_by_repository_id_public_allows_non_member_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        set_repo_public(&fx.pool, fx.repo_id, true).await;
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let sbom_id = seed_sbom_for_handler(&fx.pool, artifact_id, fx.repo_id, "cyclonedx").await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+
+        let res = list_sboms_by_repo(&fx, tdh::make_auth(outsider, &outname), fx.repo_id).await;
+
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+
+        let listed = res.expect("public repo listing must stay open").0;
+        assert!(
+            listed.iter().any(|s| s.id == sbom_id),
+            "a public repository's SBOMs must remain listable by any authed caller"
+        );
     }
 }

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -130,9 +130,47 @@ impl AuthExtension {
         self.allowed_repo_ids.clone()
     }
 
-    /// Check whether this auth context has access to a specific repository.
-    /// Returns true if unrestricted (admin scope) or if the repo is in the
-    /// allowed set.
+    /// TOKEN SCOPE only: is `repo_id` within the set this credential was minted
+    /// for? Returns true if unrestricted ([`AccessScope::Admin`]) or if the repo
+    /// is in the allowed set.
+    ///
+    /// # This does NOT answer "may this caller see this repository"
+    ///
+    /// `AccessScope::Admin` grants unconditionally, and that is the scope of
+    /// every browser JWT session, every unscoped API token and every global
+    /// admin. So for the most common caller this returns `true` for EVERY
+    /// repository in the instance, and using it as a visibility gate means any
+    /// authenticated user reads the resource. That mistake has now produced four
+    /// separate cross-tenant leaks: #3081, #3163, and the two in #3174.
+    ///
+    /// The visibility predicate is
+    ///
+    /// ```text
+    /// is_public OR (in_scope AND (is_admin OR grants))
+    /// ```
+    ///
+    /// where `in_scope` is this function and `grants` is
+    /// `RepositoryService::user_can_access_repo` (a similar NAME, an entirely
+    /// different question: role assignments, not token scope). Do not open-code
+    /// it — use one of:
+    ///
+    /// * [`repositories::require_visible`] — a loaded `Repository`;
+    /// * [`repositories::require_repo_id_visible`] — a bare `repository_id`;
+    /// * [`repositories::member_read_visibility`] — a DB-side aggregate;
+    /// * [`repositories::member_grant_visibility`] + `member_passes_token_scope`
+    ///   — row-wise listing;
+    /// * `RepositoryService::filter_visible_repo_ids` — a set of ids.
+    ///
+    /// Calling this directly is correct only where it is one CONJUNCT of a
+    /// larger check that supplies the entitlement half separately (as
+    /// `require_visible` and `repo_visibility_middleware` do), or where token
+    /// scope genuinely is the question being asked (a mutation whose
+    /// entitlement is established by a following permission check).
+    ///
+    /// [`repositories::require_visible`]: crate::api::handlers::repositories::require_visible
+    /// [`repositories::require_repo_id_visible`]: crate::api::handlers::repositories::require_repo_id_visible
+    /// [`repositories::member_read_visibility`]: crate::api::handlers::repositories::member_read_visibility
+    /// [`repositories::member_grant_visibility`]: crate::api::handlers::repositories::member_grant_visibility
     pub fn can_access_repo(&self, repo_id: Uuid) -> bool {
         self.access_scope().grants(repo_id)
     }


### PR DESCRIPTION
Fixes #3174

`can_access_repo` answers **"is this repo within my token's scope?"** — it resolves to `access_scope().grants(repo_id)`, and `AccessScope::Admin => true` unconditionally. That is the scope of every browser JWT session, every unscoped API token and every global admin, so used as a *visibility* gate it returns `true` for every repository in the instance.

Two endpoints used it as one.

### 1. `GET /api/v1/quarantine/{artifact_id}`

Both uses were defeated. Any authenticated caller holding an artifact UUID from another tenant's **private** repository learned that the artifact exists, that it is held, and the free-text `quarantine_reason` — which carries the malware or CVE finding behind the hold. #2912 deliberately keeps that field off the anonymous-reachable download 403 for exactly this reason.

* **Existence gate** now uses `require_repo_id_visible` — the canonical `is_public OR (in_scope AND (is_admin OR grants))`. It also collapses "repository row is gone" into the same existence-hiding 404 instead of surfacing a `Repository '<key>' not found` message that would name it.
* **Reason gate** is deliberately **stricter** than the existence gate: it drops the `is_public` arm, leaving `in_scope AND (is_admin OR grants)`. A caller who can see the artifact only because its repository happens to be public does not get the finding text. That is precisely what the pre-existing comment claimed ("excludes an authenticated caller who merely happens to be able to read a public one") and did not implement — the comment is why the gate survived review.

### 2. `GET /api/v1/sbom?repository_id=…`

The sole check before returning up to 100 `sbom_documents` rows — a private repository's whole dependency inventory. The `artifact_id` branch one line above already routed through `ensure_artifact_repo_access`. Both branches now apply the same predicate, via a new `ensure_repo_visibility` wrapper that mirrors `ensure_artifact_repo_access` over the existing `require_repo_visibility`.

No new predicate variant was written — `require_repo_id_visible` and `require_repo_visibility` are reused as-is.

## Full `can_access_repo` / `require_repo_access` audit

Every production call site was classified. `RepositoryService::user_can_access_repo` is excluded — similar name, entirely different question (role assignments, not token scope), and correct everywhere it appears.

| # | Site | Use | Verdict |
|---|------|-----|---------|
| 1 | `middleware/auth.rs:136` | definition | — |
| 2 | `repositories.rs:87` | `require_repo_access` wrapper definition | — |
| 3 | `sbom.rs:1657` | pure `require_repo_access` helper definition | — |
| 4 | `middleware/auth.rs:1868` `repo_visibility_middleware` | scope conjunct; paired with `should_allow_repo_access` + permission checks | **(a)** correct |
| 5 | `artifacts.rs:49` `check_artifact_visibility` | scope, then `is_public` / admin / `user_can_access_repo` | **(a)** correct |
| 6 | `repositories.rs:115` `require_repo_write_access` | scope, then `is_public` / admin / grants | **(a)** correct |
| 7 | `repositories.rs:162` `require_repo_action` | scope, then `check_repository_action` | **(a)** correct |
| 8 | `repositories.rs:393` `require_visible` | **the reference composition's** scope conjunct | **(a)** correct |
| 9 | `repositories.rs:365` `member_passes_token_scope` | scope half of #3173's composition, by construction | **(a)** correct |
| 10 | `repositories.rs:478`, `:491` `authorize_virtual_member_mutation` | scope on parent + member; per-action permission check follows | **(a)** correct |
| 11 | `repositories.rs:3488` `update_repository` | scope, then `repository:admin` permission | **(a)** correct |
| 12 | `repositories.rs:4296` `delete_repository` | scope, then `repository:admin` permission | **(a)** correct |
| 13 | `repositories.rs:8582` `list_virtual_members` | scope, paired with `require_visible` (fixed in #3163) | **(a)** correct |
| 14 | `repositories.rs:8864` `update_virtual_members` | scope, then repo-admin permission | **(a)** correct |
| 15 | `repositories.rs:8964` `load_remote_repo` | scope only, but **both** callers add their own gate: `set_upstream_auth` → `require_repo_write_access` + `require_repo_admin`; `test_upstream` → `require_visible` | **(a)** correct |
| 16 | `proxy_helpers.rs:2742` `caller_can_read_member` | `is_public` early return, anon denied, admin bypass, scope, then permission rules | **(a)** correct |
| 17 | `email_subscriptions.rs:212` | scope, then `require_repo_write_access` | **(a)** correct |
| 18 | `repo_tokens.rs:216` | scope, then explicit `is_public` / admin / grants | **(a)** correct |
| 19 | `tree.rs:81` `authorize_tree_read` | `token_allows` conjunct of `tree_access_allowed` | **(a)** correct |
| 20 | `sbom.rs:1683` (inside `require_repo_visibility`) | scope half; membership check follows | **(a)** correct |
| 21 | **`quarantine.rs:106`** | **sole existence gate** | **(b) BUG — fixed here** |
| 22 | **`quarantine.rs:122`** | **sole gate on `quarantine_reason`** | **(b) BUG — fixed here** |
| 23 | **`sbom.rs:441`** `list_sboms` | **sole gate on the `repository_id` branch** | **(b) BUG — fixed here** |

Three (b) sites, in two adjacent files — few and cohesive, so all are fixed here and no tracking issue is needed. This matches the issue's own audit ("ten are legitimate token-scope checks").

## Tests

Four DB-backed tests. Every negative assertion ships positive controls **in the same fixture against the same seeded row**, so a fix that denied everyone would fail:

* `test_status_private_repo_denies_non_member_but_not_holders` — non-member 404; **member** and **admin** still read status *and* reason.
* `test_status_public_repo_reason_only_to_repo_holders` — non-holder gets 200 + status but **no** reason; **member** and **admin** still get the reason.
* `test_list_sboms_by_repository_id_private_denies_non_member_db` — non-member 404; **member** and **admin** still see the seeded SBOM.
* `test_list_sboms_by_repository_id_public_allows_non_member_db` — over-denial guard: a public repo's SBOMs stay listable.

The caller shape under test is `tdh::make_auth` — non-admin with `allowed_repo_ids = AccessScope::Admin`, i.e. exactly a browser JWT session, the shape for which the old gate was inert.

### Red → green → revert

Against unmodified `origin/main` (tests present, fix absent):

```
test ..quarantine::tests::test_status_private_repo_denies_non_member_but_not_holders ... FAILED
test ..quarantine::tests::test_status_public_repo_reason_only_to_repo_holders ... FAILED
test ..sbom::tests::test_list_sboms_by_repository_id_private_denies_non_member_db ... FAILED
test ..sbom::tests::test_list_sboms_by_repository_id_public_allows_non_member_db ... ok

assertion `left == right` failed: a non-member must not learn that a private repo's
artifact exists; got {"artifact_id":"a8a26b69-...","is_blocked":true,
"quarantine_reason":"Policy 'cve-gate': 2 findings at or above high",
"quarantine_status":"quarantined","quarantine_until":null}
  left: 200
 right: 404

the finding text must not reach a caller who merely reads a public repo:
{"artifact_id":"c8a180d0-...","is_blocked":true,
"quarantine_reason":"Policy 'malware-gate': eicar signature match", ...}

a non-member listing a private repo's SBOMs must get an existence-hiding 404, got Ok(1)

test result: FAILED. 1 passed; 3 failed
```

With the fix: `test result: ok. 4 passed; 0 failed`.

Reverting **only** the three handler predicates and keeping the tests reproduces the same three failures (`test result: FAILED. 1 passed; 3 failed`), confirming they are load-bearing rather than passing incidentally.

## Gates

* `cargo fmt --check` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- quarantine sbom repositories::` — **898 passed, 0 failed**
* No `sqlx::query!` macro text changed (the new query uses runtime `query_as`), so no `.sqlx` regeneration. Verified anyway: `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` unset succeeds.
