### PR TITLE
fix(saml): key the no-email placeholder address on the NameID, not the username

### DIFF
--- a/backend/src/services/federated_email.rs
+++ b/backend/src/services/federated_email.rs
@@ -1,0 +1,168 @@
+//! Synthetic address derivation shared by the federated login paths.
+//!
+//! `users.email` is `VARCHAR(255) UNIQUE NOT NULL`
+//! (`backend/migrations/001_users.sql:8`), but every federated protocol treats
+//! the user's address as optional: OIDC releases the `email` claim only when
+//! the scope is granted and the IdP chooses to disclose it, and a SAML IdP is
+//! free to assert no email attribute at all. Something has to be stored
+//! regardless, and whatever is stored has to satisfy the unique index.
+//!
+//! Each login path grew its own answer to that, which is how the same defect
+//! shipped twice: OIDC defaulted every claim-less user to a shared `""`
+//! (#3119, fixed in #3161) and SAML defaulted to `{username}@unknown`, built
+//! from the *pre-uniquification* username, so two NameIDs whose username
+//! attribute matched collided on `users_email_key` (#3167). This module is the
+//! single implementation both now call, so a third variant cannot drift.
+//!
+//! A synthetic address must satisfy four properties. Getting any one wrong
+//! reintroduces a bug rather than fixing one:
+//!
+//! 1. **Unique per identity.** A shared sentinel lets only the first
+//!    address-less user provision; every later one dies on `users_email_key`.
+//! 2. **Stable across logins.** Re-login writes `email` back to the row. A
+//!    value that changes per login (a random nonce, a timestamp) rewrites the
+//!    user every time, and on the provisioning path would mint a *new* account
+//!    per login — orphaning that user's uploads, quota and permissions. This
+//!    is strictly worse than the collision it would "fix".
+//! 3. **Keyed on the IdP's subject**, never on a username or display name.
+//!    Those are self-settable at many IdPs, so keying on them lets one user
+//!    choose a value that collides with another's — turning an availability
+//!    defect into a targeted one. The subject is also the value each service
+//!    already stores as `users.external_id`, which makes the synthetic address
+//!    exactly as unique and exactly as stable as the account row itself.
+//! 4. **Non-routable.** `.invalid` is reserved by RFC 2606 and can never
+//!    resolve, so a synthetic address can neither be confused with a real
+//!    mailbox nor collide against one.
+
+use sha2::{Digest, Sha256};
+
+/// Domain for the synthetic address stored when an OIDC provider releases no
+/// usable `email` claim.
+pub(crate) const OIDC_NO_EMAIL_DOMAIN: &str = "no-email.oidc.invalid";
+
+/// Domain for the synthetic address stored when a SAML IdP asserts no usable
+/// email attribute.
+pub(crate) const SAML_NO_EMAIL_DOMAIN: &str = "no-email.saml.invalid";
+
+/// Longest sanitized subject prefix kept in the synthetic local-part. Bounds
+/// the result well inside `users.email VARCHAR(255)` for arbitrarily long
+/// subjects.
+const MAX_SYNTHETIC_LOCAL_PREFIX: usize = 48;
+
+/// Resolve the address to store in `users.email` for a federated user.
+///
+/// Returns a provider-supplied address verbatim. Falls back to a per-subject
+/// synthetic address when the provider supplied nothing — or supplied a blank
+/// value, which some IdPs send for machine identities and which collides
+/// exactly the same way a missing one does.
+///
+/// `subject` must be the IdP's stable per-user identifier: the OIDC `sub`, or
+/// the SAML `NameID`. See the module docs for why nothing else will do.
+pub(crate) fn resolve_federated_email(claim: Option<&str>, subject: &str, domain: &str) -> String {
+    match claim.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(email) => email.to_string(),
+        None => synthetic_email_for_subject(subject, domain),
+    }
+}
+
+/// Build a stable, unique, non-routable address for a subject with no address.
+///
+/// The subject is opaque: it may contain characters that are invalid in an
+/// address local-part and may be longer than the column allows. Keep a
+/// sanitized, human-recognizable prefix for operators, then append a digest of
+/// the *raw* subject so two distinct subjects can never sanitize down to the
+/// same address.
+pub(crate) fn synthetic_email_for_subject(subject: &str, domain: &str) -> String {
+    let fingerprint = hex::encode(&Sha256::digest(subject.as_bytes())[..8]);
+
+    let sanitized: String = subject
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .take(MAX_SYNTHETIC_LOCAL_PREFIX)
+        .collect();
+    let prefix = sanitized.trim_matches(|c| matches!(c, '.' | '-' | '_'));
+    let prefix = if prefix.is_empty() { "user" } else { prefix };
+
+    format!("{}.{}@{}", prefix, fingerprint, domain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_supplied_address_is_returned_verbatim() {
+        assert_eq!(
+            resolve_federated_email(Some("carol@example.com"), "sub", OIDC_NO_EMAIL_DOMAIN),
+            "carol@example.com"
+        );
+    }
+
+    #[test]
+    fn blank_claim_is_treated_as_missing() {
+        assert_eq!(
+            resolve_federated_email(Some("   "), "sub", SAML_NO_EMAIL_DOMAIN),
+            resolve_federated_email(None, "sub", SAML_NO_EMAIL_DOMAIN)
+        );
+    }
+
+    #[test]
+    fn distinct_subjects_get_distinct_addresses() {
+        assert_ne!(
+            synthetic_email_for_subject("subject-a", SAML_NO_EMAIL_DOMAIN),
+            synthetic_email_for_subject("subject-b", SAML_NO_EMAIL_DOMAIN)
+        );
+    }
+
+    #[test]
+    fn one_subject_gets_one_stable_address() {
+        assert_eq!(
+            synthetic_email_for_subject("subject-a", SAML_NO_EMAIL_DOMAIN),
+            synthetic_email_for_subject("subject-a", SAML_NO_EMAIL_DOMAIN)
+        );
+    }
+
+    #[test]
+    fn subjects_that_sanitize_alike_still_differ() {
+        // Sanitization is lossy — both of these reduce to `a-b`. The digest of
+        // the raw subject is what keeps them apart.
+        assert_ne!(
+            synthetic_email_for_subject("a b", SAML_NO_EMAIL_DOMAIN),
+            synthetic_email_for_subject("a/b", SAML_NO_EMAIL_DOMAIN)
+        );
+    }
+
+    #[test]
+    fn hostile_subject_still_fits_the_column() {
+        let hostile = format!("{}@evil.example/ ünïcode", "x".repeat(400));
+        let email = synthetic_email_for_subject(&hostile, SAML_NO_EMAIL_DOMAIN);
+
+        assert!(
+            email.len() <= 255,
+            "must fit users.email VARCHAR(255), got {} chars: {}",
+            email.len(),
+            email
+        );
+        assert_eq!(email.matches('@').count(), 1, "exactly one @: {}", email);
+        assert!(email.ends_with(SAML_NO_EMAIL_DOMAIN));
+    }
+
+    #[test]
+    fn the_two_providers_use_distinct_reserved_domains() {
+        assert_ne!(OIDC_NO_EMAIL_DOMAIN, SAML_NO_EMAIL_DOMAIN);
+        for domain in [OIDC_NO_EMAIL_DOMAIN, SAML_NO_EMAIL_DOMAIN] {
+            assert!(
+                domain.ends_with(".invalid"),
+                "{} must sit under the RFC 2606 reserved TLD so it can never \
+                 resolve to, or collide with, a real mailbox",
+                domain
+            );
+        }
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -24,6 +24,7 @@ pub mod email_dispatcher;
 pub mod email_rate_limiter;
 pub mod encryption;
 pub mod event_bus;
+pub mod federated_email;
 pub mod grype_scanner;
 pub mod helm_lint_checker;
 pub mod http_client;

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -8,23 +8,14 @@ use std::sync::Arc;
 
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::config::Config;
 use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
+use crate::services::federated_email::OIDC_NO_EMAIL_DOMAIN;
 use crate::services::http_client::{read_json_capped, MAX_OIDC_RESPONSE_BYTES};
-
-/// Domain for the synthetic address stored when the IdP releases no usable
-/// `email` claim. `.invalid` is reserved by RFC 2606 and can never resolve, so
-/// the address cannot be confused with — or collide against — a real mailbox.
-const NO_EMAIL_DOMAIN: &str = "no-email.oidc.invalid";
-
-/// Longest sanitized subject prefix kept in the synthetic local-part. Bounds the
-/// result well inside `users.email VARCHAR(255)` for arbitrarily long subjects.
-const MAX_SYNTHETIC_LOCAL_PREFIX: usize = 48;
 
 /// Resolve the address to store in `users.email` for a federated (OIDC) user.
 ///
@@ -36,42 +27,16 @@ const MAX_SYNTHETIC_LOCAL_PREFIX: usize = 48;
 /// (issue #3119).
 ///
 /// When the claim is absent — or present but blank, which some IdPs send for
-/// machine identities — derive a per-subject synthetic address instead. This
-/// mirrors what the SAML (`saml_service.rs`) and LDAP (`ldap_service.rs`) paths
-/// already do with `{username}@unknown`, but keys off the OIDC subject, which is
-/// the stable per-user identifier this service already provisions against.
-pub(crate) fn resolve_federated_email(claim: Option<&str>, sub: &str) -> String {
-    match claim.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(email) => email.to_string(),
-        None => synthetic_email_for_sub(sub),
-    }
-}
-
-/// Build a stable, unique, non-routable address for a subject with no email.
+/// machine identities — derive a per-subject synthetic address instead, keyed
+/// off the OIDC subject: the stable per-user identifier this service already
+/// provisions `external_id` against.
 ///
-/// The subject is opaque: it may contain characters that are invalid in an
-/// address local-part and may be longer than the column allows. Keep a
-/// sanitized, human-recognizable prefix for operators, then append a digest of
-/// the *raw* subject so two distinct subjects can never sanitize down to the
-/// same address.
-fn synthetic_email_for_sub(sub: &str) -> String {
-    let fingerprint = hex::encode(&Sha256::digest(sub.as_bytes())[..8]);
-
-    let sanitized: String = sub
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
-                c
-            } else {
-                '-'
-            }
-        })
-        .take(MAX_SYNTHETIC_LOCAL_PREFIX)
-        .collect();
-    let prefix = sanitized.trim_matches(|c| matches!(c, '.' | '-' | '_'));
-    let prefix = if prefix.is_empty() { "user" } else { prefix };
-
-    format!("{}.{}@{}", prefix, fingerprint, NO_EMAIL_DOMAIN)
+/// The derivation itself lives in `services::federated_email` because the SAML
+/// path needs the identical guarantees; see that module for why each of them
+/// matters. This wrapper only pins the OIDC domain, so the addresses it returns
+/// are byte-identical to the ones #3161 shipped.
+pub(crate) fn resolve_federated_email(claim: Option<&str>, sub: &str) -> String {
+    crate::services::federated_email::resolve_federated_email(claim, sub, OIDC_NO_EMAIL_DOMAIN)
 }
 
 /// OIDC provider configuration
@@ -1431,7 +1396,7 @@ mod tests {
     /// The derivation must key on `sub`, not on the username.
     ///
     /// In every other test here sub and username co-vary, so substituting
-    /// `synthetic_email_for_sub(&username)` at both call sites leaves the
+    /// `synthetic_email_for_subject(&username, ..)` at both call sites leaves the
     /// whole module green -- while reintroducing the collision for two
     /// subjects that share a `preferred_username`. That is worse than the
     /// original bug: `preferred_username` is self-settable at many IdPs, so it

--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 use crate::config::Config;
 use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
+use crate::services::federated_email::{resolve_federated_email, SAML_NO_EMAIL_DOMAIN};
 
 /// SAML configuration
 #[derive(Clone)]
@@ -969,13 +970,38 @@ impl SamlService {
                 .unwrap_or_else(|| assertion.name_id.clone())
         };
 
-        // Get email
-        let email = assertion
-            .attributes
-            .get(&self.config.email_attr)
-            .and_then(|v| v.first())
-            .cloned()
-            .unwrap_or_else(|| format!("{}@unknown", username));
+        // Get email.
+        //
+        // When the IdP asserts no email attribute we must still store
+        // something: `users.email` is `VARCHAR(255) UNIQUE NOT NULL`
+        // (`migrations/001_users.sql:8`). The placeholder used to be
+        // `{username}@unknown`, which was wrong twice over (#3167):
+        //
+        //  * It keyed on `username` — the value read off the assertion
+        //    *before* `get_or_create_user` runs it through
+        //    `generate_unique_username`. Two NameIDs whose username attribute
+        //    matched were stored as `alice` and `alice_1`, but both derived
+        //    `alice@unknown`, so the second provisioning died on
+        //    `users_email_key`. `username` is also attacker-influenced at any
+        //    IdP that lets a user set the attribute it is read from, which
+        //    makes a username-keyed placeholder targetable rather than merely
+        //    unlucky.
+        //  * `unknown` is a resolvable TLD, so the address could collide with
+        //    a real mailbox.
+        //
+        // Key on the NameID instead. It is the SAML subject, and it is already
+        // what `get_or_create_user` stores in `users.external_id` and looks
+        // the account up by — so the synthetic address is unique and stable in
+        // exactly the same cases the account row itself is, and no more.
+        let email = resolve_federated_email(
+            assertion
+                .attributes
+                .get(&self.config.email_attr)
+                .and_then(|v| v.first())
+                .map(String::as_str),
+            &assertion.name_id,
+            SAML_NO_EMAIL_DOMAIN,
+        );
 
         // Get display name
         let display_name = assertion
@@ -2303,8 +2329,26 @@ mod tests {
         };
 
         let user_info = service.extract_user_info(&assertion).unwrap();
-        // No email attribute => default email is "{username}@unknown"
-        assert_eq!(user_info.email, "jdoe@unknown");
+
+        // This test used to pin the literal `jdoe@unknown` — it asserted the
+        // #3167 bug rather than a requirement, which is a large part of why
+        // the bug survived. What actually matters about the placeholder is
+        // that it is derived from the NameID, non-empty, and non-routable; the
+        // collision and stability properties are pinned by the dedicated
+        // #3167 tests at the end of this module.
+        assert!(!user_info.email.trim().is_empty());
+        assert!(
+            user_info.email.starts_with("jdoe."),
+            "placeholder should stay recognizable to an operator reading the \
+             users table: {}",
+            user_info.email
+        );
+        assert!(
+            user_info.email.ends_with("@no-email.saml.invalid"),
+            "placeholder must sit in an RFC 2606 reserved domain, not the old \
+             resolvable `@unknown`: {}",
+            user_info.email
+        );
     }
 
     #[tokio::test]
@@ -3917,5 +3961,275 @@ mod tests {
         )
         .await;
         assert!(again.is_err(), "state must be single-use");
+    }
+
+    // =======================================================================
+    // #3167: placeholder address for an assertion with no email attribute
+    //
+    // `users.email` is VARCHAR(255) UNIQUE NOT NULL
+    // (migrations/001_users.sql:8). The old placeholder was
+    // `format!("{}@unknown", username)`, built from the username read off the
+    // assertion -- i.e. BEFORE `get_or_create_user` runs it through
+    // `generate_unique_username`. Two NameIDs whose username attribute
+    // matched therefore got distinct usernames but the identical placeholder
+    // address, and the second provisioning died on `users_email_key`.
+    // =======================================================================
+
+    /// A service whose username comes from an attribute rather than the NameID.
+    ///
+    /// This is load-bearing for the tests below. With the default
+    /// `username_attr = "NameID"` the username *is* the NameID, so every
+    /// fixture would co-vary and a username-keyed derivation would satisfy the
+    /// whole suite -- which is exactly how the OIDC twin (#3161) came to ship
+    /// with nine tests its own bug could pass. Reading the username from `uid`
+    /// forces subject and username apart, so these tests can actually tell the
+    /// two derivations apart.
+    fn saml_service_keyed_on_uid() -> SamlService {
+        let mut config = make_test_saml_config();
+        config.username_attr = "uid".to_string();
+        SamlService::with_config(
+            PgPool::connect_lazy("postgres://invalid:invalid@localhost/invalid").unwrap(),
+            config,
+        )
+    }
+
+    /// Build an assertion carrying only the attributes these tests care about.
+    fn assertion_with(name_id: &str, uid: &str, email: Option<&str>) -> SamlAssertion {
+        let mut attributes = HashMap::new();
+        attributes.insert("uid".to_string(), vec![uid.to_string()]);
+        if let Some(email) = email {
+            attributes.insert("email".to_string(), vec![email.to_string()]);
+        }
+        SamlAssertion {
+            id: "_assertion".to_string(),
+            issuer: "https://idp.example.com".to_string(),
+            name_id: name_id.to_string(),
+            name_id_format: None,
+            recipient: None,
+            session_index: None,
+            not_before: None,
+            not_on_or_after: None,
+            audiences: Vec::new(),
+            attributes,
+        }
+    }
+
+    fn user_info(name_id: &str, uid: &str, email: Option<&str>) -> SamlUserInfo {
+        saml_service_keyed_on_uid()
+            .extract_user_info(&assertion_with(name_id, uid, email))
+            .expect("assertion yields user info")
+    }
+
+    /// The #3167 shape exactly: two people in one directory whose username
+    /// attribute happens to match, distinct NameIDs, neither assertion
+    /// carrying an email attribute.
+    #[tokio::test]
+    async fn two_name_ids_sharing_a_username_attribute_get_distinct_emails() {
+        let first = user_info("urn:idp:nameid:alice-0001", "alice", None);
+        let second = user_info("urn:idp:nameid:alice-0002", "alice", None);
+
+        assert_eq!(
+            first.username, second.username,
+            "fixture guard: both assertions must present the SAME username \
+             attribute, or this test is not exercising the collision"
+        );
+        assert_ne!(
+            first.name_id, second.name_id,
+            "fixture guard: the two identities must differ by NameID"
+        );
+
+        assert!(!first.email.trim().is_empty(), "must store something");
+        assert_ne!(
+            first.email, second.email,
+            "two distinct NameIDs must never derive the same placeholder \
+             address: users.email is UNIQUE NOT NULL, so the second user's \
+             INSERT dies on users_email_key and the login fails outright"
+        );
+    }
+
+    /// The derivation must key on the NameID, not on the username.
+    ///
+    /// Covers the converse of the test above: keep the subject fixed and let
+    /// the username attribute change, as it does whenever the directory
+    /// renames someone. A username-keyed derivation hands that user a brand
+    /// new address, and since re-login writes `email` back to the row, the
+    /// address would churn on every rename.
+    ///
+    /// Taken together the two tests pin the key: substituting the username
+    /// fails this one, and substituting anything per-login fails the
+    /// stability test below.
+    #[tokio::test]
+    async fn derivation_keys_on_name_id_not_username() {
+        let before = user_info("urn:idp:nameid:stable-0007", "old_uid", None).email;
+        let after = user_info("urn:idp:nameid:stable-0007", "new_uid", None).email;
+
+        assert_eq!(
+            before, after,
+            "one NameID must keep one address even when the username \
+             attribute changes between logins"
+        );
+        assert!(
+            !before.contains("old_uid") && !before.contains("new_uid"),
+            "the address must not embed the username attribute at all: it is \
+             self-settable at any IdP that maps it from a user-editable \
+             directory field, which would make the collision targetable \
+             rather than merely unlucky -- got {}",
+            before
+        );
+    }
+
+    /// Re-login writes `email` back to the row (see `get_or_create_user`). An
+    /// unstable value would rewrite the user on every login, and on the
+    /// provisioning path would mint a new account each time -- orphaning that
+    /// user's uploads, quota and permissions.
+    #[tokio::test]
+    async fn same_name_id_gets_the_same_address_across_logins() {
+        let first = user_info("urn:idp:nameid:frank-0006", "frank", None).email;
+        let second = user_info("urn:idp:nameid:frank-0006", "frank", None).email;
+
+        assert!(!first.trim().is_empty());
+        assert_eq!(first, second);
+    }
+
+    /// Positive control: the fix must not disturb IdPs that DO assert email.
+    #[tokio::test]
+    async fn provider_supplied_email_attribute_is_stored_verbatim() {
+        let user = user_info(
+            "urn:idp:nameid:carol-0003",
+            "carol",
+            Some("carol@example.com"),
+        );
+        assert_eq!(user.email, "carol@example.com");
+    }
+
+    /// Some IdPs assert the attribute with an empty value rather than omitting
+    /// it. That collides exactly the same way a missing one does.
+    #[tokio::test]
+    async fn blank_email_attribute_is_treated_as_missing() {
+        let blank = user_info("urn:idp:nameid:dave-0004", "dave", Some("   "));
+        let absent = user_info("urn:idp:nameid:erin-0005", "erin", None);
+
+        assert!(!blank.email.trim().is_empty());
+        assert_ne!(blank.email, absent.email);
+        assert_eq!(
+            blank.email,
+            user_info("urn:idp:nameid:dave-0004", "dave", None).email,
+            "a blank attribute must fall back to the same address the absent \
+             case derives for that NameID"
+        );
+    }
+
+    /// A NameID is opaque: IdPs emit long, non-ASCII, punctuation-heavy
+    /// values, and transient formats emit URL-ish ones.
+    #[tokio::test]
+    async fn synthetic_address_fits_the_column_and_is_non_routable() {
+        let hostile = format!("{}@evil.example/ unicode-\u{fc}\u{ef}", "x".repeat(400));
+        let email = user_info(&hostile, "hostile", None).email;
+
+        assert!(
+            email.len() <= 255,
+            "must fit users.email VARCHAR(255), got {} chars: {}",
+            email.len(),
+            email
+        );
+        assert_eq!(email.matches('@').count(), 1, "exactly one @: {}", email);
+        assert!(
+            email.ends_with("@no-email.saml.invalid"),
+            "must land in a reserved, never-resolving domain rather than the \
+             old resolvable `@unknown`: {}",
+            email
+        );
+    }
+
+    /// Sanitizing the NameID is lossy; the digest of the raw value is what
+    /// keeps distinct subjects mapped to distinct addresses.
+    #[tokio::test]
+    async fn name_ids_that_sanitize_alike_still_differ() {
+        assert_ne!(
+            user_info("a b", "u1", None).email,
+            user_info("a/b", "u2", None).email
+        );
+    }
+
+    /// The default deployment reads the username straight off the NameID. The
+    /// fix must hold there too -- and there the old code looks correct, which
+    /// is why the bug survived review.
+    #[tokio::test]
+    async fn default_name_id_username_config_still_gets_distinct_addresses() {
+        let svc = make_test_saml_service();
+        let one = svc
+            .extract_user_info(&assertion_with("urn:idp:nameid:g-1", "ignored", None))
+            .expect("user info");
+        let two = svc
+            .extract_user_info(&assertion_with("urn:idp:nameid:g-2", "ignored", None))
+            .expect("user info");
+
+        assert_eq!(one.username, "urn:idp:nameid:g-1", "fixture guard");
+        assert_ne!(one.email, two.email);
+    }
+
+    /// End-to-end against a real database, the shape from the issue: two SAML
+    /// identities that collide on the username attribute and assert no email
+    /// both provision.
+    ///
+    /// Before the fix the second `get_or_create_user` failed with
+    ///   duplicate key value violates unique constraint "users_email_key"
+    /// DB-backed; no-ops without `DATABASE_URL`.
+    #[tokio::test]
+    async fn two_saml_users_sharing_a_username_attribute_both_provision() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let mut config = make_test_saml_config();
+        config.username_attr = "uid".to_string();
+        let svc = SamlService::with_config(pool.clone(), config);
+
+        // Namespaced per run so concurrent/repeat runs cannot collide with
+        // each other -- and so cleanup below can never touch a real user.
+        let run = Uuid::new_v4();
+        let shared_uid = format!("collide_{}", run.simple());
+
+        let mut created = Vec::new();
+        for n in 1..=2 {
+            let info = svc
+                .extract_user_info(&assertion_with(
+                    &format!("urn:idp:nameid:{}-{}", run.simple(), n),
+                    &shared_uid,
+                    None,
+                ))
+                .expect("user info");
+            assert_eq!(info.username, shared_uid, "fixture guard: same username");
+
+            match svc.get_or_create_user(&info).await {
+                Ok(user) => created.push(user),
+                Err(e) => {
+                    for user in &created {
+                        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user.id)
+                            .execute(&pool)
+                            .await;
+                    }
+                    panic!(
+                        "provisioning SAML user {} of 2 with no email attribute failed: {}",
+                        n, e
+                    );
+                }
+            }
+        }
+
+        // The usernames diverge exactly as the issue describes...
+        assert_ne!(created[0].id, created[1].id);
+        assert_ne!(
+            created[0].username, created[1].username,
+            "generate_unique_username must have suffixed the second user"
+        );
+        // ...and the addresses must diverge with them, which is the fix.
+        assert_ne!(created[0].email, created[1].email);
+
+        for user in &created {
+            sqlx::query!("DELETE FROM users WHERE id = $1", user.id)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
     }
 }


### PR DESCRIPTION
## The bug

When a SAML assertion omits the configured email attribute, `extract_user_info` invented a placeholder:

```rust
.unwrap_or_else(|| format!("{}@unknown", username));
```

That `username` is the value read straight off the assertion. But `get_or_create_user` stores a *different* one — it runs the same value through `generate_unique_username` first:

```rust
let username = self.generate_unique_username(&saml_user.username).await?;
```

So two distinct NameIDs whose username attribute happens to match get distinct usernames — `alice`, `alice_1` — and the **identical** placeholder address `alice@unknown`. `users.email` is `VARCHAR(255) UNIQUE NOT NULL` (`migrations/001_users.sql:8`, plain unique index, no migration relaxes it), so the second user's `INSERT` dies on `users_email_key` and that person cannot log in at all.

`unknown` is also a resolvable TLD, so the placeholder could collide with a real mailbox rather than merely with another placeholder.

## The fix

Derive the placeholder from the **NameID**.

The NameID is the SAML subject, and — this is the property that makes it the right key — it is already what `get_or_create_user` writes to `users.external_id` and looks the account up by. So the synthetic address is unique and stable in exactly the cases the account row itself is, and no more. No new failure mode is introduced: if the NameID is unstable (a `transient` format), the *account* was already unstable for the same reason.

Keying on the username instead would have been **worse than the original bug**. The username attribute is self-settable at any IdP that maps it from a user-editable directory field, so a username-keyed placeholder lets one user pick a value that collides with another's — turning an availability defect into a targeted one.

This is the SAML twin of #3119 / #3161 (OIDC). Rather than add a third independent implementation of "invent an address when the directory did not supply one", the derivation moves to `services::federated_email` and both federated paths call it. The OIDC wrapper pins the OIDC domain, so **the addresses #3161 shipped are unchanged byte-for-byte**.

Properties the shared helper guarantees (documented in the module, each pinned by a test):

| | why it matters |
|---|---|
| unique per subject | a shared sentinel lets only the first address-less user provision |
| stable across logins | re-login writes `email` back; an unstable value mints a new account per login, orphaning uploads, quota and permissions |
| keyed on the subject | usernames are self-settable at many IdPs |
| non-routable (`.invalid`, RFC 2606) | can never resolve to, or collide with, a real mailbox |

## Tests

Nine new tests plus a rewritten one. `test_extract_user_info_missing_email_generates_default` asserted the literal `jdoe@unknown` — it pinned the *bug* rather than a requirement, which is part of why this survived review. It now asserts the properties that actually matter.

The fixtures deliberately configure `username_attr = "uid"` so the NameID and the username **differ**. That is load-bearing: with the default `username_attr = "NameID"` the two co-vary, and a username-keyed derivation would satisfy the entire suite — which is exactly how #3161 came to ship with nine tests its own bug could pass.

**Revert proof.** Restoring the pre-fix derivation fails 6 tests, including the DB-backed one reproducing the production symptom verbatim:

```
---- two_name_ids_sharing_a_username_attribute_get_distinct_emails ----
assertion `left != right` failed: two distinct NameIDs must never derive the same
placeholder address: users.email is UNIQUE NOT NULL, so the second user's INSERT
dies on users_email_key and the login fails outright
  left: "alice@unknown"
 right: "alice@unknown"

---- two_saml_users_sharing_a_username_attribute_both_provision ----
provisioning SAML user 2 of 2 with no email attribute failed: Database error:
error returned from database: duplicate key value violates unique constraint "users_email_key"
```

**Substitution proof** (the trap #3161 fell into). Keeping the fix but keying it on `&username` instead of `&assertion.name_id` still fails 3 tests, including the DB one — the suite genuinely pins the subject, not just the shape:

```
---- derivation_keys_on_name_id_not_username ----
assertion `left == right` failed: one NameID must keep one address even when the
username attribute changes between logins
  left: "old_uid.024abdcb0a2fc15e@no-email.saml.invalid"
 right: "new_uid.ea5205f6fb6d3064@no-email.saml.invalid"
```

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- saml sso auth` — **1239 passed, 0 failed**
- No `sqlx::query!` text changed (the only new query, `DELETE FROM users WHERE id = $1`, is already cached from #3161), so `.sqlx` needs no regeneration. Verified rather than assumed: `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` **unset** builds clean.

## Out of scope, noted

- `ldap_service.rs:637` still has the third variant of this pattern (`{username}@unknown`). It is not reachable by the same trigger — LDAP usernames are the directory key — but it should move onto the shared helper. Left out to keep this PR to the reported path.
- There is no validation that a NameID is non-empty. An empty NameID would collapse distinct identities onto one account at the `external_id` lookup, *before* email is ever considered — a separate and more serious defect this PR neither introduces nor worsens. Worth its own issue.

Fixes #3167
