### PR TITLE
fix(virtual): gate virtual repo member reads and attaches on repository visibility, not token scope

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -1099,6 +1099,7 @@ async fn public_key(
 
 async fn download_package(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, branch, repository, arch, filename)): Path<(
         String,
         String,
@@ -1159,6 +1160,7 @@ async fn download_package(
                 let artifact_path_clone = artifact_path.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -387,6 +387,7 @@ async fn version_info(
 
 async fn download_collection(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, file_path)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -401,6 +402,7 @@ async fn download_collection(
                 let upstream_path = format!("download/{}", filename);
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
+                    auth.as_ref(),
                     &repo,
                     &ctx,
                     proxy_helpers::DownloadResponseOpts {

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -821,6 +821,7 @@ async fn publish(
 
 async fn download(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -998,6 +999,7 @@ async fn download(
 
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     proxy_for_virtual,
                     repo.id,
                     &upstream_path,
@@ -1942,6 +1944,19 @@ mod tests {
         .execute(&virt.pool)
         .await
         .expect("link remote member into the virtual repo");
+
+        // #3178: the virtual byte path filters members by CALLER, and this
+        // request is ANONYMOUS. The subject here is Content-Encoding
+        // forwarding, not authorization, so publish both repositories --
+        // `require_visible` early-returns on a public repo. Before #3178 an
+        // anonymous caller was served a PRIVATE member's bytes, which is
+        // exactly the bug; that behaviour is now asserted (inverted) in
+        // `repositories::virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![virt.repo_id, member.repo_id])
+            .execute(&virt.pool)
+            .await
+            .expect("publish the virtual repo and its member");
 
         let (state, _dir) = tdh::rewire_remote_proxy(&member, &server.uri()).await;
         let (status, body, headers) = tdh::send_with_headers(

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -245,6 +245,7 @@ async fn version_info(
 
 async fn download_cookbook(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -303,6 +304,7 @@ async fn download_cookbook(
                 let version_clone = version.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -389,6 +389,7 @@ async fn get_podspec(
 
 async fn download_pod(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, pod_file)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -452,6 +453,7 @@ async fn download_pod(
                 let vversion = path_info.version.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1245,6 +1245,7 @@ async fn metadata_v1(
 
 async fn download_archive(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, vendor, package, version, reference)): Path<(
         String,
         String,
@@ -1330,6 +1331,7 @@ async fn download_archive(
                     format!("dist/{}/{}/{}/{}.zip", vendor, package, version, reference);
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1554,6 +1554,7 @@ async fn recipe_files_list(
 
 async fn recipe_file_download(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, name, version, user, channel, revision, file_path)): Path<(
         String,
         String,
@@ -1626,6 +1627,7 @@ async fn recipe_file_download(
                 let vpath = artifact_path.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,
@@ -2333,6 +2335,7 @@ fn files_listing_response(filenames: Vec<String>) -> Response {
 #[allow(clippy::type_complexity)]
 async fn package_file_download(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, name, version, user, channel, revision, package_id, pkg_revision, file_path)): Path<(
         String,
         String,
@@ -2427,6 +2430,7 @@ async fn package_file_download(
                 let vpath = artifact_path.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2683,6 +2683,7 @@ async fn download_package(
                 let artifact_path_clone = artifact_path.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -195,6 +195,7 @@ async fn package_index_gz(
 
 async fn download_package(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, filename)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -207,6 +208,7 @@ async fn download_package(
                 let upstream_path = format!("src/contrib/{}", filename);
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
+                    auth.as_ref(),
                     &repo,
                     &ctx,
                     proxy_helpers::DownloadResponseOpts {

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -2721,6 +2721,7 @@ fn xz_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
 
 async fn pool_download(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, component, path)): Path<(String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -2814,6 +2815,16 @@ async fn pool_download(
                 // aggregate. Fail-closed per member: a filter-load error skips
                 // only that member, it does not fail the whole request open.
                 let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+                // #3178: authorize the member set against the CALLER before any
+                // format-specific filtering, so a member this caller could not
+                // read directly can never reach the byte resolver.
+                let members = proxy_helpers::authorize_virtual_members(
+                    &state.db,
+                    auth.as_ref(),
+                    repo.id,
+                    members,
+                )
+                .await;
                 let mut allowed_members = Vec::with_capacity(members.len());
                 for member in members {
                     match remote_member_upstream(&member) {

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -595,6 +595,7 @@ async fn upload_object(
 
 async fn download_object(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, oid)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -653,6 +654,7 @@ async fn download_object(
                 let upstream_path = format!("objects/{}", oid);
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -203,6 +203,7 @@ async fn resolve_go_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respon
 
 async fn handle_get(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, path)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -215,10 +216,10 @@ async fn handle_get(
             version_info(&state, &repo, &module, &version).await
         }
         GoProxyRequest::Mod { module, version } => {
-            get_mod_file(&state, &repo, &module, &version, &ctx).await
+            get_mod_file(&state, auth.as_ref(), &repo, &module, &version, &ctx).await
         }
         GoProxyRequest::Zip { module, version } => {
-            download_zip(&state, &repo, &module, &version, &ctx).await
+            download_zip(&state, auth.as_ref(), &repo, &module, &version, &ctx).await
         }
         GoProxyRequest::Latest { module } => latest_version(&state, &repo, &module).await,
         GoProxyRequest::SumDb { host, path } => proxy_sumdb(&host, &path).await,
@@ -838,6 +839,7 @@ async fn version_info(
 
 async fn get_mod_file(
     state: &SharedState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     repo: &RepoInfo,
     module: &str,
     version: &str,
@@ -905,6 +907,7 @@ async fn get_mod_file(
                 let version_clone = version.to_string();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth,
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,
@@ -970,6 +973,7 @@ async fn get_mod_file(
 
 async fn download_zip(
     state: &SharedState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     repo: &RepoInfo,
     module: &str,
     version: &str,
@@ -1040,6 +1044,12 @@ async fn download_zip(
             // the structured 451 is the answer, not a bare 404.
             if repo.repo_type == RepositoryType::Virtual {
                 let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+                // #3178: authorize the member set against the CALLER before any
+                // format-specific filtering, so a member this caller could not
+                // read directly can never reach the byte resolver.
+                let members =
+                    proxy_helpers::authorize_virtual_members(&state.db, auth, repo.id, members)
+                        .await;
                 let mut allowed = Vec::with_capacity(members.len());
                 let mut blocked_response = None;
                 for member in members {
@@ -1692,9 +1702,16 @@ mod tests {
 
         // The requested artifact itself blocks with the structured 451.
         let ctx = Default::default();
-        let err = download_zip(&state, &repo, module, "v1.1.0", &ctx)
-            .await
-            .expect_err("young zip must block");
+        let err = download_zip(
+            &state,
+            tdh::admin_auth_ext().as_ref(),
+            &repo,
+            module,
+            "v1.1.0",
+            &ctx,
+        )
+        .await
+        .expect_err("young zip must block");
         assert_eq!(err.status(), StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
         let blocked: serde_json::Value =
             serde_json::from_str(&body_string(err).await).expect("451 JSON body");
@@ -1734,9 +1751,16 @@ mod tests {
             .expect("aged latest must serve");
         let latest_body = body_string(latest).await;
         assert!(latest_body.contains("v1.1.0"), "got {latest_body}");
-        let zip = download_zip(&state, &repo, module, "v1.1.0", &ctx)
-            .await
-            .expect("aged zip must serve");
+        let zip = download_zip(
+            &state,
+            tdh::admin_auth_ext().as_ref(),
+            &repo,
+            module,
+            "v1.1.0",
+            &ctx,
+        )
+        .await
+        .expect("aged zip must serve");
         assert_eq!(zip.status(), StatusCode::OK);
 
         tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -556,6 +556,7 @@ async fn package_info(
 
 async fn download_tarball(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, tarball_file)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -597,8 +598,14 @@ async fn download_tarball(
             if repo.repo_type == RepositoryType::Virtual
                 && virtual_local_owns_tarball_name(&state.db, repo.id, filename).await?
             {
-                return serve_virtual_tarball_local_only(&state, repo.id, &upstream_path, filename)
-                    .await;
+                return serve_virtual_tarball_local_only(
+                    &state,
+                    auth.as_ref(),
+                    repo.id,
+                    &upstream_path,
+                    filename,
+                )
+                .await;
             }
 
             // Remote: no Content-Disposition; Virtual: include filename.
@@ -609,6 +616,7 @@ async fn download_tarball(
             };
             if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                 &state,
+                auth.as_ref(),
                 &repo,
                 &ctx,
                 proxy_helpers::DownloadResponseOpts {
@@ -749,6 +757,7 @@ async fn virtual_local_owns_tarball_name(
 /// and `order_members_local_first` (metadata side, see `package_info`).
 async fn serve_virtual_tarball_local_only(
     state: &SharedState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     virtual_repo_id: uuid::Uuid,
     upstream_path: &str,
     filename: &str,
@@ -758,6 +767,7 @@ async fn serve_virtual_tarball_local_only(
 
     let result = proxy_helpers::resolve_virtual_download(
         &state.db,
+        auth,
         // Explicit None: any Remote member would route to upstream, which is
         // exactly what the shadowing guard must block. Local members fall
         // through to `local_fetch_by_path_suffix` regardless of proxy state.
@@ -3151,6 +3161,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("link virtual member");
+        // #3178: the virtual byte/metadata paths filter members by CALLER using
+        // `require_visible`. This fixture is about resolution order, not
+        // authorization, so publish the members -- `require_visible`
+        // early-returns on a public repo. (Before #3178 the fixture passed
+        // with private members because the predicate fell open for any
+        // authenticated caller; that fail-open is the bug.) Authorization is
+        // covered by `repositories::virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![local_repo_id])
+            .execute(&pool)
+            .await
+            .expect("publish virtual members");
 
         let name = "jason";
         let version = "1.4.1";
@@ -3278,6 +3300,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("link virtual member");
+        // #3178: the virtual byte/metadata paths filter members by CALLER using
+        // `require_visible`. This fixture is about resolution order, not
+        // authorization, so publish the members -- `require_visible`
+        // early-returns on a public repo. (Before #3178 the fixture passed
+        // with private members because the predicate fell open for any
+        // authenticated caller; that fail-open is the bug.) Authorization is
+        // covered by `repositories::virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![local_repo_id])
+            .execute(&pool)
+            .await
+            .expect("publish virtual members");
 
         let local_repo =
             tdh::make_repo_info(local_repo_id, "local-hex", &local_storage_dir, "hex", None);

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -834,14 +834,16 @@ async fn virtual_member_checksum(
 
 async fn download_file(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, model_id, revision, filename)): Path<(String, String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
-    download_file_impl(state, repo_key, model_id, revision, filename, ctx).await
+    download_file_impl(state, auth, repo_key, model_id, revision, filename, ctx).await
 }
 
 async fn download_file_namespaced(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, namespace, name, revision, filename)): Path<(
         String,
         String,
@@ -853,6 +855,7 @@ async fn download_file_namespaced(
 ) -> Result<Response, Response> {
     download_file_impl(
         state,
+        auth,
         repo_key,
         format!("{namespace}/{name}"),
         revision,
@@ -864,6 +867,7 @@ async fn download_file_namespaced(
 
 async fn download_file_impl(
     state: SharedState,
+    auth: Option<crate::api::middleware::auth::AuthExtension>,
     repo_key: String,
     model_id: String,
     revision: String,
@@ -907,6 +911,7 @@ async fn download_file_impl(
         );
         if let Some(mut resp) = proxy_helpers::try_remote_or_virtual_download(
             &state,
+            auth.as_ref(),
             &repo,
             &ctx,
             proxy_helpers::DownloadResponseOpts {

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -146,6 +146,7 @@ async fn list_plugins(
 
 async fn download_plugin(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -201,6 +202,7 @@ async fn download_plugin(
                 let vversion = version.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1165,8 +1165,9 @@ async fn download(
             // way the artifact bytes are.
             let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
             let members = proxy_helpers::authorize_virtual_members(
-                &state.permission_service,
+                &state.db,
                 auth.as_ref(),
+                repo.id,
                 members,
             )
             .await;
@@ -1326,8 +1327,7 @@ async fn fetch_maven_metadata_bytes(
     if repo.repo_type == RepositoryType::Virtual {
         let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
         let members =
-            proxy_helpers::authorize_virtual_members(&state.permission_service, auth, members)
-                .await;
+            proxy_helpers::authorize_virtual_members(&state.db, auth, repo.id, members).await;
 
         if let Some((group_id, artifact_id)) = parse_metadata_path(path) {
             let cache_key: VirtualMetadataCacheKey =
@@ -1845,12 +1845,9 @@ async fn serve_artifact(
                 // member behaves exactly as if it did not contain the artifact
                 // (404), never leaking its existence.
                 let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
-                let members = proxy_helpers::authorize_virtual_members(
-                    &state.permission_service,
-                    auth,
-                    members,
-                )
-                .await;
+                let members =
+                    proxy_helpers::authorize_virtual_members(&state.db, auth, repo.id, members)
+                        .await;
 
                 let result = proxy_helpers::resolve_virtual_download_from_members(
                     members,
@@ -4470,6 +4467,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("insert virtual member");
+        // #3178: the virtual byte/metadata paths filter members by CALLER using
+        // `require_visible`. This fixture is about resolution order, not
+        // authorization, so publish the members -- `require_visible`
+        // early-returns on a public repo. (Before #3178 the fixture passed
+        // with private members because the predicate fell open for any
+        // authenticated caller; that fail-open is the bug.) Authorization is
+        // covered by `repositories::virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![hosted_id])
+            .execute(&pool)
+            .await
+            .expect("publish virtual members");
 
         // -- Build a state rooted at the hosted storage dir so the
         //    virtual-resolution callback can read the jar bytes back.
@@ -4875,6 +4884,18 @@ mod tests {
             .execute(&pool)
             .await
             .expect("insert virtual member");
+            // #3178: the virtual byte/metadata paths filter members by CALLER using
+            // `require_visible`. This fixture is about resolution order, not
+            // authorization, so publish the members -- `require_visible`
+            // early-returns on a public repo. (Before #3178 the fixture passed
+            // with private members because the predicate fell open for any
+            // authenticated caller; that fail-open is the bug.) Authorization is
+            // covered by `repositories::virtual_member_authz_tests`.
+            sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+                .bind(vec![member_a, member_b])
+                .execute(&pool)
+                .await
+                .expect("publish virtual members");
         }
 
         let state = tdh::build_state(pool.clone(), dir_a.to_str().unwrap());
@@ -5290,6 +5311,18 @@ mod tests {
             .execute(&pool)
             .await
             .expect("link virtual member");
+            // #3178: the virtual byte/metadata paths filter members by CALLER using
+            // `require_visible`. This fixture is about resolution order, not
+            // authorization, so publish the members -- `require_visible`
+            // early-returns on a public repo. (Before #3178 the fixture passed
+            // with private members because the predicate fell open for any
+            // authenticated caller; that fail-open is the bug.) Authorization is
+            // covered by `repositories::virtual_member_authz_tests`.
+            sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+                .bind(vec![local_id, remote_id])
+                .execute(&pool)
+                .await
+                .expect("publish virtual members");
         }
 
         let proxy = tdh::build_proxy_service_with_fs(pool.clone(), dir_r.to_str().unwrap());
@@ -5398,6 +5431,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("link local (prio 1) and remote (prio 2) as virtual members");
+        // #3178: the virtual byte/metadata paths filter members by CALLER using
+        // `require_visible`. This fixture is about resolution order, not
+        // authorization, so publish the members -- `require_visible`
+        // early-returns on a public repo. (Before #3178 the fixture passed
+        // with private members because the predicate fell open for any
+        // authenticated caller; that fail-open is the bug.) Authorization is
+        // covered by `repositories::virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![local_id, remote_id])
+            .execute(&pool)
+            .await
+            .expect("publish virtual members");
 
         let proxy = tdh::build_proxy_service_with_fs(pool.clone(), dir.to_str().unwrap());
         let state = tdh::build_state_with_proxy(pool.clone(), dir.to_str().unwrap(), proxy);
@@ -5590,6 +5635,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("link local (prio 1) and remote (prio 2) as virtual members");
+        // #3178: the virtual byte/metadata paths filter members by CALLER using
+        // `require_visible`. This fixture is about resolution order, not
+        // authorization, so publish the members -- `require_visible`
+        // early-returns on a public repo. (Before #3178 the fixture passed
+        // with private members because the predicate fell open for any
+        // authenticated caller; that fail-open is the bug.) Authorization is
+        // covered by `repositories::virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![local_id, remote_id])
+            .execute(&pool)
+            .await
+            .expect("publish virtual members");
 
         let auth = tdh::make_auth(user_id, "ph-2328-user");
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2828,16 +2828,18 @@ fn rewrite_and_respond_inner(
 
 async fn download_tarball(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, package, filename)): Path<(String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let package = normalize_package_name(&package);
     validate_package_name(&package)?;
-    serve_tarball(&state, &repo_key, &package, &filename, &ctx).await
+    serve_tarball(&state, auth.as_ref(), &repo_key, &package, &filename, &ctx).await
 }
 
 async fn download_scoped_tarball(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, scope, package, filename)): Path<(String, String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -2845,7 +2847,15 @@ async fn download_scoped_tarball(
     let package = normalize_package_name(&package);
     let full_name = build_scoped_package_name(&scope, &package);
     validate_package_name(&full_name)?;
-    serve_tarball(&state, &repo_key, &full_name, &filename, &ctx).await
+    serve_tarball(
+        &state,
+        auth.as_ref(),
+        &repo_key,
+        &full_name,
+        &filename,
+        &ctx,
+    )
+    .await
 }
 
 /// Fetch an npm tarball from a virtual member's local storage, matching
@@ -2946,6 +2956,7 @@ async fn npm_local_fetch(
 
 async fn serve_tarball(
     state: &SharedState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     repo_key: &str,
     package_name: &str,
     filename: &str,
@@ -3112,6 +3123,11 @@ async fn serve_tarball(
         // always eligible, preserving the `virtual_non_remote_owns_name`
         // shadowing guard and the local-only primitive above.
         let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+        // #3178: authorize the member set against the CALLER before any
+        // format-specific filtering, so a member this caller could not read
+        // directly can never reach the byte resolver.
+        let members =
+            proxy_helpers::authorize_virtual_members(&state.db, auth, repo.id, members).await;
         let member_ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
         let scope_policies = fetch_npm_scope_policies(&state.db, &member_ids)
             .await
@@ -7334,6 +7350,7 @@ mod tests {
         // segments via the Path extractor.
         let result = super::download_scoped_tarball(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 "e2escope".to_string(),
@@ -7437,6 +7454,7 @@ mod tests {
             }
             let result = super::download_tarball(
                 axum::extract::State(state.clone()),
+                axum::Extension(tdh::admin_auth_ext()),
                 axum::extract::Path((
                     fx.repo_key.clone(),
                     "bigpkg".to_string(),
@@ -9694,6 +9712,7 @@ mod db_cov_tests {
 
         let young = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             package,
             &format!("{package}-9.9.9.tgz"),
@@ -9702,6 +9721,7 @@ mod db_cov_tests {
         .await;
         let aged = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             package,
             &format!("{package}-1.0.0.tgz"),
@@ -10544,9 +10564,15 @@ mod proxy_scan_block_tests {
         let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
         let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
 
-        let result =
-            super::serve_tarball(&state, &fx.repo_key, package, filename, &Default::default())
-                .await;
+        let result = super::serve_tarball(
+            &state,
+            tdh::admin_auth_ext().as_ref(),
+            &fx.repo_key,
+            package,
+            filename,
+            &Default::default(),
+        )
+        .await;
 
         cleanup_proxy_scan_row(&fx.pool, &digest).await;
         cleanup_npm_member(&fx.pool, member_id, &member_dir).await;
@@ -10606,9 +10632,15 @@ mod proxy_scan_block_tests {
         let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
         let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
 
-        let result =
-            super::serve_tarball(&state, &fx.repo_key, package, filename, &Default::default())
-                .await;
+        let result = super::serve_tarball(
+            &state,
+            tdh::admin_auth_ext().as_ref(),
+            &fx.repo_key,
+            package,
+            filename,
+            &Default::default(),
+        )
+        .await;
         let status = result
             .as_ref()
             .map(|r| r.status())
@@ -10817,6 +10849,7 @@ mod proxy_scan_block_tests {
 
             let result = super::serve_tarball(
                 &state,
+                tdh::admin_auth_ext().as_ref(),
                 &fx.repo_key,
                 "lodash",
                 "lodash-4.17.11.tgz",
@@ -10876,6 +10909,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "lodash",
             "lodash-4.17.11.tgz",
@@ -10936,6 +10970,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "sealed-widget",
             "sealed-widget-1.0.0.tgz",
@@ -10985,6 +11020,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "open-widget",
             "open-widget-2.0.0.tgz",
@@ -11089,6 +11125,7 @@ mod proxy_scan_block_tests {
         for pull in ["first", "second (cache-served)"] {
             let result = super::serve_tarball(
                 &state,
+                tdh::admin_auth_ext().as_ref(),
                 &fx.repo_key,
                 "poisoned-widget",
                 "poisoned-widget-0.1.0.tgz",
@@ -11166,6 +11203,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "@acme/secret-widget",
             "secret-widget-1.0.0.tgz",
@@ -11235,6 +11273,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "verified-widget",
             "verified-widget-3.2.1.tgz",
@@ -11328,6 +11367,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "staleclean-widget",
             "staleclean-widget-1.0.0.tgz",
@@ -11407,6 +11447,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "probenone-widget",
             "probenone-widget-1.0.0.tgz",
@@ -11455,6 +11496,7 @@ mod proxy_scan_block_tests {
 
         let result = super::serve_tarball(
             &state,
+            tdh::admin_auth_ext().as_ref(),
             &fx.repo_key,
             "plain-widget",
             "plain-widget-1.0.0.tgz",
@@ -11565,6 +11607,7 @@ mod content_encoding_forwarding_tests {
         let (state, _dir) = tdh::rewire_remote_proxy(&fx, &upstream.uri()).await;
         let result = super::download_tarball(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 "coded-pkg".to_string(),
@@ -11629,6 +11672,7 @@ mod content_encoding_forwarding_tests {
         let (state, _dir) = tdh::rewire_remote_proxy(&fx, &upstream.uri()).await;
         let result = super::download_tarball(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 "plain-pkg".to_string(),
@@ -11697,6 +11741,7 @@ mod content_encoding_forwarding_tests {
 
         let result = super::download_tarball(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 "vcoded-pkg".to_string(),

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -1224,6 +1224,7 @@ async fn flatcontainer_versions(
 
 async fn flatcontainer_download(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, package_id, version, filename)): Path<(String, String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -1314,6 +1315,7 @@ async fn flatcontainer_download(
                 );
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,
@@ -3136,6 +3138,7 @@ mod tests {
         // Call the handler directly via extractors.
         let result = super::flatcontainer_download(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 package_id_lower.clone(),
@@ -4328,6 +4331,7 @@ mod read_db_tests {
 
         let resp = super::flatcontainer_download(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 "newtonsoft.json".to_string(),
@@ -4456,6 +4460,7 @@ mod read_db_tests {
 
         let resp = super::flatcontainer_download(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 package_id.to_string(),
@@ -4600,6 +4605,7 @@ mod read_db_tests {
 
         let resp = super::flatcontainer_download(
             axum::extract::State(state.clone()),
+            axum::Extension(tdh::admin_auth_ext()),
             axum::extract::Path((
                 fx.repo_key.clone(),
                 package_id.to_string(),

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1262,6 +1262,7 @@ async fn upload(
 
 async fn download(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path(repo_key): Path<String>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
     axum::Json(body): axum::Json<DownloadRequest>,
@@ -1375,6 +1376,7 @@ async fn download(
 
                     let result = proxy_helpers::resolve_virtual_download(
                         &state.db,
+                        auth.as_ref(),
                         state.proxy_service.as_deref(),
                         repo.id,
                         &upstream_path,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -2082,8 +2082,16 @@ pub(crate) fn classify_streaming_upstream(
 ///
 /// Returns the first successful result, or `NOT_FOUND` if no member
 /// has the artifact.
+///
+/// `auth` is the CALLER (#3178). It is not optional-by-omission: this function
+/// used to take no caller at all, so it structurally could not filter members
+/// and streamed a PRIVATE member's bytes to anyone who could reach the virtual
+/// parent — including, when that parent was public, an anonymous `curl`. The
+/// member set is narrowed by [`authorize_virtual_members`] before any member is
+/// probed, so a member the caller could not read directly can never serve.
 pub async fn resolve_virtual_download<F, Fut>(
     db: &PgPool,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     proxy_service: Option<&ProxyService>,
     virtual_repo_id: Uuid,
     path: &str,
@@ -2094,6 +2102,18 @@ where
     Fut: std::future::Future<Output = Result<StreamingFetchResult, Response>>,
 {
     let members = fetch_virtual_members(db, virtual_repo_id).await?;
+    let had_members = !members.is_empty();
+    let members = authorize_virtual_members(db, auth, virtual_repo_id, members).await;
+    if had_members && members.is_empty() {
+        // Do NOT fall through to the "has no members" message: that would
+        // distinguish "this virtual is empty" from "this virtual has members
+        // you may not see", an existence oracle over private repositories.
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Artifact not found in any member repository",
+        )
+            .into_response());
+    }
     resolve_virtual_download_from_members(members, proxy_service, path, local_fetch).await
 }
 
@@ -2246,8 +2266,13 @@ fn is_quarantine_block_response(resp: &Response) -> bool {
 /// upstream-free only for immutable content; mutable indexes/metadata must go
 /// through [`resolve_virtual_metadata`] / the metadata-merge helpers instead.
 #[allow(clippy::too_many_arguments)]
+///
+/// `auth` is the CALLER (#3178), applied by [`authorize_virtual_members`]
+/// exactly as in the buffered [`resolve_virtual_download`]: both byte paths
+/// must agree on which members this caller may see.
 pub async fn resolve_virtual_download_streaming<F, Fut>(
     state: &AppState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     proxy_service: Option<&ProxyService>,
     virtual_repo_id: Uuid,
     path: &str,
@@ -2264,6 +2289,18 @@ where
 
     if members.is_empty() {
         return Err((StatusCode::NOT_FOUND, "Virtual repository has no members").into_response());
+    }
+
+    // #3178: narrow to the members this caller may read BEFORE any member is
+    // probed. The collapsed message is deliberate — see `resolve_virtual_
+    // download` for why it must not be distinguishable from a genuine miss.
+    let members = authorize_virtual_members(&state.db, auth, virtual_repo_id, members).await;
+    if members.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Artifact not found in any member repository",
+        )
+            .into_response());
     }
 
     // Two-phase, priority-preserving resolution (#2069), streaming sibling of
@@ -2695,95 +2732,115 @@ pub async fn fetch_virtual_members(
     .map_err(map_db_err)
 }
 
-/// Decide whether `auth` is allowed to read `member` directly, mirroring the
-/// read-access model that [`crate::api::middleware::auth::repo_visibility_middleware`]
-/// applies to the URL-named repository.
+/// Filter a virtual repository's members down to those the caller may read
+/// DIRECTLY, preserving priority order.
 ///
 /// Security (#1804): the visibility middleware only authorizes the URL repo. A
-/// public Virtual repo therefore became a confused deputy that streamed its
-/// PRIVATE members' bytes to anyone allowed to read the virtual. Every member
-/// that would actually serve a response must be re-checked against the same
-/// model as a direct read so aggregation cannot bypass access control.
+/// Virtual repo is therefore a confused deputy — everything it aggregates on
+/// the caller's behalf is a SEPARATE repository with its own ACL, and must be
+/// re-checked against the same model as a direct read so aggregation cannot
+/// bypass access control.
 ///
-/// The decision is:
-/// * public member → readable by anyone;
-/// * otherwise the caller must be authenticated, and either:
-///   * an admin, or
-///   * pass the API-token repo scope ([`AuthExtension::can_access_repo`]) AND,
-///     if fine-grained rules exist for the member, hold the `read` (or `admin`)
-///     action on it.
+/// The predicate is `require_visible`'s composition, verbatim:
+///
+/// ```text
+/// is_public OR (in_scope AND (is_admin OR grants))
+/// ```
+///
+/// composed here exactly as PR #3173 composes it for the member LISTING paths:
+/// the GRANT half in SQL via
+/// [`RepositoryService::filter_visible_repo_ids`] +
+/// [`member_grant_visibility`], and the token-SCOPE half per row via
+/// [`member_passes_token_scope`]. Reusing those two helpers is deliberate:
+/// listing and byte resolution now evaluate the SAME predicate from the SAME
+/// code, so "which members does this caller see" cannot drift between the two.
+///
+/// What this replaces (#3178). The previous implementation was NOT this
+/// predicate. Its entitlement half was
+///
+/// ```text
+/// can_access_repo(member.id) AND (rules_exist_for_member ? holds_read : TRUE)
+/// ```
+///
+/// which is wrong twice over:
+///
+/// * `can_access_repo` is the caller's TOKEN SCOPE, not repository visibility.
+///   It returns `true` for every repository in the instance whenever the
+///   principal is unscoped — a browser JWT session, an unrestricted API token —
+///   so for the common caller it was not a check at all.
+/// * the `Ok(false) => true` arm FELL OPEN: a private member carrying no
+///   fine-grained `permissions` rows was readable by any authenticated caller,
+///   regardless of grants. Measured on the same repo and principal,
+///   `require_visible` said false while this said true.
+///
+/// Together those two made an authenticated caller with no grant — and, through
+/// a public Virtual parent, an ANONYMOUS caller — able to read a private
+/// member's bytes.
+///
+/// Note the entitlement half is now identical to a direct read of the member
+/// ([`build_grant_predicate`] honours BOTH the `role_assignments` store and the
+/// fine-grained `permissions` store, including group grants), so a member is
+/// readable through the virtual exactly when its own `GET` would succeed.
+///
+/// Fails CLOSED: a database error yields the empty set rather than the
+/// unfiltered one.
 ///
 /// Callers should treat a denied member as if it did not contain the artifact
 /// (continue to the next member / return not-found) so member existence is not
 /// leaked through the virtual repo.
-pub async fn caller_can_read_member(
-    permission_service: &crate::services::permission_service::PermissionService,
-    auth: Option<&crate::api::middleware::auth::AuthExtension>,
-    member: &Repository,
-) -> bool {
-    // Public members are readable by everyone, exactly like a direct read of a
-    // public repo.
-    if member.is_public {
-        return true;
-    }
-
-    // Private member: anonymous callers can never read it directly.
-    let Some(ext) = auth else {
-        return false;
-    };
-
-    // Admins bypass fine-grained checks, matching the middleware.
-    if ext.is_admin {
-        return true;
-    }
-
-    // API-token repository scope (#504): a token scoped to other repos must not
-    // reach this member.
-    if !ext.can_access_repo(member.id) {
-        return false;
-    }
-
-    // Fine-grained repository permissions (#817): if rules exist for the member,
-    // the caller must hold the `read` action (or `admin`, which implies it). If
-    // no rules exist, the visibility check above (private + authenticated) is
-    // the access model. Fail closed on DB errors.
-    match permission_service
-        .has_any_rules_for_target("repository", member.id)
-        .await
-    {
-        Ok(true) => {
-            let read = permission_service
-                .check_permission(ext.user_id, "repository", member.id, "read", false)
-                .await
-                .unwrap_or(false);
-            if read {
-                return true;
-            }
-            permission_service
-                .check_permission(ext.user_id, "repository", member.id, "admin", false)
-                .await
-                .unwrap_or(false)
-        }
-        Ok(false) => true,
-        Err(_) => false,
-    }
-}
-
-/// Filter a virtual repository's members down to those the caller may read
-/// directly, preserving priority order. See [`caller_can_read_member`] for the
-/// per-member access model and the #1804 confused-deputy background.
+///
+/// [`member_grant_visibility`]: crate::api::handlers::repositories::member_grant_visibility
+/// [`member_passes_token_scope`]: crate::api::handlers::repositories::member_passes_token_scope
+/// [`build_grant_predicate`]: crate::services::repository_service::build_grant_predicate
+/// [`RepositoryService::filter_visible_repo_ids`]: crate::services::repository_service::RepositoryService::filter_visible_repo_ids
 pub async fn authorize_virtual_members(
-    permission_service: &crate::services::permission_service::PermissionService,
+    db: &PgPool,
     auth: Option<&crate::api::middleware::auth::AuthExtension>,
+    virtual_repo_id: Uuid,
     members: Vec<Repository>,
 ) -> Vec<Repository> {
-    let mut allowed = Vec::with_capacity(members.len());
-    for member in members {
-        if caller_can_read_member(permission_service, auth, &member).await {
-            allowed.push(member);
-        }
+    use crate::api::handlers::repositories::{member_grant_visibility, member_passes_token_scope};
+
+    if members.is_empty() {
+        return members;
     }
-    allowed
+    let member_ids: Vec<Uuid> = members.iter().map(|m| m.id).collect();
+    let granted: std::collections::HashSet<Uuid> =
+        match crate::services::repository_service::RepositoryService::new(db.clone())
+            .filter_visible_repo_ids(&member_ids, &member_grant_visibility(auth))
+            .await
+        {
+            Ok(ids) => ids.into_iter().collect(),
+            // Fail closed: a DB error must never WIDEN the member set.
+            Err(e) => {
+                tracing::warn!(
+                    virtual_repo_id = %virtual_repo_id,
+                    error = %e,
+                    "virtual member authorization query failed; denying all members"
+                );
+                return Vec::new();
+            }
+        };
+    members
+        .into_iter()
+        .filter(|m| {
+            granted.contains(&m.id)
+                && member_passes_token_scope(auth, virtual_repo_id, m.id, m.is_public)
+        })
+        .collect()
+}
+
+/// Single-member form of [`authorize_virtual_members`]; see it for the access
+/// model and the #1804 / #3178 background.
+pub async fn caller_can_read_member(
+    db: &PgPool,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
+    virtual_repo_id: Uuid,
+    member: &Repository,
+) -> bool {
+    !authorize_virtual_members(db, auth, virtual_repo_id, vec![member.clone()])
+        .await
+        .is_empty()
 }
 
 /// Row type for local artifact fetch queries, including quarantine fields.
@@ -3967,8 +4024,12 @@ pub(crate) async fn record_proxy_download(
     }
 }
 
+/// `auth` is the CALLER (#3178). Only the Virtual arm consults it, to narrow
+/// the member set to what this caller may read; the Remote arm is the URL repo
+/// itself, already authorized by `repo_visibility_middleware`.
 pub async fn try_remote_or_virtual_download(
     state: &crate::api::SharedState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     repo: &RepoInfo,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
     opts: DownloadResponseOpts<'_>,
@@ -4026,6 +4087,7 @@ pub async fn try_remote_or_virtual_download(
                 let state_arc = state.clone();
                 resolve_virtual_download_streaming(
                     state,
+                    auth,
                     proxy_for_virtual,
                     repo.id,
                     opts.upstream_path,
@@ -4049,6 +4111,7 @@ pub async fn try_remote_or_virtual_download(
                 let state_arc = state.clone();
                 resolve_virtual_download_streaming(
                     state,
+                    auth,
                     proxy_for_virtual,
                     repo.id,
                     opts.upstream_path,
@@ -9483,6 +9546,7 @@ mod tests {
         };
         let result = try_remote_or_virtual_download(
             &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
             &repo,
             &crate::api::middleware::download_telemetry::DownloadContext {
                 client_ip: None,
@@ -9535,6 +9599,7 @@ mod tests {
         };
         let result = try_remote_or_virtual_download(
             &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
             &repo,
             &crate::api::middleware::download_telemetry::DownloadContext {
                 client_ip: None,
@@ -9586,6 +9651,7 @@ mod tests {
         };
         let result = try_remote_or_virtual_download(
             &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
             &repo,
             &crate::api::middleware::download_telemetry::DownloadContext {
                 client_ip: None,
@@ -10662,6 +10728,7 @@ mod tests {
 
         let resp = resolve_virtual_download_streaming(
             &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
             Some(&proxy),
             virtual_id,
             "pkg/pkg-1.0.0-py3-none-any.whl",
@@ -10938,6 +11005,7 @@ mod tests {
 
         let err = resolve_virtual_download_streaming(
             &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
             Some(&proxy),
             virtual_id,
             "pkg/pkg-1.0.0-py3-none-any.whl",
@@ -11459,6 +11527,7 @@ mod tests {
         // proxy_service = None so only the Local member can win.
         let result = resolve_virtual_download_streaming(
             &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
             None,
             virtual_id,
             path,
@@ -11491,41 +11560,7 @@ mod tests {
         );
     }
 
-    // ── #1804: per-member authorization for virtual repos ───────────────
-
-    /// Build an in-memory `Repository` for member-authorization tests. Only the
-    /// fields the access decision reads (`id`, `is_public`) are meaningful; the
-    /// rest are inert defaults. Keeping this local avoids duplicating the wide
-    /// struct literal across each member variant (jscpd).
-    fn member_repo(id: Uuid, is_public: bool) -> Repository {
-        Repository {
-            versioning_enabled: false,
-            id,
-            key: format!("member-{}", id.simple()),
-            name: "member".to_string(),
-            description: None,
-            format: RepositoryFormat::Maven,
-            repo_type: RepositoryType::Local,
-            storage_backend: "filesystem".to_string(),
-            storage_path: "/tmp/member-1804".to_string(),
-            upstream_url: None,
-            is_public,
-            quota_bytes: None,
-            promotion_only: false,
-            replication_priority: ReplicationPriority::OnDemand,
-            curation_enabled: false,
-            curation_source_repo_id: None,
-            curation_target_repo_id: None,
-            curation_default_action: "allow".to_string(),
-            curation_sync_interval_secs: 0,
-            curation_auto_fetch: false,
-            age_gate_enabled: false,
-            age_gate_min_age_days: 0,
-            project_id: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }
-    }
+    // ── #1804 / #3178: per-member authorization for virtual repos ───────
 
     fn nonadmin_auth(user_id: Uuid) -> crate::api::middleware::auth::AuthExtension {
         crate::api::middleware::auth::AuthExtension {
@@ -11541,64 +11576,75 @@ mod tests {
         }
     }
 
-    /// Verified-bug regression for #1804: a public virtual repo must not serve a
-    /// PRIVATE member's bytes to a caller who could not read that member
-    /// directly. This drives the exact authorization predicate the maven
-    /// download path now applies to every member before fetching bytes:
+    /// Verified-bug regression for #1804, CORRECTED by #3178.
     ///
-    ///   * public member            -> readable by anyone (even anonymous);
-    ///   * private member, no rules  -> readable by any authenticated user,
-    ///                                   denied to anonymous (matches the
-    ///                                   middleware's default access model);
-    ///   * private member WITH rules -> only the caller holding `read` may
-    ///                                   read it; admins are exempt.
+    /// A virtual repo must not serve a PRIVATE member's bytes to a caller who
+    /// could not read that member directly. The predicate is `require_visible`:
     ///
-    /// `authorize_virtual_members` then drops the members the caller could not
-    /// read, so a denied private member behaves as a 404 (never leaked) — the
-    /// fix for the confused-deputy aggregation bypass.
+    /// ```text
+    /// is_public OR (in_scope AND (is_admin OR grants))
+    /// ```
+    ///
+    /// so:
+    ///
+    ///   * public member             -> readable by anyone, even anonymous;
+    ///   * private member, NO grant  -> denied, whether or not the member
+    ///                                  carries fine-grained `permissions` rows;
+    ///   * private member, granted   -> readable (either authz store);
+    ///   * admin                     -> readable.
+    ///
+    /// The middle case is the #3178 correction. This test previously asserted
+    /// the OPPOSITE for a private member with no rules —
+    /// `assert!(caller_can_read_member(perms, Some(&auth), &private_norules))`
+    /// — because the implementation's `Ok(false) => true` arm fell open there.
+    /// The test was written from the implementation, so it pinned the bug
+    /// instead of catching it: an authenticated caller holding NOTHING read a
+    /// private repository's bytes through any virtual that listed it.
+    ///
+    /// Repositories are seeded as REAL rows, not in-memory structs: the grant
+    /// half is evaluated in SQL against `repositories`, so a synthetic id would
+    /// be denied for the wrong reason and the positive controls below would be
+    /// vacuous.
     #[tokio::test]
     async fn test_caller_can_read_member_blocks_private_member_1804() {
+        use crate::api::handlers::test_db_helpers as tdh3178;
         let Some(pool) = db_helpers::try_pool().await else {
             return;
         };
-        let storage_dir = std::env::temp_dir().join(format!("p1804-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(&storage_dir).expect("storage dir");
-        let state = db_helpers::build_state(pool.clone(), storage_dir.to_str().unwrap());
-        let perms = state.permission_service.as_ref();
+        let virtual_id = Uuid::new_v4();
 
-        // Two private members: one with NO fine-grained rules, one WITH rules
-        // (so the user must hold `read`). Plus a public member.
-        let public_id = Uuid::new_v4();
-        let private_norules_id = Uuid::new_v4();
-        let private_ruled_id = Uuid::new_v4();
+        // Three real member repositories: public; private with no fine-grained
+        // rows; private carrying a rule for an UNRELATED principal (the shape
+        // whose absence used to make the gate fall open).
+        let (public_id, _pk, public_dir) = db_helpers::create_repo(&pool, "local", "maven").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(public_id)
+            .execute(&pool)
+            .await
+            .expect("publish member");
+        let (private_norules_id, _nk, norules_dir) =
+            db_helpers::create_repo(&pool, "local", "maven").await;
+        let (private_ruled_id, _rk, ruled_dir) =
+            db_helpers::create_repo(&pool, "local", "maven").await;
 
-        let user_id = Uuid::new_v4();
-        sqlx::query(
-            "INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active) \
-             VALUES ($1, $2, $3, 'unused', 'local', false, true)",
-        )
-        .bind(user_id)
-        .bind(format!("u1804-{}", user_id.simple()))
-        .bind(format!("u1804-{}@test.local", user_id.simple()))
-        .execute(&pool)
-        .await
-        .expect("create user");
+        let (user_id, _uname) = tdh3178::create_user(&pool).await;
+        let (other_id, _oname) = tdh3178::create_user(&pool).await;
 
-        // A rule on `private_ruled_id` (granted to an unrelated principal) makes
-        // `has_any_rules_for_target` true, so the member is gated by `read`.
-        sqlx::query(
-            "INSERT INTO permissions (principal_type, principal_id, target_type, target_id, actions) \
-             VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
-        )
-        .bind(Uuid::new_v4())
-        .bind(private_ruled_id)
-        .execute(&pool)
-        .await
-        .expect("seed ruled-member permission");
+        // A rule on `private_ruled_id` held by someone ELSE.
+        tdh3178::grant_repo_actions(&pool, private_ruled_id, other_id, &["read"]).await;
 
-        let public = member_repo(public_id, true);
-        let private_norules = member_repo(private_norules_id, false);
-        let private_ruled = member_repo(private_ruled_id, false);
+        let load = |id: Uuid| {
+            let pool = pool.clone();
+            async move {
+                crate::services::repository_service::RepositoryService::new(pool)
+                    .get_by_id(id)
+                    .await
+                    .expect("load member row")
+            }
+        };
+        let public = load(public_id).await;
+        let private_norules = load(private_norules_id).await;
+        let private_ruled = load(private_ruled_id).await;
 
         let auth = nonadmin_auth(user_id);
         let admin = crate::api::middleware::auth::AuthExtension {
@@ -11606,73 +11652,79 @@ mod tests {
             ..nonadmin_auth(Uuid::new_v4())
         };
 
-        // Public member: everyone, including anonymous.
-        assert!(caller_can_read_member(perms, None, &public).await);
-        assert!(caller_can_read_member(perms, Some(&auth), &public).await);
+        // Public member: everyone, including anonymous. (Positive control: a
+        // fix that denied everything would fail here.)
+        assert!(caller_can_read_member(&pool, None, virtual_id, &public).await);
+        assert!(caller_can_read_member(&pool, Some(&auth), virtual_id, &public).await);
 
-        // Private member, no rules: anonymous denied, authenticated allowed.
+        // Private member with NO fine-grained rows -- the #3178 correction.
         assert!(
-            !caller_can_read_member(perms, None, &private_norules).await,
+            !caller_can_read_member(&pool, None, virtual_id, &private_norules).await,
             "anonymous must NOT read a private member (the #1804 leak)"
         );
-        assert!(caller_can_read_member(perms, Some(&auth), &private_norules).await);
-
-        // Private member WITH rules: anonymous + zero-grant user denied.
-        assert!(!caller_can_read_member(perms, None, &private_ruled).await);
         assert!(
-            !caller_can_read_member(perms, Some(&auth), &private_ruled).await,
+            !caller_can_read_member(&pool, Some(&auth), virtual_id, &private_norules).await,
+            "#3178: an authenticated caller holding NO grant must not read a private \
+             member just because the member carries no fine-grained permission rows"
+        );
+
+        // Private member WITH rules held by someone else: still denied.
+        assert!(!caller_can_read_member(&pool, None, virtual_id, &private_ruled).await);
+        assert!(
+            !caller_can_read_member(&pool, Some(&auth), virtual_id, &private_ruled).await,
             "zero-grant non-admin must NOT read a ruled private member (#1804)"
         );
         // Admins are exempt.
-        assert!(caller_can_read_member(perms, Some(&admin), &private_ruled).await);
+        assert!(caller_can_read_member(&pool, Some(&admin), virtual_id, &private_ruled).await);
 
-        // The aggregating filter drops members the anonymous caller cannot read,
-        // leaving only the public member (so private members never serve bytes).
+        // The aggregating filter drops what the anonymous caller cannot read,
+        // leaving ONLY the public member.
         let members = vec![
             public.clone(),
             private_norules.clone(),
             private_ruled.clone(),
         ];
-        let allowed_anon = authorize_virtual_members(perms, None, members.clone()).await;
+        let allowed_anon =
+            authorize_virtual_members(&pool, None, virtual_id, members.clone()).await;
         assert_eq!(
             allowed_anon.iter().map(|m| m.id).collect::<Vec<_>>(),
             vec![public_id],
             "anonymous virtual aggregation must keep ONLY public members (#1804)"
         );
 
-        // Grant the user `read` on the ruled member -> it becomes readable, and a
-        // fresh PermissionService (fresh cache) observes the new grant.
-        sqlx::query(
-            "INSERT INTO permissions (principal_type, principal_id, target_type, target_id, actions) \
-             VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
-        )
-        .bind(user_id)
-        .bind(private_ruled_id)
-        .execute(&pool)
-        .await
-        .expect("grant user read");
-        let state2 = db_helpers::build_state(pool.clone(), storage_dir.to_str().unwrap());
-        let perms2 = state2.permission_service.as_ref();
-        let allowed_user = authorize_virtual_members(perms2, Some(&auth), members).await;
+        // POSITIVE CONTROL for the whole change: grant this user on BOTH private
+        // members -- one through each authz store -- and every member comes back.
+        // Without this, a fix that denied all private members would pass.
+        tdh3178::grant_repo_actions(&pool, private_ruled_id, user_id, &["read"]).await;
+        tdh3178::grant_repo_access(&pool, private_norules_id, user_id).await;
+        let allowed_user = authorize_virtual_members(&pool, Some(&auth), virtual_id, members).await;
         assert_eq!(
             allowed_user
                 .iter()
                 .map(|m| m.id)
                 .collect::<std::collections::HashSet<_>>(),
             std::collections::HashSet::from([public_id, private_norules_id, private_ruled_id]),
-            "a user granted read on the member must still see it (no over-restriction)"
+            "a user granted on the members must still see them (no over-restriction)"
         );
 
+        // An admin sees everything regardless of grants.
+        let allowed_admin = authorize_virtual_members(
+            &pool,
+            Some(&admin),
+            virtual_id,
+            vec![public, private_norules, private_ruled],
+        )
+        .await;
+        assert_eq!(allowed_admin.len(), 3, "admin must still see every member");
+
         // -- Cleanup.
-        let _ = sqlx::query("DELETE FROM permissions WHERE target_id = ANY($1)")
-            .bind(vec![private_ruled_id])
-            .execute(&pool)
-            .await;
-        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
-            .bind(user_id)
-            .execute(&pool)
-            .await;
-        let _ = std::fs::remove_dir_all(&storage_dir);
+        db_helpers::cleanup(&pool, public_id, user_id).await;
+        db_helpers::cleanup(&pool, private_norules_id, other_id).await;
+        db_helpers::cleanup(&pool, private_ruled_id, user_id).await;
+        tdh3178::cleanup_user(&pool, other_id).await;
+        for d in [public_dir, norules_dir, ruled_dir] {
+            let _ = std::fs::remove_dir_all(d);
+        }
     }
 
     #[test]

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -421,6 +421,7 @@ async fn version_info(
 
 async fn download_archive(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, archive_path)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -506,6 +507,7 @@ async fn download_archive(
                 let vversion = version.to_string();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -277,6 +277,7 @@ async fn release_info(
 
 async fn download_module(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, file_path)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -297,6 +298,7 @@ async fn download_module(
                 };
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
+                    auth.as_ref(),
                     &repo,
                     &ctx,
                     proxy_helpers::DownloadResponseOpts {

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1736,7 +1736,7 @@ async fn serve_virtual_metadata(
     }
 
     let members =
-        proxy_helpers::authorize_virtual_members(&state.permission_service, auth, members).await;
+        proxy_helpers::authorize_virtual_members(&state.db, auth, virtual_repo.id, members).await;
 
     // Keep PEP 658 metadata resolution symmetric with the simple-index and
     // distribution-download paths. A higher-priority local owner suppresses a
@@ -2420,12 +2420,9 @@ async fn serve_file(
                 // as if it did not contain the artifact (404) and its existence
                 // is never leaked. Routes through the SAME helper the Maven
                 // download path uses.
-                let members = proxy_helpers::authorize_virtual_members(
-                    &state.permission_service,
-                    auth,
-                    members,
-                )
-                .await;
+                let members =
+                    proxy_helpers::authorize_virtual_members(&state.db, auth, repo.id, members)
+                        .await;
 
                 // PEP 708 dependency-confusion guard (#1600), superseding the
                 // version-aware shadowing guard (#1217, #1582) and the

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -446,17 +446,69 @@ fn member_mutation_admin_allowed(is_admin: bool, has_repo_admin: bool) -> bool {
     is_admin || has_repo_admin
 }
 
+/// The gate every virtual-member ATTACH must pass on the MEMBER being attached
+/// (#3177).
+///
+/// Attaching a repository as a virtual member re-exports its contents through a
+/// repository the caller controls, so the member must be one the caller can
+/// actually see. `require_repo_access` is NOT that check: it is a two-line
+/// wrapper over `AuthExtension::can_access_repo`, the caller's TOKEN SCOPE,
+/// which returns `true` for every repository in the instance whenever the
+/// principal is unscoped — which is every browser session. A non-admin who held
+/// `repository:admin` on a virtual of their own could therefore attach any
+/// private repository in the instance and read it straight back out.
+///
+/// The gate is [`require_visible`] — the canonical
+/// `is_public OR (in_scope AND (is_admin OR grants))` — applied to the member
+/// repository the handler has already loaded. A member the caller may not see
+/// therefore collapses to the same existence-hiding 404 as a direct `GET`,
+/// rather than the 403 the old token-scope wrapper produced, which confirmed
+/// the repository exists.
+///
+/// Note this is a VISIBILITY bar, not a write/ownership bar. Whether re-export
+/// through a virtual should additionally require write or ownership on the
+/// member is the open question raised in #3177; raising the bar further is a
+/// product decision, and this change deliberately closes the escalation without
+/// making it.
+async fn require_member_attachable(
+    db: &sqlx::PgPool,
+    auth: &AuthExtension,
+    virtual_repo: &crate::models::repository::Repository,
+    member_repo: &crate::models::repository::Repository,
+    action: &str,
+) -> Result<()> {
+    let service = RepositoryService::new(db.clone());
+    if let Err(e) = require_visible(member_repo, &Some(auth.clone()), &service).await {
+        tracing::warn!(
+            actor_user_id = %auth.user_id,
+            actor_username = %auth.username,
+            virtual_repo_id = %virtual_repo.id,
+            virtual_repo_key = %virtual_repo.key,
+            member_repo_id = %member_repo.id,
+            member_repo_key = %member_repo.key,
+            action = action,
+            "denied virtual-member mutation: member repository is not visible to the caller"
+        );
+        return Err(e);
+    }
+    Ok(())
+}
+
 /// Issue #913: authorize a virtual-member mutation.
 ///
 /// All three mutating handlers (`add_virtual_member`, `remove_virtual_member`,
-/// per-iteration step of `update_virtual_members`) must enforce two things
+/// per-iteration step of `update_virtual_members`) must enforce three things
 /// before mutating membership:
 ///
-///   1. Token-scope (`require_repo_access`) on BOTH the virtual parent and the
-///      member repo. A repository-scoped API token must not reach repos it was
-///      not granted. Tokens with `allowed_repo_ids = None` (admins, JWT
-///      sessions, unrestricted API tokens) pass this naturally.
-///   2. Fine-grained privilege on the virtual parent: managing a virtual
+///   1. Token-scope (`require_repo_access`) on the virtual parent. A
+///      repository-scoped API token must not reach repos it was not granted.
+///      Tokens with `allowed_repo_ids = None` (admins, JWT sessions,
+///      unrestricted API tokens) pass this naturally.
+///   2. VISIBILITY on the member repository being attached
+///      ([`require_member_attachable`]). This slot used to hold a second
+///      `require_repo_access` — token scope again, under a name that reads like
+///      an access check — which is the #3177 privilege escalation.
+///   3. Fine-grained privilege on the virtual parent: managing a virtual
 ///      repository's member resolution graph is an administrative change to
 ///      that repository, so non-admins must hold `repository:admin` on the
 ///      virtual parent — the same check `update_repository` /
@@ -469,6 +521,7 @@ fn member_mutation_admin_allowed(is_admin: bool, has_repo_admin: bool) -> bool {
 /// On denial, emit a structured `tracing::warn!` so the event is recoverable
 /// from logs.
 async fn authorize_virtual_member_mutation(
+    db: &sqlx::PgPool,
     auth: &AuthExtension,
     virtual_repo: &crate::models::repository::Repository,
     member_repo: &crate::models::repository::Repository,
@@ -488,19 +541,7 @@ async fn authorize_virtual_member_mutation(
         );
         return Err(e);
     }
-    if let Err(e) = require_repo_access(auth, member_repo.id) {
-        tracing::warn!(
-            actor_user_id = %auth.user_id,
-            actor_username = %auth.username,
-            virtual_repo_id = %virtual_repo.id,
-            virtual_repo_key = %virtual_repo.key,
-            member_repo_id = %member_repo.id,
-            member_repo_key = %member_repo.key,
-            action = action,
-            "denied virtual-member mutation: caller lacks access to member repo"
-        );
-        return Err(e);
-    }
+    require_member_attachable(db, auth, virtual_repo, member_repo, action).await?;
 
     // Fine-grained privilege gate on the virtual parent. Admins short-circuit
     // with no DB lookup; non-admins need `repository:admin` on the virtual repo.
@@ -2809,6 +2850,14 @@ pub async fn create_repository(
             );
             for (idx, input) in member_inputs.iter().enumerate() {
                 let member_repo = service.get_by_key(&input.repo_key).await?;
+                // #3177: this loop applied NO member check at all -- not even
+                // the token-scope one `authorize_virtual_member_mutation` had.
+                // Creating a virtual with a member list is the same re-export
+                // as attaching one afterwards, so it takes the same visibility
+                // gate. `create_repository` is already gated on system-level
+                // `admin` for non-admins, which makes this the narrower of the
+                // two attach paths -- but "narrower" is not "closed".
+                require_member_attachable(&state.db, &auth, &repo, &member_repo, "create").await?;
                 let priority = resolve_member_priority(input.priority, idx);
                 tracing::debug!(
                     virtual_repo = %repo.key,
@@ -6923,6 +6972,7 @@ pub async fn get_artifact_metadata(
         let state_clone = state.clone();
         let result = proxy_helpers::resolve_virtual_download(
             &state.db,
+            auth.as_ref(),
             proxy_for_virtual,
             repo.id,
             &path,
@@ -8090,7 +8140,7 @@ pub async fn download_artifact(
         .download_stream(
             repo.id,
             &path,
-            auth.map(|a| a.user_id),
+            auth.as_ref().map(|a| a.user_id),
             client_ip_str.clone(),
             user_agent.as_deref(),
             // #2260 §5: a HEAD serves no body, so it must not count.
@@ -8208,6 +8258,7 @@ pub async fn download_artifact(
             let path_clone = path.clone();
             let result = proxy_helpers::resolve_virtual_download(
                 &state.db,
+                auth.as_ref(),
                 proxy_for_virtual,
                 repo.id,
                 &path,
@@ -8680,6 +8731,7 @@ pub async fn add_virtual_member(
     let virtual_repo = service.get_by_key(&key).await?;
     let member_repo = service.get_by_key(&payload.member_key).await?;
     authorize_virtual_member_mutation(
+        &state.db,
         &auth,
         &virtual_repo,
         &member_repo,
@@ -8768,6 +8820,7 @@ pub async fn remove_virtual_member(
     }
     let member_repo = service.get_by_key(&member_key).await?;
     authorize_virtual_member_mutation(
+        &state.db,
         &auth,
         &virtual_repo,
         &member_repo,
@@ -8891,6 +8944,7 @@ pub async fn update_virtual_members(
     for member in &payload.members {
         let member_repo = service.get_by_key(&member.member_key).await?;
         authorize_virtual_member_mutation(
+            &state.db,
             &auth,
             &virtual_repo,
             &member_repo,
@@ -13258,17 +13312,30 @@ mod tests {
         let v = make_repo_with_id(virtual_id, "v");
         let m = make_repo_with_id(member_id, "m");
         let ext = make_auth_ext(Some(vec![virtual_id]));
-        let result =
-            authorize_virtual_member_mutation(&ext, &v, &m, "add", &lazy_perm_service()).await;
+        let result = authorize_virtual_member_mutation(
+            &tdh::lazy_pool(),
+            &ext,
+            &v,
+            &m,
+            "add",
+            &lazy_perm_service(),
+        )
+        .await;
         assert!(
             result.is_err(),
             "caller with access to parent only must be denied"
         );
+        // #3177: the member gate is now VISIBILITY, not token scope, so a
+        // member the caller may not see is existence-hidden as a 404 rather
+        // than answered with a 403 that confirms the repository exists. `m` is
+        // private and out of the token's scope, so `require_visible` refuses
+        // at its `can_access_repo` conjunct -- with no database round trip,
+        // which is why the lazy pool here is never contacted.
         match result.unwrap_err() {
-            AppError::Authorization(msg) => {
-                assert!(msg.contains("does not have access"))
+            AppError::NotFound(msg) => {
+                assert!(msg.contains("not found"), "unexpected message: {msg}")
             }
-            other => panic!("Expected Authorization error, got: {:?}", other),
+            other => panic!("Expected NotFound error, got: {:?}", other),
         }
     }
 
@@ -13281,8 +13348,15 @@ mod tests {
         let v = make_repo_with_id(virtual_id, "v");
         let m = make_repo_with_id(member_id, "m");
         let ext = make_auth_ext(Some(vec![member_id]));
-        let result =
-            authorize_virtual_member_mutation(&ext, &v, &m, "remove", &lazy_perm_service()).await;
+        let result = authorize_virtual_member_mutation(
+            &tdh::lazy_pool(),
+            &ext,
+            &v,
+            &m,
+            "remove",
+            &lazy_perm_service(),
+        )
+        .await;
         assert!(
             result.is_err(),
             "caller with access to member only must be denied"
@@ -13298,8 +13372,15 @@ mod tests {
         let v = make_repo_with_id(virtual_id, "v");
         let m = make_repo_with_id(member_id, "m");
         let ext = make_admin_ext();
-        let result =
-            authorize_virtual_member_mutation(&ext, &v, &m, "update", &lazy_perm_service()).await;
+        let result = authorize_virtual_member_mutation(
+            &tdh::lazy_pool(),
+            &ext,
+            &v,
+            &m,
+            "update",
+            &lazy_perm_service(),
+        )
+        .await;
         assert!(
             result.is_ok(),
             "admin must be allowed via is_admin short-circuit with no DB: {:?}",
@@ -13317,8 +13398,15 @@ mod tests {
         let v = make_repo_with_id(virtual_id, "v");
         let m = make_repo_with_id(member_id, "m");
         let ext = make_auth_ext(Some(vec![other]));
-        let result =
-            authorize_virtual_member_mutation(&ext, &v, &m, "add", &lazy_perm_service()).await;
+        let result = authorize_virtual_member_mutation(
+            &tdh::lazy_pool(),
+            &ext,
+            &v,
+            &m,
+            "add",
+            &lazy_perm_service(),
+        )
+        .await;
         assert!(result.is_err());
     }
 
@@ -14116,13 +14204,22 @@ mod tests {
         let virtual_id = Uuid::new_v4();
         let member_id = Uuid::new_v4();
         let v = make_repo_with_id(virtual_id, "v");
-        let m = make_repo_with_id(member_id, "m");
+        // #3177: this test measures the `repository:admin` gate on the PARENT.
+        // Make the member PUBLIC so `require_member_attachable` early-returns
+        // and cannot be what fails -- otherwise a denial here would no longer
+        // distinguish the two gates. The member gate has its own coverage in
+        // `virtual_member_authz_tests`.
+        let m = crate::models::repository::Repository {
+            is_public: true,
+            ..make_repo_with_id(member_id, "m")
+        };
         // Non-admin, unrestricted token-scope (allowed_repo_ids = None) — exactly
         // the password/JWT session shape that the old code let through.
         let ext = tdh::make_auth(user_id, &username);
 
         // Deny: no repository:admin grant on the virtual parent.
         let denied = authorize_virtual_member_mutation(
+            &pool,
             &ext,
             &v,
             &m,
@@ -14153,6 +14250,7 @@ mod tests {
         .expect("grant repository:admin");
 
         let allowed = authorize_virtual_member_mutation(
+            &pool,
             &ext,
             &v,
             &m,
@@ -17317,6 +17415,13 @@ mod tests {
         .await
         .expect("add virtual member");
 
+        // #3178: the virtual byte paths now filter members by CALLER, so the
+        // fixture user needs a grant on the MEMBER, not just on the virtual
+        // parent. Before that fix this test passed without one -- which is
+        // precisely the leak: an unentitled caller was served the member's
+        // bytes.
+        tdh::grant_repo_access(&fx.pool, member_id, fx.user_id).await;
+
         let body_bytes: &[u8] = b"virtual-member-content-bytes";
         let member_repo = tdh::make_repo_info(member_id, &member_key, &member_dir, "local", None);
         let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
@@ -17371,11 +17476,16 @@ mod tests {
         assert_eq!(rows[0].2.as_deref(), Some("dl-telemetry-test/1.0"));
 
         // Anonymous content GET: user_id records as NULL, not dropped.
-        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
-            .bind(fx.repo_id)
+        // #3178: a PUBLIC virtual no longer re-exports a PRIVATE member to
+        // anonymous callers, so publish the MEMBER as well. This test is about
+        // download attribution, not authorization; the authorization behaviour
+        // it used to depend on is now asserted (inverted) in
+        // `virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![fx.repo_id, member_id])
             .execute(&fx.pool)
             .await
-            .expect("make virtual repo public");
+            .expect("make virtual repo and member public");
         let mut anon_req = tdh::get(format!("/{}/artifacts/vpath/blob.bin", fx.repo_key));
         anon_req
             .headers_mut()
@@ -17548,6 +17658,13 @@ mod tests {
         .await
         .expect("add virtual member");
 
+        // #3178: the virtual byte paths now filter members by CALLER, so the
+        // fixture user needs a grant on the MEMBER, not just on the virtual
+        // parent. Before that fix this test passed without one -- which is
+        // precisely the leak: an unentitled caller was served the member's
+        // bytes.
+        tdh::grant_repo_access(&fx.pool, member_id, fx.user_id).await;
+
         let body_bytes: &[u8] = b"virtual-member-download-bytes";
         let member_repo = tdh::make_repo_info(member_id, &member_key, &member_dir, "local", None);
         let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
@@ -17602,11 +17719,16 @@ mod tests {
         assert_eq!(rows[0].2.as_deref(), Some("dl-telemetry-test/2.0"));
 
         // Anonymous download: user_id records as NULL, not dropped.
-        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
-            .bind(fx.repo_id)
+        // #3178: a PUBLIC virtual no longer re-exports a PRIVATE member to
+        // anonymous callers, so publish the MEMBER as well. This test is about
+        // download attribution, not authorization; the authorization behaviour
+        // it used to depend on is now asserted (inverted) in
+        // `virtual_member_authz_tests`.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![fx.repo_id, member_id])
             .execute(&fx.pool)
             .await
-            .expect("make virtual repo public");
+            .expect("make virtual repo and member public");
         let mut anon_req = tdh::get(format!("/{}/download/vdl/blob.bin", fx.repo_key));
         anon_req
             .headers_mut()

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -23149,3 +23149,556 @@ mod virtual_member_visibility_tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #3177 / #3178: virtual-repository member AUTHORIZATION
+// ---------------------------------------------------------------------------
+//
+// Both issues are the same root cause wearing two names: `can_access_repo` --
+// the caller's TOKEN SCOPE -- used where repository VISIBILITY was meant.
+// `can_access_repo` returns `true` for every repository in the instance
+// whenever the principal is unscoped, which is every browser JWT session.
+//
+//   * #3178 (read/bytes) -- `proxy_helpers::resolve_virtual_download` takes no
+//     caller at all, so `GET /{key}/download/*path` and
+//     `GET /{key}/artifacts/*path` stream a PRIVATE member's bytes to anyone
+//     who can see the virtual parent, including anonymous callers when the
+//     parent is public. The one predicate that does exist,
+//     `proxy_helpers::caller_can_read_member`, gates on
+//     `can_access_repo(member.id)` and then falls OPEN (`Ok(false) => true`)
+//     when the member carries no fine-grained permission rows.
+//   * #3177 (write) -- `authorize_virtual_member_mutation` checks the member
+//     being attached with `require_repo_access`, a two-line wrapper over the
+//     same `can_access_repo`. A repo-admin on their OWN virtual can therefore
+//     attach any private repository in the instance, then read it through the
+//     hole above.
+//
+// The correct predicate in both places is `require_visible`'s composition:
+//
+//     is_public OR (in_scope AND (is_admin OR grants))
+//
+// Every fixture below is shaped so that each denial assertion ships with a
+// POSITIVE CONTROL in the SAME fixture -- an entitled caller still gets the
+// bytes, an admin still sees everything, a public member is still reachable.
+// A "fix" that denied everyone would fail those controls.
+#[cfg(test)]
+mod virtual_member_authz_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use crate::api::middleware::auth::AuthExtension;
+    use axum::http::StatusCode;
+    use bytes::Bytes;
+    use sqlx::PgPool;
+
+    /// Bytes only an entitled caller may ever see.
+    const SECRET_BYTES: &[u8] = b"VICTIM-CROWN-JEWELS";
+    /// Bytes of the PUBLIC member -- the positive control. Every caller,
+    /// including anonymous, must keep getting these.
+    const OPEN_BYTES: &[u8] = b"PUBLIC-MEMBER-CONTROL";
+    const SECRET_PATH: &str = "vm/secret.bin";
+    const OPEN_PATH: &str = "vm/open.bin";
+
+    /// A virtual parent with one PRIVATE and one PUBLIC member, plus the four
+    /// principals every assertion is made as.
+    ///
+    /// * `virt`   -- the virtual parent, private. `viewer` and `insider` hold a
+    ///   grant on it; `outsider` holds nothing.
+    /// * `secret` -- PRIVATE member holding [`SECRET_BYTES`]. Only `insider`
+    ///   (and the global admin) may read it. `viewer`'s direct `GET` 404s.
+    /// * `open`   -- PUBLIC member holding [`OPEN_BYTES`]. Readable by anyone,
+    ///   which is what makes it a usable control.
+    struct Fx {
+        pool: PgPool,
+        state: SharedState,
+        virt_id: Uuid,
+        virt_key: String,
+        secret_id: Uuid,
+        secret_key: String,
+        open_id: Uuid,
+        open_key: String,
+        dirs: Vec<std::path::PathBuf>,
+        owner: (Uuid, String),
+        viewer: (Uuid, String),
+        insider: (Uuid, String),
+        outsider: (Uuid, String),
+        admin: (Uuid, String),
+    }
+
+    async fn link_member(pool: &PgPool, virt: Uuid, member: Uuid, priority: i32) {
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(virt)
+        .bind(member)
+        .bind(priority)
+        .execute(pool)
+        .await
+        .expect("link virtual member");
+    }
+
+    impl Fx {
+        async fn setup() -> Option<Fx> {
+            let pool = tdh::try_pool().await?;
+            let (virt_id, virt_key, virt_dir) = tdh::create_repo(&pool, "virtual", "generic").await;
+            let (secret_id, secret_key, secret_dir) =
+                tdh::create_repo(&pool, "local", "generic").await;
+            let (open_id, open_key, open_dir) = tdh::create_repo(&pool, "local", "generic").await;
+            sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+                .bind(open_id)
+                .execute(&pool)
+                .await
+                .expect("publish the public member");
+
+            link_member(&pool, virt_id, secret_id, 1).await;
+            link_member(&pool, virt_id, open_id, 2).await;
+
+            let owner = tdh::create_user(&pool).await;
+            let viewer = tdh::create_user(&pool).await;
+            let insider = tdh::create_user(&pool).await;
+            let outsider = tdh::create_user(&pool).await;
+            let admin = tdh::create_user(&pool).await;
+
+            // `viewer` sees the virtual PARENT only. `insider` additionally
+            // holds a grant on the private member, so the member is genuinely
+            // readable by them -- that is the positive control.
+            tdh::grant_repo_access(&pool, virt_id, viewer.0).await;
+            tdh::grant_repo_access(&pool, virt_id, insider.0).await;
+            tdh::grant_repo_access(&pool, secret_id, insider.0).await;
+            tdh::grant_repo_access(&pool, virt_id, owner.0).await;
+
+            let state = tdh::build_state(pool.clone(), virt_dir.to_str().unwrap());
+
+            let secret_info =
+                tdh::make_repo_info(secret_id, &secret_key, &secret_dir, "local", None);
+            tdh::seed_artifact(
+                &state,
+                &pool,
+                &secret_info,
+                &format!("vma/{}.bin", Uuid::new_v4()),
+                SECRET_PATH,
+                "secret",
+                "1.0.0",
+                "application/octet-stream",
+                Bytes::from_static(SECRET_BYTES),
+                owner.0,
+            )
+            .await;
+
+            let open_info = tdh::make_repo_info(open_id, &open_key, &open_dir, "local", None);
+            tdh::seed_artifact(
+                &state,
+                &pool,
+                &open_info,
+                &format!("vma/{}.bin", Uuid::new_v4()),
+                OPEN_PATH,
+                "open",
+                "1.0.0",
+                "application/octet-stream",
+                Bytes::from_static(OPEN_BYTES),
+                owner.0,
+            )
+            .await;
+
+            Some(Fx {
+                pool,
+                state,
+                virt_id,
+                virt_key,
+                secret_id,
+                secret_key,
+                open_id,
+                open_key,
+                dirs: vec![virt_dir, secret_dir, open_dir],
+                owner,
+                viewer,
+                insider,
+                outsider,
+                admin,
+            })
+        }
+
+        fn session(&self, who: &(Uuid, String)) -> AuthExtension {
+            tdh::make_auth(who.0, &who.1)
+        }
+
+        fn admin_session(&self) -> AuthExtension {
+            tdh::admin_auth(self.admin.0, &self.admin.1)
+        }
+
+        /// Both byte-serving virtual routes live here: `/:key/download/*path`
+        /// is in `download_router()`, `/:key/artifacts/*path` in `router()`.
+        fn byte_routes() -> Router<SharedState> {
+            super::router().merge(super::download_router())
+        }
+
+        async fn fetch_as(&self, uri: String, auth: Option<AuthExtension>) -> (StatusCode, Bytes) {
+            let router = match auth {
+                Some(a) => tdh::router_with_auth(Self::byte_routes(), self.state.clone(), a),
+                None => tdh::router_anon(Self::byte_routes(), self.state.clone()),
+            };
+            tdh::send(router, tdh::get(uri)).await
+        }
+
+        async fn make_virt_public(&self) {
+            sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+                .bind(self.virt_id)
+                .execute(&self.pool)
+                .await
+                .expect("publish virtual parent");
+        }
+
+        async fn teardown(&self) {
+            let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+                .bind(self.virt_id)
+                .execute(&self.pool)
+                .await;
+            for (repo, user) in [
+                (self.virt_id, self.owner.0),
+                (self.secret_id, self.viewer.0),
+                (self.open_id, self.insider.0),
+            ] {
+                tdh::cleanup(&self.pool, repo, user).await;
+            }
+            for u in [&self.outsider, &self.admin] {
+                tdh::cleanup_user(&self.pool, u.0).await;
+            }
+            for d in &self.dirs {
+                let _ = std::fs::remove_dir_all(d);
+            }
+        }
+    }
+
+    /// #3178, `/download/*path`: a caller who can see the virtual PARENT but
+    /// holds no grant on a PRIVATE member must not receive that member's bytes
+    /// through the virtual.
+    ///
+    /// Controls in the same fixture: `insider` (grant on the member) and the
+    /// global admin must both still get [`SECRET_BYTES`], and `viewer` must
+    /// still get the public member's [`OPEN_BYTES`]. Denying everyone fails.
+    #[tokio::test]
+    async fn test_3178_virtual_download_denies_unentitled_caller() {
+        let Some(fx) = Fx::setup().await else {
+            return;
+        };
+
+        // Ground truth: `viewer` genuinely cannot see the member directly.
+        let (direct, _) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.secret_key, SECRET_PATH),
+                Some(fx.session(&fx.viewer)),
+            )
+            .await;
+        assert_eq!(
+            direct,
+            StatusCode::NOT_FOUND,
+            "precondition: viewer's DIRECT read of the private member must 404"
+        );
+
+        // THE LEAK.
+        let (status, body) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.virt_key, SECRET_PATH),
+                Some(fx.session(&fx.viewer)),
+            )
+            .await;
+        assert_ne!(
+            &body[..],
+            SECRET_BYTES,
+            "#3178: virtual /download/ served a PRIVATE member's bytes to a caller \
+             whose direct GET of that member 404s (status {status})"
+        );
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "#3178: unentitled caller must get 404 from the virtual download path"
+        );
+
+        // POSITIVE CONTROL 1: the entitled caller still gets the bytes.
+        let (ok_status, ok_body) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.virt_key, SECRET_PATH),
+                Some(fx.session(&fx.insider)),
+            )
+            .await;
+        assert_eq!(
+            ok_status,
+            StatusCode::OK,
+            "control: a caller granted on the member must still resolve it"
+        );
+        assert_eq!(
+            &ok_body[..],
+            SECRET_BYTES,
+            "control: entitled caller must still receive the member's bytes"
+        );
+
+        // POSITIVE CONTROL 2: a global admin still sees everything.
+        let (admin_status, admin_body) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.virt_key, SECRET_PATH),
+                Some(fx.admin_session()),
+            )
+            .await;
+        assert_eq!(admin_status, StatusCode::OK, "control: admin must resolve");
+        assert_eq!(
+            &admin_body[..],
+            SECRET_BYTES,
+            "control: admin must still receive the member's bytes"
+        );
+
+        // POSITIVE CONTROL 3: the PUBLIC member stays reachable for `viewer`.
+        let (pub_status, pub_body) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.virt_key, OPEN_PATH),
+                Some(fx.session(&fx.viewer)),
+            )
+            .await;
+        assert_eq!(
+            pub_status,
+            StatusCode::OK,
+            "control: a PUBLIC member must stay reachable through the virtual"
+        );
+        assert_eq!(&pub_body[..], OPEN_BYTES, "control: public member bytes");
+
+        fx.teardown().await;
+    }
+
+    /// #3178, `/artifacts/*path`: the sibling byte route through
+    /// `get_artifact_metadata`'s Virtual branch has the same hole.
+    #[tokio::test]
+    async fn test_3178_virtual_artifacts_path_denies_unentitled_caller() {
+        let Some(fx) = Fx::setup().await else {
+            return;
+        };
+
+        let (status, body) = fx
+            .fetch_as(
+                format!("/{}/artifacts/{}", fx.virt_key, SECRET_PATH),
+                Some(fx.session(&fx.viewer)),
+            )
+            .await;
+        assert_ne!(
+            &body[..],
+            SECRET_BYTES,
+            "#3178: virtual /artifacts/ served a PRIVATE member's bytes to an \
+             unentitled caller (status {status})"
+        );
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "#3178: unentitled caller must get 404 from the virtual artifacts path"
+        );
+
+        // POSITIVE CONTROLS in the same fixture.
+        let (ok_status, ok_body) = fx
+            .fetch_as(
+                format!("/{}/artifacts/{}", fx.virt_key, SECRET_PATH),
+                Some(fx.session(&fx.insider)),
+            )
+            .await;
+        assert_eq!(ok_status, StatusCode::OK, "control: entitled caller");
+        assert_eq!(&ok_body[..], SECRET_BYTES, "control: entitled caller bytes");
+
+        let (pub_status, pub_body) = fx
+            .fetch_as(
+                format!("/{}/artifacts/{}", fx.virt_key, OPEN_PATH),
+                Some(fx.session(&fx.viewer)),
+            )
+            .await;
+        assert_eq!(pub_status, StatusCode::OK, "control: public member");
+        assert_eq!(&pub_body[..], OPEN_BYTES, "control: public member bytes");
+
+        fx.teardown().await;
+    }
+
+    /// #3178, the worst shape: a PUBLIC virtual with a PRIVATE member served
+    /// [`SECRET_BYTES`] to a request carrying NO credentials at all.
+    #[tokio::test]
+    async fn test_3178_public_virtual_denies_anonymous_private_member_bytes() {
+        let Some(fx) = Fx::setup().await else {
+            return;
+        };
+        fx.make_virt_public().await;
+
+        let (status, body) = fx
+            .fetch_as(format!("/{}/download/{}", fx.virt_key, SECRET_PATH), None)
+            .await;
+        assert_ne!(
+            &body[..],
+            SECRET_BYTES,
+            "#3178: an ANONYMOUS request read a private member's bytes through a \
+             public virtual (status {status})"
+        );
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "#3178: anonymous caller must get 404 for a private member"
+        );
+
+        // POSITIVE CONTROL: anonymous must still get the PUBLIC member, which
+        // is the whole point of a public virtual.
+        let (pub_status, pub_body) = fx
+            .fetch_as(format!("/{}/download/{}", fx.virt_key, OPEN_PATH), None)
+            .await;
+        assert_eq!(
+            pub_status,
+            StatusCode::OK,
+            "control: anonymous must still reach the PUBLIC member"
+        );
+        assert_eq!(&pub_body[..], OPEN_BYTES, "control: public member bytes");
+
+        // POSITIVE CONTROL: the entitled caller is unaffected by the parent
+        // flipping public.
+        let (ok_status, ok_body) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.virt_key, SECRET_PATH),
+                Some(fx.session(&fx.insider)),
+            )
+            .await;
+        assert_eq!(ok_status, StatusCode::OK, "control: entitled caller");
+        assert_eq!(&ok_body[..], SECRET_BYTES, "control: entitled caller bytes");
+
+        fx.teardown().await;
+    }
+
+    /// #3177: a repo-admin on their OWN virtual repository must not be able to
+    /// attach a private repository they cannot see.
+    ///
+    /// `outsider` is given a virtual of their own plus `repository:admin` on
+    /// it -- everything the mutation gate legitimately requires -- and holds
+    /// nothing at all on `secret`.
+    ///
+    /// Controls in the same fixture: the same caller may still attach a PUBLIC
+    /// repository and a repository they hold a grant on, and a global admin may
+    /// still attach `secret`.
+    #[tokio::test]
+    async fn test_3177_member_attach_requires_member_visibility() {
+        let Some(fx) = Fx::setup().await else {
+            return;
+        };
+        let (own_id, own_key, own_dir) = tdh::create_repo(&fx.pool, "virtual", "generic").await;
+        tdh::grant_repo_access(&fx.pool, own_id, fx.outsider.0).await;
+        tdh::grant_repo_admin(&fx.pool, own_id, fx.outsider.0).await;
+
+        // A private repo the attacker DOES hold a grant on -- the control that
+        // proves the fix did not simply deny every attach.
+        let (granted_id, granted_key, granted_dir) =
+            tdh::create_repo(&fx.pool, "local", "generic").await;
+        tdh::grant_repo_access(&fx.pool, granted_id, fx.outsider.0).await;
+
+        let attach = |auth: AuthExtension, virt: String, member: String| {
+            let state = fx.state.clone();
+            async move {
+                let router = tdh::router_with_auth(super::router(), state, auth);
+                tdh::send(
+                    router,
+                    tdh::post(
+                        format!("/{virt}/members"),
+                        "application/json",
+                        Bytes::from(format!(r#"{{"member_key":"{member}"}}"#)),
+                    ),
+                )
+                .await
+            }
+        };
+
+        let member_row_exists = |virt: Uuid, member: Uuid| {
+            let pool = fx.pool.clone();
+            async move {
+                sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*) FROM virtual_repo_members \
+                     WHERE virtual_repo_id = $1 AND member_repo_id = $2",
+                )
+                .bind(virt)
+                .bind(member)
+                .fetch_one(&pool)
+                .await
+                .expect("count membership rows")
+                    > 0
+            }
+        };
+
+        // Ground truth: the attacker genuinely cannot see `secret`.
+        let (direct, _) = fx
+            .fetch_as(
+                format!("/{}/download/{}", fx.secret_key, SECRET_PATH),
+                Some(fx.session(&fx.outsider)),
+            )
+            .await;
+        assert_eq!(
+            direct,
+            StatusCode::NOT_FOUND,
+            "precondition: attacker's DIRECT read of the victim repo must 404"
+        );
+
+        // THE ESCALATION.
+        let (status, body) = attach(
+            fx.session(&fx.outsider),
+            own_key.clone(),
+            fx.secret_key.clone(),
+        )
+        .await;
+        assert_ne!(
+            status,
+            StatusCode::OK,
+            "#3177: a repo-admin attached a PRIVATE repository they cannot see as a \
+             virtual member: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert!(
+            !member_row_exists(own_id, fx.secret_id).await,
+            "#3177: the membership row was persisted despite the caller having no \
+             visibility on the member"
+        );
+
+        // POSITIVE CONTROL 1: a PUBLIC repository still attaches.
+        let (pub_status, pub_body) = attach(
+            fx.session(&fx.outsider),
+            own_key.clone(),
+            fx.open_key.clone(),
+        )
+        .await;
+        assert_eq!(
+            pub_status,
+            StatusCode::OK,
+            "control: attaching a PUBLIC repository must still succeed: {}",
+            String::from_utf8_lossy(&pub_body)
+        );
+
+        // POSITIVE CONTROL 2: a private repository the caller IS granted on
+        // still attaches.
+        let (granted_status, granted_body) = attach(
+            fx.session(&fx.outsider),
+            own_key.clone(),
+            granted_key.clone(),
+        )
+        .await;
+        assert_eq!(
+            granted_status,
+            StatusCode::OK,
+            "control: attaching a repository the caller holds a grant on must still \
+             succeed: {}",
+            String::from_utf8_lossy(&granted_body)
+        );
+
+        // POSITIVE CONTROL 3: a global admin may still attach anything.
+        let (admin_status, admin_body) =
+            attach(fx.admin_session(), own_key.clone(), fx.secret_key.clone()).await;
+        assert_eq!(
+            admin_status,
+            StatusCode::OK,
+            "control: a global admin must still be able to attach any member: {}",
+            String::from_utf8_lossy(&admin_body)
+        );
+
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(own_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup(&fx.pool, own_id, fx.outsider.0).await;
+        tdh::cleanup(&fx.pool, granted_id, fx.outsider.0).await;
+        let _ = std::fs::remove_dir_all(&own_dir);
+        let _ = std::fs::remove_dir_all(&granted_dir);
+        fx.teardown().await;
+    }
+}

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1414,6 +1414,7 @@ async fn upstream_proxy(
 
 async fn download_package(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, pkg_path)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -1433,6 +1434,7 @@ async fn download_package(
                 };
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
+                    auth.as_ref(),
                     &repo,
                     &ctx,
                     proxy_helpers::DownloadResponseOpts {

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -200,6 +200,7 @@ async fn gem_versions(
 
 async fn download_gem(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, gem_file)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -243,6 +244,7 @@ async fn download_gem(
 
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
+                    auth.as_ref(),
                     &repo,
                     &ctx,
                     proxy_helpers::DownloadResponseOpts {

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -61,6 +61,7 @@ async fn resolve_sbt_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respo
 
 async fn download_by_path(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, artifact_path)): Path<(String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -113,6 +114,7 @@ async fn download_by_path(
                 let path_clone = artifact_path.to_string();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     artifact_path,

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -321,6 +321,7 @@ pub async fn query_release_versions_virtual(
 
 async fn version_path_handler(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, scope, name, version_path)): Path<(String, String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -329,7 +330,16 @@ async fn version_path_handler(
     if version_path.ends_with(".zip") {
         // Download source archive: /:scope/:name/:version.zip
         let version = version_path.trim_end_matches(".zip");
-        return download_archive(state, &repo_key, &scope, &name, version, &ctx).await;
+        return download_archive(
+            state,
+            auth.as_ref(),
+            &repo_key,
+            &scope,
+            &name,
+            version,
+            &ctx,
+        )
+        .await;
     }
 
     if version_path.ends_with("/Package.swift") || version_path.contains("/Package.swift") {
@@ -491,6 +501,7 @@ async fn get_release_metadata(
 
 async fn download_archive(
     state: SharedState,
+    auth: Option<&crate::api::middleware::auth::AuthExtension>,
     repo_key: &str,
     scope: &str,
     name: &str,
@@ -557,6 +568,7 @@ async fn download_archive(
                 let upstream_path = format!("{}/{}/{}.zip", scope, name, version);
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth,
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,
@@ -1570,6 +1582,7 @@ mod db_cov_tests {
             }
             let result = super::download_archive(
                 state.clone(),
+                tdh::admin_auth_ext().as_ref(),
                 &fx.repo_key,
                 "apple",
                 "swift-nio",

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -272,6 +272,7 @@ async fn list_module_versions(
 
 async fn download_module(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, namespace, name, provider, version)): Path<(
         String,
         String,
@@ -349,6 +350,7 @@ async fn download_module(
                 let vversion = version.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,
@@ -796,6 +798,7 @@ async fn list_provider_versions(
 
 async fn download_provider(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, namespace, type_name, version, os, arch)): Path<(
         String,
         String,
@@ -881,6 +884,7 @@ async fn download_provider(
                 let vversion = version.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1600,3 +1600,20 @@ pub async fn collect_response(
         .expect("body");
     (status, body, headers)
 }
+
+/// An admin-shaped `Extension<Option<AuthExtension>>` payload for tests that
+/// invoke a download handler (or `proxy_helpers` resolver) DIRECTLY rather than
+/// through a router.
+///
+/// Since #3178 the virtual-repo byte resolvers filter members by caller, so a
+/// direct call must supply one. A global admin reproduces the pre-#3178
+/// unfiltered member set exactly, which keeps those tests measuring what they
+/// were written to measure (resolution order, caching, telemetry) instead of
+/// silently becoming authorization tests. Authorization itself is covered by
+/// `repositories::virtual_member_authz_tests`.
+///
+/// No `users` row is required: `RepoVisibility::All` short-circuits before any
+/// query.
+pub fn admin_auth_ext() -> Option<AuthExtension> {
+    Some(admin_auth(Uuid::new_v4(), "tdh-resolver-admin"))
+}

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -132,6 +132,7 @@ async fn query_extensions(
 
 async fn download_vsix(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, publisher, name, version)): Path<(String, String, String, String)>,
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
@@ -191,6 +192,7 @@ async fn download_vsix(
                 let vversion = version.clone();
                 let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
+                    auth.as_ref(),
                     state.proxy_service.as_deref(),
                     repo.id,
                     &upstream_path,


### PR DESCRIPTION
## Summary

`#3177` and `#3178` are the same root cause with two names: **`can_access_repo` — the caller's TOKEN SCOPE — used where repository VISIBILITY was meant.** `can_access_repo` returns `true` for every repository in the instance whenever the principal is unscoped, which is every browser session, so as an access check it was inert for the common caller.

One PR, because a single predicate fixes both and splitting it would mean writing that predicate twice.

* **#3178 (read)** — `proxy_helpers::resolve_virtual_download` took *no caller at all*, so it structurally could not filter members. The one predicate that did exist, `caller_can_read_member`, gated on `can_access_repo(member.id)` and then had `Ok(false) => true`: a private member carrying no fine-grained `permissions` rows was readable by any authenticated caller. Confirmed, not assumed — see the reproduction below.
* **#3177 (write)** — `authorize_virtual_member_mutation` checked the member being attached with `require_repo_access`, a two-line wrapper over the same `can_access_repo`. `create_repository`'s member loop had no member check at all.

## The predicate

Everything now evaluates `require_visible`'s composition:

```
is_public OR (in_scope AND (is_admin OR grants))
```

built by **reusing the helpers #3162/#3173 introduced**, not a fourth variant: `member_grant_visibility` (grant half, in SQL via `filter_visible_repo_ids`) composed with `member_passes_token_scope` (scope half, per row). Listing and byte resolution now evaluate the same predicate from the same code, so they cannot drift.

Two consequences worth stating:

* The entitlement half is now identical to a direct read of the member — `build_grant_predicate` honours both the `role_assignments` store and fine-grained `permissions`, including group grants. A member is readable through a virtual exactly when its own `GET` would succeed.
* Denials collapse to the same `404` a genuine miss produces, and `resolve_virtual_download` no longer distinguishes "this virtual is empty" from "this virtual has members you may not see" — that difference was an existence oracle over private repositories.

`authorize_virtual_members` fails **closed**: a database error yields the empty member set, never the unfiltered one.

## What changed

* `proxy_helpers::authorize_virtual_members` — rewritten to the predicate above; `caller_can_read_member` is now a single-member wrapper over it. Both take `&PgPool` instead of `&PermissionService`.
* `resolve_virtual_download` and `resolve_virtual_download_streaming` take the caller and filter members **before any member is probed**. This closes all 22 + 7 call sites at once rather than one handler at a time, and means the next format handler cannot reintroduce the hole by forgetting a check. `Extension(auth)` was added to the ~25 route handlers that lacked it; four internal helpers (`goproxy::get_mod_file`/`download_zip`, `swift::download_archive`, `huggingface::download_file_impl`, `hex::serve_virtual_tarball_local_only`) take it as a parameter.
* `npm::serve_tarball`, `goproxy::download_zip` and `debian::pool_download` reach `resolve_virtual_download_from_members` directly with format-filtered member lists; they now authorize **before** that filtering.
* `authorize_virtual_member_mutation` gates the member on `require_visible` (the handler already has the loaded `Repository`, so no extra lookup). `create_repository`'s member loop gets the same gate.
* `require_repo_access` is left in place for the virtual **parent**, where token scope is the right question. Renaming it to say what it checks — the suggestion in #3177 — is deliberately not done here so this diff stays reviewable as a security fix.

## Verification

Both reproduced on unmodified `origin/main` first. `SECRET_BYTES` is `VICTIM-CROWN-JEWELS`; every fixture is three-repository shaped (private virtual parent, private member, **public** member) so each denial ships with a positive control in the same fixture.

**On `origin/main` — 4 failed, 0 passed:**

```
test test_3177_member_attach_requires_member_visibility ... FAILED
assertion `left != right` failed: #3177: a repo-admin attached a PRIVATE repository
  they cannot see as a virtual member: {"id":"8882adf2-...","member_repo_key":"ph-test-generic-9d189fac-..."}
  left: 200   right: 200

test test_3178_public_virtual_denies_anonymous_private_member_bytes ... FAILED
assertion `left != right` failed: #3178: an ANONYMOUS request read a private member's
  bytes through a public virtual (status 200 OK)
  left: [86, 73, 67, 84, 73, 77, 45, 67, 82, 79, 87, 78, 45, 74, 69, 87, 69, 76, 83]

test test_3178_virtual_artifacts_path_denies_unentitled_caller ... FAILED
test test_3178_virtual_download_denies_unentitled_caller ... FAILED

test result: FAILED. 0 passed; 4 failed
```

The `precondition:` assertions ran first and did not fire, so the attacker genuinely could not see the victim repository directly (`404`) while reading it through the virtual (`200`).

**With the fix — 4 passed,** including every positive control: the granted caller and a global admin still receive `SECRET_BYTES`, the public member stays reachable (anonymously, through a public virtual), and the attacker may still attach a public repository and one they hold a grant on, while an admin may still attach anything.

**Full production revert (predicate + caller threading restored to their pre-fix form, tests untouched) — 4 failed again:**

```
test test_3177_member_attach_requires_member_visibility ... FAILED
test test_3178_public_virtual_denies_anonymous_private_member_bytes ... FAILED
test test_3178_virtual_artifacts_path_denies_unentitled_caller ... FAILED
test test_3178_virtual_download_denies_unentitled_caller ... FAILED
test result: FAILED. 0 passed; 4 failed
```

A partial revert of the predicate alone left the anonymous case passing, and a partial revert of the caller threading alone left the others passing — so both halves are load-bearing and neither is decoration.

### Tests that were pinning the bug

`test_caller_can_read_member_blocks_private_member_1804` asserted the fail-open directly:

```rust
assert!(caller_can_read_member(perms, Some(&auth), &private_norules).await);
```

It was written from the implementation, so it pinned the defect instead of catching it. Rewritten to the corrected model against **real** repository rows — the grant half is SQL over `repositories`, so the previous in-memory `Repository` structs would have been denied for the wrong reason and made the positive controls vacuous.

Ten pre-existing fixtures depended on the leak: they linked a **private** member and never granted the acting user on it (two `repositories` telemetry tests, five `maven`, two `hex`, one `cargo` — the `cargo` one was **anonymous**). Each is about resolution order, shadowing or attribution rather than authorization, so each now grants or publishes its member, with a comment recording that it previously passed only because the predicate fell open.

## Gates

* `cargo fmt --check` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- repositories:: proxy_helpers repository_service` — **851 passed, 0 failed**
* All touched format-handler suites (npm, maven, pypi, nuget, swift, goproxy, debian, hex, conan, cargo, alpine, conda, composer, terraform, rpm, rubygems, cran, ansible, puppet, huggingface, vscode, protobuf, gitlfs, chef, jetbrains, cocoapods, sbt, pub_registry, helm) — **0 failed**
* No `sqlx::query!` macro text changed, so `.sqlx` is untouched; `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` unset succeeds.

## Deliberately out of scope

#3178's sweep counted 51 `fetch_virtual_members` call sites serving caller-visible data. This PR closes the ones that serve **bytes** — the resolvers and the three handlers that bypass them. The remaining metadata/index aggregation paths disclose names and versions rather than content and are a separate change; #3174 already tracks that class for quarantine status and SBOM listing.

The stronger question #3177 raises — whether attaching a repository as a virtual member should require *write* or *ownership* on it rather than mere visibility — is a product decision, and is not made here. This closes the escalation at the visibility bar.

Fixes #3177
Fixes #3178
