### PR TITLE
fix(maven): never answer a HEAD with a method-scoped presigned redirect

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -4178,6 +4178,138 @@ mod tests {
         tdh::cleanup(&pool, repo_id, user_id).await;
     }
 
+    /// #3181: `HEAD` on a Maven artifact served from a presigned-redirect
+    /// backend must NOT be answered with a 302.
+    ///
+    /// The Maven router registers only `get(..)`/`put(..)`, so axum answers a
+    /// HEAD by running the GET handler — which short-circuits into a presigned
+    /// redirect for blob extensions. A presigned URL is signed for one HTTP
+    /// method, so the client's follow-up HEAD against that URL is rejected with
+    /// 403 by the object store. Maven itself never HEADs an artifact, but
+    /// Gradle does before every download, so this breaks Gradle builds against
+    /// any repository with `S3_REDIRECT_DOWNLOADS` enabled.
+    ///
+    /// Drives the real router so the assertion covers the wiring, not just the
+    /// helper. The GET arms are the negative control: they must still 302, or
+    /// a "fix" that just turned presigning off would pass.
+    #[tokio::test]
+    async fn test_head_is_not_presigned_redirect_3181() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "maven").await;
+        sqlx::query(
+            "UPDATE repositories SET storage_backend = 's3', storage_path = key WHERE id = $1",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("set cloud backend");
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (state, _mem) = tdh::build_state_with_presigning_cloud(pool.clone(), "s3");
+        let router =
+            tdh::router_with_auth(super::router(), state, tdh::make_auth(user_id, &username));
+
+        let path = "com/example/head3181/demo/1.0.0/demo-1.0.0.jar";
+        let jar = bytes::Bytes::from_static(b"head-3181-jar-bytes");
+        let (status, body) = tdh::send(
+            router.clone(),
+            tdh::put(format!("/{repo_key}/{path}"), jar.clone()),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "PUT failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        // Negative control FIRST: presigning really is active on this router,
+        // so the HEAD assertion below is not passing for the trivial reason.
+        let (get_status, _, get_headers) =
+            tdh::send_with_headers(router.clone(), tdh::get(format!("/{repo_key}/{path}"))).await;
+        assert_eq!(
+            get_status,
+            StatusCode::FOUND,
+            "GET on a hosted .jar must still redirect to the presigned URL"
+        );
+        let location = get_headers
+            .get(axum::http::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            location.contains("X-Amz-Signature"),
+            "GET must redirect to a signed URL, got {location}"
+        );
+
+        let (head_status, head_body, head_headers) =
+            tdh::send_with_headers(router.clone(), tdh::head(format!("/{repo_key}/{path}"))).await;
+
+        // The .pom sidecar is not redirect-eligible, so its HEAD exercises the
+        // path that already worked; it must be unchanged by this fix.
+        let pom_path = "com/example/head3181/demo/1.0.0/demo-1.0.0.pom";
+        let pom = bytes::Bytes::from_static(b"<project/>");
+        let (pom_put, _) = tdh::send(
+            router.clone(),
+            tdh::put(format!("/{repo_key}/{pom_path}"), pom.clone()),
+        )
+        .await;
+        let (pom_head_status, _, _) =
+            tdh::send_with_headers(router.clone(), tdh::head(format!("/{repo_key}/{pom_path}")))
+                .await;
+
+        let _ = sqlx::query("DELETE FROM maven_flat_object_owner WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        tdh::cleanup(&pool, repo_id, user_id).await;
+
+        assert_ne!(
+            head_status,
+            StatusCode::FOUND,
+            "#3181: HEAD must not return a 302 to a method-scoped presigned URL"
+        );
+        assert_eq!(
+            head_status,
+            StatusCode::OK,
+            "HEAD must answer with the artifact's metadata"
+        );
+        assert!(
+            head_headers.get(axum::http::header::LOCATION).is_none(),
+            "HEAD must carry no Location header"
+        );
+        assert_eq!(
+            head_headers
+                .get(axum::http::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(jar.len().to_string().as_str()),
+            "HEAD must advertise the artifact's real Content-Length"
+        );
+        assert_eq!(
+            head_headers
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/java-archive"),
+            "HEAD must advertise the artifact's Content-Type"
+        );
+        assert!(
+            head_body.is_empty(),
+            "a HEAD response carries no body, got {} bytes",
+            head_body.len()
+        );
+
+        assert_eq!(pom_put, StatusCode::CREATED, "pom PUT failed");
+        assert_eq!(
+            pom_head_status,
+            StatusCode::OK,
+            "HEAD on the non-eligible .pom sidecar must keep working"
+        );
+    }
+
     /// #2624 back-compat: objects stored under the LEGACY flat scheme
     /// (`maven/{path}`) must stay readable after the repo-scoped scheme takes
     /// over new writes — row-anchored artifacts through the storage_key their

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3401,6 +3401,8 @@ pub fn is_blob_redirect_eligible(path: &str) -> bool {
 /// Only ever called on the hosted (Local/Staging) artifact-row path: remote and
 /// virtual repos return earlier via `proxy_fetch_streaming`/`stream_fetch_result`
 /// because their bytes are not in this repo's S3 handle and must never redirect.
+///
+/// A `HEAD` is never redirected (#3181) — see the guard below.
 pub async fn try_hosted_blob_redirect(
     state: &AppState,
     storage: &dyn crate::storage::StorageBackend,
@@ -3409,6 +3411,24 @@ pub async fn try_hosted_blob_redirect(
     artifact_id: Uuid,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Option<Response> {
+    // #3181: a presigned URL is signed for ONE HTTP method — the method is part
+    // of the SigV4 canonical request (and of GCS's V4 signing), so a URL signed
+    // for GET rejects a HEAD with 403 SignatureDoesNotMatch. Handing a HEAD a
+    // 302 to a GET-signed URL therefore hands the client a URL it cannot use:
+    // the client re-issues its HEAD against the signature and the object store
+    // refuses it. Maven never HEADs an artifact so it never hit this, but
+    // Gradle HEADs before every download, which fails every Gradle build
+    // against a redirect-enabled repository.
+    //
+    // Returning `None` falls through to the caller's normal serve path, which
+    // answers with the real Content-Type / Content-Length / X-Checksum-*
+    // headers. That path builds a body, but a HEAD response's body is dropped
+    // without ever being polled, so the fall-through costs a metadata round
+    // trip rather than a body transfer — measured at parity with the 302 on a
+    // 64 MiB jar, against a 64 MiB GET.
+    if ctx.is_head {
+        return None;
+    }
     if !state.config.presigned_downloads_enabled || !is_blob_redirect_eligible(path) {
         return None;
     }
@@ -3417,10 +3437,9 @@ pub async fn try_hosted_blob_redirect(
     // returns `None` for filesystem backends or on a signing error.
     let redirect = try_presigned_redirect(storage, storage_key, true, expiry).await?;
     // Count-at-redirect (#2260): record BEFORE handing back the 302, matching the
-    // generic download handler. A body-less redirect otherwise never counts. This
-    // funnels through the single canonical recorder, which short-circuits on
-    // `ctx.is_head` (#2505), so a HEAD probe on an eligible blob still returns the
-    // 302 but records +0.
+    // generic download handler. A body-less redirect otherwise never counts.
+    // Only GETs reach here (HEAD returned above), so the recorder's `ctx.is_head`
+    // short circuit (#2505) is now belt-and-braces rather than load-bearing.
     crate::services::artifact_service::record_download(&state.db, artifact_id, ctx).await;
     Some(redirect)
 }
@@ -12102,9 +12121,10 @@ mod tests {
         // #2522: the GET's stats INSERT is spawned off the hot path — wait for it.
         let after_get = poll_artifact_download_count(&pool, artifact_id, 1).await;
 
-        // HEAD on the same redirect-eligible .jar: still 302 (headers only) but
-        // records +0 — the canonical record_download honours ctx.is_head
-        // (#2260/#2505), so a metadata probe never inflates download stats.
+        // HEAD on the same redirect-eligible .jar: NO redirect (#3181). A
+        // presigned URL is signed per method, so a 302 here hands the client a
+        // GET-signed URL that 403s the HEAD it is about to re-issue. The helper
+        // declines and the caller serves headers inline; records +0 either way.
         let head_ctx = ctx_for(user_id, /* is_head = */ true);
         let head_out = super::try_hosted_blob_redirect(
             &state,
@@ -12139,15 +12159,108 @@ mod tests {
             "GET on the redirect records exactly one download"
         );
 
-        let head_resp = head_out.expect("HEAD on an eligible .jar still returns the 302");
-        assert_eq!(head_resp.status(), StatusCode::FOUND, "jar HEAD must 302");
+        assert!(
+            head_out.is_none(),
+            "#3181: HEAD must NOT be answered with a presigned 302 — the URL is \
+             signed for GET and 403s the HEAD the client re-issues against it"
+        );
         assert_eq!(
             after_head, 1,
             "HEAD on the redirect records +0 (still 1 total)"
         );
 
-        // Two presign attempts (one per call), two redirects, but only one stat.
-        assert_eq!(presign_calls, 2, "each call signs the key");
+        // Only the GET signs the key: the HEAD declines before reaching the
+        // signer, so it costs no presign round trip either.
+        assert_eq!(presign_calls, 1, "only the GET signs the key");
+    }
+
+    /// #3181: a HEAD on a redirect-eligible hosted blob declines the redirect
+    /// for EVERY blob extension, and does so before touching the signer.
+    ///
+    /// The companion assertion to the GET arm above: without a method guard the
+    /// helper would sign and 302, and a Gradle client following that 302 would
+    /// HEAD a GET-scoped signature and get a 403 from the object store.
+    #[tokio::test]
+    async fn try_hosted_blob_redirect_head_never_redirects_3181() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _key, _dir) = db_helpers::create_repo(&pool, "local", "maven").await;
+
+        let state = db_helpers::build_state_presigned(
+            pool.clone(),
+            "s3-test",
+            StdArc::new(RecordingStorage::new(true)),
+        );
+
+        // Every extension `is_blob_redirect_eligible` accepts, so a new entry
+        // added to that list cannot quietly reopen the HEAD hole.
+        let cases = [
+            "com/example/lib/1.0/lib-1.0.jar",
+            "com/example/lib/1.0/lib-1.0.war",
+            "com/example/lib/1.0/lib-1.0.aar",
+            "com/example/lib/1.0/lib-1.0.zip",
+            "com/example/lib/1.0/lib-1.0.tar.gz",
+            "com/example/lib/1.0/lib-1.0.jmod",
+        ];
+
+        let storage = RecordingStorage::new(/* supports = */ true);
+        let mut redirected = Vec::new();
+        for path in cases {
+            assert!(
+                super::is_blob_redirect_eligible(path),
+                "test fixture {path} must be redirect-eligible or it proves nothing"
+            );
+            let storage_key = format!("artifact-keeper/cas/ab/cd/{path}");
+            let artifact_id = seed_blob_artifact(&pool, repo_id, user_id, path, &storage_key).await;
+
+            // Negative control: the same artifact on a GET still redirects, so a
+            // fix that simply switched presigning off would fail here.
+            let get_out = super::try_hosted_blob_redirect(
+                &state,
+                &storage,
+                path,
+                &storage_key,
+                artifact_id,
+                &ctx_for(user_id, /* is_head = */ false),
+            )
+            .await;
+            let get_status = get_out.map(|r| r.status());
+
+            let head_out = super::try_hosted_blob_redirect(
+                &state,
+                &storage,
+                path,
+                &storage_key,
+                artifact_id,
+                &ctx_for(user_id, /* is_head = */ true),
+            )
+            .await;
+            redirected.push((path, get_status, head_out.map(|r| r.status())));
+        }
+
+        let presign_calls = storage
+            .presigned_calls
+            .load(std::sync::atomic::Ordering::SeqCst);
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+
+        for (path, get_status, head_status) in &redirected {
+            assert_eq!(
+                *get_status,
+                Some(StatusCode::FOUND),
+                "GET on {path} must still 302 (presigning stays on)"
+            );
+            assert_eq!(
+                *head_status, None,
+                "#3181: HEAD on {path} must not be answered with a presigned 302"
+            );
+        }
+        assert_eq!(
+            presign_calls,
+            cases.len(),
+            "only the GETs sign: the HEADs decline before reaching the signer"
+        );
     }
 
     /// A hosted `.pom` (non-blob) is NOT eligible: the helper returns `None`

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -486,6 +486,10 @@ pub fn build_state_with(
 #[derive(Default)]
 pub struct MemStorage {
     pub objects: std::sync::Mutex<std::collections::HashMap<String, Bytes>>,
+    /// When true the double advertises presigned-redirect capability, standing
+    /// in for an S3/GCS backend with `S3_REDIRECT_DOWNLOADS=true`. Defaults to
+    /// false so every existing `MemStorage` user keeps the streaming path.
+    pub presign: bool,
 }
 
 #[async_trait::async_trait]
@@ -523,6 +527,32 @@ impl crate::storage::StorageBackend for MemStorage {
     ) -> crate::error::Result<crate::storage::PutStreamResult> {
         crate::storage::buffered_put_stream_fallback(self, key, stream).await
     }
+
+    fn supports_redirect(&self) -> bool {
+        self.presign
+    }
+
+    async fn get_presigned_url(
+        &self,
+        key: &str,
+        expires_in: std::time::Duration,
+    ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+        if !self.presign {
+            return Ok(None);
+        }
+        // Shaped like a real SigV4 URL — in particular the signature is bound
+        // to a single HTTP method, which is the whole point of #3181. Tests
+        // assert on the `X-Amz-` marker rather than parsing it.
+        Ok(Some(crate::storage::PresignedUrl {
+            url: format!(
+                "https://signed.example.com/{key}?X-Amz-Algorithm=AWS4-HMAC-SHA256\
+                 &X-Amz-Expires={}&X-Amz-Signature=deadbeef",
+                expires_in.as_secs()
+            ),
+            expires_in,
+            source: crate::storage::PresignedUrlSource::S3,
+        }))
+    }
 }
 
 /// Like [`build_state`], but the registry carries an in-memory backend
@@ -530,7 +560,30 @@ impl crate::storage::StorageBackend for MemStorage {
 /// namespace. Returns the state plus the backing [`MemStorage`] so tests can
 /// assert exactly which physical keys were written (#2624).
 pub fn build_state_with_cloud(pool: PgPool, backend_name: &str) -> (SharedState, Arc<MemStorage>) {
-    let mem = Arc::new(MemStorage::default());
+    build_cloud_state(pool, backend_name, /* presign = */ false)
+}
+
+/// Like [`build_state_with_cloud`], but the in-memory backend advertises
+/// presigned-redirect capability AND `presigned_downloads_enabled` is on —
+/// i.e. the S3-with-`S3_REDIRECT_DOWNLOADS=true` deployment shape of #1555 /
+/// #1945. Used by the #3181 HEAD regression coverage, which needs a router
+/// whose GETs really do 302 so the HEAD assertion is not vacuous.
+pub fn build_state_with_presigning_cloud(
+    pool: PgPool,
+    backend_name: &str,
+) -> (SharedState, Arc<MemStorage>) {
+    build_cloud_state(pool, backend_name, /* presign = */ true)
+}
+
+fn build_cloud_state(
+    pool: PgPool,
+    backend_name: &str,
+    presign: bool,
+) -> (SharedState, Arc<MemStorage>) {
+    let mem = Arc::new(MemStorage {
+        presign,
+        ..Default::default()
+    });
     let mut backends: std::collections::HashMap<String, Arc<dyn crate::storage::StorageBackend>> =
         std::collections::HashMap::new();
     backends.insert(backend_name.to_string(), mem.clone());
@@ -539,12 +592,9 @@ pub fn build_state_with_cloud(pool: PgPool, backend_name: &str) -> (SharedState,
         backend_name.to_string(),
     ));
     let storage: Arc<dyn crate::storage::StorageBackend> = mem.clone();
-    let state = Arc::new(AppState::new(
-        cfg("/tmp/ak-cloud-test-unused"),
-        pool,
-        storage,
-        registry,
-    ));
+    let mut config = cfg("/tmp/ak-cloud-test-unused");
+    config.presigned_downloads_enabled = presign;
+    let state = Arc::new(AppState::new(config, pool, storage, registry));
     (state, mem)
 }
 
@@ -1199,6 +1249,19 @@ pub fn get(uri: String) -> Request<Body> {
         .uri(uri)
         .body(Body::empty())
         .expect("build GET request")
+}
+
+/// Build a HEAD request.
+///
+/// Note that a router registering only `get(..)` still answers HEAD by running
+/// the GET handler, so this exercises the same handler code the GET does — the
+/// distinction lives in `DownloadContext::is_head` (#3181).
+pub fn head(uri: String) -> Request<Body> {
+    Request::builder()
+        .method("HEAD")
+        .uri(uri)
+        .body(Body::empty())
+        .expect("build HEAD request")
 }
 
 /// Build a POST request with the given body and content-type header.


### PR DESCRIPTION
Fixes #3181

## What breaks

A presigned URL is signed for **one HTTP method** — the method is part of the SigV4 canonical request (and of GCS's V4 signing). The Maven router registers only `get(..)`/`put(..)`, so axum answers a `HEAD` by running the GET handler, which short-circuits into `try_hosted_blob_redirect` and returns a `302` pointing at a **GET-signed** URL. The client then re-issues its `HEAD` against that signature and the object store rejects it with `403`.

Maven never HEADs an artifact, so this stayed invisible. Gradle HEADs before every download, so every Gradle build against a repository with `S3_REDIRECT_DOWNLOADS` enabled fails.

## Reproduced first, at `origin/main`

MinIO + Postgres + the backend with `STORAGE_BACKEND=s3`, `S3_REDIRECT_DOWNLOADS=true`, `PRESIGNED_DOWNLOADS_ENABLED=true`; hosted Maven repo, one uploaded `.jar`:

```
--- GET, following redirects (Maven behaviour) ---
final HTTP 200  size=4374

--- HEAD, following redirects (Gradle behaviour) ---
final HTTP 403

--- HEAD against the redirect target ---
HTTP/1.1 403 Forbidden
Server: MinIO
--- same URL with GET ---
HTTP 200 size=4374
```

Same URL, same signature: GET 200, HEAD 403. Exactly as reported.

**Scope.** Maven presigns from exactly two call sites, both `try_hosted_blob_redirect`, both on the hosted (Local/Staging) artifact-row path. Remote repos return earlier via `proxy_fetch_streaming` and virtual repos via `stream_fetch_result`, so neither ever emits a 302 — the remote/virtual complication raised in the issue does not arise for this fix. Confirmed live that non-blob companions (`.pom`, `.sha1`, `.md5`) are not redirect-eligible and their HEADs already returned 200.

## The fix

`try_hosted_blob_redirect` declines on `ctx.is_head` and falls through to the caller's normal serve path, which answers with the real `Content-Type` / `Content-Length` / `X-Checksum-*` headers.

This is the issue's second suggested option ("simply return the content-type and content-length headers"), reached without adding a HEAD handler. The alternative — signing a second URL for HEAD — would need a per-backend method-aware signing API (S3, GCS and Azure differ here) and still costs the client a round trip to learn a length the backend already knows.

The fall-through builds a body, but a HEAD response's body is dropped without ever being polled, so it costs a metadata round trip rather than a body transfer. Measured on the fixed build against real MinIO, 64 MiB jar:

```
HEAD 200 time=0.013574s bytes=0
HEAD 200 time=0.014945s bytes=0
HEAD 200 time=0.012246s bytes=0
GET  200 time=0.067103s bytes=67108976
```

Because the guard lives in the shared helper, hosted Ivy/sbt blobs are covered too.

## Verified end to end on the fixed build

Real MinIO, real SigV4:

```
--- GET (negative control: presigning MUST still redirect) ---
HTTP/1.1 302 Found
location: http://127.0.0.1:19000/artifact-keeper/maven/.../lib-1.0.0.jar?X-Amz-Algorithm=AWS4-HMAC-SHA256&...&X-Amz-Signature=a28ff336...
x-artifact-storage: redirect-s3

--- HEAD ---
HTTP/1.1 200 OK
content-type: application/java-archive
content-length: 4374
x-checksum-sha256: af41581b70b44f41d01ad927b236e9105f8310cc1202868530196abbb89cf8cf

--- Gradle-style, following redirects ---
HEAD -L final HTTP 200
GET  -L final HTTP 200  bytes=4374
```

## Tests

Three tests, each carrying a **negative control** asserting the GET still returns a `302` to a signed URL — so a "fix" that merely disabled presigning fails them:

- `maven::tests::test_head_is_not_presigned_redirect_3181` — drives the real Maven router against a presign-capable backend: GET must 302 to an `X-Amz-Signature` URL, HEAD must be 200 with the real `Content-Type`/`Content-Length`, no `Location`, empty body. Also asserts the non-eligible `.pom` HEAD keeps working.
- `proxy_helpers::tests::try_hosted_blob_redirect_head_never_redirects_3181` — every extension `is_blob_redirect_eligible` accepts, so adding one to that list cannot quietly reopen the hole. Asserts the HEAD declines *before* reaching the signer.
- `proxy_helpers::tests::try_hosted_blob_redirect_jar_redirects_and_counts_once` — the existing #1945/#2260 test asserted `"jar HEAD must 302"`, i.e. it encoded this bug. Its HEAD arm is flipped; the GET arm and the download-count assertions are unchanged.

### Revert check

With the production guard disabled and the tests left in place, all three fail and the GET arms still pass:

```
test proxy_helpers::tests::try_hosted_blob_redirect_head_never_redirects_3181 ... FAILED
test proxy_helpers::tests::try_hosted_blob_redirect_jar_redirects_and_counts_once ... FAILED
test maven::tests::test_head_is_not_presigned_redirect_3181 ... FAILED

assertion `left == right` failed: #3181: HEAD on com/example/lib/1.0/lib-1.0.jar must not be answered with a presigned 302
  left: Some(302)
 right: None

#3181: HEAD must NOT be answered with a presigned 302 — the URL is signed for GET and 403s the HEAD the client re-issues against it

assertion `left != right` failed: #3181: HEAD must not return a 302 to a method-scoped presigned URL
  left: 302
 right: 302

test result: FAILED. 3 passed; 3 failed; 0 ignored; 0 measured; 14884 filtered out
```

With the guard restored:

```
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 14884 filtered out
```

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- maven proxy_helpers storage` — `1349 passed; 0 failed; 2 ignored`
- No `sqlx::query!` macro text changed, so no `.sqlx` regeneration.

## Test helper changes

`MemStorage` gains an opt-in `presign` flag (defaults false, so existing users are untouched) implementing `supports_redirect`/`get_presigned_url`, plus `build_state_with_presigning_cloud` and a `head(uri)` request builder — needed so the router test's GETs genuinely redirect and its HEAD assertion is not vacuous.
