### PR TITLE
fix(pypi): forward upstream Content-Encoding on PEP 658 remote metadata, and decode coded wheels before extraction

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -8666,7 +8666,7 @@ async fn fetch_upstream_tags_page(
     })?;
 
     let upstream_path = format!("v2/{}/{}", ctx.image, build_remote_tags_list_path(n, last));
-    let (content, _ct, link) = proxy_helpers::proxy_fetch_uncached_with_link(
+    let upstream = proxy_helpers::proxy_fetch_uncached_with_link(
         proxy,
         ctx.repo_id,
         ctx.repo_key,
@@ -8687,6 +8687,34 @@ async fn fetch_upstream_tags_page(
         ),
     })?;
 
+    // This arm PARSES the upstream body (it rebuilds the tag page rather than
+    // forwarding bytes), so the upstream coding must come OFF here rather than
+    // be forwarded: `serde_json::from_slice` over a gzipped tags document fails
+    // and the page 502s. Reachable because the shared HTTP client no longer
+    // decodes upstream bodies and object stores return a stored
+    // `Content-Encoding` regardless of `Accept-Encoding` (#3193; same
+    // decode-before-parse class as the PyPI wheel fallback, surfaced by the
+    // `fetch_upstream_direct_with_link` widening that made the coding visible
+    // to callers at all).
+    let content = match crate::util::content_coding::strip_content_coding(
+        &upstream.content,
+        upstream.content_encoding.as_deref(),
+    ) {
+        Ok(crate::util::content_coding::Decoded::Bytes(bytes)) => bytes,
+        Ok(crate::util::content_coding::Decoded::Unsupported) | Err(_) => {
+            warn!(
+                "Upstream tags/list response for {} used a content coding this build \
+                 cannot decode ({:?})",
+                ctx.image, upstream.content_encoding
+            );
+            return Err(oci_error(
+                StatusCode::BAD_GATEWAY,
+                "UNKNOWN",
+                "invalid upstream tags response",
+            ));
+        }
+    };
+    let link = upstream.link;
     let parsed = serde_json::from_slice::<serde_json::Value>(&content).map_err(|e| {
         warn!(
             "Invalid upstream tags/list response for {}: {}",
@@ -26799,6 +26827,59 @@ mod content_encoding_forwarding_tests {
         );
         let (_s, body, _h) = tdh::collect_response(resp).await;
         assert_eq!(&body[..], &coded[..], "layer bytes must pass through");
+    }
+
+    /// #3193, the OTHER caller of the widened
+    /// `fetch_upstream_direct_with_link`. Tag pagination PARSES the upstream
+    /// body (it rebuilds the page rather than forwarding bytes), so it is the
+    /// mirror image of the blob arm above: the coding must come OFF, not be
+    /// forwarded.
+    ///
+    /// Before the widening the coding was not in the primitive's return type at
+    /// all, so a `deflate`-coded tags document reached `serde_json::from_slice`
+    /// still compressed and the whole tag listing 502'd. Fixture is `deflate`,
+    /// never gzip, for the same reason as everywhere else in this class.
+    #[tokio::test]
+    async fn test_upstream_tags_page_decodes_coded_body_before_parsing() {
+        let Some(fx) = tdh::Fixture::setup("remote", "docker").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let page = br#"{"name":"myimage","tags":["v1","v2"]}"#;
+        let coded = tdh::code_bytes("deflate", page);
+        assert_ne!(
+            &coded[..],
+            &page[..],
+            "fixture must actually be coded or the test proves nothing"
+        );
+
+        Mock::given(method("GET"))
+            .and(wm_path("/v2/myimage/tags/list"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-encoding", "deflate")
+                    .set_body_bytes(coded),
+            )
+            .mount(&server)
+            .await;
+
+        let upstream_url = server.uri();
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &upstream_url).await;
+        let ctx = super::TagsFetchCtx {
+            state: &state,
+            repo_id: fx.repo_id,
+            repo_key: &fx.repo_key,
+            upstream_url: &upstream_url,
+            image: "myimage",
+        };
+        let result = super::fetch_upstream_tags_page(&ctx, 10, None).await;
+
+        fx.teardown().await;
+
+        let page = result
+            .map_err(|r| r.status())
+            .expect("a deflate-coded tags/list document must be decoded before parsing, not 502'd");
+        assert_eq!(page.tags, vec!["v1".to_string(), "v2".to_string()]);
     }
 
     /// Negative control: no upstream coding, no manufactured header, and a

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -17,8 +17,8 @@ use crate::models::repository::{
     ReplicationPriority, Repository, RepositoryFormat, RepositoryType,
 };
 use crate::services::proxy_hydration::{Coordinator, HydrationCoordinator};
-use crate::services::proxy_service::ProxyService;
 pub use crate::services::proxy_service::StreamingFetchResult;
+use crate::services::proxy_service::{DirectUpstreamBody, ProxyService};
 // Re-export the per-format buffered-metadata byte ceilings (#1608 Phase 4b /
 // #2181) so format handlers select a cap via `proxy_helpers::<CONST>`.
 pub use crate::services::proxy_service::{DEFAULT_METADATA_MAX_BYTES, LARGE_METADATA_MAX_BYTES};
@@ -1719,13 +1719,18 @@ pub async fn proxy_fetch_uncached(
 }
 
 /// Fetch from upstream directly, preserving the upstream `Link` header.
+///
+/// Returns the whole [`DirectUpstreamBody`], including the upstream
+/// `Content-Encoding` (#3193). Callers must handle the coding explicitly:
+/// forward it if they pass `content` through verbatim, or strip it with
+/// [`crate::util::content_coding::strip_content_coding`] before parsing.
 pub async fn proxy_fetch_uncached_with_link(
     proxy_service: &ProxyService,
     repo_id: Uuid,
     repo_key: &str,
     upstream_url: &str,
     path: &str,
-) -> Result<(Bytes, Option<String>, Option<String>), Response> {
+) -> Result<DirectUpstreamBody, Response> {
     with_proxy_repo(repo_id, repo_key, upstream_url, path, |repo| async move {
         proxy_service
             .fetch_upstream_direct_with_link(&repo, path)

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2023,17 +2023,30 @@ async fn serve_remote_metadata(
         .fetch_upstream_direct_with_link(&remote_repo, &target.fetch_path)
         .await
     {
-        Ok((content, _content_type, _)) => {
+        Ok(upstream) => {
             // The content-type is fixed, never relayed from upstream: a PEP 658
             // metadata resource is always the plain-text METADATA file, so a
             // hostile or misconfigured upstream labelling it `text/html` must
             // not get that type echoed back under this origin. Matches the
             // wheel-extraction arm below.
-            Ok(Response::builder()
+            //
+            // The content *coding* is the opposite case (#3193). These bytes are
+            // forwarded VERBATIM, and the shared HTTP client no longer lets
+            // reqwest decode upstream bodies, so a `.metadata` from a gzipping
+            // CDN or an object-store upstream arrives here still coded. Pinning
+            // the type while dropping the coding is the worst of both: pip gets
+            // compressed bytes labelled `text/plain; charset=utf-8` with no
+            // coding declared, and PEP 658 metadata parsing fails. Declare what
+            // the bytes actually are. `None` upstream means the header stays
+            // ABSENT — manufacturing a coding would mislabel every ordinary
+            // uncoded serve, which is the common case.
+            let mut builder = Response::builder()
                 .status(StatusCode::OK)
-                .header(CONTENT_TYPE, "text/plain; charset=utf-8")
-                .body(Body::from(content))
-                .unwrap())
+                .header(CONTENT_TYPE, "text/plain; charset=utf-8");
+            if let Some(enc) = upstream.content_encoding.as_deref() {
+                builder = builder.header(CONTENT_ENCODING, enc);
+            }
+            Ok(builder.body(Body::from(upstream.content)).unwrap())
         }
         Err(AppError::NotFound(_)) => {
             let wheel_target = resolve_pypi_remote_fetch_target(
@@ -2052,17 +2065,51 @@ async fn serve_remote_metadata(
                 &wheel_target.fetch_base,
                 RepositoryFormat::Pypi,
             );
-            let (wheel, _) = proxy
-                .fetch_artifact_with_cache_path(
+            // Unlike the arm above, this one PARSES the upstream bytes: it
+            // opens the wheel as a zip to read `*.dist-info/METADATA`. A coded
+            // wheel is not a parseable zip, so before #3193 a perfectly valid
+            // wheel behind a gzipping intermediary answered "Metadata not
+            // available" — forwarding a header would not have helped, the bytes
+            // have to be DECODED before the parser sees them.
+            //
+            // `_capped` at `DEFAULT_METADATA_MAX_BYTES` is the same ceiling the
+            // uncapped `fetch_artifact_with_cache_path` already delegates with,
+            // so the byte budget is unchanged; the capped form is used because
+            // it is the variant that reports the coding (#3184).
+            let (wheel, _content_type, wheel_encoding) = proxy
+                .fetch_artifact_with_cache_path_capped(
                     &wheel_repo,
                     &wheel_target.fetch_path,
                     &wheel_target.cache_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await
                 .map_err(|e| e.into_response())?;
+            // Decode and parse under ONE extraction permit: both halves are
+            // CPU work on upstream-controlled bytes, so they are admission-
+            // controlled together, and the decode is bounded by the same
+            // decompression-bomb budget the zip walk uses.
             let metadata = crate::util::bounded_archive::with_ingest_extraction(|| {
-                extract_metadata_from_wheel(&wheel)
+                match crate::util::content_coding::strip_content_coding(
+                    &wheel,
+                    wheel_encoding.as_deref(),
+                ) {
+                    Ok(crate::util::content_coding::Decoded::Bytes(bytes)) => {
+                        Ok(extract_metadata_from_wheel(&bytes))
+                    }
+                    // A coding this build cannot strip (`br`) degrades to the
+                    // pre-existing "not available" answer rather than a hard
+                    // upstream error: pip recovers from that by downloading the
+                    // wheel itself, which succeeds because the download path
+                    // forwards the coding for the client to strip (#3176).
+                    Ok(crate::util::content_coding::Decoded::Unsupported) => Ok(None),
+                    // A supported coding that will not decode is a corrupt or
+                    // bomb stream; surface it rather than reporting it as a
+                    // missing resource.
+                    Err(e) => Err(e),
+                }
             })
+            .map_err(|e| e.into_response())?
             .map_err(|e| e.into_response())?
             .ok_or_else(|| {
                 AppError::NotFound("Metadata not available".to_string()).into_response()
@@ -10188,6 +10235,215 @@ mod tests {
             &body[..],
             metadata,
             "served metadata must be the wheel's METADATA bytes"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3193: `serve_remote_metadata` and content codings. Two independent bugs,
+    // one per arm, needing opposite remediations:
+    //
+    //   arm 1 (upstream serves `.metadata`) forwards the bytes VERBATIM, so it
+    //         must re-declare the upstream `Content-Encoding`;
+    //   arm 2 (upstream 404s, extract METADATA from the wheel) PARSES the
+    //         bytes, so it must DECODE them first — forwarding a header would
+    //         do nothing for a zip reader handed a deflate stream.
+    //
+    // Every fixture below is `deflate`, never gzip. #3176 shipped fourteen
+    // tests that all stayed green when the forwarded value was replaced with a
+    // hardcoded `"gzip"`, because every fixture WAS gzip: they pinned "a coding
+    // is declared", not "the UPSTREAM's coding is declared". `tdh::gzip_fixture`
+    // is for the GET/HEAD parity arms and is deliberately not used here.
+    //
+    // These run the real router end to end, so they fail against the handler
+    // itself rather than against a response-builder helper.
+    // -----------------------------------------------------------------------
+
+    /// Fixed coordinates for the `.metadata` end-to-end cases below.
+    const CODING_PROJECT: &str = "demo";
+    const CODING_WHEEL: &str = "demo-1.0-py3-none-any.whl";
+
+    /// Drive one PEP 658 `.metadata` request end to end against a mock upstream
+    /// that answers `<wheel>.metadata` with `metadata_response` and `<wheel>`
+    /// with `wheel_response`.
+    ///
+    /// Returns `None` when no database is available (the suite's standing
+    /// skip), otherwise the served status, body and headers. Shared by the
+    /// three cases so the fixture/mock/rewire scaffolding is written once.
+    async fn serve_remote_metadata_e2e(
+        metadata_response: wiremock::ResponseTemplate,
+        wheel_response: wiremock::ResponseTemplate,
+    ) -> Option<(StatusCode, Bytes, axum::http::HeaderMap)> {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::Mock;
+
+        let fx = tdh::Fixture::setup("remote", "pypi").await?;
+        let (upstream, _ssrf_allowlist) = non_loopback_upstream().await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{CODING_PROJECT}/")))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_string(pep658_index_html(CODING_WHEEL)),
+            )
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{CODING_WHEEL}.metadata")))
+            .respond_with(metadata_response)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/packages/{CODING_WHEEL}")))
+            .respond_with(wheel_response)
+            .mount(&upstream)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &upstream.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let served = tdh::send_with_headers(
+            app,
+            tdh::get(format!(
+                "/{}/simple/{CODING_PROJECT}/{CODING_WHEEL}.metadata",
+                fx.repo_key
+            )),
+        )
+        .await;
+
+        fx.teardown().await;
+        Some(served)
+    }
+
+    /// Arm 1, positive. A `deflate`-coded upstream `.metadata` must be served
+    /// with `Content-Encoding: deflate`, and the served bytes must decode under
+    /// that declared coding.
+    ///
+    /// Before #3193 the handler pinned `text/plain; charset=utf-8` and declared
+    /// no coding at all — `fetch_upstream_direct_with_link`'s third tuple slot
+    /// was the `Link` header, not the coding — so pip received compressed bytes
+    /// labelled as plain text.
+    ///
+    /// Fails if the coding is dropped (asserts the header is present), and
+    /// fails if it is hardcoded to `"gzip"` (asserts `deflate`, and decodes the
+    /// body with a deflate decoder).
+    #[tokio::test]
+    async fn test_remote_pypi_metadata_forwards_upstream_deflate_coding() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let (plain, coded) = tdh::coded_fixture("deflate", b"Metadata-Version: 2.1\n");
+        let Some((status, body, headers)) = serve_remote_metadata_e2e(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-encoding", "deflate")
+                .set_body_bytes(coded.clone()),
+            wiremock::ResponseTemplate::new(404),
+        )
+        .await
+        else {
+            return;
+        };
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            tdh::header_str(&headers, CONTENT_ENCODING).as_deref(),
+            Some("deflate"),
+            "the served `.metadata` must declare the UPSTREAM's coding; \
+             `gzip` means the value is hardcoded, `None` means #3193 is live"
+        );
+        // The proxy must not decode on pip's behalf: the wire bytes stay coded,
+        // which is the whole reason the header has to be declared.
+        assert_eq!(
+            &body[..],
+            coded.as_slice(),
+            "coded upstream bytes must be forwarded verbatim"
+        );
+        assert_eq!(
+            tdh::inflate_deflate(&body),
+            plain,
+            "the served body must decode under the coding the response declares"
+        );
+    }
+
+    /// Arm 1, negative control. An UNCODED upstream `.metadata` must be served
+    /// with NO `Content-Encoding`.
+    ///
+    /// This is the overwhelmingly common case — most indexes serve `.metadata`
+    /// uncoded — so a header emitted unconditionally would break the default
+    /// path, not an edge case: pip would try to inflate plain text. Fails if
+    /// the header is set unconditionally.
+    #[tokio::test]
+    async fn test_remote_pypi_metadata_omits_coding_when_upstream_uncoded() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let plain: &[u8] = b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n";
+        let Some((status, body, headers)) = serve_remote_metadata_e2e(
+            wiremock::ResponseTemplate::new(200).set_body_bytes(plain),
+            wiremock::ResponseTemplate::new(404),
+        )
+        .await
+        else {
+            return;
+        };
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], plain);
+        assert_eq!(
+            tdh::header_str(&headers, CONTENT_ENCODING),
+            None,
+            "an uncoded upstream must be served with NO Content-Encoding; \
+             manufacturing one makes pip try to inflate plain text"
+        );
+    }
+
+    /// Arm 2. When upstream 404s the `.metadata`, a `deflate`-coded WHEEL must
+    /// still yield its METADATA.
+    ///
+    /// This arm needs decode-before-parse, not header forwarding:
+    /// `extract_metadata_from_wheel` opens the bytes as a zip, and a coded wheel
+    /// is not a parseable zip, so before #3193 a present and perfectly valid
+    /// wheel answered 404 "Metadata not available". The served response carries
+    /// no coding of its own — the extracted METADATA is freshly built plaintext,
+    /// not the upstream bytes — so this also pins that the arm-1 header is not
+    /// leaking across arms.
+    #[tokio::test]
+    async fn test_remote_pypi_metadata_extracts_from_deflate_coded_wheel() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let metadata: &[u8] = b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n";
+        let wheel = wheel_with_metadata("demo-1.0", metadata);
+        let coded_wheel = tdh::code_bytes("deflate", &wheel);
+        assert_ne!(
+            coded_wheel, wheel,
+            "the wheel fixture must actually be coded or the test proves nothing"
+        );
+
+        let Some((status, body, headers)) = serve_remote_metadata_e2e(
+            wiremock::ResponseTemplate::new(404),
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-encoding", "deflate")
+                .set_body_bytes(coded_wheel),
+        )
+        .await
+        else {
+            return;
+        };
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a deflate-coded wheel is still a valid wheel; its METADATA must be \
+             extracted rather than 404'd as unavailable; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert_eq!(
+            &body[..],
+            metadata,
+            "served metadata must be the coded wheel's METADATA bytes"
+        );
+        assert_eq!(
+            tdh::header_str(&headers, CONTENT_ENCODING),
+            None,
+            "the extracted METADATA is freshly built plaintext, so the upstream \
+             wheel's coding must NOT be echoed onto it"
         );
     }
 

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1506,29 +1506,41 @@ pub async fn rewire_remote_proxy(
 ///
 /// Use a NON-gzip coding in at least one test per builder.
 pub fn coded_fixture(encoding: &str, seed: &[u8]) -> (Vec<u8>, Vec<u8>) {
-    use flate2::write::{DeflateEncoder, GzEncoder};
-    use flate2::Compression;
-    use std::io::Write;
-
     let plain = seed.repeat(64);
-    let coded = match encoding {
-        "gzip" => {
-            let mut e = GzEncoder::new(Vec::new(), Compression::default());
-            e.write_all(&plain).expect("gzip encode");
-            e.finish().expect("gzip finish")
-        }
-        "deflate" => {
-            let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
-            e.write_all(&plain).expect("deflate encode");
-            e.finish().expect("deflate finish")
-        }
-        other => panic!("unsupported test coding {other}"),
-    };
+    let coded = code_bytes(encoding, &plain);
     assert_ne!(
         coded, plain,
         "fixture must actually be coded or the test proves nothing"
     );
     (plain, coded)
+}
+
+/// Apply `encoding` to arbitrary bytes.
+///
+/// [`coded_fixture`] builds its own repetitive plaintext, which is right when
+/// the payload is opaque. Tests whose payload has to be a *specific* artifact —
+/// a real wheel zip whose METADATA the server then extracts (#3193) — need to
+/// code bytes they already have, so the encoder block lives here and both entry
+/// points share it rather than each suite growing a copy (the jscpd duplication
+/// gate scores changed files).
+pub fn code_bytes(encoding: &str, plain: &[u8]) -> Vec<u8> {
+    use flate2::write::{DeflateEncoder, GzEncoder};
+    use flate2::Compression;
+    use std::io::Write;
+
+    match encoding {
+        "gzip" => {
+            let mut e = GzEncoder::new(Vec::new(), Compression::default());
+            e.write_all(plain).expect("gzip encode");
+            e.finish().expect("gzip finish")
+        }
+        "deflate" => {
+            let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+            e.write_all(plain).expect("deflate encode");
+            e.finish().expect("deflate finish")
+        }
+        other => panic!("unsupported test coding {other}"),
+    }
 }
 
 /// Decode a `deflate` body, so a test can assert the client receives BYTES it

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1035,6 +1035,30 @@ impl CacheKeys {
 /// replayed to the client — see [`UpstreamResponse::content_encoding`].
 pub(crate) type CachedBody = (Bytes, Option<String>, Option<String>);
 
+/// An uncached, straight-from-upstream buffered read — the result of
+/// [`ProxyService::fetch_upstream_direct_with_link`].
+///
+/// Named fields, not a tuple. This value carries three `Option<String>`s that a
+/// positional destructure cannot tell apart, and #3193 is precisely what that
+/// costs: the PyPI PEP 658 handler read the old triple's third slot as the
+/// content coding (which is where the coding sits on [`CachedBody`]) when it was
+/// actually the `Link` header, so a coded `.metadata` reached pip as
+/// undeclared binary labelled `text/plain`.
+pub struct DirectUpstreamBody {
+    pub content: Bytes,
+    /// Upstream `Content-Type`. Handlers that pin their own media type (PEP 658
+    /// metadata is always `text/plain`) deliberately ignore this rather than
+    /// echo a hostile upstream's type back under this origin.
+    pub content_type: Option<String>,
+    /// Upstream `Content-Encoding` — see [`UpstreamResponse::content_encoding`].
+    /// A handler that forwards `content` verbatim MUST re-declare this; a
+    /// handler that parses `content` must instead strip it first with
+    /// [`crate::util::content_coding::strip_content_coding`].
+    pub content_encoding: Option<String>,
+    /// Upstream `Link` header, for OCI tag-pagination continuation cursors.
+    pub link: Option<String>,
+}
+
 pub(crate) struct CacheStore {
     storage: Arc<StorageService>,
 }
@@ -2853,6 +2877,13 @@ impl ProxyService {
     /// PyPI hosts files on a different domain) but the caller wants a stable,
     /// locally-computed cache key so that subsequent requests can hit the
     /// cache without rediscovering the upstream URL.
+    ///
+    /// DROPS the upstream `Content-Encoding`, and is exactly equivalent to
+    /// [`Self::fetch_artifact_with_cache_path_capped`] at
+    /// [`DEFAULT_METADATA_MAX_BYTES`] otherwise. A caller that forwards the
+    /// buffered body verbatim, or that PARSES it (a coded body is not a
+    /// parseable zip/tar/JSON — #3193), must use the capped form and handle the
+    /// coding, or it reproduces #3149.
     pub async fn fetch_artifact_with_cache_path(
         &self,
         repo: &Repository,
@@ -3837,18 +3868,37 @@ impl ProxyService {
     /// OCI tag pagination relies on the upstream continuation cursor when the
     /// registry enforces its own page-size cap. Callers that need to reconstruct
     /// pagination accurately should use this instead of [`fetch_upstream_direct`].
+    ///
+    /// Returns a named [`DirectUpstreamBody`] rather than the
+    /// `(Bytes, Option<String>, Option<String>)` triple it used to (#3193). The
+    /// coding was not in the old return type at all, so the PyPI PEP 658
+    /// `.metadata` caller could not forward it — and, worse, the triple's third
+    /// slot was the `Link` header while *looking* exactly like the coding slot
+    /// on the sibling `CachedBody` triple, so that caller's `Ok((content, _ct,
+    /// _))` read as "coding deliberately dropped" when it was in fact "coding
+    /// never available". Widening in place, and to named fields rather than a
+    /// fourth positional `Option<String>`, is deliberate: it breaks every caller
+    /// at compile time and forces each to say whether it forwards the bytes
+    /// verbatim (must declare [`DirectUpstreamBody::content_encoding`]) or
+    /// parses them (must DECODE first — see `util::content_coding`), and it
+    /// makes the three same-typed optionals impossible to transpose.
     pub async fn fetch_upstream_direct_with_link(
         &self,
         repo: &Repository,
         path: &str,
-    ) -> Result<(Bytes, Option<String>, Option<String>)> {
+    ) -> Result<DirectUpstreamBody> {
         let upstream_url = Self::remote_target(repo)?;
 
         let full_url = Self::build_upstream_url(upstream_url, path);
         let resp = self
             .fetch_from_upstream(&full_url, repo.id, DEFAULT_METADATA_MAX_BYTES)
             .await?;
-        Ok((resp.content, resp.content_type, resp.link))
+        Ok(DirectUpstreamBody {
+            content: resp.content,
+            content_type: resp.content_type,
+            content_encoding: resp.content_encoding,
+            link: resp.link,
+        })
     }
 
     /// Invalidate cached artifact
@@ -13764,12 +13814,77 @@ mod tests {
         let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
         let repo = wiremock_remote_repo("s8-link", &server.uri(), tmp.to_str().unwrap());
 
-        let (_body, _ct, link) = proxy
+        let upstream = proxy
             .fetch_upstream_direct_with_link(&repo, "v2/_catalog")
             .await
             .expect("direct-with-link fetch must succeed");
         let _ = std::fs::remove_dir_all(&tmp);
-        assert_eq!(link.as_deref(), Some("</v2/_catalog?last=z>; rel=\"next\""));
+        assert_eq!(
+            upstream.link.as_deref(),
+            Some("</v2/_catalog?last=z>; rel=\"next\"")
+        );
+        // Negative control for #3193: an upstream that declared no coding must
+        // not acquire one on the way through the primitive, or every handler
+        // downstream mislabels an ordinary uncoded body.
+        assert_eq!(
+            upstream.content_encoding, None,
+            "an uncoded upstream must report no Content-Encoding"
+        );
+    }
+
+    /// #3193: `fetch_upstream_direct_with_link` must report the upstream
+    /// `Content-Encoding`. It previously did not carry it AT ALL — the third
+    /// slot of its triple was the `Link` header — so the PyPI PEP 658 handler
+    /// could not forward a coding it never received.
+    ///
+    /// The fixture is `deflate`, never gzip: a gzip fixture cannot distinguish
+    /// "reports the upstream's coding" from "hardcodes gzip". It also asserts
+    /// the primitive does NOT decode — the bytes must arrive still coded, since
+    /// the verbatim-forwarding caller declares the coding and passes them on.
+    #[tokio::test]
+    async fn test_fetch_upstream_direct_with_link_reports_upstream_content_encoding() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (plain, coded) = tdh::coded_fixture("deflate", b"direct-upstream-");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/coded"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-encoding", "deflate")
+                    .set_body_bytes(coded.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-coding-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-coding", &server.uri(), tmp.to_str().unwrap());
+
+        let upstream = proxy
+            .fetch_upstream_direct_with_link(&repo, "coded")
+            .await
+            .expect("direct-with-link fetch must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(
+            upstream.content_encoding.as_deref(),
+            Some("deflate"),
+            "the UPSTREAM's coding must reach the caller; `gzip` here would mean \
+             it is hardcoded, `None` means #3193 is live"
+        );
+        assert_eq!(
+            upstream.content.as_ref(),
+            coded.as_slice(),
+            "the primitive must not decode on the caller's behalf"
+        );
+        assert_eq!(tdh::inflate_deflate(&upstream.content), plain);
     }
 
     // -- fetch_stream + read_upstream_response_streaming ---------------------

--- a/backend/src/util/content_coding.rs
+++ b/backend/src/util/content_coding.rs
@@ -1,0 +1,325 @@
+//! Bounded stripping of an HTTP **content coding** from a buffered proxied
+//! body, for the handlers that have to *parse* upstream bytes.
+//!
+//! # Why this exists
+//!
+//! `http_client::base_client_builder` disables reqwest's transparent
+//! decompression (`no_gzip`/`no_brotli`/`no_deflate`/`no_zstd`) so a proxied
+//! `Content-Length` survives intact. The consequence is that every buffered
+//! upstream body now arrives **still coded** whenever the upstream declared a
+//! coding — and object stores (notably S3) return a *stored* `Content-Encoding`
+//! regardless of what the request's `Accept-Encoding` advertised, so this is
+//! reachable even though the shared client asks for `identity`.
+//!
+//! That splits proxy callers into two kinds, and they need opposite treatment:
+//!
+//! * a caller that forwards the buffered bytes **verbatim** must re-declare the
+//!   upstream coding on its own response (#3149 / #3176 / #3184). It must NOT
+//!   use this module — decoding on the client's behalf would also invalidate
+//!   the `Content-Length` it copies from `bytes.len()`.
+//! * a caller that **parses or transforms** the buffered bytes (a zip/tar
+//!   walker, a JSON or index parser) sees compressed bytes where it expects the
+//!   payload format, and fails. Forwarding a header does nothing for it; it has
+//!   to decode *before* it parses. That is what this module is for (#3193).
+//!
+//! # Bounding
+//!
+//! The input is attacker-influenceable upstream data, so every decode runs
+//! through [`bounded_archive::read_capped`] against the shared ingest
+//! decompressed-byte budget ([`bounded_archive::max_ingest_decompressed_bytes`],
+//! 128 MiB by default and env-tunable). A coded body that inflates past the
+//! budget is rejected as a suspected decompression bomb rather than buffered.
+//! Callers should additionally hold an ingest-extraction permit
+//! ([`bounded_archive::with_ingest_extraction`]) around the decode + parse pair
+//! so the CPU cost is admission-controlled like every other serve-time
+//! extraction.
+
+use std::borrow::Cow;
+
+use crate::error::{AppError, Result};
+use crate::util::bounded_archive;
+
+/// What was made of a (possibly) content-coded body.
+///
+/// The `Unsupported` arm is deliberately not an `Err`: "the upstream used a
+/// coding this build cannot strip" is a different decision for each caller than
+/// "the stream is corrupt or is a bomb", and collapsing the two would force
+/// every caller into the same status code. See the PyPI wheel-extraction
+/// fallback, which degrades an unsupported coding to its existing
+/// "metadata not available" answer (a client can recover from that by fetching
+/// the wheel itself) rather than to a hard upstream error.
+#[derive(Debug)]
+pub enum Decoded<'a> {
+    /// Bytes that are safe to hand to a parser: either the body was already
+    /// identity-coded (borrowed unchanged) or it was successfully decoded.
+    Bytes(Cow<'a, [u8]>),
+    /// The upstream declared a coding this build has no decoder for — `br` is
+    /// the live example, since no brotli decoder is linked in. The caller must
+    /// NOT parse the bytes: they are still compressed.
+    Unsupported,
+}
+
+/// Strip the content coding named by `coding` off `body`.
+///
+/// `coding` is the raw upstream `Content-Encoding` header value, so it may name
+/// several codings applied in order (`gzip, deflate` means deflate was applied
+/// first, then gzip); they are stripped right-to-left, as RFC 9110 §8.4
+/// requires. `None`, an empty value, and `identity` all borrow the body
+/// unchanged and never allocate.
+///
+/// Returns `Err` when a coding this module *does* support fails to decode — a
+/// truncated or corrupt stream, or one that inflates past the shared
+/// decompression budget.
+pub fn strip_content_coding<'a>(body: &'a [u8], coding: Option<&str>) -> Result<Decoded<'a>> {
+    strip_content_coding_to(
+        body,
+        coding,
+        bounded_archive::max_ingest_decompressed_bytes(),
+    )
+}
+
+/// Like [`strip_content_coding`] but with an explicit decompressed-byte budget,
+/// mirroring [`bounded_archive::budgeted_to`]. Exists so the bomb-rejection
+/// tests can drive a tiny budget against a tiny fixture instead of mutating a
+/// process-global env var, which would race every other test in the binary.
+pub fn strip_content_coding_to<'a>(
+    body: &'a [u8],
+    coding: Option<&str>,
+    budget: u64,
+) -> Result<Decoded<'a>> {
+    let Some(coding) = coding else {
+        return Ok(Decoded::Bytes(Cow::Borrowed(body)));
+    };
+
+    let tokens: Vec<&str> = coding
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty() && !t.eq_ignore_ascii_case("identity"))
+        .collect();
+    if tokens.is_empty() {
+        return Ok(Decoded::Bytes(Cow::Borrowed(body)));
+    }
+    if !tokens.iter().all(|t| is_supported_token(t)) {
+        return Ok(Decoded::Unsupported);
+    }
+
+    // Applied in the order listed, so they come off in reverse.
+    let mut current = Cow::Borrowed(body);
+    for token in tokens.iter().rev() {
+        current = Cow::Owned(strip_one(&current, token, budget)?);
+    }
+    Ok(Decoded::Bytes(current))
+}
+
+/// Whether this build can strip `token`. Kept private so it cannot drift out of
+/// step with [`strip_one`]'s match — the two are checked against each other by
+/// `test_supported_tokens_all_decode`.
+fn is_supported_token(token: &str) -> bool {
+    matches!(
+        token.to_ascii_lowercase().as_str(),
+        "gzip" | "x-gzip" | "deflate" | "zstd"
+    )
+}
+
+fn strip_one(body: &[u8], token: &str, cap: u64) -> Result<Vec<u8>> {
+    let what = "content-coded upstream body";
+    match token.to_ascii_lowercase().as_str() {
+        "gzip" | "x-gzip" => {
+            bounded_archive::read_capped(flate2::read::GzDecoder::new(body), cap, what)
+        }
+        // RFC 9110 defines `deflate` as the zlib wrapper, but a long tail of
+        // servers emits RAW deflate under the same token and every browser
+        // accepts both, so a proxy that only handled one would reject bodies
+        // its own clients would have decoded. Sniff the zlib header to choose
+        // which to try first, then fall back to the other; the *first*
+        // attempt's error is the one reported, so a genuine budget breach is
+        // not masked by the fallback's "invalid stream".
+        "deflate" => {
+            type Inflate = fn(&[u8], u64, &str) -> Result<Vec<u8>>;
+            let (first, second): (Inflate, Inflate) = if looks_like_zlib(body) {
+                (inflate_zlib, inflate_raw_deflate)
+            } else {
+                (inflate_raw_deflate, inflate_zlib)
+            };
+            first(body, cap, what).or_else(|primary| second(body, cap, what).map_err(|_| primary))
+        }
+        "zstd" => bounded_archive::read_capped(
+            zstd::stream::read::Decoder::new(body)
+                .map_err(|e| AppError::BadGateway(format!("Invalid zstd upstream body: {e}")))?,
+            cap,
+            what,
+        ),
+        // Unreachable: `strip_content_coding` returns `Unsupported` before
+        // calling this for anything `is_supported_token` rejects.
+        other => Err(AppError::BadGateway(format!(
+            "Unsupported upstream content coding: {other}"
+        ))),
+    }
+}
+
+fn inflate_zlib(body: &[u8], cap: u64, what: &str) -> Result<Vec<u8>> {
+    bounded_archive::read_capped(flate2::read::ZlibDecoder::new(body), cap, what)
+}
+
+fn inflate_raw_deflate(body: &[u8], cap: u64, what: &str) -> Result<Vec<u8>> {
+    bounded_archive::read_capped(flate2::read::DeflateDecoder::new(body), cap, what)
+}
+
+/// RFC 1950 §2.2: a zlib stream starts with CMF/FLG where the compression
+/// method (low nibble of CMF) is 8 and the two bytes together are a multiple
+/// of 31. Raw deflate can coincidentally satisfy this, which is why this only
+/// *orders* the two attempts rather than deciding between them.
+fn looks_like_zlib(body: &[u8]) -> bool {
+    body.len() >= 2
+        && body[0] & 0x0f == 0x08
+        && (u16::from(body[0]) << 8 | u16::from(body[1])) % 31 == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn gzip(plain: &[u8]) -> Vec<u8> {
+        let mut e = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        e.write_all(plain).unwrap();
+        e.finish().unwrap()
+    }
+
+    fn raw_deflate(plain: &[u8]) -> Vec<u8> {
+        let mut e = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+        e.write_all(plain).unwrap();
+        e.finish().unwrap()
+    }
+
+    fn zlib(plain: &[u8]) -> Vec<u8> {
+        let mut e = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        e.write_all(plain).unwrap();
+        e.finish().unwrap()
+    }
+
+    fn bytes(d: Decoded<'_>) -> Vec<u8> {
+        match d {
+            Decoded::Bytes(b) => b.into_owned(),
+            Decoded::Unsupported => panic!("expected a decoded body, got Unsupported"),
+        }
+    }
+
+    #[test]
+    fn test_identity_and_absent_coding_pass_through() {
+        let body = b"PK\x03\x04not-coded";
+        assert_eq!(bytes(strip_content_coding(body, None).unwrap()), body);
+        assert_eq!(bytes(strip_content_coding(body, Some("")).unwrap()), body);
+        assert_eq!(
+            bytes(strip_content_coding(body, Some("identity")).unwrap()),
+            body
+        );
+    }
+
+    /// The coding actually in play must decide the decoder. Every arm here is
+    /// checked against a DIFFERENT encoder's output so a decoder hardcoded to
+    /// one coding cannot pass.
+    #[test]
+    fn test_supported_tokens_all_decode() {
+        let plain = b"payload-".repeat(64);
+        for (token, coded) in [
+            ("gzip", gzip(&plain)),
+            ("x-gzip", gzip(&plain)),
+            ("deflate", raw_deflate(&plain)),
+            ("zstd", zstd::encode_all(&plain[..], 3).unwrap()),
+        ] {
+            assert!(is_supported_token(token), "{token} must be advertised");
+            assert_eq!(
+                bytes(strip_content_coding(&coded, Some(token)).unwrap()),
+                plain,
+                "{token} body must decode to the plaintext"
+            );
+        }
+    }
+
+    /// `deflate` covers both the RFC's zlib wrapper and the raw form real
+    /// servers emit. Both must work under the single token.
+    #[test]
+    fn test_deflate_accepts_both_zlib_wrapped_and_raw() {
+        let plain = b"deflate-both-forms-".repeat(64);
+        assert_eq!(
+            bytes(strip_content_coding(&zlib(&plain), Some("deflate")).unwrap()),
+            plain
+        );
+        assert_eq!(
+            bytes(strip_content_coding(&raw_deflate(&plain), Some("deflate")).unwrap()),
+            plain
+        );
+    }
+
+    #[test]
+    fn test_case_insensitive_and_whitespace_tolerant() {
+        let plain = b"case-".repeat(64);
+        assert_eq!(
+            bytes(strip_content_coding(&gzip(&plain), Some("  GZip ")).unwrap()),
+            plain
+        );
+    }
+
+    /// Multiple codings come off in reverse application order (RFC 9110 §8.4).
+    #[test]
+    fn test_layered_codings_are_stripped_right_to_left() {
+        let plain = b"layered-".repeat(64);
+        let coded = gzip(&raw_deflate(&plain));
+        assert_eq!(
+            bytes(strip_content_coding(&coded, Some("deflate, gzip")).unwrap()),
+            plain
+        );
+    }
+
+    /// `br` is the live unsupported case (no brotli decoder is linked in). It
+    /// must be reported as `Unsupported`, NOT as an error and above all not as
+    /// a successful "decode" of still-compressed bytes.
+    #[test]
+    fn test_unsupported_coding_is_reported_not_silently_passed_through() {
+        let body = b"\x1b\x0e\x00brotli-ish";
+        assert!(matches!(
+            strip_content_coding(body, Some("br")).unwrap(),
+            Decoded::Unsupported
+        ));
+        // A layered list is unsupported if ANY member is: stripping only the
+        // outer gzip would still leave a brotli payload behind.
+        assert!(matches!(
+            strip_content_coding(body, Some("br, gzip")).unwrap(),
+            Decoded::Unsupported
+        ));
+    }
+
+    #[test]
+    fn test_corrupt_stream_is_an_error_not_a_silent_passthrough() {
+        let err = strip_content_coding(b"not-actually-gzip-at-all", Some("gzip"))
+            .expect_err("a corrupt gzip stream must not decode");
+        assert!(
+            matches!(err, AppError::Validation(_)),
+            "unexpected error shape: {err:?}"
+        );
+    }
+
+    /// A decompression bomb must be rejected by the budget rather than
+    /// buffered. The input here is upstream-controlled, so an unbounded decode
+    /// would be a remote memory-exhaustion primitive on the serve path.
+    #[test]
+    fn test_bomb_is_rejected_by_the_budget() {
+        let plain = vec![0u8; 4 * 1024 * 1024];
+        let coded = gzip(&plain);
+        assert!(
+            coded.len() < 64 * 1024,
+            "fixture must actually amplify or the test proves nothing"
+        );
+        assert!(
+            strip_content_coding_to(&coded, Some("gzip"), 4096).is_err(),
+            "a body inflating past the budget must be rejected, not buffered"
+        );
+        // ...and the same fixture decodes fine under a budget that fits it, so
+        // the rejection above is the budget and not a broken fixture.
+        assert_eq!(
+            bytes(strip_content_coding_to(&coded, Some("gzip"), 8 * 1024 * 1024).unwrap()).len(),
+            plain.len()
+        );
+    }
+}

--- a/backend/src/util/mod.rs
+++ b/backend/src/util/mod.rs
@@ -1,4 +1,5 @@
 //! Small, dependency-free utilities shared across the backend.
 
 pub mod bounded_archive;
+pub mod content_coding;
 pub mod glob;


### PR DESCRIPTION
Fixes #3193

`serve_remote_metadata` (`backend/src/api/handlers/pypi.rs`) carried two independent content-coding bugs, one per arm, needing opposite remediations. Unlike #3184 this route is **not** gated on `scan_on_proxy` — it is the ordinary remote-PyPI metadata path, so it is the wider exposure.

## Arm 1 — forward the upstream coding

The `.metadata` arm forwards the upstream body **verbatim** while pinning `text/plain; charset=utf-8` and declaring no coding. The coding was not in `fetch_upstream_direct_with_link`'s return type at all — the third slot of its triple was the `Link` header — so the handler could not forward what it never received. Since the shared HTTP client no longer lets reqwest decode upstream bodies, a coded `.metadata` from a gzipping CDN or an object-store upstream reached pip as compressed bytes labelled as plain text.

The handler now re-declares `upstream.content_encoding`; `None` upstream means the header stays **absent** rather than manufactured, which is the common case.

## Arm 2 — decode before parse

On upstream 404 the handler extracts `METADATA` from the wheel. `extract_metadata_from_wheel` opens the bytes as a zip, and a coded wheel is not a parseable zip, so a present and perfectly valid wheel answered 404 "Metadata not available". Forwarding a header does nothing here — the bytes have to be decoded before the parser sees them.

The wheel fetch moves to `fetch_artifact_with_cache_path_capped` at `DEFAULT_METADATA_MAX_BYTES` — the ceiling the uncapped wrapper already delegates with, so the byte budget is unchanged — because that is the variant #3184 widened to report the coding. Decode and parse run under **one** ingest-extraction permit, so both halves of the CPU work on upstream-controlled bytes stay admission-controlled together.

## The widening, and the caller audit

`fetch_upstream_direct_with_link` is widened **in place**, following #3194's reasoning: widening breaks every caller at compile time and forces each to declare its intent, whereas a `_with_encoding` sibling lets the next caller silently reintroduce the bug — which is how #3149 outlived #3176.

It is widened to a named `DirectUpstreamBody { content, content_type, content_encoding, link }` rather than a fourth positional `Option<String>`. That is a deliberate deviation in *form*, not reasoning: the mechanism that produced this bug was positional confusion — the old triple's third slot was `Link` while the sibling `CachedBody` triple's third slot is the coding, so `Ok((content, _ct, _))` read as "coding deliberately dropped" when it was "coding never available". A 4-tuple of three consecutive `Option<String>`s makes that failure mode more likely, not less.

Every caller, and what it declared:

| Caller | Bytes | Treatment |
|---|---|---|
| `pypi.rs::serve_remote_metadata` arm 1 | **verbatim** | forwards `content_encoding` on the response (the #3193 fix) |
| `proxy_helpers::proxy_fetch_uncached_with_link` | pass-through wrapper | returns the whole `DirectUpstreamBody`; documents that callers must forward *or* strip |
| `oci_v2.rs::fetch_upstream_tags_page` (via that wrapper) | **parses** (`serde_json::from_slice`, rebuilds the page) | **strips the coding before parsing** — see below |

The OCI tag-pagination caller had the same decode-before-parse gap: a coded `tags/list` document reached `serde_json::from_slice` still compressed and the whole tag listing 502'd. It is fixed here, with its own test, because the honest outcome of auditing it was "transforms, and cannot currently handle coded input" — leaving a known break in a caller this PR touches would be worse than the small scope increase. Happy to split it out if a reviewer prefers.

Two related primitives are documented rather than changed, matching how #3194 documented `proxy_fetch_capped_with_cache_key`:

- `ProxyService::fetch_artifact_with_cache_path` now states that it DROPS the coding and is otherwise identical to the capped form at `DEFAULT_METADATA_MAX_BYTES`, so a verbatim-forwarding or parsing caller must use the capped one.

## New: `util::content_coding`

Coding removal was open-coded nowhere and needed in two places, so it is centralised. It handles `gzip`/`x-gzip`, `deflate` (both the RFC's zlib wrapper and the raw form real servers emit — chosen by sniffing the zlib header, then falling back, with the *first* attempt's error reported so a budget breach is not masked), `zstd`, `identity`, and layered codings stripped right-to-left per RFC 9110 §8.4.

Two properties worth review attention:

- **Bounded.** The input is upstream-controlled, so every decode runs through the shared ingest decompressed-byte budget (`bounded_archive`, 128 MiB default, env-tunable). An unbounded decode here would be a remote memory-exhaustion primitive on the serve path. A `strip_content_coding_to` variant takes an explicit budget so the bomb test drives a tiny budget against a tiny fixture instead of mutating a process-global env var and racing the rest of the binary.
- **`Unsupported` is not an `Err`.** "This build has no decoder for `br`" is a different decision per caller than "the stream is corrupt or is a bomb". The PyPI wheel arm degrades an unsupported coding to its **pre-existing** "Metadata not available" answer rather than a new hard error: pip recovers from that by downloading the wheel itself, which succeeds because the download path forwards the coding for the client to strip (#3176). A 502 there would turn a recoverable case into a failed install.

## Tests

Every fixture is **`deflate`, never gzip** — a gzip fixture cannot distinguish "forwards the upstream's coding" from "hardcodes gzip", which is how the gap in #3176 survived fourteen tests. `tdh::gzip_fixture` is for GET/HEAD parity arms and is deliberately untouched. `tdh::coded_fixture`'s encoder block is factored into `tdh::code_bytes` so the wheel test can code a *specific* artifact (a real zip) rather than a generated payload.

The PyPI tests run the **real router end to end** against a mock upstream, so they fail against the handler rather than against a response-builder helper.

- `test_remote_pypi_metadata_forwards_upstream_deflate_coding` — deflate upstream ⇒ served `Content-Encoding: deflate`; body is the coded bytes verbatim; **body decodes** under the declared coding.
- `test_remote_pypi_metadata_omits_coding_when_upstream_uncoded` — negative control: uncoded upstream ⇒ **no** `Content-Encoding`.
- `test_remote_pypi_metadata_extracts_from_deflate_coded_wheel` — arm 2: a deflate-coded wheel's METADATA is extracted (200, correct bytes), and the wheel's coding is not echoed onto the freshly-built plaintext.
- `test_fetch_upstream_direct_with_link_reports_upstream_content_encoding` — the widened primitive reports the upstream coding and does **not** decode; the pre-existing `Link` test gains an uncoded negative control.
- `test_upstream_tags_page_decodes_coded_body_before_parsing` — OCI: a deflate-coded `tags/list` parses instead of 502ing.
- Eight `util::content_coding` unit tests: identity/absent pass-through, all supported tokens against *different* encoders' output, deflate in both zlib and raw forms, case/whitespace tolerance, layered right-to-left stripping, `br` reported as `Unsupported` (not silently passed through as "decoded"), corrupt stream as an error, and bomb rejection with a same-fixture control proving the rejection is the budget and not a broken fixture.

### Mutation results

Each mutation was applied to the fixed tree and the suite re-run; all five were caught.

**A — hardcode `"gzip"` in arm 1:**
```
test test_remote_pypi_metadata_forwards_upstream_deflate_coding ... FAILED
assertion `left == right` failed: the served `.metadata` must declare the UPSTREAM's coding; `gzip` means the value is hardcoded, `None` means #3193 is live
  left: Some("gzip")
 right: Some("deflate")
```

**B — emit the header unconditionally in arm 1:**
```
test test_remote_pypi_metadata_omits_coding_when_upstream_uncoded ... FAILED
assertion `left == right` failed: an uncoded upstream must be served with NO Content-Encoding; manufacturing one makes pip try to inflate plain text
  left: Some("identity")
 right: None
```

**C — revert arm 2's decode (parse the coded wheel directly):** reproduces the reported symptom exactly.
```
test test_remote_pypi_metadata_extracts_from_deflate_coded_wheel ... FAILED
assertion `left == right` failed: a deflate-coded wheel is still a valid wheel; its METADATA must be extracted rather than 404'd as unavailable; body: {"code":"NOT_FOUND","message":"Metadata not available"}
  left: 404
 right: 200
```

**D — drop the coding in the widened primitive (the pre-fix state):** fails at both layers.
```
test test_remote_pypi_metadata_forwards_upstream_deflate_coding ... FAILED
  left: None
 right: Some("deflate")

test test_fetch_upstream_direct_with_link_reports_upstream_content_encoding ... FAILED
assertion `left == right` failed: the UPSTREAM's coding must reach the caller; `gzip` here would mean it is hardcoded, `None` means #3193 is live
  left: None
 right: Some("deflate")
```

**E — revert the OCI decode:**
```
test test_upstream_tags_page_decodes_coded_body_before_parsing ... FAILED
a deflate-coded tags/list document must be decoded before parsing, not 502'd: 502
```

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- pypi` — 400 passed, 0 failed
- `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- oci_v2` — 525 passed, 0 failed
- `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- proxy_service` — 344 passed, 0 failed
- `cargo test --lib -- content_coding` — 8 passed, 0 failed
- No `sqlx::query!` macro text changed, so `.sqlx` is untouched; `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` unset succeeds.

## Adjacent, deliberately not fixed here

`maven.rs::download_root` (both the Remote and Virtual-member arms) forwards the upstream body **verbatim** — it copies the upstream `Content-Type` and sets `Content-Length` from `content.len()` — through `fetch_artifact_with_cache_path`, which drops the coding. That is the same #3149 class on a different handler and outside this issue's scope; worth its own issue. It is why `fetch_artifact_with_cache_path` gained the explicit "DROPS the coding" doc rather than being widened.
