### PR TITLE
fix(oci-gc): close the cleanup-key pre-delete window with a two-phase tombstone

### DIFF
--- a/backend/migrations/194_oci_cleanup_keys_pending_delete.sql
+++ b/backend/migrations/194_oci_cleanup_keys_pending_delete.sql
@@ -1,0 +1,68 @@
+-- Two-phase tombstone on the OCI upload cleanup journal, closing the
+-- pre-delete liveness window #3158 deliberately only narrowed (#3187).
+--
+-- #3158 re-asserts blob liveness in the same atomic UPDATE that extends a
+-- claimed key's lease, immediately before the object-store delete. That
+-- UPDATE runs on the pool as a single autocommit statement: its row lock is
+-- on `oci_upload_cleanup_keys`, never on `oci_blobs`, and it is released the
+-- instant the statement commits. The sweep then deletes the object holding
+-- nothing, so a push that commits its `oci_blobs` row inside that gap still
+-- has its bytes destroyed.
+--
+-- The racing push INSERTs a *new* `oci_blobs` row, so there is no `oci_blobs`
+-- row to lock -- `FOR UPDATE` there would lock nothing. The only object both
+-- sides already touch is the journal row (UNIQUE on `storage_key`, registered
+-- by the push before the storage write it tracks), so that row is where the
+-- two sides have to meet.
+--
+-- `pending_delete_at` makes the sweep's intent durable and visible BEFORE the
+-- destructive delete, which is the property that closes the window:
+--
+--   sweep  phase 1: UPDATE ... SET pending_delete_at = NOW() WHERE <liveness>
+--                   -- atomic with the liveness check, then committed
+--   sweep  phase 2: storage.delete()          -- no lock held, no tx open
+--   sweep  phase 3: DELETE ... WHERE pending_delete_at IS NOT NULL AND <liveness>
+--
+--   push:           SELECT ... FOR UPDATE on the same journal row, in the SAME
+--                   transaction that commits `oci_blobs`. A live tombstone
+--                   means the bytes are already being destroyed, so the push
+--                   refuses to commit; no tombstone means the push deletes the
+--                   journal row under the lock, and the sweep's phase-1 UPDATE
+--                   then matches zero rows and skips its storage delete.
+--
+-- This is the same shape migration 141 gave `oci_blobs` for blob GC
+-- (`run_blob_gc_mark` / `run_blob_gc_sweep`), applied one layer up. It is
+-- preferred over holding an explicit `FOR UPDATE` transaction across the
+-- object-store call: a cleanup batch is up to
+-- OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT (1000) keys, and holding a pooled
+-- connection plus a row lock across each of 1000 sequential object-store
+-- round trips would make every push of a swept digest wait on object-store
+-- latency (or its timeout). Here neither side holds anything across storage.
+ALTER TABLE oci_upload_cleanup_keys
+    ADD COLUMN pending_delete_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN oci_upload_cleanup_keys.pending_delete_at IS
+    'Two-phase sweep tombstone (#3187): set atomically with the pre-delete liveness re-check, before the object-store delete. A push that finds it set while claim_expires_at is still in the future must not commit an oci_blobs row for this key.';
+
+-- The tombstone is only meaningful while the sweep that set it still holds a
+-- live claim. A crashed sweep leaves a tombstone behind; it expires with the
+-- claim lease (OCI_CLEANUP_KEY_CLAIM_TTL) rather than dooming the key's
+-- digest forever, and the push side treats an expired claim as no tombstone.
+--
+-- Partial index: the push's commit-time guard looks the row up by primary key,
+-- but operators and the reaper need to find stranded tombstones cheaply, and
+-- tombstoned rows are a vanishing fraction of the table.
+CREATE INDEX IF NOT EXISTS idx_oci_upload_cleanup_keys_pending_delete
+    ON oci_upload_cleanup_keys (pending_delete_at)
+    WHERE pending_delete_at IS NOT NULL;
+
+-- CREATE INDEX CONCURRENTLY is intentionally not used: sqlx::migrate! runs
+-- each migration file inside a transaction and CONCURRENTLY is rejected in a
+-- transaction block (same constraint as migrations 166 and 193). The ALTER
+-- TABLE ... ADD COLUMN is a catalog-only change on PostgreSQL 11+ (no default,
+-- so no table rewrite), and the partial index build only sees rows that
+-- already satisfy the predicate -- of which there are none at migration time.
+-- Both take ACCESS EXCLUSIVE / SHARE only momentarily.
+--
+-- Reversible: DROP INDEX idx_oci_upload_cleanup_keys_pending_delete;
+--             ALTER TABLE oci_upload_cleanup_keys DROP COLUMN pending_delete_at;

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -917,25 +917,41 @@ async fn delete_storage_key_best_effort(
     }
 }
 
+/// Register a cleanup-journal row for a storage key that is about to be
+/// written, returning the row's id.
+///
+/// The id matters for final `oci-blobs/<digest>` keys: the commit-time guard
+/// [`claim_cleanup_journal_row_for_blob_commit`] re-reads *this specific row*
+/// rather than looking the key up again, so that "a sweep reaped the row this
+/// push registered" (its object is gone) stays distinguishable from "there was
+/// never a row" (#3187). Looking up by `storage_key` at commit time cannot tell
+/// those apart.
+///
+/// `ON CONFLICT ... DO UPDATE SET storage_key = EXCLUDED.storage_key` is a
+/// no-op write chosen over `DO NOTHING` purely because `DO NOTHING` returns no
+/// row on conflict, and a re-push of a digest whose journal row still exists is
+/// the common case.
 async fn register_oci_upload_cleanup_key(
     db: &PgPool,
     repository_id: Uuid,
     upload_session_id: Option<Uuid>,
     storage_key: &str,
-) -> Result<(), Response> {
+) -> Result<i64, Response> {
     sqlx::query(
         r#"
         INSERT INTO oci_upload_cleanup_keys (repository_id, upload_session_id, storage_key)
         VALUES ($1, $2, $3)
-        ON CONFLICT (storage_key) DO NOTHING
+        ON CONFLICT (storage_key) DO UPDATE SET storage_key = EXCLUDED.storage_key
+        RETURNING id
         "#,
     )
     .bind(repository_id)
     .bind(upload_session_id)
     .bind(storage_key)
-    .execute(db)
+    .fetch_one(db)
     .await
-    .map(|_| ())
+    .map_err(|e| oci_internal_error(&e.to_string()))?
+    .try_get::<i64, _>("id")
     .map_err(|e| oci_internal_error(&e.to_string()))
 }
 
@@ -970,28 +986,65 @@ async fn mark_oci_upload_cleanup_key_committed(
     Ok(())
 }
 
-/// Remove a cleanup-journal row once the storage object it tracked is durably
-/// referenced (an `oci_blobs` row now points at it). Used on the blob-upload
-/// success path so a now-live `oci-blobs/<digest>` key does not leave a journal
-/// row behind forever. Best-effort: a failed delete only leaves a stale row,
-/// and the reaper's `oci_blobs` EXISTS guard still refuses to reclaim the live
-/// blob, so it is never data loss — just a row to be cleaned up later.
+/// Remove a cleanup-journal row for a **temp / part / completion** key whose
+/// storage object the push path has already deleted itself, so the 24-48h
+/// sweeps do not have to issue a redundant `NotFound` delete for it later.
+///
+/// Best-effort: a failed delete only leaves a stale row for those sweeps to
+/// pick up.
+///
+/// This is **not** the guard for a final `oci-blobs/<digest>` key. That path
+/// must use [`claim_cleanup_journal_row_for_blob_commit`] inside the same
+/// transaction as its `oci_blobs` INSERT — the whole point of #3187 is that a
+/// blob key's journal row is the object the push and the sweep serialize on,
+/// which an out-of-band `DELETE` like this one cannot do.
+///
+/// It still refuses to remove a row a sweep has tombstoned under a live claim
+/// (#3187). Before, this was a bare `DELETE ... WHERE storage_key = $1`: a push
+/// could erase an in-flight sweep's journal row, the sweep's guarded row
+/// `DELETE` would then match nothing, and — because neither sweep inspected
+/// `rows_affected` — the lost race was recorded as a clean success. The sweeps
+/// now report a zero-row reap, and this no longer causes one.
 async fn clear_oci_upload_cleanup_key_best_effort(db: &PgPool, storage_key: &str) {
-    if let Err(e) = sqlx::query(
+    match sqlx::query(
         r#"
         DELETE FROM oci_upload_cleanup_keys
         WHERE storage_key = $1
+          AND (pending_delete_at IS NULL OR claim_expires_at <= NOW())
         "#,
     )
     .bind(storage_key)
     .execute(db)
     .await
     {
-        warn!(
-            storage_key = %storage_key,
-            error = %e,
-            "Failed to clear OCI upload cleanup-key row after blob became referenced"
-        );
+        Ok(r) if r.rows_affected() == 0 => {
+            // Either the row was already gone (the common, uninteresting case)
+            // or a sweep owns it right now. Distinguishing the two is what
+            // makes a lost race observable rather than silent.
+            let tombstoned = sqlx::query(
+                "SELECT 1 AS present FROM oci_upload_cleanup_keys \
+                 WHERE storage_key = $1 AND pending_delete_at IS NOT NULL \
+                   AND (claim_expires_at IS NULL OR claim_expires_at > NOW())",
+            )
+            .bind(storage_key)
+            .fetch_optional(db)
+            .await;
+            if matches!(tombstoned, Ok(Some(_))) {
+                warn!(
+                    storage_key = %storage_key,
+                    "Left an in-flight cleanup sweep's tombstoned journal row in place; \
+                     the sweep is deleting this object now (#3187)"
+                );
+            }
+        }
+        Ok(_) => {}
+        Err(e) => {
+            warn!(
+                storage_key = %storage_key,
+                error = %e,
+                "Failed to clear OCI upload cleanup-key row after blob became referenced"
+            );
+        }
     }
 }
 
@@ -4980,15 +5033,19 @@ async fn handle_start_upload(
         // key first so the cleanup-key reaper can reclaim it on DB failure; the
         // reaper treats a blob key as referenced once an `oci_blobs` row for the
         // digest exists, so a committed/referenced blob is never reclaimed.
-        if let Err(resp) = register_oci_upload_cleanup_key(&state.db, repo_id, None, &key).await {
-            delete_storage_key_best_effort(
-                &storage,
-                &temp_key,
-                "monolithic blob cleanup registration failed",
-            )
-            .await;
-            return resp;
-        }
+        let blob_journal_id =
+            match register_oci_upload_cleanup_key(&state.db, repo_id, None, &key).await {
+                Ok(id) => id,
+                Err(resp) => {
+                    delete_storage_key_best_effort(
+                        &storage,
+                        &temp_key,
+                        "monolithic blob cleanup registration failed",
+                    )
+                    .await;
+                    return resp;
+                }
+            };
 
         if let Err(e) = storage.copy(&temp_key, &key).await {
             delete_storage_key_best_effort(&storage, &temp_key, "monolithic blob copy failed")
@@ -5002,23 +5059,96 @@ async fn handle_start_upload(
 
         // Record in oci_blobs. On conflict the blob already exists; clear any
         // `pending_delete_at` marker (#1660) so re-uploading a blob that GC had
-        // marked for deletion resurrects it. The push path holds no row lock
-        // here, but the sweep re-check re-reads `pending_delete_at` under its
-        // own `FOR UPDATE`, so a marker cleared before that re-check protects
-        // the blob and one cleared after is re-marked on the next mark pass.
+        // marked for deletion resurrects it.
+        //
+        // #3187: the INSERT and the blob key's cleanup-journal guard commit in
+        // ONE transaction. The guard takes `SELECT ... FOR UPDATE` on the
+        // journal row registered above, which is the only lock a cleanup sweep
+        // and this push both contend for — the sweep cannot lock the `oci_blobs`
+        // row because this statement is the thing that creates it. Committing
+        // the row without that lock is what let a sweep delete the bytes of a
+        // blob this push had just made live.
+        let mut blob_tx = match state.db.begin().await {
+            Ok(tx) => tx,
+            Err(e) => {
+                delete_storage_key_best_effort(
+                    &storage,
+                    &temp_key,
+                    "monolithic blob commit begin failed",
+                )
+                .await;
+                return oci_error(
+                    crate::api::handlers::db_status(&e.to_string()),
+                    "INTERNAL_ERROR",
+                    &e.to_string(),
+                );
+            }
+        };
+
+        match crate::services::storage_gc_service::claim_cleanup_journal_row_for_blob_commit(
+            &mut blob_tx,
+            blob_journal_id,
+            repo_id,
+            &key,
+        )
+        .await
+        {
+            Ok(crate::services::storage_gc_service::CleanupJournalClaim::Cleared) => {}
+            Ok(crate::services::storage_gc_service::CleanupJournalClaim::Doomed) => {
+                // A cleanup sweep owns this key and is deleting (or has
+                // deleted) its object. Committing an `oci_blobs` row now would
+                // publish a blob whose bytes are gone — #3085 exactly. Fail the
+                // push instead; it is retryable, and the retry re-journals a
+                // fresh row once the sweep has finished with this one.
+                let _ = blob_tx.rollback().await;
+                delete_storage_key_best_effort(
+                    &storage,
+                    &temp_key,
+                    "monolithic blob raced a cleanup sweep",
+                )
+                .await;
+                warn!(
+                    storage_key = %key,
+                    digest = %canonical_digest,
+                    "Monolithic blob push lost the race with a cleanup sweep deleting the same \
+                     key; refusing to commit an oci_blobs row for deleted bytes (#3187)"
+                );
+                return oci_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "BLOB_UPLOAD_INVALID",
+                    "blob storage was being reclaimed concurrently; retry the upload",
+                );
+            }
+            Err(e) => {
+                let _ = blob_tx.rollback().await;
+                delete_storage_key_best_effort(
+                    &storage,
+                    &temp_key,
+                    "monolithic blob cleanup-journal guard failed",
+                )
+                .await;
+                return oci_error(
+                    crate::api::handlers::db_status(&e.to_string()),
+                    "INTERNAL_ERROR",
+                    &e.to_string(),
+                );
+            }
+        }
+
         if let Err(e) = sqlx::query!(
             "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1, $2, $3, $4) ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
             repo_id, canonical_digest.as_str(), put_result.bytes_written as i64, key
         )
-        .execute(&state.db)
+        .execute(&mut *blob_tx)
         .await
         {
-            // Leave the (still NULL-marked) journal entry for the blob key in
-            // place: the pending reaper reclaims the orphaned
-            // `oci-blobs/<digest>` object since no `oci_blobs` row references it.
-            // Do NOT delete the blob object here — a concurrent push of the same
-            // digest may be committing it (the reaper's `oci_blobs` EXISTS guard
-            // protects that live blob).
+            // Rolling back restores the (still NULL-marked) journal entry for
+            // the blob key, so the pending reaper reclaims the orphaned
+            // `oci-blobs/<digest>` object since no `oci_blobs` row references
+            // it. Do NOT delete the blob object here — a concurrent push of the
+            // same digest may be committing it (the reaper's `oci_blobs` EXISTS
+            // guard protects that live blob).
+            let _ = blob_tx.rollback().await;
             delete_storage_key_best_effort(&storage, &temp_key, "monolithic blob row insert failed")
                 .await;
             return oci_error(
@@ -5028,10 +5158,18 @@ async fn handle_start_upload(
             );
         }
 
-        // The blob row is durable, so the blob key is now referenced. Drop its
-        // journal entry; the reaper would in any case refuse to reclaim it via
-        // the `oci_blobs` EXISTS guard.
-        clear_oci_upload_cleanup_key_best_effort(&state.db, &key).await;
+        // Commit publishes the `oci_blobs` row and the journal-row removal
+        // together: no sweep can observe one without the other.
+        if let Err(e) = blob_tx.commit().await {
+            delete_storage_key_best_effort(&storage, &temp_key, "monolithic blob commit failed")
+                .await;
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                &e.to_string(),
+            );
+        }
+
         delete_storage_key_best_effort(&storage, &temp_key, "monolithic upload completed").await;
         // GC-LOW-3: the streamed temp object has now been deleted and the
         // `oci_blobs` row is durable, so the temp key's cleanup-journal row is
@@ -5947,6 +6085,15 @@ async fn handle_complete_upload(
     // cleared inline on the confirmed success path below (post-commit). It is
     // created inside the multi-part branch, so carry its key out here.
     let mut completion_temp_journal_key: Option<String> = None;
+    // #3187: the cleanup-journal row id for `blob_key`, registered by whichever
+    // completion branch runs below — both journal the blob key before promoting
+    // an object to it, so this is always assigned before the commit transaction
+    // reads it. That transaction re-reads THIS row under `FOR UPDATE` before
+    // publishing the `oci_blobs` row, which is how this push and a cleanup
+    // sweep serialize on the same key. Deliberately left uninitialised so the
+    // compiler enforces that a branch which skips the journal registration also
+    // fails to compile, rather than silently skipping the guard.
+    let blob_journal_id: i64;
 
     // Single-part fast path: one streamed part whose digest was already computed
     // and cached during PATCH/POST and already equals the client's requested
@@ -5978,9 +6125,9 @@ async fn handle_complete_upload(
         // `oci_blobs` commit below fails, the copied `oci-blobs/<digest>` object
         // would otherwise be an unreclaimable orphan. The reaper treats the key
         // as referenced once an `oci_blobs` row exists, so a committed blob is
-        // never reclaimed; see `clear_oci_upload_cleanup_key_best_effort` after
-        // the transaction commits.
-        if let Err(resp) = register_oci_upload_cleanup_key(
+        // never reclaimed. The row is removed inside the commit transaction by
+        // the #3187 guard, not by a best-effort DELETE afterwards.
+        match register_oci_upload_cleanup_key(
             &state.db,
             session.repository_id,
             Some(session_id),
@@ -5988,17 +6135,20 @@ async fn handle_complete_upload(
         )
         .await
         {
-            if let Err(reset_resp) = reset_oci_upload_session_state(
-                &state.db,
-                session_id,
-                session.repository_id,
-                completion_state_token,
-            )
-            .await
-            {
-                return reset_resp;
+            Ok(id) => blob_journal_id = id,
+            Err(resp) => {
+                if let Err(reset_resp) = reset_oci_upload_session_state(
+                    &state.db,
+                    session_id,
+                    session.repository_id,
+                    completion_state_token,
+                )
+                .await
+                {
+                    return reset_resp;
+                }
+                return resp;
             }
-            return resp;
         }
         if let Err(e) = storage.copy(&parts[0].storage_key, &blob_key).await {
             if let Err(reset_resp) = reset_oci_upload_session_state(
@@ -6258,7 +6408,7 @@ async fn handle_complete_upload(
         // it, mirroring the single-part branch above. On `oci_blobs` commit
         // failure the reaper reclaims the orphaned `oci-blobs/<digest>` object;
         // once the row commits the reaper treats the key as referenced.
-        if let Err(resp) = register_oci_upload_cleanup_key(
+        match register_oci_upload_cleanup_key(
             &state.db,
             session.repository_id,
             Some(session_id),
@@ -6266,31 +6416,34 @@ async fn handle_complete_upload(
         )
         .await
         {
-            delete_storage_key_best_effort(
-                &storage,
-                &completion_temp_key,
-                "completion blob cleanup registration failed",
-            )
-            .await;
-            if final_part.is_some() {
+            Ok(id) => blob_journal_id = id,
+            Err(resp) => {
                 delete_storage_key_best_effort(
                     &storage,
-                    &final_part_key,
+                    &completion_temp_key,
                     "completion blob cleanup registration failed",
                 )
                 .await;
+                if final_part.is_some() {
+                    delete_storage_key_best_effort(
+                        &storage,
+                        &final_part_key,
+                        "completion blob cleanup registration failed",
+                    )
+                    .await;
+                }
+                if let Err(reset_resp) = reset_oci_upload_session_state(
+                    &state.db,
+                    session_id,
+                    session.repository_id,
+                    completion_state_token,
+                )
+                .await
+                {
+                    return reset_resp;
+                }
+                return resp;
             }
-            if let Err(reset_resp) = reset_oci_upload_session_state(
-                &state.db,
-                session_id,
-                session.repository_id,
-                completion_state_token,
-            )
-            .await
-            {
-                return reset_resp;
-            }
-            return resp;
         }
         if let Err(e) = storage.copy(&completion_temp_key, &blob_key).await {
             delete_storage_key_best_effort(
@@ -6382,6 +6535,82 @@ async fn handle_complete_upload(
             );
         }
     };
+    // #3187: take the blob key's cleanup-journal row under `FOR UPDATE` inside
+    // THIS transaction, before the `oci_blobs` INSERT below commits. A cleanup
+    // sweep tombstones that same row before it deletes the object, so whichever
+    // of the two reaches the row lock first decides: we find a live tombstone
+    // and refuse to publish a row for bytes that are being destroyed, or we
+    // delete the row here and the sweep's tombstone `UPDATE` then matches
+    // nothing and skips its storage delete. Mirrors the monolithic path above.
+    match crate::services::storage_gc_service::claim_cleanup_journal_row_for_blob_commit(
+        &mut tx,
+        blob_journal_id,
+        session.repository_id,
+        &blob_key,
+    )
+    .await
+    {
+        Ok(crate::services::storage_gc_service::CleanupJournalClaim::Cleared) => {}
+        Ok(crate::services::storage_gc_service::CleanupJournalClaim::Doomed) => {
+            let _ = tx.rollback().await;
+            if final_part.is_some() {
+                delete_storage_key_best_effort(
+                    &storage,
+                    &final_part_key,
+                    "completion blob raced a cleanup sweep",
+                )
+                .await;
+            }
+            if let Err(reset_resp) = reset_oci_upload_session_state(
+                &state.db,
+                session_id,
+                session.repository_id,
+                completion_state_token,
+            )
+            .await
+            {
+                return reset_resp;
+            }
+            warn!(
+                session_id = %session_id,
+                storage_key = %blob_key,
+                digest = %digest,
+                "Chunked blob completion lost the race with a cleanup sweep deleting the \
+                 same key; refusing to commit an oci_blobs row for deleted bytes (#3187)"
+            );
+            return oci_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "BLOB_UPLOAD_INVALID",
+                "blob storage was being reclaimed concurrently; retry the upload",
+            );
+        }
+        Err(e) => {
+            let _ = tx.rollback().await;
+            if final_part.is_some() {
+                delete_storage_key_best_effort(
+                    &storage,
+                    &final_part_key,
+                    "completion cleanup-journal guard failed",
+                )
+                .await;
+            }
+            if let Err(reset_resp) = reset_oci_upload_session_state(
+                &state.db,
+                session_id,
+                session.repository_id,
+                completion_state_token,
+            )
+            .await
+            {
+                return reset_resp;
+            }
+            return oci_error(
+                crate::api::handlers::db_status(&e.to_string()),
+                "INTERNAL_ERROR",
+                &e.to_string(),
+            );
+        }
+    }
     // On conflict clear any `pending_delete_at` marker (#1660): finalizing a
     // chunked upload of a blob GC had marked resurrects it, mirroring the
     // monolithic-upload path above.
@@ -6485,10 +6714,10 @@ async fn handle_complete_upload(
         .await
         {
             Ok(true) => {
-                // The `oci_blobs` row is durable, so the blob key is now
-                // referenced. Drop its journal entry (the reaper's `oci_blobs`
-                // guard would refuse to reclaim it regardless).
-                clear_oci_upload_cleanup_key_best_effort(&state.db, &blob_key).await;
+                // The `oci_blobs` row is durable, which means the transaction
+                // committed — and the #3187 guard's DELETE of the blob key's
+                // journal row was part of that same transaction, so the row is
+                // already gone. Nothing to clear here.
                 let mut cleanup_keys: Vec<String> =
                     parts.iter().map(|part| part.storage_key.clone()).collect();
                 cleanup_keys.push(session.storage_temp_key.clone());
@@ -6545,11 +6774,10 @@ async fn handle_complete_upload(
         );
     }
 
-    // The `oci_blobs` row committed durably, so the blob key is now referenced.
-    // Drop its journal entry. (The reaper independently refuses to reclaim it via
-    // the `oci_blobs` EXISTS guard, so a committed blob is never reclaimed even
-    // if this best-effort clear is lost.)
-    clear_oci_upload_cleanup_key_best_effort(&state.db, &blob_key).await;
+    // The `oci_blobs` row committed durably. The blob key's journal row was
+    // deleted by the #3187 guard inside that same transaction, so the row and
+    // the reference it protected became visible together — there is deliberately
+    // no best-effort clear here to lose.
 
     let mut cleanup_keys: Vec<String> = parts.iter().map(|part| part.storage_key.clone()).collect();
     cleanup_keys.push(session.storage_temp_key.clone());

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -1650,16 +1650,17 @@ impl StorageGcService {
                 }
             };
 
-            // Re-assert ownership AND liveness immediately before the
-            // destructive delete: earlier keys in this batch may have taken
-            // long enough that this row's claim lapsed and another replica's
-            // sweep now owns it, or that a concurrent push committed an
-            // `oci_blobs` row for this key and the object is live again
-            // (#3085). The row DELETE below re-checks liveness too, but it
-            // runs after the bytes are gone, so this is the check that
-            // prevents the data loss.
+            // PHASE 1 (#3187): re-assert ownership AND liveness and publish the
+            // `pending_delete_at` tombstone, atomically, before touching
+            // storage. Earlier keys in this batch may have taken long enough
+            // that this row's claim lapsed and another replica's sweep now owns
+            // it, or that a concurrent push committed an `oci_blobs` row for
+            // this key and the object is live again (#3085). The tombstone is
+            // what a racing push reads to know it must not commit; a push that
+            // beat us to the row lock has already deleted the row, so this
+            // matches nothing and we skip the delete.
             if !self
-                .hold_cleanup_key_claim_for_delete(&cleanup_key, CleanupSweepKind::Unreferenced)
+                .tombstone_cleanup_key_for_delete(&cleanup_key, CleanupSweepKind::Unreferenced)
                 .await
             {
                 tracing::info!(
@@ -1686,11 +1687,15 @@ impl StorageGcService {
                 }
             }
 
-            if let Err(e) = sqlx::query(
+            // PHASE 3 (#3187): reap the journal row. `pending_delete_at IS NOT
+            // NULL` ties this to the tombstone phase 1 published, so the row we
+            // remove is provably the one whose object we just deleted.
+            let reaped = sqlx::query(
                 r#"
                 DELETE FROM oci_upload_cleanup_keys
                 WHERE id = $1
                   AND claim_token = $2
+                  AND pending_delete_at IS NOT NULL
                   AND storage_write_completed_at IS NOT NULL
                   -- Intentionally NOT guarded by `s.id = upload_session_id`
                   -- (unlike the pending reaper): a committed cleanup key is a
@@ -1726,12 +1731,34 @@ impl StorageGcService {
             .bind(cleanup_key.id)
             .bind(cleanup_key.claim_token)
             .execute(&self.db)
-            .await
-            {
+            .await;
+
+            let reaped = match reaped {
+                Ok(r) => r,
+                Err(e) => {
+                    let msg = format_gc_error(
+                        "delete OCI upload cleanup-key row",
+                        &cleanup_key.storage_key,
+                        &e.to_string(),
+                    );
+                    tracing::warn!("{}", msg);
+                    result.errors.push(msg);
+                    continue;
+                }
+            };
+
+            // #3187: a zero-row match used to be counted as a clean success —
+            // the sweep incremented both counters unconditionally — which is
+            // precisely how a lost race made itself invisible. Phase 1 proved
+            // this row was ours, tombstoned, and reclaimable, and the push side
+            // can no longer remove a live tombstone, so a miss here is a real
+            // anomaly: report it instead of banking it.
+            if reaped.rows_affected() != 1 {
                 let msg = format_gc_error(
-                    "delete OCI upload cleanup-key row",
+                    "reap OCI upload cleanup-key row",
                     &cleanup_key.storage_key,
-                    &e.to_string(),
+                    "tombstoned row vanished or stopped matching between the storage delete \
+                     and its reap; the object was deleted but its journal row was not",
                 );
                 tracing::warn!("{}", msg);
                 result.errors.push(msg);
@@ -1893,10 +1920,12 @@ impl StorageGcService {
         .await;
     }
 
-    /// Re-assert ownership **and liveness** for one cleanup key immediately
-    /// before its storage delete. Returns `true` only when the key is still
-    /// this sweeper's and still reclaimable; the caller must skip the
-    /// destructive delete otherwise.
+    /// **Phase 1 of the two-phase cleanup-key sweep (#3187).** Re-assert
+    /// ownership **and liveness** for one cleanup key and, in the same atomic
+    /// `UPDATE`, stamp `pending_delete_at` — the durable tombstone that tells
+    /// the push path this key's bytes are about to be destroyed. Returns `true`
+    /// only when the key is still this sweeper's, still reclaimable, and now
+    /// tombstoned; the caller must skip the destructive delete otherwise.
     ///
     /// Two independent things can change between the claim and the delete:
     ///
@@ -1907,71 +1936,65 @@ impl StorageGcService {
     ///    replica's sweep while this one is still walking its list, letting
     ///    both attempt the same destructive delete.
     /// 2. **Liveness (#3085).** A digest re-pushed after this row was claimed
-    ///    commits an `oci_blobs` row for the very same `storage_key` (the push
-    ///    path re-uses the journal row via `ON CONFLICT (storage_key)`), so
-    ///    the object is live again. The claim-time predicate is stale by then
-    ///    and the sweep's guarded row `DELETE` re-checks liveness only *after*
-    ///    the bytes are already gone — it saves the journal row, not the blob.
-    ///    Re-asserting the predicate here is the check that actually protects
-    ///    the data.
+    ///    commits an `oci_blobs` row for the very same `storage_key`, so the
+    ///    object is live again. The claim-time predicate is stale by then and
+    ///    the sweep's guarded row `DELETE` re-checks liveness only *after* the
+    ///    bytes are already gone — it saves the journal row, not the blob.
     ///
-    /// This re-check is deliberately *weaker* than the per-row re-check
-    /// [`is_blob_still_orphan`] performs before the two-phase blob GC's
-    /// destructive act, and the difference is the whole point of the caveat
-    /// below. `is_blob_still_orphan` runs inside an open transaction that took
-    /// `SELECT ... FOR UPDATE` on the `oci_blobs` row and *holds that lock
-    /// across the storage delete*, so a racing pusher blocks. This hook holds
-    /// nothing: it is a single autocommit `UPDATE` whose lock is gone before
-    /// the caller touches storage. Same predicate, different guarantee — do not
-    /// read the two as equivalent.
+    /// # Why the tombstone, and why this closes the window
     ///
-    /// The renewal and the re-check are one atomic `UPDATE`, so a row that has
-    /// become live cannot have its lease extended. `kind` selects the predicate
-    /// matching the calling sweep's own row `DELETE`.
+    /// #3158 performed the re-check here but nothing else, and was explicit
+    /// that this only *narrowed* the race: the `UPDATE` runs on the pool as a
+    /// single autocommit statement, so its row lock — on
+    /// `oci_upload_cleanup_keys`, never on `oci_blobs` — is released the
+    /// instant it commits, and the caller then deletes the object holding
+    /// nothing. A push committing its `oci_blobs` row inside that gap still
+    /// lost its bytes.
     ///
-    /// This NARROWS the window; it does not close it. Be precise about what is
-    /// and is not guaranteed here, because the difference decides whether
-    /// anyone finishes the job:
+    /// It cannot be fixed on this side alone. The blob GC one layer down gets
+    /// its guarantee from [`is_blob_still_orphan`] holding `SELECT ... FOR
+    /// UPDATE` on the *`oci_blobs` row* across the storage delete, which works
+    /// because a re-push of a marked blob `ON CONFLICT`s onto that existing
+    /// row and blocks. Here the racing push **INSERTs a new** `oci_blobs` row,
+    /// so there is no row to lock and `FOR UPDATE` on `oci_blobs` would lock
+    /// nothing. The only object both sides already touch is this journal row,
+    /// so the push has to participate — see
+    /// [`claim_cleanup_journal_row_for_blob_commit`], which is the other half
+    /// of this protocol and must be read with it.
     ///
-    /// The `UPDATE` runs on the pool as a single autocommit statement, so its
-    /// row lock — which is on `oci_upload_cleanup_keys`, never on `oci_blobs` —
-    /// is released the instant it commits. The caller then performs an
-    /// object-store `DELETE` with no lock held. A push that commits its
-    /// `oci_blobs` row inside that gap still has its bytes destroyed. Nothing
-    /// in the push path serializes against this: `register_oci_upload_cleanup_key`
-    /// is `ON CONFLICT (storage_key) DO NOTHING`, which against an already
-    /// claimed row is a complete no-op, and the push's success path calls
-    /// `clear_oci_upload_cleanup_key_best_effort` (`api/handlers/oci_v2.rs`), a
-    /// bare `DELETE ... WHERE storage_key = $1` with no `claim_token` guard —
-    /// so the push can remove the journal row out from under an in-flight
-    /// sweep. Nor is that interleaving observable: each sweep's guarded row
-    /// `DELETE` never inspects `rows_affected`, so a zero-row match is counted
-    /// as a clean success.
+    /// The two halves meet on this row's lock, and the tombstone is what makes
+    /// the meeting decisive in both orders:
     ///
-    /// What this buys is a large reduction, not a proof. Before the re-check,
-    /// liveness was evaluated once per batch in the candidate `SELECT`, so the
-    /// exposure spanned the entire batch walk — up to
-    /// `OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT` sequential object-store deletes,
-    /// which is minutes. It is now one storage round trip, order tens of
-    /// milliseconds.
+    /// * **Sweep first.** This `UPDATE` commits the tombstone. The push's
+    ///   `SELECT ... FOR UPDATE` then sees `pending_delete_at` set with a live
+    ///   claim and refuses to commit its `oci_blobs` row at all. The storage
+    ///   delete destroys bytes nothing references.
+    /// * **Push first.** The push holds `FOR UPDATE` on this row and deletes
+    ///   it inside the same transaction that inserts `oci_blobs`. This
+    ///   `UPDATE` blocks on that lock, and when it is released the row is
+    ///   gone — zero rows affected, `false`, and the caller skips the storage
+    ///   delete. The bytes survive.
     ///
-    /// Closing it properly requires the push and the sweep to serialize on the
-    /// journal row — an explicit transaction holding `SELECT ... FOR UPDATE`
-    /// across the storage delete, with the push taking the same row lock before
-    /// committing `oci_blobs` — or a two-phase tombstone, which this codebase
-    /// already implements for blob GC via `oci_blobs.pending_delete_at`
-    /// (migration 141, `run_blob_gc_mark` / `run_blob_gc_sweep`).
+    /// Neither side holds a lock across the object-store call, which is the
+    /// reason this shape was chosen over wrapping the storage delete in an
+    /// explicit `FOR UPDATE` transaction (see migration 194 for the cost
+    /// comparison).
     ///
-    /// Tracked in #3187. Until that lands, this remains a narrowed window, not
-    /// a closed one.
-    async fn hold_cleanup_key_claim_for_delete(
+    /// A tombstone is only binding while the claim that set it is live. A
+    /// sweep that crashes between phase 1 and phase 3 leaves one behind; it
+    /// lapses with `claim_expires_at` rather than dooming that digest forever,
+    /// and the push side treats an expired claim as no tombstone.
+    ///
+    /// `kind` selects the liveness predicate matching the calling sweep's own
+    /// row `DELETE`, so phase 1 and phase 3 agree on "still reclaimable".
+    async fn tombstone_cleanup_key_for_delete(
         &self,
         cleanup_key: &OciUploadCleanupKey,
         kind: CleanupSweepKind,
     ) -> bool {
         let sql = format!(
             "UPDATE oci_upload_cleanup_keys \
-             SET claim_expires_at = NOW() + {claim_ttl} \
+             SET claim_expires_at = NOW() + {claim_ttl}, pending_delete_at = NOW() \
              WHERE id = $1 AND claim_token = $2{liveness}",
             claim_ttl = OCI_CLEANUP_KEY_CLAIM_TTL_SQL,
             liveness = kind.liveness_predicate_sql(),
@@ -1987,7 +2010,7 @@ impl StorageGcService {
                 tracing::warn!(
                     storage_key = %cleanup_key.storage_key,
                     error = %e,
-                    "failed to re-assert cleanup-key claim; skipping its storage delete"
+                    "failed to tombstone cleanup-key claim; skipping its storage delete"
                 );
                 false
             }
@@ -2053,14 +2076,14 @@ impl StorageGcService {
                 }
             };
 
-            // Same tail-expiry and same liveness window as the unreferenced
-            // sweep (#3085): re-assert ownership and the pending-key liveness
-            // predicate immediately before the destructive delete, so neither
-            // a lapsed claim nor a concurrent push that committed an
-            // `oci_blobs` row for this key can be followed by a delete of its
-            // bytes.
+            // PHASE 1 (#3187): same tail-expiry and same liveness window as the
+            // unreferenced sweep (#3085), and the same tombstone. Re-assert
+            // ownership and the pending-key liveness predicate and publish
+            // `pending_delete_at` atomically, so neither a lapsed claim nor a
+            // concurrent push that committed an `oci_blobs` row for this key
+            // can be followed by a delete of its bytes.
             if !self
-                .hold_cleanup_key_claim_for_delete(&cleanup_key, CleanupSweepKind::Pending)
+                .tombstone_cleanup_key_for_delete(&cleanup_key, CleanupSweepKind::Pending)
                 .await
             {
                 tracing::info!(
@@ -2095,11 +2118,14 @@ impl StorageGcService {
             // upload is still live is never reaped, even when the row's
             // storage_key is a part key that does not textually match the
             // session's storage_temp_key.
-            if let Err(e) = sqlx::query(
+            // PHASE 3 (#3187): see the unreferenced sweep. `pending_delete_at
+            // IS NOT NULL` ties the reap to the tombstone phase 1 published.
+            let reaped = sqlx::query(
                 r#"
                 DELETE FROM oci_upload_cleanup_keys
                 WHERE id = $1
                   AND claim_token = $2
+                  AND pending_delete_at IS NOT NULL
                   AND storage_write_completed_at IS NULL
                   AND NOT EXISTS (
                     SELECT 1 FROM oci_upload_sessions s
@@ -2123,12 +2149,30 @@ impl StorageGcService {
             .bind(cleanup_key.id)
             .bind(cleanup_key.claim_token)
             .execute(&self.db)
-            .await
-            {
+            .await;
+
+            let reaped = match reaped {
+                Ok(r) => r,
+                Err(e) => {
+                    let msg = format_gc_error(
+                        "delete pending OCI upload cleanup-key row",
+                        &cleanup_key.storage_key,
+                        &e.to_string(),
+                    );
+                    tracing::warn!("{}", msg);
+                    result.errors.push(msg);
+                    continue;
+                }
+            };
+
+            // #3187: a zero-row match is an anomaly, not a success. See the
+            // matching block in `cleanup_unreferenced_oci_upload_keys`.
+            if reaped.rows_affected() != 1 {
                 let msg = format_gc_error(
-                    "delete pending OCI upload cleanup-key row",
+                    "reap pending OCI upload cleanup-key row",
                     &cleanup_key.storage_key,
-                    &e.to_string(),
+                    "tombstoned row vanished or stopped matching between the storage delete \
+                     and its reap; the object was deleted but its journal row was not",
                 );
                 tracing::warn!("{}", msg);
                 result.errors.push(msg);
@@ -2827,6 +2871,143 @@ async fn is_blob_still_orphan(
         .await?;
 
     Ok(row.try_get::<bool, _>("still_orphan").unwrap_or(false))
+}
+
+/// Outcome of the push side's commit-time guard on a blob key's
+/// cleanup-journal row. See [`claim_cleanup_journal_row_for_blob_commit`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CleanupJournalClaim {
+    /// No sweep owns this key. The journal row (if it still existed) has been
+    /// deleted inside the caller's transaction, under the row lock, so a sweep
+    /// that reaches phase 1 afterwards will match zero rows and skip its
+    /// storage delete. The caller may commit its `oci_blobs` row.
+    Cleared,
+    /// A cleanup sweep has tombstoned this key under a live claim, or has
+    /// already reaped its journal row: the object either is being deleted right
+    /// now or is already gone. The caller **must not** commit an `oci_blobs`
+    /// row for it, and must roll back and report a retryable failure.
+    Doomed,
+}
+
+/// **The push side of the two-phase cleanup-key protocol (#3187).** Read this
+/// together with [`StorageGcService::tombstone_cleanup_key_for_delete`], which
+/// is the sweep side; neither half is correct alone.
+///
+/// Call this inside the *same transaction* that commits the `oci_blobs` row
+/// for `storage_key`, strictly before that INSERT commits. `journal_id` is the
+/// row id returned when the push registered the key
+/// (`register_oci_upload_cleanup_key`), captured then rather than looked up by
+/// `storage_key` now, so that a sweep having reaped *the row this push
+/// registered* is distinguishable from there never having been one.
+///
+/// # Why the push has to participate
+///
+/// The cleanup sweep destroys `oci-blobs/<digest>` objects it believes nothing
+/// references. Its liveness predicate is `NOT EXISTS (SELECT 1 FROM oci_blobs
+/// ...)`, and a re-push of a swept digest **INSERTs a new** `oci_blobs` row —
+/// there is no existing row for the sweep to have locked, so no amount of
+/// `FOR UPDATE` on `oci_blobs` (the mechanism that protects the blob GC one
+/// layer down, via [`is_blob_still_orphan`]) can serialize the two. The
+/// journal row is the only object both sides touch, and this function is what
+/// makes the push touch it under a lock.
+///
+/// # The protocol
+///
+/// 1. `SELECT ... FOR UPDATE` the journal row. This blocks against a sweep's
+///    in-flight phase-1 tombstone `UPDATE`, and makes a sweep's phase-1
+///    `UPDATE` block against us. That mutual exclusion is the whole guarantee;
+///    everything below is just deciding who won.
+/// 2. **Row present, tombstoned, claim still live** → [`Doomed`]. The sweep
+///    committed its intent before we took the lock, so its `storage.delete()`
+///    is already in flight or done. Committing an `oci_blobs` row here is
+///    exactly the #3085 data loss.
+/// 3. **Row present, no tombstone (or a lapsed claim)** → delete it under the
+///    lock and return [`Cleared`]. A sweep's phase-1 `UPDATE` now finds no row,
+///    so it never deletes the object. A tombstone whose `claim_expires_at` has
+///    passed belongs to a crashed sweep and is not binding — otherwise a crash
+///    would doom that digest permanently.
+/// 4. **Row absent** → the push registered a row and something removed it.
+///    Three causes, and they must not be conflated:
+///    * A **concurrent push of the same key** won and cleared the row in the
+///      same transaction that committed its own `oci_blobs` row. An
+///      `oci_blobs` row referencing this key proves it: the peer's journal
+///      delete and its INSERT commit together, so we cannot observe one
+///      without the other. The bytes are live → [`Cleared`].
+///    * The **repository was deleted**, cascading the journal row away
+///      (`oci_upload_cleanup_keys.repository_id ... ON DELETE CASCADE`). No
+///      sweep is involved and there is nothing to protect; return [`Cleared`]
+///      so the caller's own `oci_blobs` INSERT fails on its foreign key and
+///      reports *that*, rather than this function inventing a concurrent-GC
+///      diagnosis for an unrelated failure.
+///    * Otherwise a **sweep reaped it**. Phase 3 only removes a row whose
+///      object it just deleted, so the bytes are gone → [`Doomed`].
+///
+/// [`Doomed`]: CleanupJournalClaim::Doomed
+/// [`Cleared`]: CleanupJournalClaim::Cleared
+pub(crate) async fn claim_cleanup_journal_row_for_blob_commit(
+    conn: &mut sqlx::PgConnection,
+    journal_id: i64,
+    repository_id: Uuid,
+    storage_key: &str,
+) -> sqlx::Result<CleanupJournalClaim> {
+    // Step 1: take the row lock. `FOR UPDATE` conflicts with the sweep's
+    // phase-1 `UPDATE`, so from here on exactly one of the two proceeds.
+    //
+    // `claim_expires_at IS NULL` is folded into "binding", not out of it, so
+    // the expression is never SQL NULL and the conservative answer is the
+    // default. Phase 1 always writes the tombstone and the lease together, so
+    // a tombstone with no lease should not exist; if one ever does, refusing
+    // the push is the safe way to be wrong.
+    let row = sqlx::query(
+        "SELECT pending_delete_at IS NOT NULL \
+              AND (claim_expires_at IS NULL OR claim_expires_at > NOW()) AS doomed \
+         FROM oci_upload_cleanup_keys WHERE id = $1 FOR UPDATE",
+    )
+    .bind(journal_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    let Some(row) = row else {
+        // Step 4: our journal row is gone. A peer push that cleared it
+        // committed its `oci_blobs` row in the same transaction, so that row
+        // is visible to us now if it exists at all.
+        let live = sqlx::query("SELECT 1 AS present FROM oci_blobs WHERE storage_key = $1 LIMIT 1")
+            .bind(storage_key)
+            .fetch_optional(&mut *conn)
+            .await?;
+        if live.is_some() {
+            return Ok(CleanupJournalClaim::Cleared);
+        }
+        // Not a peer push. Before blaming a sweep, rule out the repository
+        // having been deleted underneath us, which cascades the journal row
+        // away for reasons that have nothing to do with GC.
+        let repo_alive = sqlx::query("SELECT 1 AS present FROM repositories WHERE id = $1")
+            .bind(repository_id)
+            .fetch_optional(&mut *conn)
+            .await?;
+        return Ok(if repo_alive.is_some() {
+            CleanupJournalClaim::Doomed
+        } else {
+            CleanupJournalClaim::Cleared
+        });
+    };
+
+    // Step 2: a live tombstone means the sweep got here first. A decode
+    // failure propagates rather than defaulting — a guard against data loss
+    // must not fail open on an unreadable answer.
+    if row.try_get::<bool, _>("doomed")? {
+        return Ok(CleanupJournalClaim::Doomed);
+    }
+
+    // Step 3: we hold the lock and the key is not doomed. Remove the journal
+    // row inside the caller's transaction so it lands atomically with the
+    // `oci_blobs` INSERT that follows.
+    sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE id = $1")
+        .bind(journal_id)
+        .execute(&mut *conn)
+        .await?;
+
+    Ok(CleanupJournalClaim::Cleared)
 }
 
 /// Accumulate dry-run totals into a GC result.
@@ -7460,7 +7641,7 @@ mod tests {
         // invisible to concurrent sweepers.
         assert!(
             service
-                .hold_cleanup_key_claim_for_delete(&mine, CleanupSweepKind::Unreferenced)
+                .tombstone_cleanup_key_for_delete(&mine, CleanupSweepKind::Unreferenced)
                 .await,
             "the live owner must be able to renew its claim"
         );
@@ -7494,7 +7675,7 @@ mod tests {
         );
         assert!(
             !service
-                .hold_cleanup_key_claim_for_delete(&mine, CleanupSweepKind::Unreferenced)
+                .tombstone_cleanup_key_for_delete(&mine, CleanupSweepKind::Unreferenced)
                 .await,
             "a superseded token must not renew (the delete is skipped)"
         );
@@ -7843,6 +8024,732 @@ mod tests {
             !deleted.contains(&revive_key),
             "#3085: the pending reaper shares the pre-delete hook and must also refuse to \
              delete the bytes of a blob that went live after the claim: {deleted:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3187: closing the pre-delete window #3158 only narrowed.
+    //
+    // The tests above cover the POST-CLAIM gap: a push landing after the batch
+    // was claimed but before the sweep reached that key, which the #3158
+    // per-key liveness re-check already refuses. They deliberately do NOT
+    // cover the residual window, which is what these tests exist for: the gap
+    // between the sweep's pre-delete hook returning `true` and its
+    // `storage.delete()` completing. In #3158 the hook held no lock there, so
+    // a push committing an `oci_blobs` row inside that gap still lost its
+    // bytes and nothing could observe it.
+    //
+    // Proving a TOCTOU closure needs a seam at the exact instant of the race,
+    // not a sequence of calls. Two seams are used:
+    //
+    //   * `PreDeleteWindowStorage` runs the real push-side protocol INSIDE the
+    //     sweep's own `storage.delete()` await for the very key being deleted.
+    //     That is, by construction, the post-hold/pre-delete window.
+    //   * `cleanup_key_tombstone_blocks_while_a_push_holds_the_journal_row`
+    //     drives the opposite order with two live connections and proves the
+    //     sweep's phase 1 genuinely BLOCKS on the push's row lock — the
+    //     mutual exclusion #3158's autocommit `UPDATE` did not have.
+    // -----------------------------------------------------------------------
+
+    /// What the simulated push did when it ran inside the sweep's storage
+    /// delete. `None` means the seam never fired.
+    type PushOutcome = std::sync::Mutex<Option<CleanupJournalClaim>>;
+
+    /// Storage backend that, while deleting `target_key`, runs the **real**
+    /// push-side commit protocol
+    /// ([`claim_cleanup_journal_row_for_blob_commit`]) on its own connection
+    /// and, if that protocol permits it, commits the `oci_blobs` row exactly
+    /// as a real push would.
+    ///
+    /// The push therefore executes strictly after the sweep's phase-1 hook
+    /// returned `true` and strictly before the object is gone — the window
+    /// #3158 left open. Committing the `oci_blobs` row for real (rather than
+    /// just recording a verdict) is what makes the test revert-sensitive: with
+    /// the tombstone removed from phase 1, the guard returns `Cleared`, the
+    /// row lands, and the invariant assertion below fails on live bytes being
+    /// deleted.
+    struct PreDeleteWindowStorage {
+        db: PgPool,
+        target_key: String,
+        target_journal_id: i64,
+        target_repo: Uuid,
+        target_digest: String,
+        deleted: std::sync::Mutex<Vec<String>>,
+        outcome: PushOutcome,
+    }
+
+    impl PreDeleteWindowStorage {
+        fn deleted_keys(&self) -> Vec<String> {
+            self.deleted.lock().expect("deleted lock").clone()
+        }
+        fn outcome(&self) -> Option<CleanupJournalClaim> {
+            *self.outcome.lock().expect("outcome lock")
+        }
+    }
+
+    #[async_trait]
+    impl crate::storage::StorageBackend for PreDeleteWindowStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            Ok(Bytes::new())
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, key: &str) -> crate::error::Result<()> {
+            let fire = {
+                let mut seen = self.deleted.lock().expect("deleted lock");
+                seen.push(key.to_string());
+                key == self.target_key
+            };
+            if fire {
+                // The push runs on its own connection, as it does in
+                // production: this is a different request, not the sweep.
+                let mut tx = self.db.begin().await.expect("push begins its transaction");
+                let claim = claim_cleanup_journal_row_for_blob_commit(
+                    &mut tx,
+                    self.target_journal_id,
+                    self.target_repo,
+                    &self.target_key,
+                )
+                .await
+                .expect("push runs the cleanup-journal guard");
+                match claim {
+                    CleanupJournalClaim::Cleared => {
+                        // The protocol said it was safe to publish the blob.
+                        sqlx::query(
+                            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, \
+                             storage_key) VALUES ($1, $2, 1, $3) \
+                             ON CONFLICT (repository_id, digest) DO NOTHING",
+                        )
+                        .bind(self.target_repo)
+                        .bind(&self.target_digest)
+                        .bind(&self.target_key)
+                        .execute(&mut *tx)
+                        .await
+                        .expect("push commits its oci_blobs row");
+                        tx.commit().await.expect("push commits");
+                    }
+                    CleanupJournalClaim::Doomed => {
+                        // The protocol refused. A real push returns a
+                        // retryable 503 here and publishes nothing.
+                        tx.rollback().await.expect("push rolls back");
+                    }
+                }
+                *self.outcome.lock().expect("outcome lock") = Some(claim);
+            }
+            Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
+    }
+
+    /// Seed one aged, unreferenced blob-key journal row plus a control key,
+    /// and wire a [`PreDeleteWindowStorage`] that races the blob key.
+    async fn setup_pre_delete_window_sweep(
+        fixture: &crate::api::handlers::test_db_helpers::Fixture,
+        tag: &str,
+        marked_complete: bool,
+    ) -> (StorageGcService, Arc<PreDeleteWindowStorage>, [String; 2]) {
+        set_repo_backend(&fixture.pool, fixture.repo_id, "s3").await;
+
+        let run = Uuid::new_v4().simple().to_string();
+        let digest = format!("sha256:{run}{}", "0".repeat(32));
+        let blob_key = format!("oci-blobs/{digest}");
+        let control_key = format!("oci-uploads/{tag}-control/{run}");
+        let marker = if marked_complete {
+            "NOW() - INTERVAL '72 hours'"
+        } else {
+            "NULL"
+        };
+
+        let journal_id: i64 = sqlx::query(&format!(
+            "INSERT INTO oci_upload_cleanup_keys \
+                 (repository_id, storage_key, created_at, storage_write_completed_at) \
+             VALUES ($1, $2, NOW() - INTERVAL '72 hours', {marker}) RETURNING id"
+        ))
+        .bind(fixture.repo_id)
+        .bind(&blob_key)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("seed blob cleanup key")
+        .try_get("id")
+        .expect("journal id");
+
+        sqlx::query(&format!(
+            "INSERT INTO oci_upload_cleanup_keys \
+                 (repository_id, storage_key, created_at, storage_write_completed_at) \
+             VALUES ($1, $2, NOW() - INTERVAL '71 hours', {marker})"
+        ))
+        .bind(fixture.repo_id)
+        .bind(&control_key)
+        .execute(&fixture.pool)
+        .await
+        .expect("seed control cleanup key");
+
+        let storage = Arc::new(PreDeleteWindowStorage {
+            db: fixture.pool.clone(),
+            target_key: blob_key.clone(),
+            target_journal_id: journal_id,
+            target_repo: fixture.repo_id,
+            target_digest: digest,
+            deleted: std::sync::Mutex::new(Vec::new()),
+            outcome: std::sync::Mutex::new(None),
+        });
+        let mut backends = std::collections::HashMap::new();
+        backends.insert(
+            "s3".to_string(),
+            storage.clone() as Arc<dyn crate::storage::StorageBackend>,
+        );
+        let registry = Arc::new(crate::storage::StorageRegistry::new(
+            backends,
+            "s3".to_string(),
+        ));
+        let service = StorageGcService::new(fixture.pool.clone(), registry);
+        (service, storage, [blob_key, control_key])
+    }
+
+    /// Is there a live `oci_blobs` row for this storage key?
+    async fn blob_row_exists(pool: &PgPool, storage_key: &str) -> bool {
+        sqlx::query("SELECT 1 AS present FROM oci_blobs WHERE storage_key = $1")
+            .bind(storage_key)
+            .fetch_optional(pool)
+            .await
+            .expect("query oci_blobs")
+            .is_some()
+    }
+
+    async fn cleanup_pre_delete_window(
+        fixture: &crate::api::handlers::test_db_helpers::Fixture,
+        keys: &[String; 2],
+    ) {
+        let _ = sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE storage_key = ANY($1)")
+            .bind(&keys[..])
+            .execute(&fixture.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM oci_blobs WHERE storage_key = $1")
+            .bind(&keys[0])
+            .execute(&fixture.pool)
+            .await;
+        fixture.teardown().await;
+    }
+
+    /// #3187, the window itself: a push that commits **inside** the sweep's
+    /// `storage.delete()` await for the very key being deleted.
+    ///
+    /// This is the interleaving #3158 explicitly could not cover. The sweep's
+    /// phase-1 hook has already returned `true`, so under #3158 nothing at all
+    /// stood between the push and a live `oci_blobs` row pointing at bytes the
+    /// next instruction destroys.
+    ///
+    /// The invariant asserted is the one that actually matters, and it is
+    /// symmetric: the registry must never end up with BOTH the object deleted
+    /// AND a row referencing it. Either outcome alone is fine — a refused push
+    /// is a retry, a survived blob is a skipped sweep.
+    #[tokio::test]
+    async fn unreferenced_sweep_refuses_a_push_landing_in_the_pre_delete_window() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        // Both guards, for the reasons documented on the #3085 tests above:
+        // the in-process mutex excludes the sibling cluster-wide sweeps, the
+        // advisory lock excludes other processes under nextest.
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let (service, storage, keys) =
+            setup_pre_delete_window_sweep(&fixture, "gc3187u", true).await;
+        let [blob_key, control_key] = keys.clone();
+
+        let mut result = empty_gc_result(false);
+        service
+            .cleanup_unreferenced_oci_upload_keys(Some(fixture.repo_id), false, &mut result)
+            .await
+            .expect("unreferenced cleanup-key sweep runs");
+
+        let outcome = storage.outcome();
+        let deleted = storage.deleted_keys();
+        let row_live = blob_row_exists(&fixture.pool, &blob_key).await;
+        cleanup_pre_delete_window(&fixture, &keys).await;
+
+        // Precondition first: if the seam never fired, the test entered no
+        // window at all and every assertion below would pass vacuously.
+        assert!(
+            outcome.is_some(),
+            "precondition: the simulated push must run inside the sweep's storage delete for \
+             this key, otherwise this test proves nothing. deleted={deleted:?}"
+        );
+        // THE claim. Not "the push was refused" — that is one way to satisfy
+        // it. The registry must simply never end up with the object deleted
+        // AND a row still pointing at it.
+        assert!(
+            !(deleted.contains(&blob_key) && row_live),
+            "#3187 data loss: the sweep deleted {blob_key} AND an oci_blobs row references it. \
+             A push landing in the post-hold, pre-storage-delete window must never produce \
+             both. outcome={outcome:?} deleted={deleted:?}"
+        );
+        // And the mechanism that delivered it, so a future change that
+        // satisfies the invariant by accident is still visible here.
+        assert_eq!(
+            outcome,
+            Some(CleanupJournalClaim::Doomed),
+            "the two-phase tombstone must be what refused the push. `Cleared` means the push \
+             was allowed to publish a blob whose bytes are being destroyed. deleted={deleted:?}"
+        );
+        assert!(
+            !row_live,
+            "a push the protocol refused must not leave an oci_blobs row behind"
+        );
+        assert!(
+            deleted.contains(&control_key),
+            "positive control: a genuinely unreferenced key must still be swept, otherwise \
+             the guard could pass by never deleting anything: {deleted:?}"
+        );
+    }
+
+    /// Same window on the pending (NULL-marked) reaper, which shares phase 1.
+    #[tokio::test]
+    async fn pending_reaper_refuses_a_push_landing_in_the_pre_delete_window() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let (service, storage, keys) =
+            setup_pre_delete_window_sweep(&fixture, "gc3187p", false).await;
+        let [blob_key, control_key] = keys.clone();
+
+        let mut result = empty_gc_result(false);
+        service
+            .reap_pending_oci_upload_cleanup_keys(Some(fixture.repo_id), false, &mut result)
+            .await
+            .expect("pending cleanup-key reaper runs");
+
+        let outcome = storage.outcome();
+        let deleted = storage.deleted_keys();
+        let row_live = blob_row_exists(&fixture.pool, &blob_key).await;
+        cleanup_pre_delete_window(&fixture, &keys).await;
+
+        assert!(
+            outcome.is_some(),
+            "precondition: the simulated push must run inside the reaper's storage delete for \
+             this key. deleted={deleted:?}"
+        );
+        assert!(
+            !(deleted.contains(&blob_key) && row_live),
+            "#3187 data loss via the pending reaper: {blob_key} deleted AND referenced. \
+             outcome={outcome:?} deleted={deleted:?}"
+        );
+        assert_eq!(
+            outcome,
+            Some(CleanupJournalClaim::Doomed),
+            "the pending reaper shares phase 1, so a push landing inside its storage delete \
+             must be refused the same way. deleted={deleted:?}"
+        );
+        assert!(
+            deleted.contains(&control_key),
+            "positive control: a genuinely unreferenced pending key must still be reaped: \
+             {deleted:?}"
+        );
+    }
+
+    /// #3187, the other order: the **push** reaches the journal row first.
+    ///
+    /// This is the half a sequential test cannot fake, and the half #3158's
+    /// autocommit `UPDATE` did not have. Two live connections: the push holds
+    /// `SELECT ... FOR UPDATE` on the journal row inside an open transaction,
+    /// and the sweep's phase-1 tombstone `UPDATE` must **block** on it rather
+    /// than sail past and go on to delete the object.
+    ///
+    /// The blocking assertion is one-sided in the safe direction: Postgres
+    /// cannot grant two conflicting row locks, so this cannot pass by timing
+    /// luck. It can only fail if phase 1 stopped taking the row lock at all.
+    #[tokio::test]
+    async fn cleanup_key_tombstone_blocks_while_a_push_holds_the_journal_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use std::time::Duration;
+
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let run = Uuid::new_v4().simple().to_string();
+        let digest = format!("sha256:{run}{}", "0".repeat(32));
+        let blob_key = format!("oci-blobs/{digest}");
+        let claim_token = Uuid::new_v4();
+        let journal_id: i64 = sqlx::query(
+            "INSERT INTO oci_upload_cleanup_keys \
+                 (repository_id, storage_key, created_at, storage_write_completed_at, \
+                  claim_token, claim_expires_at) \
+             VALUES ($1, $2, NOW() - INTERVAL '72 hours', NOW() - INTERVAL '72 hours', \
+                     $3, NOW() + INTERVAL '15 minutes') RETURNING id",
+        )
+        .bind(fixture.repo_id)
+        .bind(&blob_key)
+        .bind(claim_token)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("seed claimed blob cleanup key")
+        .try_get("id")
+        .expect("journal id");
+
+        let cleanup_key = OciUploadCleanupKey {
+            id: journal_id,
+            location: StorageLocation {
+                backend: "s3".to_string(),
+                path: String::new(),
+            },
+            storage_key: blob_key.clone(),
+            claim_token: Some(claim_token),
+        };
+        let service = StorageGcService::new(
+            fixture.pool.clone(),
+            Arc::new(crate::storage::StorageRegistry::new(
+                std::collections::HashMap::new(),
+                "s3".to_string(),
+            )),
+        );
+
+        // The push gets there first and holds the row lock in an open
+        // transaction, exactly as it does around its `oci_blobs` INSERT.
+        let mut push_tx = fixture.pool.begin().await.expect("push begins");
+        let claim = claim_cleanup_journal_row_for_blob_commit(
+            &mut push_tx,
+            journal_id,
+            fixture.repo_id,
+            &blob_key,
+        )
+        .await
+        .expect("push runs the cleanup-journal guard");
+        assert_eq!(
+            claim,
+            CleanupJournalClaim::Cleared,
+            "no sweep has tombstoned this key yet, so the push must be allowed to proceed"
+        );
+
+        // Phase 1 must not be able to make progress while that transaction is
+        // open. `timeout` returning Err is the proof: the future is parked on
+        // the row lock.
+        let tombstone =
+            service.tombstone_cleanup_key_for_delete(&cleanup_key, CleanupSweepKind::Unreferenced);
+        tokio::pin!(tombstone);
+        let blocked = tokio::time::timeout(Duration::from_millis(750), &mut tombstone).await;
+        assert!(
+            blocked.is_err(),
+            "#3187: the sweep's phase-1 tombstone must BLOCK on the journal row lock a \
+             committing push holds. It completed instead, which means the push and the \
+             sweep no longer serialize and the sweep would go on to delete live bytes."
+        );
+
+        // Release: the push commits its journal-row delete (in production, in
+        // the same transaction as the `oci_blobs` INSERT).
+        push_tx.commit().await.expect("push commits");
+
+        let held = tombstone.await;
+        assert!(
+            !held,
+            "once the push committed, the journal row is gone, so phase 1 must match zero \
+             rows and report `false` — the caller then skips the storage delete and the \
+             pushed bytes survive"
+        );
+
+        let _ = sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE id = $1")
+            .bind(journal_id)
+            .execute(&fixture.pool)
+            .await;
+        fixture.teardown().await;
+    }
+
+    /// A tombstone left by a sweep that crashed must not doom the digest
+    /// forever: it lapses with the claim lease, and a later push proceeds.
+    #[tokio::test]
+    async fn expired_cleanup_key_tombstone_does_not_block_a_push() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let run = Uuid::new_v4().simple().to_string();
+        let blob_key = format!("oci-blobs/sha256:{run}{}", "0".repeat(32));
+        let journal_id: i64 = sqlx::query(
+            "INSERT INTO oci_upload_cleanup_keys \
+                 (repository_id, storage_key, storage_write_completed_at, \
+                  claim_token, claim_expires_at, pending_delete_at) \
+             VALUES ($1, $2, NOW(), $3, NOW() - INTERVAL '1 hour', NOW() - INTERVAL '1 hour') \
+             RETURNING id",
+        )
+        .bind(fixture.repo_id)
+        .bind(&blob_key)
+        .bind(Uuid::new_v4())
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("seed stranded tombstone")
+        .try_get("id")
+        .expect("journal id");
+
+        let mut tx = fixture.pool.begin().await.expect("push begins");
+        let claim = claim_cleanup_journal_row_for_blob_commit(
+            &mut tx,
+            journal_id,
+            fixture.repo_id,
+            &blob_key,
+        )
+        .await
+        .expect("push runs the cleanup-journal guard");
+        tx.commit().await.expect("push commits");
+
+        let _ = sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE id = $1")
+            .bind(journal_id)
+            .execute(&fixture.pool)
+            .await;
+        fixture.teardown().await;
+
+        assert_eq!(
+            claim,
+            CleanupJournalClaim::Cleared,
+            "a tombstone whose claim lease has lapsed belongs to a crashed sweep and must \
+             not block the push — otherwise one crash strands that digest permanently"
+        );
+    }
+
+    /// A push whose journal row a sweep already reaped must NOT be allowed to
+    /// publish an `oci_blobs` row: the reap only happens after the object was
+    /// deleted, so those bytes are gone.
+    #[tokio::test]
+    async fn push_whose_journal_row_was_reaped_is_refused() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let run = Uuid::new_v4().simple().to_string();
+        let blob_key = format!("oci-blobs/sha256:{run}{}", "0".repeat(32));
+        let journal_id: i64 = sqlx::query(
+            "INSERT INTO oci_upload_cleanup_keys (repository_id, storage_key) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(fixture.repo_id)
+        .bind(&blob_key)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("seed journal row")
+        .try_get("id")
+        .expect("journal id");
+
+        // The sweep completes: object deleted, row reaped.
+        sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE id = $1")
+            .bind(journal_id)
+            .execute(&fixture.pool)
+            .await
+            .expect("sweep reaps the row");
+
+        let mut tx = fixture.pool.begin().await.expect("push begins");
+        let claim = claim_cleanup_journal_row_for_blob_commit(
+            &mut tx,
+            journal_id,
+            fixture.repo_id,
+            &blob_key,
+        )
+        .await
+        .expect("push runs the cleanup-journal guard");
+        tx.rollback().await.expect("push rolls back");
+        fixture.teardown().await;
+
+        assert_eq!(
+            claim,
+            CleanupJournalClaim::Doomed,
+            "the journal row this push registered is gone and no oci_blobs row references \
+             the key, so a sweep reaped it after deleting the object. Treating a missing \
+             row as `Cleared` would publish a blob whose bytes no longer exist."
+        );
+    }
+
+    /// The counterpart to the test above: a journal row that vanished because
+    /// its **repository** was deleted (`ON DELETE CASCADE`) was not reaped by a
+    /// sweep, and must not be reported as one.
+    ///
+    /// Absence of the row is not by itself evidence of GC. Conflating the two
+    /// makes an unrelated failure — a push racing a repository deletion, whose
+    /// `oci_blobs` INSERT is about to fail on its foreign key — surface as a
+    /// misleading "storage was being reclaimed concurrently; retry" that no
+    /// retry can fix.
+    #[tokio::test]
+    async fn push_whose_repository_was_deleted_is_not_blamed_on_gc() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let run = Uuid::new_v4().simple().to_string();
+        let blob_key = format!("oci-blobs/sha256:{run}{}", "0".repeat(32));
+        let journal_id: i64 = sqlx::query(
+            "INSERT INTO oci_upload_cleanup_keys (repository_id, storage_key) \
+             VALUES ($1, $2) RETURNING id",
+        )
+        .bind(fixture.repo_id)
+        .bind(&blob_key)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("seed journal row")
+        .try_get("id")
+        .expect("journal id");
+        let repo_id = fixture.repo_id;
+
+        // The repository goes away mid-push; the journal row cascades with it.
+        // `teardown` deletes the repository, so run it before the guard.
+        fixture.teardown().await;
+
+        let mut tx = fixture.pool.begin().await.expect("push begins");
+        let claim =
+            claim_cleanup_journal_row_for_blob_commit(&mut tx, journal_id, repo_id, &blob_key)
+                .await
+                .expect("push runs the cleanup-journal guard");
+        tx.rollback().await.expect("push rolls back");
+
+        assert_eq!(
+            claim,
+            CleanupJournalClaim::Cleared,
+            "the repository is gone, so no sweep reaped this row and there are no bytes to \
+             protect. The caller's oci_blobs INSERT will fail on its foreign key and report \
+             that accurately, instead of this guard inventing a concurrent-GC diagnosis."
+        );
+    }
+
+    /// The acceptance criterion the issue calls out separately: a reap that
+    /// matches zero rows must be REPORTED, not banked as a success.
+    ///
+    /// Before #3187 the sweeps incremented `cleanup_rows_removed` and
+    /// `storage_keys_deleted` unconditionally, so the exact interleaving where
+    /// a push won left no journal row and no error — the data loss was
+    /// invisible. Here the seam removes the journal row during the storage
+    /// delete, reproducing what the old unguarded
+    /// `clear_oci_upload_cleanup_key_best_effort` did.
+    #[tokio::test]
+    async fn sweep_reports_a_zero_row_reap_instead_of_counting_it_as_a_success() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let _sweep_guard = storage_gc_test_guard().await;
+        let _gc_guard = tdh::blob_gc_serial_lock().await;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        /// Deletes the journal row out from under the sweep, mid storage
+        /// delete — the old push behaviour this fix removed.
+        struct RowStealingStorage {
+            db: PgPool,
+            journal_id: i64,
+        }
+
+        #[async_trait]
+        impl crate::storage::StorageBackend for RowStealingStorage {
+            async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+                Ok(())
+            }
+            async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+                Ok(Bytes::new())
+            }
+            async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+                Ok(true)
+            }
+            async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+                sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE id = $1")
+                    .bind(self.journal_id)
+                    .execute(&self.db)
+                    .await
+                    .expect("steal the journal row");
+                Ok(())
+            }
+            async fn put_stream(
+                &self,
+                key: &str,
+                stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+            ) -> crate::error::Result<crate::storage::PutStreamResult> {
+                crate::storage::buffered_put_stream_fallback(self, key, stream).await
+            }
+        }
+
+        set_repo_backend(&fixture.pool, fixture.repo_id, "s3").await;
+        let run = Uuid::new_v4().simple().to_string();
+        let blob_key = format!("oci-blobs/sha256:{run}{}", "0".repeat(32));
+        let journal_id: i64 = sqlx::query(
+            "INSERT INTO oci_upload_cleanup_keys \
+                 (repository_id, storage_key, created_at, storage_write_completed_at) \
+             VALUES ($1, $2, NOW() - INTERVAL '72 hours', NOW() - INTERVAL '72 hours') \
+             RETURNING id",
+        )
+        .bind(fixture.repo_id)
+        .bind(&blob_key)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("seed journal row")
+        .try_get("id")
+        .expect("journal id");
+
+        let mut backends = std::collections::HashMap::new();
+        backends.insert(
+            "s3".to_string(),
+            Arc::new(RowStealingStorage {
+                db: fixture.pool.clone(),
+                journal_id,
+            }) as Arc<dyn crate::storage::StorageBackend>,
+        );
+        let service = StorageGcService::new(
+            fixture.pool.clone(),
+            Arc::new(crate::storage::StorageRegistry::new(
+                backends,
+                "s3".to_string(),
+            )),
+        );
+
+        let mut result = empty_gc_result(false);
+        service
+            .cleanup_unreferenced_oci_upload_keys(Some(fixture.repo_id), false, &mut result)
+            .await
+            .expect("unreferenced cleanup-key sweep runs");
+
+        let _ = sqlx::query("DELETE FROM oci_upload_cleanup_keys WHERE storage_key = $1")
+            .bind(&blob_key)
+            .execute(&fixture.pool)
+            .await;
+        fixture.teardown().await;
+
+        assert_eq!(
+            result.storage_keys_deleted, 0,
+            "#3187: a reap that matched zero rows must not be counted as a swept key — \
+             counting it unconditionally is exactly what made a lost race invisible"
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("reap OCI upload cleanup-key row")),
+            "#3187: a zero-row reap must be reported as an error so the operator can see \
+             the object was deleted but its journal row was not: {:?}",
+            result.errors
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes the pre-delete liveness window that #3158 deliberately only narrowed.

**The window is CLOSED, not narrowed further.** #3158's PR body originally overclaimed closure and had to be corrected, so this section is the claim and the rest of the PR is the evidence for it. The claim is specific:

> No interleaving of a blob push and a cleanup sweep can leave the registry with the storage object deleted **and** an `oci_blobs` row referencing it.

It rests on the push and the sweep taking the same Postgres row lock, which is a mutual-exclusion argument rather than a timing argument, and it is exercised in both orders by tests that fail when either half is removed (see **Concurrency tests** below).

What is *not* claimed: that a losing push still succeeds. A push that loses the race is refused with a retryable `503`. That is a deliberate trade, costed below.

## Why #3158 could not close it, and why the fix touches the push path

#3158's hook re-asserts liveness in the same atomic `UPDATE` that extends the claim lease. That `UPDATE` runs on the pool as a single autocommit statement: its row lock is on `oci_upload_cleanup_keys`, never on `oci_blobs`, and it is released the instant the statement commits. The sweep then deletes the object holding nothing.

The obvious repair — copy `run_blob_gc_sweep`, which holds `SELECT ... FOR UPDATE` on the `oci_blobs` row across the storage delete via `is_blob_still_orphan` — **does not transfer**. That works one layer down because a re-push of a marked blob `ON CONFLICT`s onto an *existing* `oci_blobs` row and blocks on it. Here the racing push **INSERTs a new** `oci_blobs` row. There is no row to lock; `FOR UPDATE` on `oci_blobs` would lock nothing.

The only object both sides already touch is the journal row (`UNIQUE (storage_key)`, registered by the push before the storage write it tracks). So the push has to participate. That is what #3158 stopped short of, and it is unavoidable under either option in #3187 — which is the main input into the choice below.

## Which closure, and why

**Option B — the `pending_delete_at` two-phase tombstone** (the issue's recommendation), with the push taking the journal row lock at commit time.

Both options in #3187 require the same push-side change, because neither works without the push touching the journal row. Given that the push-side cost is common, the options differ only on the sweep side, and there option A is strictly worse:

| | A: `FOR UPDATE` across the delete | B: tombstone (chosen) |
|---|---|---|
| Postgres tx open across the object-store call | yes, per key, up to 1000 per batch | no |
| Pooled connection pinned during storage I/O | yes | no |
| What a push of a swept digest waits on | the sweep's object-store round trip, or its timeout | a short DB statement |
| Precedent in this codebase | `run_blob_gc_sweep` | migration 141 / `run_blob_gc_mark` |

Option A would make every push of a contended digest block on object-store latency, and would hold a connection from the pool for the duration of each of up to `OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT` (1000) sequential deletes. Option B holds nothing across storage on either side. Migration 141 already solved the identical problem this way one layer down.

## The protocol

Sweep (both `cleanup_unreferenced_oci_upload_keys` and `reap_pending_oci_upload_cleanup_keys`, which share the hook):

1. **Phase 1** — `tombstone_cleanup_key_for_delete` (was `hold_cleanup_key_claim_for_delete`): one atomic `UPDATE` re-asserting claim ownership + the sweep's liveness predicate, and stamping `pending_delete_at`. Committed before storage is touched.
2. **Phase 2** — `storage.delete()`. No lock held, no transaction open.
3. **Phase 3** — the guarded row `DELETE`, now additionally requiring `pending_delete_at IS NOT NULL`.

Push (`claim_cleanup_journal_row_for_blob_commit`, called inside the same transaction as the `oci_blobs` INSERT):

1. `SELECT ... FOR UPDATE` the journal row it registered, by id.
2. Live tombstone → **Doomed**: refuse to commit, return a retryable `503`.
3. No tombstone → delete the row under the lock, commit it together with `oci_blobs`.

Both orders resolve decisively, and the resolution is a lock conflict rather than a race:

- **Sweep first.** Tombstone commits. The push's `FOR UPDATE` sees it and publishes nothing. The delete destroys bytes nothing references.
- **Push first.** The push holds the row lock. Phase 1 *blocks*, and when it is released the row is gone — zero rows affected, `false`, storage delete skipped. The pushed bytes survive.

The two halves are written as counterparts and their doc comments point at each other; neither is correct alone.

### Tombstone expiry

A tombstone binds only while `claim_expires_at` is in the future. A sweep that crashes between phases 1 and 3 leaves one behind; it lapses with the claim lease (15 min) rather than dooming that digest permanently, and the push treats a lapsed tombstone as no tombstone.

## Cost: a push can now be refused

When a push loses the race it gets `503 BLOB_UPLOAD_INVALID` ("blob storage was being reclaimed concurrently; retry the upload") instead of silently losing its bytes. This is the honest cost of the fix and it is stated here rather than buried.

It requires a digest to be re-pushed in the same instant a sweep is deleting it — and the sweep only touches keys that have been unreferenced for over 24h. The retry re-journals a fresh row and succeeds. Trading a rare retryable error for a silent data-loss window is the intended trade; if it ever shows up in practice, the warning log names the key and the digest.

## Also fixed, from the same review

- **`clear_oci_upload_cleanup_key_best_effort` no longer erases an in-flight sweep's row.** It was a bare `DELETE ... WHERE storage_key = $1` with no claim guard. It now refuses a row tombstoned under a live claim, and warns when it declines. More to the point, it is **no longer used for blob keys at all** — the blob-commit paths use the transactional guard, so the two post-commit `clear_..._best_effort(&blob_key)` calls are gone. It remains for temp/part/completion keys, whose objects the push has already deleted itself.
- **A lost race is now observable.** Both sweeps inspected nothing: they incremented `cleanup_rows_removed` and `result.storage_keys_deleted` unconditionally, so a zero-row reap was recorded as a clean success. They now check `rows_affected` and report a zero-row reap as an error instead of banking it.
- **`register_oci_upload_cleanup_key` returns the row id** (`ON CONFLICT DO UPDATE ... RETURNING id`, since `DO NOTHING` returns nothing on conflict — and a re-push of a journaled digest is the common case). The guard re-reads *that* row rather than looking the key up again, so "a sweep reaped the row this push registered" stays distinguishable from "there was never a row".
- **A missing journal row is not automatically blamed on GC.** Absence has three causes, and conflating them produces a misleading diagnosis: a peer push of the same key won (proved by an `oci_blobs` row, which commits together with the peer's journal delete); the repository was deleted, cascading the row away; or a sweep reaped it. Only the third is `Doomed`. Without this, a push racing a repository deletion — whose `oci_blobs` INSERT is about to fail on its foreign key — would report "storage was being reclaimed concurrently; retry", which no retry can fix. `monolithic_upload_returns_error_when_blob_record_insert_fails` caught exactly this and still asserts its original `500`.

## Concurrency tests

A TOCTOU closure cannot be tested by calling things in sequence, so each test drives a seam at the exact instant of the race. #3158's `MidBatchPushStorage` established the technique — commit the racing `oci_blobs` row synchronously inside the sweep's own `storage.delete()` await — and it is extended here rather than replaced. #3158's own tests are unchanged and still pass; they cover the *post-claim* gap, these cover the *post-hold, pre-storage-delete* gap it explicitly could not reach.

**`PreDeleteWindowStorage` — the window itself.** Runs the **real** push protocol (`claim_cleanup_journal_row_for_blob_commit`, on its own connection) inside the sweep's `storage.delete()` await *for the very key being deleted*. That is by construction the post-hold window: phase 1 has already returned `true`. When the protocol permits it, the interceptor commits the `oci_blobs` row for real, which is what makes the test revert-sensitive rather than a verdict-recorder.

- `unreferenced_sweep_refuses_a_push_landing_in_the_pre_delete_window`
- `pending_reaper_refuses_a_push_landing_in_the_pre_delete_window`

The primary assertion is the invariant, not the mechanism: `!(object deleted && oci_blobs row exists)`. A precondition assert (the seam fired) runs first so the invariant cannot pass vacuously; a positive control (a genuinely unreferenced key in the same batch **is** still swept) prevents passing by refusing to delete anything.

**`cleanup_key_tombstone_blocks_while_a_push_holds_the_journal_row` — the other order.** The half a sequential test cannot fake. Two live connections: the push holds `FOR UPDATE` on the journal row in an open transaction, and phase 1 must **block**. `tokio::time::timeout` returning `Err` is the proof; the assertion is one-sided in the safe direction, since Postgres cannot grant two conflicting row locks, so it cannot pass by timing luck — it can only fail if phase 1 stopped taking the lock. Then the push commits and phase 1 is asserted to return `false`, so the caller skips the storage delete.

Plus: `expired_cleanup_key_tombstone_does_not_block_a_push`, `push_whose_journal_row_was_reaped_is_refused`, `push_whose_repository_was_deleted_is_not_blamed_on_gc`, and `sweep_reports_a_zero_row_reap_instead_of_counting_it_as_a_success`.

Tests are in-crate (`storage_gc_service.rs` `mod tests`) so they count toward the `nextest --lib` coverage gate.

### Test isolation

The discipline #3158 established is preserved. Every DB-backed test here takes **both** `storage_gc_test_guard` (in-process mutex, which is what excludes the sibling cluster-wide `test_run_gc_*` sweeps under single-process `cargo test --lib`) and `blob_gc_serial_lock` (Postgres advisory lock, for nextest's process-per-test). Every sweep is repo-scoped to its own fixture. No test depends on the order of the claim query's `UPDATE ... RETURNING`, which has **no row-order guarantee**: the new tests seed a single blob key plus a control and key their seam off the target key by name, never off a positional "head".

### Revert-proof

Each guard was removed individually, with the tests untouched, and the specific test failed on the specific assertion:

**1. Phase-1 tombstone dropped (restoring #3158 exactly).** Both window tests fail on the data-loss invariant:

```
#3187 data loss: the sweep deleted oci-blobs/sha256:455dc9bb... AND an oci_blobs
row references it. A push landing in the post-hold, pre-storage-delete window
must never produce both. outcome=Some(Cleared) deleted=[...]
```

`outcome=Some(Cleared)` is the push being allowed to publish a blob whose bytes are being destroyed — #3085, reproduced in the residual window. (Three pre-existing cleanup-key sweep tests also fail, confirming phases 1 and 3 are wired to each other.)

**2. Push-side participation removed** (the guard returns `Cleared` without touching the row — the pre-#3187 world):

```
#3187: the sweep's phase-1 tombstone must BLOCK on the journal row lock a
committing push holds. It completed instead, which means the push and the sweep
no longer serialize and the sweep would go on to delete live bytes.
```

plus the same data-loss failure on the window test.

**3. `rows_affected` checks removed** (restoring unconditional counting):

```
assertion `left == right` failed: #3187: a reap that matched zero rows must not
be counted as a swept key -- counting it unconditionally is exactly what made a
lost race invisible
  left: 1
 right: 0
```

## Schema migration

`backend/migrations/194_oci_cleanup_keys_pending_delete.sql` — adds `pending_delete_at TIMESTAMPTZ` to `oci_upload_cleanup_keys` plus a partial index on it.

`ALTER TABLE ... ADD COLUMN` with no default is a catalog-only change on PostgreSQL 11+ (no table rewrite), and the partial index build sees only rows already satisfying the predicate, of which there are none at migration time. Both locks are momentary.

`CREATE INDEX CONCURRENTLY` is not usable: `sqlx::migrate!` wraps each file in a transaction and `CONCURRENTLY` is rejected there — same constraint as migrations 166 and 193.

Reversible:

```sql
DROP INDEX idx_oci_upload_cleanup_keys_pending_delete;
ALTER TABLE oci_upload_cleanup_keys DROP COLUMN pending_delete_at;
```

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local gates against a dedicated Postgres 16 (`sqlx migrate run` applied cleanly through 194):

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- storage_gc_service oci_v2` — **642 passed; 0 failed**
- `cargo nextest run --lib -E 'test(storage_gc_service::tests)'` — **118 passed** (the module is already pinned to the `db-serial` group by `.config/nextest.toml`, so the new tests inherit it)

### On the unfiltered `cargo test --lib` run

Worth stating explicitly, because the raw number looks alarming: an unfiltered single-process `AK_TESTS_REQUIRE_DB=1 cargo test --lib` reports **423 failures on this branch**. It reports **416 on `origin/main`**, run identically against the same database.

Diffing the two failure sets: the delta is **exactly the 7 tests this PR adds, and nothing else** — zero pre-existing tests newly fail. That whole mode is broken repo-wide before this change (44 `storage_gc_service` tests already fail there on `origin/main`, including #3158's own two regression tests, alongside `proxy_service`, `auth_config_service`, `scan_result_service`, `migration_worker` and others). ~14.9k DB-backed tests sharing one Postgres at default parallelism interfere with each other, which is why `.config/nextest.toml` exists and why CI runs nextest with a `db-serial` group.

So the unfiltered run is not evidence either way, and it is reported here rather than quietly omitted. The meaningful signals are the two gates above.

No `sqlx::query!` macro text changed — the new SQL uses the runtime `sqlx::query` API that the rest of `storage_gc_service.rs` uses, and the one macro call that moved onto a transaction kept its text. `.sqlx` is therefore untouched and still valid: verified with `SQLX_OFFLINE=true cargo build --lib --tests` and `DATABASE_URL` unset.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — see **Schema migration**
- [ ] N/A - no API changes

One behavioural change on the wire, described under **Cost** above: a blob push that loses the race with a cleanup sweep now returns a retryable `503 BLOB_UPLOAD_INVALID` rather than succeeding and losing its bytes. No endpoint, request, or response shape changed.

Fixes #3187
