### PR TITLE
fix(ci): make the container CVE gate honour its declared CRITICAL,HIGH severity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,15 @@ jobs:
       - name: dtrack-init regression test
         run: bash docker/test-init-dtrack.sh
 
+      # Container CVE gate honesty (#3122): a Trivy step that BLOCKS a publish
+      # must actually apply the severity filter it declares. trivy-action
+      # silently `unset`s TRIVY_SEVERITY when the format is SARIF, which turned
+      # the documented "CRITICAL,HIGH only" gate into one that failed on a
+      # fixable CVE of ANY severity — a LOW blocked all publishing from `main`
+      # for days (#3121). Pure YAML inspection, no network, runs in ~1s.
+      - name: Check Trivy gate severity filter
+        run: ./scripts/ci/check-trivy-gate-severity.sh
+
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -581,18 +581,52 @@ jobs:
           # backend-alpine digest output skipped while alpine builds are suspended.
 
       # --- Trivy CVE scanning ---
-      # These scans ENFORCE (#2609): a CRITICAL or HIGH CVE with an available
-      # fix fails this job, and the merge-* jobs `need` this job, so no tag is
-      # published from a failing scan. The exception paths, in order:
+      # TWO PASSES PER IMAGE (#3122). This is the structure the comments here
+      # have always described; until #3122 it did not actually exist, and the
+      # single combined pass silently gated on every severity.
+      #
+      #   Pass 1 - VISIBILITY: `format: sarif`, `exit-code: '0'`. Never blocks.
+      #     Feeds the GitHub code-scanning Security tab with findings at ALL
+      #     severities. It deliberately declares no `severity:` — trivy-action
+      #     throws that input away for SARIF (see below), so writing one there
+      #     only creates the illusion of a filter.
+      #
+      #   Pass 2 - GATE: `format: 'table'`, `severity: 'CRITICAL,HIGH'`,
+      #     `exit-code: '1'`. This is the control that ENFORCES (#2609): a
+      #     CRITICAL or HIGH CVE with an available fix fails this job, and the
+      #     merge-* jobs `need` this job, so no tag is published from a failing
+      #     scan. Table format is load-bearing, not cosmetic — it is what keeps
+      #     the severity filter alive.
+      #
+      # WHY THE SPLIT (#3122): `aquasecurity/trivy-action` runs
+      # `unset TRIVY_SEVERITY` whenever the format is SARIF and
+      # `limit-severities-for-sarif` is not exactly "true"
+      # (entrypoint.sh:75-83 at the pinned SHA; it logs the giveaway line
+      # "Building SARIF report with all severities"). The old single pass was
+      # SARIF + `severity: CRITICAL,HIGH` + `exit-code: '1'`, so the filter was
+      # discarded and the gate failed on a fixable CVE of ANY severity. #3121
+      # was a LOW (`security-severity: 3.1`) that blocked all publishing from
+      # `main` for days while this file and the step summary both claimed
+      # CRITICAL/HIGH-only. Setting `limit-severities-for-sarif: true` would
+      # also fix the gate, but it truncates the SARIF to CRITICAL/HIGH and
+      # costs the Security-tab view of everything below that. Splitting keeps
+      # full visibility AND an honest gate.
+      # Guarded against regression by scripts/ci/check-trivy-gate-severity.sh.
+      #
+      # The exception paths on the GATE pass, in order:
       #   * --ignore-unfixed: CVEs with no released fix (typically UBI base
-      #     image CVEs that are Red Hat's responsibility) are reported in
-      #     SARIF for visibility but do not block publication.
+      #     image CVEs that are Red Hat's responsibility) do not block
+      #     publication. Note they are filtered out of the SARIF pass too, so
+      #     they are not surfaced in the Security tab either — dropping
+      #     `ignore-unfixed` from pass 1 would surface them, at the cost of a
+      #     large volume of base-image noise. Deliberately left as-is.
       #   * .trivyignore: per-CVE accepted exceptions, each justified in that
       #     file. This is the documented way to unblock a publish while a fix
-      #     is pending.
-      # All three scan steps run to completion (`if: always()` on the later
-      # ones) so a failing image never hides findings in the others, and the
-      # SARIF uploads below also run on failure.
+      #     is pending. Applied to both passes so the Security tab and the gate
+      #     agree on what has been accepted.
+      # All scan steps run to completion (`if: always()`) so a failing image
+      # never hides findings in the others, and the SARIF uploads below also
+      # run on failure.
       # NOTE: trivy binary extracted from official GHCR image because the
       # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
       #
@@ -683,18 +717,21 @@ jobs:
           pull_with_retry "${{ steps.refs.outputs.openscap }}"
           pull_with_retry "${{ steps.refs.outputs.scanner-adapter }}"
 
-      - name: Trivy scan - Backend
+      # ---- Pass 1: SARIF visibility (all severities, never blocks) ----
+
+      - name: Trivy SARIF - Backend
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           image-ref: ${{ steps.refs.outputs.backend }}
           format: 'sarif'
           output: 'backend-trivy.sarif'
-          severity: 'CRITICAL,HIGH'
+          # No `severity:` here on purpose — trivy-action unsets it for SARIF
+          # (#3122). All severities are reported; the gate pass below filters.
           ignore-unfixed: true
           # Suppress residual CVEs in the bundled trivy/grype CLI binaries that
           # have no fixed tool release yet (justified per-CVE in .trivyignore).
           trivyignores: '.trivyignore'
-          exit-code: '1'
+          exit-code: '0'
           skip-setup-trivy: true
           # DB caching is owned by the explicit steps above.
           cache: 'false'
@@ -702,29 +739,64 @@ jobs:
           # DB was pre-fetched (with retry) above; never download mid-scan.
           TRIVY_SKIP_DB_UPDATE: 'true'
 
-      - name: Trivy scan - OpenSCAP
+      - name: Trivy SARIF - OpenSCAP
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         if: always()
         with:
           image-ref: ${{ steps.refs.outputs.openscap }}
           format: 'sarif'
           output: 'openscap-trivy.sarif'
-          severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '1'
+          exit-code: '0'
           skip-setup-trivy: true
           cache: 'false'
         env:
           TRIVY_SKIP_DB_UPDATE: 'true'
 
-      - name: Trivy scan - Scanner Adapter
+      - name: Trivy SARIF - Scanner Adapter
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         if: always()
         with:
           image-ref: ${{ steps.refs.outputs.scanner-adapter }}
           format: 'sarif'
           output: 'scanner-adapter-trivy.sarif'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
+          exit-code: '0'
+          skip-setup-trivy: true
+          cache: 'false'
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
+
+      # Alpine scan skipped while alpine builds are suspended.
+      - name: Trivy SARIF - Backend Alpine
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        if: false
+        with:
+          image-ref: ${{ steps.refs.outputs.backend-alpine }}
+          format: 'sarif'
+          output: 'backend-alpine-trivy.sarif'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
+          exit-code: '0'
+          skip-setup-trivy: true
+          cache: 'false'
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
+
+      # ---- Pass 2: the gate (CRITICAL/HIGH, fixed only — blocks publish) ----
+      # `format: 'table'` is what keeps `severity:` alive; do not change it to
+      # sarif without setting `limit-severities-for-sarif: true` (#3122).
+      # Every image is gated with `if: always()` so one blocking image does not
+      # hide another's CRITICAL/HIGH findings.
+
+      - name: Trivy gate - Backend
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        if: always()
+        with:
+          image-ref: ${{ steps.refs.outputs.backend }}
+          format: 'table'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
@@ -734,14 +806,43 @@ jobs:
         env:
           TRIVY_SKIP_DB_UPDATE: 'true'
 
-      # Alpine scan skipped while alpine builds are suspended.
-      - name: Trivy scan - Backend Alpine
+      - name: Trivy gate - OpenSCAP
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        if: always()
+        with:
+          image-ref: ${{ steps.refs.outputs.openscap }}
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
+          exit-code: '1'
+          skip-setup-trivy: true
+          cache: 'false'
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
+
+      - name: Trivy gate - Scanner Adapter
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        if: always()
+        with:
+          image-ref: ${{ steps.refs.outputs.scanner-adapter }}
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
+          exit-code: '1'
+          skip-setup-trivy: true
+          cache: 'false'
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
+
+      # Alpine gate skipped while alpine builds are suspended.
+      - name: Trivy gate - Backend Alpine
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         if: false
         with:
           image-ref: ${{ steps.refs.outputs.backend-alpine }}
-          format: 'sarif'
-          output: 'backend-alpine-trivy.sarif'
+          format: 'table'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
@@ -861,7 +962,8 @@ jobs:
           # `exit-code: 1` and every merge-* job `needs` this job, so a
           # CRITICAL/HIGH fixable finding fails the scan and no tag is
           # published. Keep this text and that wiring in sync.
-          echo "- **Scope**: CRITICAL and HIGH severity, fixed CVEs only (\`.trivyignore\` documents accepted exceptions)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Gate scope**: CRITICAL and HIGH severity, fixed CVEs only (\`.trivyignore\` documents accepted exceptions)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Report scope**: the SARIF uploaded to the Security tab carries **all** severities, fixed CVEs only — a LOW/MEDIUM alert there does *not* block publication (#3122)" >> $GITHUB_STEP_SUMMARY
           echo "- **Policy**: enforced — a CRITICAL/HIGH CVE with an available fix fails this job, and the merge jobs depend on it, so publication is blocked" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -47,7 +47,9 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest
           format: 'sarif'
           output: 'backend-trivy.sarif'
-          severity: 'CRITICAL,HIGH'
+          # No `severity:` — this is a visibility-only scan (exit-code '0') and
+          # trivy-action unsets the severity input for SARIF anyway (#3122).
+          # All severities are reported to the Security tab; nothing is gated.
           ignore-unfixed: true
           # Suppress residual CVEs in the bundled trivy/grype CLI binaries that
           # have no fixed tool release yet (justified per-CVE in .trivyignore).
@@ -62,7 +64,6 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:latest
           format: 'sarif'
           output: 'openscap-trivy.sarif'
-          severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
           exit-code: '0'

--- a/.trivyignore
+++ b/.trivyignore
@@ -30,10 +30,21 @@
 #   automatically when the tools ship a release rebuilt against the fixed
 #   dependency — re-evaluate this whole file on every scanner bump.
 #
-# * CI scans with `ignore-unfixed: true` and `severity: CRITICAL,HIGH`, so
-#   the genuinely no-fix-available and MEDIUM/LOW entries below already don't
-#   alert; they are listed for completeness so future maintainers see the
-#   full residual set in one place.
+# * The CI publish GATE scans with `ignore-unfixed: true` and
+#   `severity: CRITICAL,HIGH`, so the genuinely no-fix-available and
+#   MEDIUM/LOW entries below do not block a publish; they are listed for
+#   completeness so future maintainers see the full residual set in one place.
+#
+#   Read that as of #3122 only. BEFORE #3122 the gate discarded its severity
+#   filter (trivy-action unsets TRIVY_SEVERITY for SARIF output) and failed on
+#   a fixable CVE of ANY severity, so "MEDIUM/LOW doesn't gate" was NOT true
+#   for most of this file's history — which is why entries accumulated here
+#   that were really just a way to unblock a publish. Anything below justified
+#   solely as "MEDIUM/LOW so it doesn't alert anyway" is now inert for gating
+#   and should be re-evaluated on the next scanner bump rather than inherited.
+#   A separate, non-blocking SARIF pass still reports ALL severities to the
+#   code-scanning Security tab, so an entry removed from here becomes visible
+#   there without gating.
 #
 # Grype tracker: https://github.com/anchore/grype/releases
 # Trivy tracker: ghcr.io/aquasecurity/trivy tags (GitHub repo has no releases)
@@ -106,12 +117,19 @@ CVE-2026-56852
 # bundled trivy CLI, not in the adapter's own binary (no dependencies) and not
 # in the backend or openscap images (0 findings, no bundled trivy, #1544).
 #
-# Note on severity, learned the hard way on the v1.6.4 cut: this CVE exports
-# to SARIF as UNKNOWN/note, so it looks non-gating in the code-scanning UI.
-# It DOES gate. Trivy filters on the vendor severity, not the NVD one, and
-# logs "Using severities from other vendors for some vulnerabilities"; under
-# `severity: CRITICAL,HIGH` this entry still failed the scan. Do not assume an
-# UNKNOWN/note alert is harmless: check whether the scan step actually failed.
+# Note on severity: CORRECTED by #3122. The previous note here recorded that
+# this CVE exports to SARIF as UNKNOWN/note yet still failed the scan under
+# `severity: CRITICAL,HIGH`, and concluded that "Trivy filters on the vendor
+# severity, not the NVD one". That conclusion was wrong. The severity filter
+# was never applied at all: trivy-action ran `unset TRIVY_SEVERITY` because the
+# format was SARIF, so the scan gated on every severity and this UNKNOWN entry
+# failed it along with everything else.
+#
+# Verified directly while fixing #3122: with every other finding suppressed,
+# this CVE alone fails the old SARIF-format gate (exit 1) and passes the
+# corrected table-format gate carrying the same `severity: CRITICAL,HIGH`
+# (exit 0). It is UNKNOWN severity and does not gate. Kept here because it is
+# still a vendored-binary finding with no fixed tool release.
 CVE-2026-46600
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci/check-trivy-gate-severity.sh
+++ b/scripts/ci/check-trivy-gate-severity.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# CI gate for issue #3122: a Trivy step that BLOCKS a publish must actually
+# apply the severity filter it declares.
+#
+# WHY THIS GATE IS LOAD-BEARING
+# -----------------------------
+# `aquasecurity/trivy-action` silently discards the `severity:` input when the
+# report format is SARIF. From the action's own `entrypoint.sh` (pinned SHA
+# ed142fd0673e97e23eac54620cfb913e5ce36c25, v0.36.0), lines 75-83:
+#
+#     # Handle SARIF
+#     if [ "${TRIVY_FORMAT:-}" = "sarif" ]; then
+#       if [ "${INPUT_LIMIT_SEVERITIES_FOR_SARIF:-false,,}" != "true" ]; then
+#         echo "Building SARIF report with all severities"
+#         unset TRIVY_SEVERITY          # <-- severity input thrown away
+#       else
+#         echo "Building SARIF report"
+#       fi
+#     fi
+#
+# Combined with `exit-code: '1'`, that turns a step documented as
+# "CRITICAL,HIGH only" into one that fails the build on a fixable CVE of ANY
+# severity — including LOW. That is exactly what happened in #3122: every
+# `main` push was blocked for days by CVE-2026-54787, a LOW
+# (`security-severity: 3.1`, SARIF level `note`), while the workflow comments
+# and the job step summary both claimed CRITICAL/HIGH-only.
+#
+# The failure mode is silent and it is *over*-blocking, which is the dangerous
+# direction for a security gate: the cheapest way to unblock a publish becomes
+# another `.trivyignore` entry, so the ignore file fills up with findings
+# nobody consciously accepted, and the gate trains people to route around it.
+# A gate that cries wolf is how a real CRITICAL eventually gets waved through.
+#
+# THE INVARIANT
+# -------------
+# For every `aquasecurity/trivy-action` step in `.github/workflows/` that gates
+# (a non-zero `exit-code`):
+#
+#   1. it MUST declare a `severity:` — an unbounded blocking scan is never
+#      intentional; and
+#   2. that `severity:` MUST actually reach Trivy, i.e. EITHER the format is
+#      not `sarif`, OR `limit-severities-for-sarif` is exactly `true`.
+#
+# Requirement (2) is what regressed in #3122. Note that the string must be
+# lowercase `true`: the action's `${INPUT_...:-false,,}` is a broken attempt at
+# bash's `,,` lowercasing (the `,,` is part of the *default value*, not a case
+# modifier), so `True`/`TRUE` compare unequal to `true` and silently fall into
+# the discard branch.
+#
+# Non-gating steps (`exit-code: '0'`, e.g. the SARIF visibility passes and
+# scheduled-container-scan.yml) are intentionally exempt: for those, scanning
+# at all severities is the desired behaviour and nothing is blocked by it.
+#
+# Exits non-zero (failing the build) on any drift.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_DIR="${1:-$ROOT/.github/workflows}"
+
+python3 - "$WORKFLOW_DIR" <<'PY'
+import os
+import sys
+
+import yaml
+
+workflow_dir = sys.argv[1]
+
+ACTION = "aquasecurity/trivy-action"
+
+violations = []
+gating_steps = 0
+exempt_steps = 0
+
+
+def norm(value):
+    """YAML may give us a bool, an int, or a string depending on quoting."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value).strip()
+
+
+def walk(workflow_path):
+    global gating_steps, exempt_steps
+
+    with open(workflow_path, encoding="utf-8") as handle:
+        doc = yaml.safe_load(handle)
+
+    if not isinstance(doc, dict):
+        return
+
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            uses = norm(step.get("uses", ""))
+            if not uses.startswith(ACTION):
+                continue
+
+            with_block = step.get("with") or {}
+            step_name = norm(step.get("name", "<unnamed>"))
+            where = f"{os.path.basename(workflow_path)} :: {job_name} :: {step_name}"
+
+            exit_code = norm(with_block.get("exit-code", "0"))
+            if exit_code == "0":
+                exempt_steps += 1
+                continue
+
+            gating_steps += 1
+
+            severity = norm(with_block.get("severity", ""))
+            fmt = norm(with_block.get("format", "table")).lower()
+            limit = norm(with_block.get("limit-severities-for-sarif", "false"))
+
+            if not severity:
+                violations.append(
+                    f"{where}\n"
+                    f"    gates with exit-code '{exit_code}' but declares no `severity:`.\n"
+                    f"    An unbounded blocking scan fails on any finding at any severity."
+                )
+                continue
+
+            if fmt == "sarif" and limit != "true":
+                violations.append(
+                    f"{where}\n"
+                    f"    declares `severity: {severity}` and gates with exit-code "
+                    f"'{exit_code}',\n"
+                    f"    but `format: sarif` makes trivy-action `unset TRIVY_SEVERITY` "
+                    f"(entrypoint.sh:75-83),\n"
+                    f"    so the filter never reaches Trivy and the step fails on ANY "
+                    f"severity (issue #3122).\n"
+                    f"    Fix: split the visibility pass (format sarif, exit-code '0') "
+                    f"from the gating pass\n"
+                    f"    (format table, exit-code '1'), or set "
+                    f"`limit-severities-for-sarif: true` (lowercase)."
+                )
+
+
+for entry in sorted(os.listdir(workflow_dir)):
+    if entry.endswith((".yml", ".yaml")):
+        walk(os.path.join(workflow_dir, entry))
+
+if violations:
+    print("ERROR: Trivy gating step(s) do not apply their declared severity filter:\n")
+    for violation in violations:
+        print(f"  - {violation}\n")
+    print(
+        "See issue #3122. A gate that fires on severities it declares it ignores\n"
+        "trains people to bypass it, which is how a real CRITICAL gets waved through."
+    )
+    sys.exit(1)
+
+if gating_steps == 0:
+    print(
+        "ERROR: found no gating aquasecurity/trivy-action step "
+        f"(non-zero exit-code) under {workflow_dir}.\n"
+        "The container CVE gate is the control this check exists to protect; if it\n"
+        "was intentionally removed or renamed, update this script deliberately."
+    )
+    sys.exit(1)
+
+print(
+    f"OK: {gating_steps} gating Trivy step(s) apply their declared severity filter "
+    f"({exempt_steps} non-gating visibility step(s) exempt)."
+)
+PY


### PR DESCRIPTION
## Summary

The container CVE gate in `docker-publish.yml` declared `severity: 'CRITICAL,HIGH'` but failed on a fixable CVE of **any** severity. This makes it honour what it declares, without weakening it.

Fixes #3122

## Reproduced first, at `origin/main`

The issue's root-cause analysis is **confirmed**, verified against the action source at the exact pinned SHA (`ed142fd`), `entrypoint.sh:75-83` — `unset TRIVY_SEVERITY` whenever `TRIVY_FORMAT=sarif` and `limit-severities-for-sarif` is not exactly `"true"`.

I then replayed the composite action locally (its own `trivy_envs.txt` generation from `action.yaml`, plus `entrypoint.sh` verbatim) driving the real trivy `0.69.3` binary the workflow uses, against `ghcr.io/aquasecurity/trivy:0.72.0`, with the 15 CRITICAL/HIGH/UNKNOWN findings suppressed via an ignore file — i.e. exactly the shape of #3121, where the HIGHs were already accepted in `.trivyignore` and a LOW leaked through:

```
export TRIVY_SEVERITY=CRITICAL\,HIGH
export TRIVY_FORMAT=sarif
Building SARIF report with all severities      <-- the giveaway line
=== ACTION EXIT CODE: 1 ===
```

The SARIF that caused that failure contained **17 findings, none of them CRITICAL or HIGH**:

```
SARIF levels: {'warning': 15, 'note': 2}
security-severity scores: {'5.5': 12, '6.3': 1, '5.9': 2, '3.1': 1, '2.0': 1}
CRITICAL/HIGH (>=7.0) present?: False
```

Max score 6.3, and `3.1` is #3121's `CVE-2026-54787` exactly. The gate blocked publication on MEDIUM/LOW findings while reporting itself as CRITICAL/HIGH-only.

## Both directions proven

The concern with any "stop over-firing" fix is that it under-fires instead. Driving the harness with the **gate config parsed out of this PR's workflow**:

| Direction | Target | Expected | Result |
|---|---|---|---|
| Must NOT block | only MEDIUM/LOW fixable (the #3121 shape) | pass | `ACTION EXIT CODE: 0` |
| Must block | 14 fixable HIGH present | fail | `Total: 9 (HIGH: 9, CRITICAL: 0)` / `Total: 5 (HIGH: 5, CRITICAL: 0)` → `ACTION EXIT CODE: 1` |

`export TRIVY_SEVERITY=CRITICAL\,HIGH` survives into the run, and the "all severities" line is gone. The gate still fails closed on a genuine CRITICAL/HIGH; it just no longer fails on severities it says it ignores.

## What changed

Option **(b)** from the issue — split scanning from gating, the structure the workflow's comments already described but which did not exist in the code:

* **Pass 1, visibility** — `format: sarif`, `exit-code: '0'`. All severities still reach the Security tab. `severity:` removed, because the action discards it there and its presence only implied a filter that wasn't there.
* **Pass 2, gate** — `format: 'table'`, `severity: 'CRITICAL,HIGH'`, `exit-code: '1'`. Table format is load-bearing: it is what keeps the severity filter alive.

Option (a) (`limit-severities-for-sarif: true`) also fixes the gate, but measured against the same target it truncates the SARIF from **17 results to 0** — the whole Security-tab view below CRITICAL/HIGH. Splitting keeps both.

Also in scope, because they are the same defect written down as fact:

* **`scripts/ci/check-trivy-gate-severity.sh`**, wired into the existing 🐚 Shell Tests job (pure YAML inspection, no network, ~1s). Fails the build if a gating Trivy step declares a severity that cannot reach Trivy, or gates with no severity at all.
* **Step summary** now states gate scope and report scope separately, so a LOW alert in the Security tab is not mistaken for something that blocks.
* **`.trivyignore`** recorded the misdiagnosis of this exact behaviour — *"Trivy filters on the vendor severity, not the NVD one … under `severity: CRITICAL,HIGH` this entry still failed the scan"*. That conclusion was wrong and I corrected it in place. Isolating `CVE-2026-46600` with everything else suppressed: it fails the old SARIF gate (exit 1) and **passes** the corrected table gate carrying the same `severity: CRITICAL,HIGH` (exit 0). It is UNKNOWN severity and never gated on its own merits. The header's claim that MEDIUM/LOW entries "already don't alert" was also untrue for most of this file's history; it is true now, and I flagged the entries justified solely on that basis for re-evaluation at the next scanner bump.
* Dropped the inert `severity:` from `scheduled-container-scan.yml` (non-gating, `exit-code: '0'`) so the same misleading pattern isn't copied.

## A test asserted the bug

Not a unit test — the `.trivyignore` note above. It recorded the over-firing as expected behaviour with a confident but incorrect explanation, which is why the gate was never questioned. Rewritten with the measured result.

## Regression test, revert-proved

Against unmodified `origin/main` (`git checkout origin/main -- .github/workflows/docker-publish.yml`):

```
ERROR: Trivy gating step(s) do not apply their declared severity filter:

  - docker-publish.yml :: scan-containers :: Trivy scan - Backend
    declares `severity: CRITICAL,HIGH` and gates with exit-code '1',
    but `format: sarif` makes trivy-action `unset TRIVY_SEVERITY` (entrypoint.sh:75-83),
    so the filter never reaches Trivy and the step fails on ANY severity (issue #3122).
    Fix: split the visibility pass (format sarif, exit-code '0') from the gating pass
    (format table, exit-code '1'), or set `limit-severities-for-sarif: true` (lowercase).

  - docker-publish.yml :: scan-containers :: Trivy scan - OpenSCAP
    [... same for OpenSCAP, Scanner Adapter, Backend Alpine ...]

See issue #3122. A gate that fires on severities it declares it ignores
trains people to bypass it, which is how a real CRITICAL gets waved through.
=== EXIT: 1 ===
```

On this branch:

```
OK: 4 gating Trivy step(s) apply their declared severity filter (6 non-gating visibility step(s) exempt).
=== EXIT: 0 ===
```

It also catches the subtler regressions: a gating step with no `severity:` at all, the gate being deleted outright, and `limit-severities-for-sarif: 'True'` — quoted capital passes through as a literal string and loses to the action's `!= "true"`, which I confirmed against the real action (exit 1 on a LOW/MEDIUM-only target). Unquoted YAML `True` is fine, since Actions stringifies booleans lowercase.

## Gates

* All 20 workflow YAML files parse (`yaml.safe_load`).
* `shellcheck` clean; `bash -n` clean.
* Existing guards still pass: `check-no-legacy-admin-scope`, `check-token-mint-surface`, `check-auth-event-audit`.
* `needs:` / `if:` traced: job name `Security Scan` is unchanged, so the branch-protection context is unchanged; all four `merge-*` jobs still `needs: scan-containers`. New steps are `if: always()` (or `if: false` for the suspended alpine pair, matching the existing steps), so no required check can be left permanently skipped, and one blocking image cannot hide another's findings.
* No Rust: the diff touches no `.rs`, `Cargo.toml/lock`, `.sqlx/`, or migrations, so the cargo fmt/clippy/test and `sqlx prepare` gates have nothing to act on here.

## Note for whoever picks up the follow-up

`.trivyignore` still describes trivy `0.72.0`, but `Dockerfile.scanner-adapter` has since moved to an in-house hardened `0.73.0` build (#3141). The burn-down of the now-inert entries is #3121's follow-up and is deliberately not in this PR — this one only corrects the claims that were factually wrong about how the gate behaves.
