### PR TITLE
fix(test): restore lib-test build after flatcontainer_download arity drift

### DIFF
--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -4650,6 +4650,7 @@ mod read_db_tests {
         for _ in 0..calls {
             let resp = super::flatcontainer_download(
                 axum::extract::State(state.clone()),
+                axum::Extension(tdh::admin_auth_ext()),
                 axum::extract::Path((
                     fx.repo_key.clone(),
                     package_id.to_string(),


### PR DESCRIPTION
`cargo test --lib` has not compiled on `main` since #3205 merged. Every Rust test job is blocked.

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
    --> backend/src/api/handlers/nuget.rs:4651:24
     | argument #4 of type `download_telemetry::DownloadContext` is missing

error[E0277]: the trait bound `Path<(String, String, String, String)>: Default` is not satisfied
    --> backend/src/api/handlers/nuget.rs:4659:17
```

## Cause

Parallel-merge signature drift, not a logic bug:

- #3172 (`897d89f`) added a second `super::flatcontainer_download(...)` call site in the `nuget.rs` test module.
- #3205 (`5760936`) added an `Extension<Option<AuthExtension>>` parameter to `flatcontainer_download` and updated the *first* call site (`nuget.rs:3303`) but not the one #3172 had added in parallel.

Each PR was green against its own base; the merged tree was never re-built.

## Change

One line, test-only: pass the same `axum::Extension(tdh::admin_auth_ext())` the sibling call site at `nuget.rs:3303` already uses. No production code path is touched.

## Verification

Before:

```
error: could not compile `artifact-keeper-backend` (lib test) due to 2 previous errors
```

After:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 53s
  Executable unittests src/lib.rs (target/debug/deps/artifact_keeper_backend-874506d00497053f)
```

Fixes #3214
