### PR TITLE
fix(proxy-cache): gate the sidecar-bypassing read paths on the metadata sidecar

### DIFF
--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -4650,6 +4650,7 @@ mod read_db_tests {
         for _ in 0..calls {
             let resp = super::flatcontainer_download(
                 axum::extract::State(state.clone()),
+                axum::Extension(tdh::admin_auth_ext()),
                 axum::extract::Path((
                     fx.repo_key.clone(),
                     package_id.to_string(),

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2869,9 +2869,25 @@ async fn serve_file(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
+            // #3147: this arm used to stream `artifacts.storage_key` straight
+            // out of storage with no sidecar, digest or freshness check of any
+            // kind. For a Remote PyPI repo that key IS proxy-cache content
+            // (`proxy-cache/<repo>/simple/<project>/<file>/__content__`), so
+            // the `__cache_meta__.json` sidecar beside it is the record of what
+            // this server actually committed there. Consult it before serving.
+            let verdict = proxy_cache_object_verdict(proxy, &artifact.storage_key).await;
+            if verdict == CachedObjectVerdict::Held {
+                // Package Age Policy (#1770 / #2075) parity: every other read
+                // path 409s on a held entry rather than serving it.
+                return Err(AppError::Conflict(
+                    "Artifact is quarantined and pending security review".to_string(),
+                )
+                .into_response());
+            }
             get_remote_cached_or_refetch_stream(
                 storage.clone(),
                 &artifact.storage_key,
+                verdict.may_serve_stored_object(),
                 || async move {
                     // Fetched lazily inside the closure: this path serves
                     // cache hits straight from storage, and the index_path is
@@ -2941,12 +2957,34 @@ async fn serve_file(
 async fn get_remote_cached_or_refetch_stream<F, Fut>(
     storage: std::sync::Arc<dyn crate::storage::StorageBackend>,
     storage_key: &str,
+    may_serve_stored_object: bool,
     refetch: F,
 ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Response>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<crate::services::proxy_service::StreamingFetchResult, Response>>,
 {
+    // #3147: when nothing vouches for the stored object, treat it exactly as if
+    // it were absent — refuse it and re-fetch upstream. That is the same
+    // self-healing move the `NotFound` arm below already makes, and the refetch
+    // runs through the proxy service's normal streaming cache path, which
+    // rewrites BOTH the object and its sidecar. So an entry rejected here is
+    // repaired by the very next request rather than refetching forever.
+    if !may_serve_stored_object {
+        tracing::warn!(
+            storage_key = %storage_key,
+            "remote PyPI proxy-cache object has no valid metadata sidecar vouching for it; \
+             refusing to serve it and re-fetching from upstream (#3147)"
+        );
+        let result = refetch().await?;
+        return Ok(tee_refetch_to_storage(
+            storage,
+            storage_key.to_string(),
+            result.content_length,
+            result.body,
+        ));
+    }
+
     match storage.get_stream(storage_key).await {
         Ok(stream) => Ok(stream
             .map(|r| r.map_err(|e| std::io::Error::other(e.to_string())))
@@ -2965,6 +3003,68 @@ where
             ))
         }
         Err(e) => Err(map_storage_err(e)),
+    }
+}
+
+/// Whether the object stored at an `artifacts.storage_key` may be streamed
+/// straight out of storage, per the proxy-cache sidecar beside it (#3147).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CachedObjectVerdict {
+    /// The key is not proxy-cache content, so no sidecar can exist and the
+    /// `artifacts` row is the metadata of record. Serve it as before — this is
+    /// an ordinary local artifact read (a locally-published wheel in a Remote
+    /// repo), not the proxy-cache path #3147 is about.
+    NotProxyCache,
+    /// A positive sidecar vouches for the object.
+    Vouched,
+    /// Proxy-cache content with no usable sidecar: absent, unreadable, or a
+    /// negative-cache marker (#1611) that vouches for no body at all.
+    Unvouched,
+    /// A Package Age Policy hold (#1770) is still active on the entry.
+    Held,
+}
+
+impl CachedObjectVerdict {
+    fn may_serve_stored_object(self) -> bool {
+        matches!(self, Self::NotProxyCache | Self::Vouched)
+    }
+}
+
+/// Map a proxy-cache CONTENT key to its metadata sidecar key.
+///
+/// Returns `None` when `storage_key` is not proxy-cache content, which is the
+/// signal that no sidecar can exist for it. Kept pure so the key algebra is
+/// unit-testable without storage.
+fn proxy_cache_metadata_key_for(storage_key: &str) -> Option<String> {
+    if !storage_key.starts_with("proxy-cache/") {
+        return None;
+    }
+    let stem = storage_key.strip_suffix("__content__")?;
+    Some(format!("{stem}__cache_meta__.json"))
+}
+
+/// Resolve the sidecar verdict for an `artifacts.storage_key`.
+///
+/// Absent and unreadable sidecars both resolve to [`CachedObjectVerdict::Unvouched`]:
+/// `load_cache_metadata_pub` collapses them, and they warrant the same answer
+/// anyway — neither tells us anything about the object, so neither is grounds
+/// to serve it.
+async fn proxy_cache_object_verdict(
+    proxy: &crate::services::proxy_service::ProxyService,
+    storage_key: &str,
+) -> CachedObjectVerdict {
+    let Some(metadata_key) = proxy_cache_metadata_key_for(storage_key) else {
+        return CachedObjectVerdict::NotProxyCache;
+    };
+    match proxy.load_cache_metadata_pub(&metadata_key).await {
+        None => CachedObjectVerdict::Unvouched,
+        Some(metadata) if metadata.negative_cached_until.is_some() => {
+            CachedObjectVerdict::Unvouched
+        }
+        Some(metadata) => match metadata.quarantine_until {
+            Some(until) if until > chrono::Utc::now() => CachedObjectVerdict::Held,
+            _ => CachedObjectVerdict::Vouched,
+        },
     }
 }
 
@@ -7173,16 +7273,20 @@ mod tests {
 
         let storage_key =
             "proxy-cache/pypi-remote/simple/fastapi/fastapi-0.136.1-py3-none-any.whl/__content__";
-        let stream =
-            super::get_remote_cached_or_refetch_stream(storage.clone(), storage_key, move || {
+        let stream = super::get_remote_cached_or_refetch_stream(
+            storage.clone(),
+            storage_key,
+            true,
+            move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
                     refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     Ok(one_shot_result(b"refetched-bytes"))
                 }
-            })
-            .await
-            .expect("refetch should succeed");
+            },
+        )
+        .await
+        .expect("refetch should succeed");
         let content = collect_stream(stream).await;
 
         assert_eq!(content, Bytes::from_static(b"refetched-bytes"));
@@ -7248,6 +7352,7 @@ mod tests {
         let stream = super::get_remote_cached_or_refetch_stream(
             storage.clone(),
             "proxy-cache/pypi-remote/simple/urllib3/urllib3-2.2.0-py3-none-any.whl/__content__",
+            true,
             move || async move { Ok(one_shot_result(b"refetched-when-disk-full")) },
         )
         .await
@@ -7270,6 +7375,7 @@ mod tests {
         let stream = super::get_remote_cached_or_refetch_stream(
             storage.clone(),
             "proxy-cache/pypi-remote/simple/numpy/numpy-2.0.0-cp312-cp312-manylinux.whl/__content__",
+            true,
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
@@ -7302,6 +7408,7 @@ mod tests {
         let result = super::get_remote_cached_or_refetch_stream(
             storage.clone(),
             "proxy-cache/pypi-remote/simple/six/six-1.16.0.tar.gz/__content__",
+            true,
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
@@ -7338,6 +7445,7 @@ mod tests {
         let result = super::get_remote_cached_or_refetch_stream(
             storage.clone(),
             "proxy-cache/pypi-remote/simple/requests/requests-2.32.0-py3-none-any.whl/__content__",
+            true,
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
@@ -7362,12 +7470,22 @@ mod tests {
         );
     }
 
+    /// #3147: this test used to be called
+    /// `..._preserves_empty_cached_payload` and asserted that "a legitimately
+    /// empty cached payload (zero bytes) is still a cache hit and must be
+    /// returned". There is no such thing as a legitimately empty PyPI
+    /// distribution: a zero-byte object on a cache content key is exactly what
+    /// a rejected or truncated write leaves behind, which is why #1365 and
+    /// #1912 exist. The assertion was codifying the leak.
+    ///
+    /// What it was actually reaching for — that the reader must not confuse
+    /// "storage returned an empty body" with "storage returned NotFound" — is
+    /// a real invariant and is what this test keeps. The zero-byte object is
+    /// still not treated as a miss by the STORAGE layer; whether it may be
+    /// served at all is now decided by the sidecar gate, which the companion
+    /// test below exercises.
     #[tokio::test]
-    async fn test_get_remote_cached_or_refetch_preserves_empty_cached_payload() {
-        // Edge case: a legitimately empty cached payload (zero bytes) is
-        // still a cache hit and must be returned without triggering a
-        // refetch. This guards against accidentally treating empty bodies
-        // as "missing".
+    async fn test_get_remote_cached_or_refetch_does_not_confuse_empty_with_missing() {
         let storage = std::sync::Arc::new(PresentStorage {
             bytes: Bytes::new(),
         });
@@ -7377,6 +7495,7 @@ mod tests {
         let stream = super::get_remote_cached_or_refetch_stream(
             storage.clone(),
             "proxy-cache/pypi-remote/simple/empty/empty-0.0.0.tar.gz/__content__",
+            true,
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
@@ -7386,14 +7505,147 @@ mod tests {
             },
         )
         .await
-        .expect("empty cached payload should still be a hit");
+        .expect("an empty read is not a NotFound");
         let content = collect_stream(stream).await;
 
         assert!(content.is_empty());
         assert_eq!(
             refetch_calls.load(std::sync::atomic::Ordering::SeqCst),
             0,
-            "empty cached payload is a cache hit, not a stale miss"
+            "an empty body from storage is not the same signal as NotFound; the \
+             decision about whether it may be SERVED belongs to the sidecar gate \
+             (#3147), not to a length heuristic buried in the storage read"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3147 -- the PyPI Remote arm's sidecar gate.
+    //
+    // For a Remote PyPI repo, `artifacts.storage_key` IS proxy-cache content
+    // (`proxy-cache/<repo>/simple/<project>/<file>/__content__`, as every
+    // fixture in this module shows). The reader streamed it straight out of
+    // storage with no sidecar, digest or freshness check, so an object that no
+    // sidecar vouched for was served under the `artifacts` row's
+    // `Content-Length` and `X-PyPI-File-SHA256` headers -- headers that assert
+    // a size and a digest nothing in the path had verified.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_proxy_cache_metadata_key_for_maps_content_to_sidecar() {
+        assert_eq!(
+            super::proxy_cache_metadata_key_for(
+                "proxy-cache/pypi-remote/simple/flask/flask-3.0.0-py3-none-any.whl/__content__"
+            )
+            .as_deref(),
+            Some(
+                "proxy-cache/pypi-remote/simple/flask/flask-3.0.0-py3-none-any.whl/__cache_meta__.json"
+            )
+        );
+    }
+
+    #[test]
+    fn test_proxy_cache_metadata_key_for_rejects_non_cache_keys() {
+        // A locally-published wheel in a Remote repo: an ordinary artifact key
+        // with no sidecar anywhere. It must NOT be gated, or every local
+        // upload into a Remote repo becomes unservable.
+        assert_eq!(
+            super::proxy_cache_metadata_key_for("pypi/flask/3.0.0/flask-3.0.0-py3-none-any.whl"),
+            None
+        );
+        // Proxy-cache-prefixed but not a content key.
+        assert_eq!(
+            super::proxy_cache_metadata_key_for(
+                "proxy-cache/pypi-remote/simple/flask/__cache_meta__.json"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_cached_object_verdict_serve_matrix() {
+        use super::CachedObjectVerdict::*;
+        assert!(NotProxyCache.may_serve_stored_object());
+        assert!(Vouched.may_serve_stored_object());
+        assert!(!Unvouched.may_serve_stored_object());
+        assert!(!Held.may_serve_stored_object());
+    }
+
+    /// The reproduction: an object present on a proxy-cache content key that
+    /// no sidecar vouches for must NOT be streamed to the client. It is
+    /// refused and re-fetched from upstream instead.
+    #[tokio::test]
+    async fn test_get_remote_cached_or_refetch_refuses_an_unvouched_object() {
+        let storage = std::sync::Arc::new(PresentStorage {
+            bytes: Bytes::from_static(b"UNVALIDATED-WHEEL-BYTES"),
+        });
+        let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let refetch_calls_clone = refetch_calls.clone();
+
+        let stream = super::get_remote_cached_or_refetch_stream(
+            storage.clone(),
+            "proxy-cache/pypi-remote/simple/jinja2/jinja2-3.1.0-py3-none-any.whl/__content__",
+            // No sidecar vouches for the stored object.
+            false,
+            move || {
+                let refetch_calls_clone = refetch_calls_clone.clone();
+                async move {
+                    refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(one_shot_result(b"refetched-from-upstream"))
+                }
+            },
+        )
+        .await
+        .expect("the refetch must succeed");
+        let content = collect_stream(stream).await;
+
+        assert_ne!(
+            content,
+            Bytes::from_static(b"UNVALIDATED-WHEEL-BYTES"),
+            "an object no sidecar vouches for must never reach the client (#3147)"
+        );
+        assert_eq!(content, Bytes::from_static(b"refetched-from-upstream"));
+        assert_eq!(
+            refetch_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "an unvouched object must be treated exactly like an absent one: \
+             refuse and refetch"
+        );
+    }
+
+    /// POSITIVE CONTROL for the guard above. A vouched-for cache entry must
+    /// still be served straight from storage, with no upstream traffic at all.
+    /// Without this, hard-wiring the gate to `false` — which would refetch every
+    /// wheel on every request and quietly destroy the proxy cache — would pass.
+    #[tokio::test]
+    async fn test_get_remote_cached_or_refetch_serves_a_vouched_object_without_upstream() {
+        let storage = std::sync::Arc::new(PresentStorage {
+            bytes: Bytes::from_static(b"cached-wheel-bytes"),
+        });
+        let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let refetch_calls_clone = refetch_calls.clone();
+
+        let stream = super::get_remote_cached_or_refetch_stream(
+            storage.clone(),
+            "proxy-cache/pypi-remote/simple/jinja2/jinja2-3.1.0-py3-none-any.whl/__content__",
+            true,
+            move || {
+                let refetch_calls_clone = refetch_calls_clone.clone();
+                async move {
+                    refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(one_shot_result(b"should-not-be-used"))
+                }
+            },
+        )
+        .await
+        .expect("a vouched cache hit must serve");
+        let content = collect_stream(stream).await;
+
+        assert_eq!(content, Bytes::from_static(b"cached-wheel-bytes"));
+        assert_eq!(
+            refetch_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a vouched cache hit must not touch upstream: the gate is a gate, \
+             not a cache bypass"
         );
     }
 
@@ -7466,12 +7718,14 @@ mod tests {
     async fn test_streaming_refetch_tees_multi_chunk_body_to_cache() {
         let storage = std::sync::Arc::new(RecordingStorage::new());
         let key = "proxy-cache/pypi-remote/simple/big/big-9.9.9-py3-none-any.whl/__content__";
-        let stream =
-            super::get_remote_cached_or_refetch_stream(storage.clone(), key, move || async move {
-                Ok(multi_chunk_result(vec![b"aaaa", b"bbbb", b"cc"], Some(10)))
-            })
-            .await
-            .expect("streaming refetch should succeed");
+        let stream = super::get_remote_cached_or_refetch_stream(
+            storage.clone(),
+            key,
+            true,
+            move || async move { Ok(multi_chunk_result(vec![b"aaaa", b"bbbb", b"cc"], Some(10))) },
+        )
+        .await
+        .expect("streaming refetch should succeed");
         let content = collect_stream(stream).await;
 
         assert_eq!(content, Bytes::from_static(b"aaaabbbbcc"));
@@ -7493,12 +7747,14 @@ mod tests {
         let storage = std::sync::Arc::new(RecordingStorage::new());
         let key = "proxy-cache/pypi-remote/simple/trunc/trunc-1.0.0-py3-none-any.whl/__content__";
         // Advertise 100 bytes but only deliver 4: the guard must delete.
-        let stream =
-            super::get_remote_cached_or_refetch_stream(storage.clone(), key, move || async move {
-                Ok(multi_chunk_result(vec![b"abcd"], Some(100)))
-            })
-            .await
-            .expect("streaming refetch should succeed even when truncated");
+        let stream = super::get_remote_cached_or_refetch_stream(
+            storage.clone(),
+            key,
+            true,
+            move || async move { Ok(multi_chunk_result(vec![b"abcd"], Some(100))) },
+        )
+        .await
+        .expect("streaming refetch should succeed even when truncated");
         let content = collect_stream(stream).await;
 
         // The caller still receives whatever bytes arrived.
@@ -9990,6 +10246,173 @@ mod tests {
         let pool = sqlx::PgPool::connect_lazy("postgres://fake:fake@localhost/fake")
             .expect("connect_lazy");
         crate::services::proxy_service::ProxyService::new(pool, storage_svc)
+    }
+
+    // -----------------------------------------------------------------------
+    // #3147 -- `proxy_cache_object_verdict` against a real sidecar.
+    // -----------------------------------------------------------------------
+
+    /// Serves one sidecar, at one key. Every other `get` is a miss, so a test
+    /// that names the wrong key sees `Unvouched` rather than a false pass.
+    struct OneSidecarStorage {
+        key: String,
+        sidecar: Bytes,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for OneSidecarStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
+            if key == self.key {
+                Ok(self.sidecar.clone())
+            } else {
+                Err(AppError::NotFound(key.to_string()))
+            }
+        }
+        async fn exists(&self, key: &str) -> crate::error::Result<bool> {
+            Ok(key == self.key)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _src: &str, _dst: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// Build a proxy service whose only readable object is the sidecar for
+    /// `content_key`.
+    ///
+    /// `load_cache_metadata` reads through a process-global LRU keyed by the
+    /// metadata key, so every test here uses its own project name to avoid
+    /// contaminating the others.
+    fn proxy_with_sidecar(
+        content_key: &str,
+        metadata: &crate::services::proxy_service::CacheMetadata,
+    ) -> crate::services::proxy_service::ProxyService {
+        use crate::services::storage_service::StorageService;
+        let storage = std::sync::Arc::new(OneSidecarStorage {
+            key: super::proxy_cache_metadata_key_for(content_key).expect("cache-shaped key"),
+            sidecar: Bytes::from(serde_json::to_vec(metadata).expect("serialize sidecar")),
+        });
+        let pool = sqlx::PgPool::connect_lazy("postgres://fake:fake@localhost/fake")
+            .expect("connect_lazy");
+        crate::services::proxy_service::ProxyService::new(
+            pool,
+            std::sync::Arc::new(StorageService::new(storage)),
+        )
+    }
+
+    fn positive_sidecar() -> crate::services::proxy_service::CacheMetadata {
+        crate::services::proxy_service::CacheMetadata {
+            cached_at: chrono::Utc::now(),
+            upstream_etag: None,
+            storage_etag: None,
+            last_modified: None,
+            negative_cached_until: None,
+            quarantine_until: None,
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            content_type: Some("application/octet-stream".to_string()),
+            content_encoding: None,
+            upstream_commit_sha: None,
+            size_bytes: 18,
+            checksum_sha256: "c".repeat(64),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verdict_is_vouched_when_a_positive_sidecar_exists() {
+        let key = "proxy-cache/pypi-remote/simple/vouchedpkg/vouchedpkg-1.0.tar.gz/__content__";
+        let proxy = proxy_with_sidecar(key, &positive_sidecar());
+
+        assert_eq!(
+            super::proxy_cache_object_verdict(&proxy, key).await,
+            super::CachedObjectVerdict::Vouched
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verdict_is_unvouched_when_no_sidecar_exists() {
+        // The proxy's storage serves a sidecar for a DIFFERENT entry only.
+        let present = "proxy-cache/pypi-remote/simple/otherpkg/otherpkg-1.0.tar.gz/__content__";
+        let missing = "proxy-cache/pypi-remote/simple/nosidecar/nosidecar-1.0.tar.gz/__content__";
+        let proxy = proxy_with_sidecar(present, &positive_sidecar());
+
+        assert_eq!(
+            super::proxy_cache_object_verdict(&proxy, missing).await,
+            super::CachedObjectVerdict::Unvouched,
+            "an object with no sidecar must not be served (#3147)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verdict_is_unvouched_under_a_negative_cache_marker() {
+        let key = "proxy-cache/pypi-remote/simple/negpkg/negpkg-1.0.tar.gz/__content__";
+        let mut marker = positive_sidecar();
+        marker.negative_cached_until = Some(chrono::Utc::now() + chrono::Duration::minutes(5));
+        marker.size_bytes = 0;
+        marker.checksum_sha256 = String::new();
+        let proxy = proxy_with_sidecar(key, &marker);
+
+        assert_eq!(
+            super::proxy_cache_object_verdict(&proxy, key).await,
+            super::CachedObjectVerdict::Unvouched,
+            "a negative-cache marker vouches for no body at all (#1611)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verdict_is_held_while_a_package_age_hold_is_active() {
+        let key = "proxy-cache/pypi-remote/simple/heldpkg/heldpkg-1.0.tar.gz/__content__";
+        let mut held = positive_sidecar();
+        held.quarantine_until = Some(chrono::Utc::now() + chrono::Duration::hours(6));
+        let proxy = proxy_with_sidecar(key, &held);
+
+        assert_eq!(
+            super::proxy_cache_object_verdict(&proxy, key).await,
+            super::CachedObjectVerdict::Held,
+            "an active Package Age Policy hold must 409, not serve (#1770/#2075)"
+        );
+    }
+
+    /// An ELAPSED hold is not a hold. Without this, hard-wiring `Held` for any
+    /// non-`None` `quarantine_until` would pass the test above.
+    #[tokio::test]
+    async fn test_verdict_is_vouched_once_a_package_age_hold_has_elapsed() {
+        let key = "proxy-cache/pypi-remote/simple/elapsedpkg/elapsedpkg-1.0.tar.gz/__content__";
+        let mut elapsed = positive_sidecar();
+        elapsed.quarantine_until = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+        let proxy = proxy_with_sidecar(key, &elapsed);
+
+        assert_eq!(
+            super::proxy_cache_object_verdict(&proxy, key).await,
+            super::CachedObjectVerdict::Vouched
+        );
+    }
+
+    /// POSITIVE CONTROL for the whole gate: a locally-published wheel in a
+    /// Remote repo has an ordinary artifact key and no sidecar anywhere. It
+    /// must resolve to `NotProxyCache` and stay servable — gating it would make
+    /// every local upload into a Remote repo unreachable.
+    #[tokio::test]
+    async fn test_verdict_leaves_non_proxy_cache_keys_alone() {
+        let key = "pypi/localpkg/1.0/localpkg-1.0-py3-none-any.whl";
+        let proxy = build_proxy_service_no_db();
+
+        let verdict = super::proxy_cache_object_verdict(&proxy, key).await;
+        assert_eq!(verdict, super::CachedObjectVerdict::NotProxyCache);
+        assert!(
+            verdict.may_serve_stored_object(),
+            "a locally-published wheel in a Remote repo must stay servable"
+        );
     }
 
     /// End-to-end test for the streaming download path via the fallback route.

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1294,9 +1294,41 @@ impl CacheStore {
                                 cache_key = %cache_key,
                                 pinned_etag = %pinned,
                                 current_etag = %current,
-                                "proxy cache multipart ETag mismatch on fast-path revalidation; falling back to existence check (#2120)"
+                                "proxy cache multipart ETag mismatch on fast-path revalidation; falling back to length check (#2120/#3147)"
                             );
-                            return matches!(self.storage.exists(cache_key).await, Ok(true));
+                            // #3147: the fallback used to be a bare
+                            // `exists()`, which is true for an object that was
+                            // written and then rejected, for a half-published
+                            // entry, and for anything written to the bucket
+                            // out-of-band. A `true` from here authorizes the
+                            // caller to hand out a presigned 302 pointing
+                            // straight at those bytes, with nothing left in the
+                            // request path to re-verify them.
+                            //
+                            // The sidecar records the exact length of the
+                            // object it vouches for, so require that instead.
+                            // #2120's tolerance is preserved in full — a
+                            // multipart mismatch is still inconclusive and
+                            // still does not force the slow path — but the
+                            // object now has to be the one the sidecar
+                            // describes, which is also what the caller's own
+                            // `Content-Length` already claims it is.
+                            return match self.storage.size(cache_key).await {
+                                Ok(len) => len == metadata.size_bytes as u64,
+                                Err(e) => {
+                                    // Includes NotFound (object gone). Not
+                                    // fresh: the slow path re-fetches and
+                                    // self-heals, which is strictly safer than
+                                    // presigning a URL for an object we could
+                                    // not measure.
+                                    tracing::debug!(
+                                        cache_key = %cache_key,
+                                        error = %e,
+                                        "proxy cache size probe failed during multipart fallback; treating as not fresh"
+                                    );
+                                    false
+                                }
+                            };
                         }
                         tracing::warn!(
                             cache_key = %cache_key,
@@ -3744,24 +3776,81 @@ impl ProxyService {
             return Err(upstream_err);
         }
 
-        // Transient failure: serve the stale body if we still hold one. The
-        // sidecar (if present) carries the content-type / size for the headers;
-        // a missing sidecar falls back to no content-type and an unknown length.
+        // Transient failure: serve the stale body, but ONLY when a valid
+        // positive sidecar still vouches for it (#3147).
+        //
+        // This used to open the body FIRST and then load the sidecar
+        // best-effort, with `unwrap_or(None)` collapsing "absent" and
+        // "unreadable" into "serve it anyway with unknown headers". That made
+        // this reader the reason a rejected proxy-cache write could not protect
+        // itself by merely skipping the sidecar — it also had to delete the
+        // object, because anything sitting on the content key was servable
+        // through here.
+        //
+        // Gating on the sidecar does not weaken stale-if-error, whose purpose
+        // is to serve something when upstream is down. Every successful cache
+        // write publishes body-then-sidecar, so a legitimately cached entry
+        // always has one, and RFC 5861's whole point — ignore TTL here — is
+        // untouched: `expires_at` is still not consulted. What stops being
+        // servable is an object that NOTHING vouches for, which by construction
+        // is a write that was rejected (empty / truncated / over-quota), an
+        // entry left half-published by a crash between the two writes, or an
+        // out-of-band write to the bucket. None of those are cache entries this
+        // server ever committed.
+        let metadata = match self.load_cache_metadata(metadata_key).await {
+            Ok(Some(metadata)) => metadata,
+            Ok(None) => {
+                tracing::warn!(
+                    cache_key = %cache_key,
+                    error = %upstream_err,
+                    "streaming upstream fetch failed and the cached object has no metadata \
+                     sidecar vouching for it; refusing to serve it (stale-if-error, #3147)"
+                );
+                return Err(upstream_err);
+            }
+            Err(e) => {
+                // "Unreadable" tells us nothing about the object, so it cannot
+                // be treated as "no objection, serve it".
+                tracing::warn!(
+                    cache_key = %cache_key,
+                    error = %e,
+                    "streaming upstream fetch failed and the cache metadata sidecar is \
+                     unreadable; refusing to serve the cached object (stale-if-error, #3147)"
+                );
+                return Err(upstream_err);
+            }
+        };
+
+        // A negative-cache marker (#1611) records an upstream 404. It vouches
+        // for no body at all — `size_bytes` is 0 and `checksum_sha256` is empty
+        // — so a body surviving underneath one must not be served.
+        if metadata.negative_cached_until.is_some() {
+            tracing::warn!(
+                cache_key = %cache_key,
+                "streaming upstream fetch failed and the cache entry is a negative-cache \
+                 marker; refusing to serve the leftover body (stale-if-error, #3147)"
+            );
+            return Err(upstream_err);
+        }
+
+        // Package Age Policy (#1770 / #2075): the fresh hit path and the
+        // `ServeStaleIfError` revalidation arm both apply this before streaming
+        // a cached body. Applying it here too stops a held entry being handed
+        // out precisely because upstream happened to be unreachable.
+        check_quarantine_until(metadata.quarantine_until)?;
+
         if let Ok(body) = self.storage.get_stream(cache_key).await {
-            let metadata = self.load_cache_metadata(metadata_key).await.unwrap_or(None);
             tracing::warn!(
                 cache_key = %cache_key,
                 error = %upstream_err,
                 "streaming upstream fetch failed; serving stale cached copy (stale-if-error)"
             );
             let headers = StreamHeaders {
-                content_type: metadata.as_ref().and_then(|m| m.content_type.clone()),
-                content_length: metadata.as_ref().map(|m| m.size_bytes as u64),
-                etag: metadata.as_ref().and_then(|m| m.upstream_etag.clone()),
-                content_encoding: metadata.as_ref().and_then(|m| m.content_encoding.clone()),
-                commit_sha: metadata
-                    .as_ref()
-                    .and_then(|m| m.upstream_commit_sha.clone()),
+                content_type: metadata.content_type.clone(),
+                content_length: Some(metadata.size_bytes as u64),
+                etag: metadata.upstream_etag.clone(),
+                content_encoding: metadata.content_encoding.clone(),
+                commit_sha: metadata.upstream_commit_sha.clone(),
             };
             return Ok(StreamHandle { body, headers });
         }
@@ -7713,24 +7802,38 @@ mod tests {
     /// Lets each test wire up just enough behavior:
     ///   * `metadata` is the JSON bytes returned by `get(metadata_key)`,
     ///     or `None` to simulate a missing sidecar (`AppError::NotFound`).
-    ///   * `content_exists` is what `exists(content_key)` returns.
+    ///   * `content_exists` is what `exists(content_key)` returns, and
+    ///     whether `size(content_key)` resolves at all.
+    ///   * `content_len` is the byte length `size(content_key)` reports when
+    ///     the object exists. It defaults to the `size_bytes` recorded by
+    ///     [`fresh_metadata_bytes`] so "object present" means "object present
+    ///     AND as long as the sidecar says", which is what the #3147
+    ///     multipart-fallback gate checks. Tests that need a leaked /
+    ///     truncated object set it explicitly.
     ///   * `head_etag_value` is what `head_etag(content_key)` returns;
     ///     `Some(Ok(...))` returns the inner result, `None` returns
     ///     `Ok(None)`. Used by #1051 revalidation tests to drive
     ///     match / mismatch / error / missing paths.
     ///   * `get_calls` records every `get(...)` call so tests can assert
     ///     the body was never downloaded.
-    ///   * `exists_calls` / `head_etag_calls` let revalidation tests
-    ///     verify that the ETag fast-path short-circuits the redundant
-    ///     `exists()` call.
+    ///   * `exists_calls` / `size_calls` / `head_etag_calls` let revalidation
+    ///     tests verify that the ETag fast-path short-circuits the redundant
+    ///     object probe.
     struct CacheFreshMock {
         metadata: Option<Bytes>,
         content_exists: bool,
+        content_len: u64,
         head_etag_value: HeadEtagBehavior,
         get_calls: AtomicUsize,
         exists_calls: AtomicUsize,
+        size_calls: AtomicUsize,
         head_etag_calls: AtomicUsize,
     }
+
+    /// `size_bytes` recorded by [`fresh_metadata_bytes`]; the default object
+    /// length for [`CacheFreshMock`] so a "present" object agrees with its
+    /// sidecar unless a test deliberately makes it disagree.
+    const FRESH_METADATA_SIZE_BYTES: u64 = 42;
 
     /// What the mock's `head_etag` should return per call. Variant
     /// names deliberately avoid `None` / `Some` / `Err` so callsite
@@ -7757,12 +7860,31 @@ mod tests {
             content_exists: bool,
             head_etag_value: HeadEtagBehavior,
         ) -> Self {
+            Self::with_head_etag_and_len(
+                metadata,
+                content_exists,
+                FRESH_METADATA_SIZE_BYTES,
+                head_etag_value,
+            )
+        }
+
+        /// As [`Self::with_head_etag`] but with an explicit stored-object
+        /// length, so a test can model an object that is present yet does not
+        /// match the length its sidecar recorded (#3147).
+        fn with_head_etag_and_len(
+            metadata: Option<Bytes>,
+            content_exists: bool,
+            content_len: u64,
+            head_etag_value: HeadEtagBehavior,
+        ) -> Self {
             Self {
                 metadata,
                 content_exists,
+                content_len,
                 head_etag_value,
                 get_calls: AtomicUsize::new(0),
                 exists_calls: AtomicUsize::new(0),
+                size_calls: AtomicUsize::new(0),
                 head_etag_calls: AtomicUsize::new(0),
             }
         }
@@ -7815,8 +7937,19 @@ mod tests {
         async fn copy(&self, _source: &str, _dest: &str) -> Result<()> {
             Ok(())
         }
-        async fn size(&self, _key: &str) -> Result<u64> {
-            Ok(0)
+        async fn size(&self, key: &str) -> Result<u64> {
+            self.size_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            if key.ends_with("__content__") {
+                if self.content_exists {
+                    Ok(self.content_len)
+                } else {
+                    Err(AppError::NotFound(key.to_string()))
+                }
+            } else if self.metadata.is_some() {
+                Ok(0)
+            } else {
+                Err(AppError::NotFound(key.to_string()))
+            }
         }
     }
 
@@ -8284,8 +8417,10 @@ mod tests {
     async fn test_is_cache_fresh_true_when_multipart_pin_vs_singlepart_current_and_present() {
         // Pinned ETag is multipart-shaped; current HEAD returns a different,
         // single-part value. Because the pin is multipart the mismatch is
-        // inconclusive and we fall back to an existence check — object present
-        // → fresh (no thrash). #2120.
+        // inconclusive and we fall back to a length check against the sidecar
+        // — object present AND the length the sidecar recorded → fresh (no
+        // thrash). #2120, with the #3147 fallback strengthened from `exists()`
+        // to a length match; the anti-thrash guarantee is unchanged.
         let mock = Arc::new(CacheFreshMock::with_head_etag(
             Some(fresh_metadata_bytes_with_storage_etag(Some(
                 "\"d41d8cd98f00b204e9800998ecf8427e-4\"".to_string(),
@@ -8307,9 +8442,15 @@ mod tests {
             "still HEADs exactly once"
         );
         assert_eq!(
-            mock.exists_calls.load(AtomicOrdering::SeqCst),
+            mock.size_calls.load(AtomicOrdering::SeqCst),
             1,
-            "multipart mismatch path falls back to a single exists() probe"
+            "multipart mismatch path falls back to a single object-length probe"
+        );
+        assert_eq!(
+            mock.exists_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "the length probe replaces the bare exists() check (#3147); a size() \
+             that resolves already proves existence"
         );
     }
 
@@ -8353,6 +8494,47 @@ mod tests {
         assert!(
             !fresh,
             "multipart mismatch with missing content must still yield not-fresh"
+        );
+    }
+
+    /// #3147 reader 3: the multipart-ETag fallback must not accept a bare
+    /// "an object is there".
+    ///
+    /// #2120 correctly decided that a multipart-vs-multipart ETag mismatch is
+    /// *inconclusive* — two replicas re-uploading byte-identical content mint
+    /// different multipart ETags — and must not force the slow path. But the
+    /// fallback it chose was `exists()`, which is true for an object that was
+    /// written and then rejected (empty / truncated / over-quota), for a
+    /// half-published entry, and for anything written to the bucket
+    /// out-of-band. `is_cache_fresh` returning `true` is what authorizes the
+    /// caller to hand the client a presigned 302 straight at those bytes, with
+    /// nothing left in the path to re-verify them.
+    ///
+    /// The sidecar records the exact length of the object it vouches for, so
+    /// require that instead: same "mismatch is inconclusive" tolerance, but
+    /// the object has to actually be the one the sidecar describes.
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_multipart_mismatch_and_object_length_disagrees() {
+        let mock = Arc::new(CacheFreshMock::with_head_etag_and_len(
+            Some(fresh_metadata_bytes_with_storage_etag(Some(
+                "\"d41d8cd98f00b204e9800998ecf8427e-4\"".to_string(),
+            ))),
+            /* content_exists = */ true,
+            // Sidecar says 42 bytes; the object on the key is empty — exactly
+            // what a rejected streaming write used to leave behind.
+            /* content_len = */
+            0,
+            HeadEtagBehavior::Present("\"d41d8cd98f00b204e9800998ecf8427e-7\"".to_string()),
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "an object whose length disagrees with its sidecar must NOT be \
+             reported fresh: the caller turns `true` into a presigned 302 and \
+             nothing downstream re-verifies the bytes (#3147)"
         );
     }
 
@@ -9236,6 +9418,330 @@ mod tests {
             "a prior positive body MUST be dropped when the negative marker is \
              written, otherwise a read can serve it alongside the marker"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3147: proxy-cache READS that reach `__content__` without the sidecar.
+    //
+    // The cache's safety model assumes readers gate on `__cache_meta__.json`,
+    // which is why a rejected write can protect itself by simply not writing
+    // one. `handle_streaming_leader_upstream_error` broke that assumption: it
+    // opened the body FIRST and then loaded the sidecar best-effort, with
+    // `unwrap_or(None)` collapsing "absent" and "unreadable" into "serve it
+    // anyway with unknown headers". That is why the reject arms also had to
+    // DELETE the object — the sidecar skip alone was not protection.
+    //
+    // #3153 made the streaming WRITE path publish through a private staging
+    // key, so `tee_stream` itself can no longer strand an unvalidated object on
+    // the live key. These tests cover the READ side, which still has to hold
+    // for objects that reach the live key another way: the >5 GiB
+    // `S3Backend::copy` restream carve-out #3153 documents, a crash between
+    // the body write and the sidecar write, or any out-of-band write to the
+    // bucket.
+    // -----------------------------------------------------------------------
+
+    /// Storage double with real object semantics: `get` / `get_stream` /
+    /// `exists` / `size` are backed by an actual key -> bytes map.
+    ///
+    /// `TeeRecordingBackend::get()` returns `NotFound` unconditionally, which
+    /// is precisely why the tee test module cannot express "the object is
+    /// present but the sidecar is not" — the shape of every #3147 leak.
+    struct CacheObjectBackend {
+        objects: tokio::sync::Mutex<std::collections::HashMap<String, Bytes>>,
+        /// Keys whose reads fail with a non-`NotFound` (transport) error,
+        /// modelling an unreadable sidecar rather than an absent one.
+        unreadable: tokio::sync::Mutex<std::collections::HashSet<String>>,
+    }
+
+    impl CacheObjectBackend {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                objects: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                unreadable: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            })
+        }
+
+        async fn put_object(&self, key: &str, bytes: &'static [u8]) {
+            self.objects
+                .lock()
+                .await
+                .insert(key.to_string(), Bytes::from_static(bytes));
+        }
+
+        async fn put_sidecar(&self, key: &str, metadata: &CacheMetadata) {
+            self.objects.lock().await.insert(
+                key.to_string(),
+                Bytes::from(serde_json::to_vec(metadata).unwrap()),
+            );
+        }
+
+        async fn make_unreadable(&self, key: &str) {
+            self.unreadable.lock().await.insert(key.to_string());
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceStorageBackend for CacheObjectBackend {
+        async fn put(&self, key: &str, content: Bytes) -> Result<()> {
+            self.objects.lock().await.insert(key.to_string(), content);
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            if self.unreadable.lock().await.contains(key) {
+                return Err(AppError::Storage(format!(
+                    "simulated read failure on {key}"
+                )));
+            }
+            self.objects
+                .lock()
+                .await
+                .get(key)
+                .cloned()
+                .ok_or_else(|| AppError::NotFound(key.to_string()))
+        }
+        async fn exists(&self, key: &str) -> Result<bool> {
+            Ok(self.objects.lock().await.contains_key(key))
+        }
+        async fn delete(&self, key: &str) -> Result<()> {
+            self.objects.lock().await.remove(key);
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, key: &str) -> Result<u64> {
+            self.objects
+                .lock()
+                .await
+                .get(key)
+                .map(|b| b.len() as u64)
+                .ok_or_else(|| AppError::NotFound(key.to_string()))
+        }
+    }
+
+    /// Drain a stream handle's body into bytes.
+    async fn drain_body(body: BoxStream<'static, Result<Bytes>>) -> Vec<u8> {
+        let mut body = body;
+        let mut out = Vec::new();
+        while let Some(chunk) = body.next().await {
+            out.extend_from_slice(&chunk.expect("body chunk"));
+        }
+        out
+    }
+
+    /// Run the stale-if-error arm and return whatever bytes it served, or
+    /// `None` when it refused and propagated the upstream error.
+    ///
+    /// `slug` gives each test its own cache coordinate: `load_cache_metadata`
+    /// reads through the process-global `PROXY_METADATA_LRU`, so tests that
+    /// shared a metadata key would contaminate each other.
+    async fn serve_stale_if_error(
+        backend: Arc<CacheObjectBackend>,
+        slug: &str,
+    ) -> std::result::Result<Vec<u8>, AppError> {
+        let content_key = format!("proxy-cache/npm-proxy/{slug}/__content__");
+        let metadata_key = format!("proxy-cache/npm-proxy/{slug}/__cache_meta__.json");
+        let proxy = build_proxy_service_with_storage(backend);
+        match proxy
+            .handle_streaming_leader_upstream_error(
+                slug,
+                &content_key,
+                &metadata_key,
+                // A transient upstream failure — the only class that reaches
+                // the stale-if-error arm (a 404 negative-caches instead).
+                AppError::BadGateway("upstream 502".to_string()),
+            )
+            .await
+        {
+            Ok(handle) => Ok(drain_body(handle.body).await),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Build a positive sidecar for a body of `size_bytes`, already past its
+    /// TTL — the normal state of an entry that reaches stale-if-error.
+    fn stale_positive_sidecar(size_bytes: i64) -> CacheMetadata {
+        CacheMetadata {
+            upstream_commit_sha: None,
+            content_encoding: None,
+            cached_at: Utc::now() - chrono::Duration::hours(2),
+            upstream_etag: Some("\"upstream-etag\"".to_string()),
+            storage_etag: None,
+            last_modified: None,
+            negative_cached_until: None,
+            quarantine_until: None,
+            expires_at: Utc::now() - chrono::Duration::seconds(1),
+            content_type: Some("application/gzip".to_string()),
+            size_bytes,
+            checksum_sha256: "b".repeat(64),
+        }
+    }
+
+    /// #3147 reader 1, the reproduction: an object on the live content key
+    /// with NO sidecar is served verbatim when upstream fails.
+    ///
+    /// Nothing else in the request path re-verifies it — `open_cached_stream`
+    /// is not involved, `CacheStore::get`'s SHA-256 check is not involved, and
+    /// the response goes out with whatever headers can be guessed.
+    #[tokio::test]
+    async fn test_stale_if_error_refuses_a_body_with_no_sidecar() {
+        let backend = CacheObjectBackend::new();
+        backend
+            .put_object(
+                "proxy-cache/npm-proxy/3147-no-sidecar/__content__",
+                b"UNVALIDATED-BYTES",
+            )
+            .await;
+        // Deliberately no sidecar at the metadata key.
+
+        let served = serve_stale_if_error(backend, "3147-no-sidecar").await;
+
+        match served {
+            Err(AppError::BadGateway(_)) => {}
+            Err(other) => panic!("expected the upstream error to propagate, got {other:?}"),
+            Ok(bytes) => panic!(
+                "stale-if-error served {} bytes off the content key with NO sidecar \
+                 vouching for them: {:?} (#3147)",
+                bytes.len(),
+                String::from_utf8_lossy(&bytes)
+            ),
+        }
+    }
+
+    /// Same leak, reached through the OTHER half of `unwrap_or(None)`: the
+    /// sidecar exists but cannot be read. "Unreadable" is not "no hold, serve
+    /// it" — we know nothing about the object, so we must not serve it.
+    #[tokio::test]
+    async fn test_stale_if_error_refuses_a_body_whose_sidecar_is_unreadable() {
+        let backend = CacheObjectBackend::new();
+        backend
+            .put_object(
+                "proxy-cache/npm-proxy/3147-unreadable/__content__",
+                b"UNVALIDATED-BYTES",
+            )
+            .await;
+        backend
+            .put_sidecar(
+                "proxy-cache/npm-proxy/3147-unreadable/__cache_meta__.json",
+                &stale_positive_sidecar(17),
+            )
+            .await;
+        backend
+            .make_unreadable("proxy-cache/npm-proxy/3147-unreadable/__cache_meta__.json")
+            .await;
+
+        let served = serve_stale_if_error(backend, "3147-unreadable").await;
+
+        match served {
+            Err(AppError::BadGateway(_)) => {}
+            Err(other) => panic!("expected the upstream error to propagate, got {other:?}"),
+            Ok(bytes) => panic!(
+                "stale-if-error served {} bytes while its sidecar was unreadable (#3147)",
+                bytes.len()
+            ),
+        }
+    }
+
+    /// POSITIVE CONTROL for the two guards above, and the whole reason
+    /// stale-if-error exists: when upstream is down and we DO hold a
+    /// legitimately-cached body, we must still serve it.
+    ///
+    /// This is what makes the guard a gate rather than a removal. Every
+    /// successful cache write publishes body-then-sidecar, so a real cache
+    /// entry always has one; RFC 5861 explicitly ignores TTL here, so the
+    /// sidecar being long expired must not matter. Without this test,
+    /// replacing the stale arm with a bare `Err(upstream_err)` would pass.
+    #[tokio::test]
+    async fn test_stale_if_error_still_serves_a_body_with_a_valid_sidecar() {
+        let backend = CacheObjectBackend::new();
+        backend
+            .put_object(
+                "proxy-cache/npm-proxy/3147-valid/__content__",
+                b"STALE-BUT-REAL",
+            )
+            .await;
+        backend
+            .put_sidecar(
+                "proxy-cache/npm-proxy/3147-valid/__cache_meta__.json",
+                &stale_positive_sidecar(14),
+            )
+            .await;
+
+        let served = serve_stale_if_error(backend, "3147-valid")
+            .await
+            .expect("stale-if-error MUST still serve a body its sidecar vouches for");
+
+        assert_eq!(
+            served, b"STALE-BUT-REAL",
+            "an expired-but-real cache entry is exactly what stale-if-error is for"
+        );
+    }
+
+    /// A negative-cache marker (#1611) records an upstream 404 and vouches for
+    /// no body at all — its `size_bytes` is 0 and its `checksum_sha256` is
+    /// empty. Requiring "a sidecar" without requiring a POSITIVE one would let
+    /// a surviving body be served underneath a marker that says the artifact
+    /// does not exist upstream, with `Content-Length: 0` headers.
+    #[tokio::test]
+    async fn test_stale_if_error_refuses_a_body_under_a_negative_cache_marker() {
+        let backend = CacheObjectBackend::new();
+        backend
+            .put_object(
+                "proxy-cache/npm-proxy/3147-negative/__content__",
+                b"LEFTOVER-BYTES",
+            )
+            .await;
+        let mut marker = stale_positive_sidecar(0);
+        marker.negative_cached_until = Some(Utc::now() + chrono::Duration::minutes(5));
+        marker.checksum_sha256 = String::new();
+        backend
+            .put_sidecar(
+                "proxy-cache/npm-proxy/3147-negative/__cache_meta__.json",
+                &marker,
+            )
+            .await;
+
+        let served = serve_stale_if_error(backend, "3147-negative").await;
+
+        match served {
+            Err(AppError::BadGateway(_)) => {}
+            Err(other) => panic!("expected the upstream error to propagate, got {other:?}"),
+            Ok(bytes) => panic!(
+                "stale-if-error served {} bytes under a negative-cache marker (#3147)",
+                bytes.len()
+            ),
+        }
+    }
+
+    /// Package Age Policy parity (#1770 / #2075). The fresh hit path and the
+    /// `ServeStaleIfError` revalidation arm both run `check_quarantine_until`
+    /// before streaming a cached body; this arm did not, so a held entry was
+    /// handed out precisely when upstream happened to be unreachable.
+    #[tokio::test]
+    async fn test_stale_if_error_respects_an_active_package_age_hold() {
+        let backend = CacheObjectBackend::new();
+        backend
+            .put_object("proxy-cache/npm-proxy/3147-held/__content__", b"HELD-BYTES")
+            .await;
+        let mut held = stale_positive_sidecar(10);
+        held.quarantine_until = Some(Utc::now() + chrono::Duration::hours(6));
+        backend
+            .put_sidecar("proxy-cache/npm-proxy/3147-held/__cache_meta__.json", &held)
+            .await;
+
+        let served = serve_stale_if_error(backend, "3147-held").await;
+
+        match served {
+            Err(AppError::Conflict(_)) | Err(AppError::Authorization(_)) => {}
+            Err(other) => panic!("expected the age-policy hold to surface, got {other:?}"),
+            Ok(bytes) => panic!(
+                "stale-if-error handed out {} bytes of a held entry (#1770/#3147)",
+                bytes.len()
+            ),
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Why

Fixes #3147.

The proxy cache's safety model assumes readers gate on the `__cache_meta__.json` sidecar. That assumption is what lets a rejected write protect itself by simply not writing one. Three readers reached the `__content__` key without consulting it, so "no sidecar was written" was never on its own enough — which is exactly why the reject arms also had to `delete()`, and why #3068's proposal to drop those deletes was wrong.

#3153 fixed the write side: `tee_stream` now publishes through a private staging key, so it can no longer strand an unvalidated object on a live cache key. This is the read side. It still has to hold, because objects reach the live key by other routes: the >5 GiB `S3Backend::copy` restream that #3153 documents as a carve-out, a crash between the body write and the sidecar write, and any out-of-band write to the bucket.

## Reproduction

Against the reader, on unmodified `main`:

```
---- test_stale_if_error_refuses_a_body_with_no_sidecar stdout ----
stale-if-error served 17 bytes off the content key with NO sidecar vouching
for them: "UNVALIDATED-BYTES" (#3147)

---- test_stale_if_error_refuses_a_body_under_a_negative_cache_marker stdout ----
stale-if-error served 14 bytes under a negative-cache marker (#3147)

---- test_stale_if_error_refuses_a_body_whose_sidecar_is_unreadable stdout ----
stale-if-error served 17 bytes while its sidecar was unreadable (#3147)

---- test_stale_if_error_respects_an_active_package_age_hold stdout ----
stale-if-error handed out 10 bytes of a held entry (#1770/#3147)

---- test_is_cache_fresh_false_when_multipart_mismatch_and_object_length_disagrees ----
an object whose length disagrees with its sidecar must NOT be reported fresh:
the caller turns `true` into a presigned 302 and nothing downstream re-verifies
the bytes (#3147)

test result: FAILED. 15 passed; 5 failed
```

Expressing this needed a new storage double. `TeeRecordingBackend::get()` returns `NotFound` unconditionally, so the tee test module was structurally incapable of representing "the object is present but the sidecar is not" — the shape of every leak in this class. The issue called that out; `CacheObjectBackend` fixes it with a real key→bytes map.

## What

**1. stale-if-error (`handle_streaming_leader_upstream_error`).** It opened the body first and loaded the sidecar afterwards, best-effort, with `unwrap_or(None)` collapsing "absent" and "unreadable" into "serve it anyway with guessed headers". It now requires a valid *positive* sidecar before serving: absent or unreadable both refuse and propagate the upstream error, a negative-cache marker (#1611) refuses because it vouches for no body at all, and an active Package Age Policy hold now 409s here exactly as it does on the fresh hit path and the `ServeStaleIfError` revalidation arm.

This does not weaken stale-if-error, and that mattered more than the fix itself. Its purpose is to serve *something* when upstream is down. Every successful cache write publishes body-then-sidecar, so a legitimately cached entry always has one, and `expires_at` is still not consulted — ignoring TTL is the whole point of RFC 5861 and it is untouched. What stops being servable is an object nothing vouches for, which by construction is a rejected write (empty / truncated / over-quota), a half-published entry, or an out-of-band write. None of those are entries this server ever committed. `test_stale_if_error_still_serves_a_body_with_a_valid_sidecar` pins that: it serves a long-expired body and fails if the arm is hard-wired to refuse.

**2. The PyPI Remote arm.** It streamed `artifacts.storage_key` with no sidecar, digest or freshness check of any kind. For a Remote PyPI repo that key *is* proxy-cache content (`proxy-cache/<repo>/simple/<project>/<file>/__content__` — as every fixture in that test module shows), so the sidecar beside it is the record of what this server actually committed. The reader now resolves a verdict from it first and treats "nothing vouches for this" exactly like "absent": refuse and refetch.

Refusing is cheap here because the refetch closure already runs through the proxy service's normal streaming cache path, which rewrites *both* the object and its sidecar. A rejected entry is repaired by the very next request rather than refetching forever.

The gate is scoped to proxy-cache-shaped keys. A locally-published wheel in a Remote repo has an ordinary artifact key and no sidecar anywhere; gating it would make every local upload into a Remote repo unreachable. `proxy_cache_metadata_key_for` returns `None` for those and they stay servable, with a test to keep it that way.

**3. `is_fresh`'s multipart-ETag fallback.** #2120 correctly decided that a multipart-vs-multipart ETag mismatch is *inconclusive* — two replicas re-uploading byte-identical content mint different multipart ETags, and forcing the slow path there thrashes permanently. But the fallback it chose was a bare `exists()`, and a `true` from `is_fresh` is what authorizes the caller to hand out a presigned 302 pointing straight at the object, with nothing left in the request path to re-verify it. `exists()` is true for a rejected write, a half-published entry, and anything written out-of-band.

The fallback now requires the object to match the length its sidecar recorded. #2120's tolerance is preserved in full — the mismatch is still inconclusive, still no slow path — but the object has to be the one the sidecar describes, which is also what the caller's own `Content-Length` already claims it is. A `size()` that fails (including `NotFound`) is not-fresh; the slow path re-fetches and self-heals, which is strictly safer than presigning a URL for an object we could not measure.

## A pre-existing test asserted the buggy behaviour

`test_get_remote_cached_or_refetch_preserves_empty_cached_payload` asserted that "a legitimately empty cached payload (zero bytes) is still a cache hit and must be returned". There is no such thing as a legitimately empty PyPI distribution, and a zero-byte object on a cache content key is precisely what a rejected or truncated write leaves behind — which is why #1365 and #1912 exist. The assertion was codifying the leak.

What it was reaching for — that the reader must not confuse "storage returned an empty body" with "storage returned `NotFound`" — is a real invariant, and that is what the test now pins, renamed to `..._does_not_confuse_empty_with_missing`. Whether such an object may be *served* is now the sidecar gate's decision rather than a length heuristic buried in a storage read.

`CacheFreshMock` also grew a real `size()`; it previously returned `Ok(0)` unconditionally while its sidecar said 42 bytes, so it could not express "present but wrong". The two #2120 tests keep their original intent (present + correct length → fresh, no thrash); only the mock's fidelity changed, and one assertion moved from `exists_calls` to `size_calls`.

## Revert proof

Every guard was reverted and the covering test confirmed to fail. Beyond the reproduction above:

- PyPI gate made a no-op (`if false && !may_serve_stored_object`) → `test_get_remote_cached_or_refetch_refuses_an_unvouched_object` fails with `left: b"UNVALIDATED-WHEEL-BYTES" / right: b"UNVALIDATED-WHEEL-BYTES"`.
- PyPI gate made unconditional (`if true || ...`) → 4 tests fail, including `test_get_remote_cached_or_refetch_serves_a_vouched_object_without_upstream` and `..._returns_cached_without_refetch`. The gate cannot be turned into a cache bypass without a test noticing.
- stale-if-error hard-wired to `Err(upstream_err)` → `test_stale_if_error_still_serves_a_body_with_a_valid_sidecar` and `..._respects_an_active_package_age_hold` fail.

## Not fixed here

The issue's "adjacent, lower priority" items are deliberately out of scope and remain open on #3147: `local_fetch_or_redirect` applying neither `is_cache_fresh` nor `cache_quarantine_gate`, the absence of a reclaimer for rejected proxy-cache objects, and `oci_v2`'s `virtual_blob_wrong_bytes_are_not_cached` no longer testing what its comment claims.

Digest verification on the PyPI serve path is also not added. It cannot retract bytes already streamed, and it would put an unconditional SHA-256 over every cache hit on a hot path; the sidecar gate closes the filed leak class without that cost.

## Note: `main` is currently red

`origin/main` does not compile `cargo test --lib`, and has not for at least the last two commits (83b9bc0, 1743098) — the `CI` workflow is failing on both. It is parallel-merge signature drift: `flatcontainer_download` gained a fourth `ctx: DownloadContext` parameter and one test call site in `nuget.rs` was never updated, so it passes `Path<...>` where `Extension<Option<AuthExtension>>` is expected.

```
error[E0277]: the trait bound `Path<(String, String, String, String)>: Default` is not satisfied
    --> backend/src/api/handlers/nuget.rs:4659:17
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
    --> backend/src/api/handlers/nuget.rs:4651:24
```

The one-line repair (add the missing `axum::Extension(tdh::admin_auth_ext())`, matching the correct sibling call at line 4835) is included here because no test gate can run without it. Happy to split it into its own PR if that is preferred — it is unrelated to everything else in this change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- proxy_service proxy_helpers pypi health` — 1112 passed, 0 failed
- [x] `AK_TESTS_REQUIRE_DB=1 cargo test --lib -- maven npm oci_v2 nuget debian` — collateral check on the other formats that reach `is_cache_fresh` via the redirect fast path
- [x] No `sqlx::query!` macro text changed, so no `.sqlx` regeneration needed
