### PR TITLE
fix(scan-policy): apply the download gate on the Generic and Terraform paths

### DIFF
--- a/backend/src/api/handlers/general.rs
+++ b/backend/src/api/handlers/general.rs
@@ -19,6 +19,112 @@ pub fn router() -> Router<SharedState> {
 mod tests {
     use crate::api::handlers::test_db_helpers as tdh;
 
+    /// #3143: the Generic download path must apply the repository's scan
+    /// policy, not just the quarantine predicate.
+    ///
+    /// `repositories::download_artifact` — re-exported here as the Generic
+    /// format route, and also mounted as the generic REST download at
+    /// `/api/v1/repositories/{key}/download/*path` — resolved the artifact row
+    /// itself and called the raw `check_download_allowed` predicate. That is
+    /// quarantine only, so `block_unscanned` / `block_on_fail` / `max_severity`
+    /// were skipped entirely, unlike the ~25 per-format handlers that route
+    /// through `enforce_download_gate`.
+    ///
+    /// The gate is placed at the handler, before the branch into the presigned
+    /// redirect / `?version=` revision / streamed-local sub-paths, because only
+    /// the last of those reaches `ArtifactService::prepare_download`.
+    ///
+    /// Positive and negative controls live in this same fixture: the identical
+    /// request serves 200 before the policy is created and 200 again after it
+    /// is removed, so the 403 is attributable to the policy alone.
+    #[tokio::test]
+    async fn test_generic_download_applies_scan_policy_3143() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let blob = bytes::Bytes::from_static(b"#3143 generic gate marker bytes");
+        let path = "files/gate.bin";
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &fx.repo_info("local", None),
+            path,
+            path,
+            "gate",
+            "1.0.0",
+            "application/octet-stream",
+            blob.clone(),
+            fx.user_id,
+        )
+        .await;
+
+        let uri = format!("/{}/{}", fx.repo_key, path);
+
+        // POSITIVE CONTROL: no scan policy -> must serve the real bytes.
+        let (before_status, before_body) =
+            tdh::send(fx.router_with_auth(super::router()), tdh::get(uri.clone())).await;
+
+        // A policy that blocks unscanned artifacts; the seeded artifact has no
+        // scan_results rows.
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3143-generic-{}", fx.repo_id))
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let (blocked_status, blocked_body) =
+            tdh::send(fx.router_with_auth(super::router()), tdh::get(uri.clone())).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+
+        // NEGATIVE CONTROL: removing the policy restores the download.
+        let (after_status, after_body) =
+            tdh::send(fx.router_with_auth(super::router()), tdh::get(uri.clone())).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            before_status,
+            axum::http::StatusCode::OK,
+            "positive control: with no scan policy the generic download must work"
+        );
+        assert_eq!(
+            before_body.as_ref(),
+            blob.as_ref(),
+            "positive control: served bytes must be the seeded artifact"
+        );
+        assert_eq!(
+            blocked_status,
+            axum::http::StatusCode::FORBIDDEN,
+            "#3143: an unscanned artifact under block_unscanned must be refused with 403 on \
+             the generic path, got {blocked_status} body={:?}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_ne!(
+            blocked_body.as_ref(),
+            blob.as_ref(),
+            "#3143: artifact bytes must not be served when the policy blocks"
+        );
+        assert_eq!(
+            after_status,
+            axum::http::StatusCode::OK,
+            "negative control: removing the policy must restore the download"
+        );
+        assert_eq!(
+            after_body.as_ref(),
+            blob.as_ref(),
+            "negative control: bytes restored"
+        );
+    }
+
     /// #2705: a proxy download through the generic `/general/{key}/*path`
     /// route must be recorded in `proxy_download_statistics`, with the same
     /// semantics as the format-specific proxy paths (first serve counts,

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -1566,6 +1566,92 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
         f.teardown().await;
     }
 
+    /// #3143 scope correction + regression guard: the Helm chart download
+    /// route ALREADY enforces the scan policy, and must keep doing so.
+    ///
+    /// #3143 reported that "`helm.rs` and `terraform.rs` call neither gate on
+    /// their download paths". That is accurate for terraform, but not for the
+    /// Helm hosted download: `download_chart` serves through
+    /// `proxy_helpers::serve_local_artifact`, which calls
+    /// `check_artifact_download` -> `enforce_download_gate`. Grepping `helm.rs`
+    /// for the gate finds nothing because the call is one level down. This test
+    /// pins that indirect coverage so a future refactor away from
+    /// `serve_local_artifact` cannot silently drop it.
+    ///
+    /// (The genuinely ungated Helm path is the VIRTUAL-member arm in
+    /// `download_chart_via_index`, which resolves via `local_fetch_by_path_suffix`.
+    /// That belongs to the cross-format virtual-member class tracked separately.)
+    #[tokio::test]
+    async fn test_hosted_chart_download_already_applies_scan_policy_3143() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let blob = bytes::Bytes::from_static(b"helm-gate-chart-bytes");
+        let filename = "gatechart-0.1.0.tgz";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &f.repo_info("local", None),
+            filename,
+            filename,
+            "gatechart",
+            "0.1.0",
+            "application/gzip",
+            blob.clone(),
+            f.user_id,
+        )
+        .await;
+
+        let uri = format!("/{}/charts/{}", f.repo_key, filename);
+
+        // POSITIVE CONTROL: no policy -> serves.
+        let (before_status, before_body) =
+            tdh::send(f.router_anon(super::router()), tdh::get(uri.clone())).await;
+
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3143-helm-{}", f.repo_id))
+        .bind(f.repo_id)
+        .execute(&f.pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let (blocked_status, _) =
+            tdh::send(f.router_anon(super::router()), tdh::get(uri.clone())).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(f.repo_id)
+            .execute(&f.pool)
+            .await;
+
+        // NEGATIVE CONTROL: policy removed -> serves again.
+        let (after_status, _) =
+            tdh::send(f.router_anon(super::router()), tdh::get(uri.clone())).await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            before_status,
+            StatusCode::OK,
+            "positive control: with no scan policy the chart must download"
+        );
+        assert_eq!(&before_body[..], &blob[..], "positive control: chart bytes");
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "the Helm hosted download must enforce the scan policy (via \
+             serve_local_artifact -> enforce_download_gate), got {blocked_status}"
+        );
+        assert_eq!(
+            after_status,
+            StatusCode::OK,
+            "negative control: removing the policy must restore the download"
+        );
+    }
+
     /// Regression guard for #3150: OCI manifest rows written into a classic
     /// Helm repository by older versions must not leak into `index.yaml`.
     #[tokio::test]

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -4650,6 +4650,7 @@ mod read_db_tests {
         for _ in 0..calls {
             let resp = super::flatcontainer_download(
                 axum::extract::State(state.clone()),
+                axum::Extension(tdh::admin_auth_ext()),
                 axum::extract::Path((
                     fx.repo_key.clone(),
                     package_id.to_string(),

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -5030,6 +5030,47 @@ pub async fn serve_local_artifact(
     ))
 }
 
+/// Streaming-path counterpart to [`serve_local_artifact`]'s gate call (#3143):
+/// enforce quarantine + scan policy on an already-resolved
+/// [`StreamingFetchResult`], then record the download.
+///
+/// [`local_fetch_by_path`] and friends only apply `check_quarantine_row` — the
+/// raw quarantine predicate — so a handler that resolves bytes through them and
+/// streams the result skips the scan policy that `serve_local_artifact` (the
+/// buffered sibling) enforces. Callers on a **terminal** download path use this
+/// to get the same contract.
+///
+/// Deliberately NOT called from inside `local_lookup_artifact`, even though
+/// that would cover every caller at once: the same helpers back the per-member
+/// `local_fetch` closures passed to [`resolve_virtual_download`], where an
+/// `Err` means "this member does not have it, try the next one". A gate
+/// rejection raised there would be swallowed as a member miss and resolution
+/// would continue to another member or upstream — converting a policy block
+/// into a silent fallback rather than a 403. The gate therefore belongs at the
+/// terminal call sites, which is where this helper is used.
+///
+/// `artifact_id: None` (a proxy/remote cache hit with no `artifacts` row) is a
+/// no-op, preserving the existing behaviour for upstream-served bytes.
+///
+/// Takes the id rather than `&StreamingFetchResult` deliberately:
+/// `StreamingFetchResult` holds a `BoxStream`, which is `Send` but not `Sync`,
+/// so holding a reference to it across this `.await` would make the calling
+/// handler's future non-`Send` and fail axum's `Handler` bound.
+pub async fn gate_and_record_streamed_local(
+    db: &PgPool,
+    artifact_id: Option<Uuid>,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
+) -> Result<(), Response> {
+    let Some(artifact_id) = artifact_id else {
+        return Ok(());
+    };
+    crate::services::quarantine_service::enforce_download_gate(db, artifact_id)
+        .await
+        .map_err(|e| e.into_response())?;
+    crate::services::artifact_service::record_download(db, artifact_id, ctx).await;
+    Ok(())
+}
+
 /// Build a 200 OK download response from proxied content.
 pub(crate) fn build_download_response(
     content: Bytes,

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -8004,17 +8004,27 @@ pub async fn download_artifact(
     // the original URL shape.
     let path = resolve_stored_path(&state, &repo, path).await?;
 
-    // Check quarantine status before serving the artifact.
-    // If the artifact is quarantined or rejected, return 409 Conflict.
+    // Enforce quarantine AND the repository's scan policy before serving the
+    // artifact: quarantined/rejected is a 409/403, a scan-policy violation
+    // (`block_unscanned` / `block_on_fail` / `max_severity`) is a 403.
+    //
+    // #3143: this used to resolve the row itself and call the raw
+    // `check_download_allowed` predicate — quarantine only. The generic REST
+    // download (`/api/v1/repositories/{key}/download/*path`) and the Generic
+    // format route (`/general/{key}/*path`, which re-exports this very handler)
+    // therefore skipped the scan policy entirely, while the ~25 per-format
+    // handlers routed through `enforce_download_gate` and blocked. An artifact
+    // a format handler would 403 was downloadable through the generic path.
+    // Resolving the artifact id and delegating to the shared choke point closes
+    // that and keeps ONE definition of "may this be downloaded" (#2954).
+    //
+    // Deliberately still keyed on the coordinate's HEAD row, so this also
+    // covers the `?version=` historical-revision branch below — which serves
+    // straight from content-addressed storage and never reaches
+    // `ArtifactService::prepare_download`.
     {
-        #[derive(sqlx::FromRow)]
-        struct QuarantineRow {
-            quarantine_status: Option<String>,
-            quarantine_until: Option<chrono::DateTime<chrono::Utc>>,
-        }
-
-        if let Some(qrow) = sqlx::query_as::<_, QuarantineRow>(
-            "SELECT quarantine_status, quarantine_until \
+        if let Some(artifact_id) = sqlx::query_scalar::<_, Uuid>(
+            "SELECT id \
              FROM artifacts \
              WHERE repository_id = $1 AND path = $2 AND is_deleted = false",
         )
@@ -8024,11 +8034,8 @@ pub async fn download_artifact(
         .await
         .map_err(|e| AppError::Database(e.to_string()))?
         {
-            crate::services::quarantine_service::check_download_allowed(
-                qrow.quarantine_status.as_deref(),
-                qrow.quarantine_until,
-                chrono::Utc::now(),
-            )?;
+            crate::services::quarantine_service::enforce_download_gate(&state.db, artifact_id)
+                .await?;
         }
     }
 

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -438,9 +438,10 @@ async fn download_module_archive(
     )
     .await?;
 
-    if let Some(artifact_id) = result.artifact_id {
-        crate::services::artifact_service::record_download(&state.db, artifact_id, &ctx).await;
-    }
+    // #3143: enforce quarantine + scan policy before streaming. `local_fetch_by_path`
+    // applies the quarantine predicate only, so this route served artifacts that
+    // `block_unscanned` / `block_on_fail` / `max_severity` should have blocked.
+    proxy_helpers::gate_and_record_streamed_local(&state.db, result.artifact_id, &ctx).await?;
 
     let filename = format!("{}-{}-{}-{}.tar.gz", namespace, name, provider, version);
     proxy_helpers::stream_fetch_result(result, "application/gzip", Some(&filename))
@@ -1020,9 +1021,9 @@ async fn serve_provider_archive(
     )
     .await?;
 
-    if let Some(artifact_id) = result.artifact_id {
-        crate::services::artifact_service::record_download(&state.db, artifact_id, ctx).await;
-    }
+    // #3143: enforce quarantine + scan policy before streaming. Also covers
+    // `mirror_download`'s hosted arm, which resolves through this function.
+    proxy_helpers::gate_and_record_streamed_local(&state.db, result.artifact_id, ctx).await?;
 
     proxy_helpers::stream_fetch_result(result, "application/zip", Some(&pkg.filename()))
 }
@@ -3885,6 +3886,110 @@ mod tests {
         assert_eq!(index_status, axum::http::StatusCode::NOT_FOUND);
         assert_eq!(version_status, axum::http::StatusCode::NOT_FOUND);
         assert_eq!(archive_status, axum::http::StatusCode::NOT_FOUND);
+    }
+
+    /// #3143: terraform download routes must apply the repository's scan
+    /// policy, not just the quarantine predicate.
+    ///
+    /// `download_provider_binary` -> `serve_provider_archive` resolves bytes via
+    /// `local_fetch_by_path`, whose only gate is `check_quarantine_row` (the raw
+    /// quarantine predicate). `block_unscanned` / `block_on_fail` /
+    /// `max_severity` were therefore never consulted on ANY terraform download
+    /// route — `terraform.rs` contained zero `check_artifact_download` calls —
+    /// while the ~25 per-format handlers routed through `enforce_download_gate`
+    /// and blocked. An artifact a format handler would 403 was downloadable here.
+    ///
+    /// Positive control in the SAME fixture: the identical request succeeds
+    /// with no policy in force, so the 403 is attributable to the policy rather
+    /// than to a broken fixture or a route that 403s unconditionally.
+    #[tokio::test]
+    async fn test_provider_binary_applies_scan_policy_3143() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "terraform").await else {
+            return;
+        };
+        let zip: &[u8] = b"PK\x03\x04 provider archive";
+        let published = publish_provider_version(&fx, "1.0.0", zip).await;
+
+        let k = fx.repo_key.clone();
+        let m = MOUNT_PREFIX;
+        let binary_path = format!("{m}/{k}/v1/providers/dtf/marker/1.0.0/binary/linux/arm64");
+
+        // POSITIVE CONTROL: no scan policy in force -> the download must work.
+        let (before_status, before_body) = tdh::send(
+            fx.router_anon(mounted_router()),
+            tdh::get(binary_path.clone()),
+        )
+        .await;
+
+        // Enable a policy that blocks unscanned artifacts. The published
+        // provider has no `scan_results` rows at all, so it is unscanned.
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3143-tf-{}", fx.repo_id))
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let (blocked_status, blocked_body) = tdh::send(
+            fx.router_anon(mounted_router()),
+            tdh::get(binary_path.clone()),
+        )
+        .await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+
+        // NEGATIVE CONTROL: with the policy removed the same request must serve
+        // again, proving the block was the policy and is fully reversible.
+        let (after_status, after_body) = tdh::send(
+            fx.router_anon(mounted_router()),
+            tdh::get(binary_path.clone()),
+        )
+        .await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            published,
+            axum::http::StatusCode::CREATED,
+            "fixture: provider must publish"
+        );
+        assert_eq!(
+            before_status,
+            axum::http::StatusCode::OK,
+            "positive control: with no scan policy the provider binary must download"
+        );
+        assert_eq!(
+            before_body.as_ref(),
+            zip,
+            "positive control: the served bytes must be the published archive"
+        );
+        assert_eq!(
+            blocked_status,
+            axum::http::StatusCode::FORBIDDEN,
+            "#3143: an unscanned provider under block_unscanned must be refused with 403, \
+             got {blocked_status} body={:?}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_ne!(
+            blocked_body.as_ref(),
+            zip,
+            "#3143: the archive bytes must not be served when the policy blocks"
+        );
+        assert_eq!(
+            after_status,
+            axum::http::StatusCode::OK,
+            "negative control: removing the policy must restore the download"
+        );
+        assert_eq!(after_body.as_ref(), zip, "negative control: bytes restored");
     }
 
     /// A package under a quarantine hold must not appear in the metadata

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1441,12 +1441,18 @@ impl ArtifactService {
         .map_err(|e| AppError::Database(e.to_string()))?
         .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
 
-        // Check quarantine status before serving the artifact
-        crate::services::quarantine_service::check_download_allowed(
-            artifact.quarantine_status.as_deref(),
-            artifact.quarantine_until,
-            chrono::Utc::now(),
-        )?;
+        // Enforce quarantine AND the repository's scan policy before serving.
+        //
+        // #3143: this called the raw `check_download_allowed` predicate, which
+        // is quarantine only — so `block_unscanned` / `block_on_fail` /
+        // `max_severity` were skipped on both the buffered (`download`) and
+        // streaming (`download_stream`) generic paths, unlike the per-format
+        // handlers that go through `enforce_download_gate`. Routing through the
+        // shared choke point (#2954) makes the scan policy apply here too.
+        //
+        // A repo with no enabled scan policy is unaffected: `evaluate_artifact`
+        // returns `allowed` when no policy matches.
+        crate::services::quarantine_service::enforce_download_gate(&self.db, artifact.id).await?;
 
         // Trigger BeforeDownload hooks - validators can reject the download
         let artifact_info = ArtifactInfo::from(&artifact);


### PR DESCRIPTION
## Problem

`enforce_download_gate` (#2954) is the shared download choke point: it enforces quarantine **and** the repository's scan policy (`block_unscanned` / `block_on_fail` / `max_severity`). The ~25 per-format handlers route through it. Two byte-serving paths did not — they called the raw `check_download_allowed` / `check_quarantine_row` predicate, which is quarantine only. An artifact a format handler would 403 was downloadable through them.

### Reproduction (at `origin/main`, verbatim)

Generic — `GET /general/{key}/{path}` with `block_unscanned` enabled on an artifact that has no scan rows:

```
assertion `left == right` failed: #3143: an unscanned artifact under block_unscanned
must be refused with 403 on the generic path, got 200 OK body="#3143 generic gate marker bytes"
  left: 200
 right: 403
```

Terraform — `GET /terraform/{key}/v1/providers/dtf/marker/1.0.0/binary/linux/arm64`, same policy:

```
assertion `left == right` failed: #3143: an unscanned provider under block_unscanned
must be refused with 403, got 200 OK body="PK\u{3}\u{4} provider archive"
  left: 200
 right: 403
```

Both serve the real artifact bytes with a 200.

## Scope correction: Helm was already gated

The issue states "`helm.rs` and `terraform.rs` call **neither** gate on their download paths". That holds for terraform — `terraform.rs` contains zero `check_artifact_download` calls — but **not** for the Helm hosted download. `download_chart` serves through `proxy_helpers::serve_local_artifact`, which calls `check_artifact_download` → `enforce_download_gate` (`proxy_helpers.rs:5014`). Grepping `helm.rs` finds nothing because the call is one level down. Verified by removing that call and watching the new Helm test flip 403 → 200.

No behaviour change was needed for Helm; this PR adds a regression test pinning the indirect coverage. Helm's genuinely ungated path is its **virtual-member** arm (`download_chart_via_index` → `local_fetch_by_path_suffix`), which belongs to the systemic class below.

## Fix

**Generic** (`repositories::download_artifact` — also re-exported as the `/general/{key}/*path` Generic-format route, and mounted as the generic REST download at `/api/v1/repositories/{key}/download/*path`): gate at the handler, before the branch into the presigned-redirect / `?version=` revision / streamed-local sub-paths. Only the last of those reaches `ArtifactService::prepare_download` — **a presigned-S3 deployment would otherwise have returned a 302 straight to the object with no policy check at all**. `prepare_download` is gated too, for its other callers.

**Terraform**: `download_module_archive` and `serve_provider_archive` (hence `download_provider_binary` and `mirror_download`'s hosted arm) now route through a new `proxy_helpers::gate_and_record_streamed_local` — the streaming-family counterpart to what `serve_local_artifact` already does for the buffered family.

### Why not gate inside `local_lookup_artifact`

That one-line change would cover every caller at once, and it is the wrong place. The same helpers back the per-member `local_fetch` closures passed to `resolve_virtual_download`, where an `Err` means *"this member does not have it, try the next one."* A gate rejection raised there would be swallowed as a member miss and resolution would continue to another member or upstream — converting a policy block into a **silent fallback** rather than a 403. The gate belongs at terminal call sites.

## Full download-path classification

Every path that returns artifact bytes to a client, by which gate it reaches. `GATED` = reaches `enforce_download_gate`; `QUARANTINE-ONLY` = quarantine enforced, scan policy skipped.

| Path | Route | Before | After |
|---|---|---|---|
| `repositories::download_artifact` | `/api/v1/repositories/:key/download/*path` | QUARANTINE-ONLY | **GATED** |
| `general.rs` (re-export) | `/general/:repo_key/*path` | QUARANTINE-ONLY | **GATED** |
| `download_artifact_version` (`?version=`) | same route | QUARANTINE-ONLY | **GATED** |
| `artifact_service::prepare_download` | service (`download` / `download_stream`) | QUARANTINE-ONLY | **GATED** |
| `terraform::download_module_archive` | `/terraform/:key/v1/modules/.../archive` | QUARANTINE-ONLY | **GATED** |
| `terraform::serve_provider_archive` / `download_provider_binary` | `/terraform/:key/v1/providers/.../binary/:os/:arch` | QUARANTINE-ONLY | **GATED** |
| `terraform::mirror_download` (hosted arm) | `/terraform/:key/:host/:ns/:type/:ver/download/:os/:arch` | QUARANTINE-ONLY | **GATED** |
| `helm::download_chart` (hosted) | `/helm/:key/charts/:filename` | GATED | GATED (test added) |
| hex, huggingface, cran, puppet, ansible, rubygems, maven, sbt, npm, pypi, debian, rpm, nuget, cargo, goproxy, conan, conda, alpine, composer, pub, swift, chef, cocoapods, jetbrains, vscode, gitlfs, incus, protobuf, tree (hosted paths) | various | GATED | unchanged |
| **Virtual-member arm** of helm, hex, huggingface, npm, pypi, maven, terraform, conan, conda, alpine, debian, gitlfs, goproxy, cargo, nuget, composer, chef, cocoapods, pub, jetbrains, swift, sbt, vscode, protobuf | various | QUARANTINE-ONLY | **unchanged — tracked separately** |
| `oci_v2::handle_get_blob` | `/v2/<name>/blobs/<digest>` | no artifact row; has its own OCI scan blocklist | unchanged |
| `rpm::serve_version_package` | frozen `@N` snapshot | no artifact row | unchanged |
| Proxy/remote cache serves (`proxy_fetch_streaming*`) | Remote arms | `artifact_id: None`, outside the model | unchanged |

Metadata/index handlers (`index.yaml`, `repodata_*`, `simple_*`, `packages.json`, service discovery, …) serve no artifact bytes and are out of scope.

### Follow-up filed

The **virtual-member class** is the largest remaining gap: in ~24 formats the *direct hosted* path is gated but the *virtual-member* path is not, so a scan-policy block is bypassable by pulling through a virtual repo that has the hosted repo as a member. It needs the fallthrough-semantics design decision described above and is deliberately out of scope here. Tracking issue: #3220.

## Verification

Every new guard was revert-proved — the guard was removed, the test observed failing with the pre-fix behaviour, then restored (outputs quoted above). The Helm test was revert-proved the same way to confirm it is not vacuous.

Every negative assertion has a positive control **in the same fixture**: the identical request serves 200 before the policy is created and 200 again after it is removed, so a 403 is attributable to the policy and not to a route that blocks unconditionally. A gate fix that over-blocks is an outage.

Gates (against Postgres 16):
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --lib -- scan quarantine curation repositories:: helm terraform` — 2084 passed, 0 failed
- No `sqlx::query!` macro text changed (all new queries are runtime `query_as` / `query_scalar`); `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` unset — clean

## Note: `origin/main` test build is currently broken

Independent of this work, `cargo build --lib --tests` fails on a pristine `origin/main` (`1743098`):

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
    --> backend/src/api/handlers/nuget.rs:4651:24
     | argument #4 of type `download_telemetry::DownloadContext` is missing
error: could not compile `artifact-keeper-backend` (lib test) due to 2 previous errors
```

#3205 added an `Extension` param to `flatcontainer_download` and updated four of its five test call sites, missing the one added concurrently by #2919 — parallel-merge signature drift. Filed as #3221. The one-line fix is included here so the test suite compiles; it is also in the #3142 branch (PR #3218), so whichever merges first makes the other a no-op hunk.

Fixes #3143
