### PR TITLE
fix(nuget): repair the flatcontainer_download test call site broken on main

### DIFF
--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -4650,6 +4650,7 @@ mod read_db_tests {
         for _ in 0..calls {
             let resp = super::flatcontainer_download(
                 axum::extract::State(state.clone()),
+                axum::extract::Extension(None),
                 axum::extract::Path((
                     fx.repo_key.clone(),
                     package_id.to_string(),


### PR DESCRIPTION
fix(nuget): repair the flatcontainer_download test call site broken on main

main does not compile. `cargo build --lib --tests` fails at
backend/src/api/handlers/nuget.rs:4651 with E0061/E0277 — the call passes
State, Path, Default and omits the Extension, while the function takes
State, Extension, Path, ctx.

Classic parallel-merge signature drift: #3205 added the Extension parameter and
updated the call sites it could see, while a concurrently-merged PR added
another one. Both were individually green; the combination is not. The lib
still builds, so only `--all-targets` consumers fail — which is Check Rust,
Backend Unit Tests and Code Coverage, i.e. every required check on every open
PR.

Fixes #3221.
