### PR TITLE
fix(maven-gc): close two more sidecar/rollup guard gaps in the delete paths

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4197,7 +4197,32 @@ async fn purge_storage_object_keys(
 /// condition present on a sidecar arm but absent from the guard it shadows
 /// re-creates this same bug for the rows it excludes, by letting a base be
 /// spared while its sidecar is collected.
+///
+/// The final guard is the `maven-metadata.xml` rollup anchor (#3197). The GC
+/// sweep has carried it since #2668 (`ORPHAN_MAVEN_FLAT_PREDICATE_SQL` guard 3)
+/// and this collector never grew it, so GC spared a rollup another repository
+/// was still serving while a repository delete purged it -- and, since the
+/// rollup is what resolves version ranges and `LATEST`/`RELEASE`, that breaks
+/// *resolution* for the surviving repository, not merely checksum verification.
+/// It is a missing BASE guard, not a missing sidecar arm: the shared
+/// `is_metadata_rollup_key_sql` strips the sidecar suffix first, so the
+/// document and its `.sha1`/`.asc` are anchored together and the #3192
+/// invariant already holds here.
+///
+/// Two deliberate asymmetries with GC's copy of that guard, both in the
+/// over-PROTECT direction (the safe one for a `NOT EXISTS` purge list):
+///
+/// * `mb.repository_id <> $1`, like every other guard here. This collector runs
+///   BEFORE the repository row and its cascading `artifacts` rows are deleted,
+///   so without the scoping the repository's own doomed artifacts would anchor
+///   its own rollup and the object would leak forever.
+/// * No `is_deleted` test, matching the four guards above. A foreign
+///   soft-deleted artifact under the prefix therefore spares the rollup; that
+///   is a temporary leak, not a leak forever, because the GC sweep's copy of
+///   the guard *does* test `is_deleted` and reclaims the key once those rows
+///   are hard-deleted. A leak GC later collects is recoverable; a purge is not.
 async fn collect_repo_maven_flat_keys(state: &SharedState, repo_id: Uuid) -> Vec<String> {
+    use crate::services::maven_flat_attribution as mfa;
     let sql = format!(
         "SELECT o.storage_key \
          FROM maven_flat_object_owner o \
@@ -4233,17 +4258,24 @@ async fn collect_repo_maven_flat_keys(state: &SharedState, repo_id: Uuid) -> Vec
                  AND spa.repository_id <> $1 \
                  AND spr.storage_backend = o.storage_backend \
                  AND {sidecar_files_match} \
+           ) \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM artifacts mb \
+               JOIN repositories mrb ON mrb.id = mb.repository_id \
+               WHERE {is_rollup} \
+                 AND mb.repository_id <> $1 \
+                 AND mrb.storage_backend = o.storage_backend \
+                 AND mb.storage_key LIKE {rollup_dir} || '%' \
            )",
-        files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
-            "am.metadata->'files'",
-            "o.storage_key",
-        ),
-        is_sidecar = crate::services::maven_flat_attribution::is_sidecar_key_sql("o.storage_key"),
-        base_key = crate::services::maven_flat_attribution::sidecar_base_key_sql("o.storage_key"),
-        sidecar_files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
+        files_match = mfa::metadata_files_name_key_sql("am.metadata->'files'", "o.storage_key"),
+        is_sidecar = mfa::is_sidecar_key_sql("o.storage_key"),
+        base_key = mfa::sidecar_base_key_sql("o.storage_key"),
+        sidecar_files_match = mfa::metadata_files_name_key_sql(
             "sam.metadata->'files'",
-            &crate::services::maven_flat_attribution::sidecar_base_key_sql("o.storage_key"),
+            &mfa::sidecar_base_key_sql("o.storage_key"),
         ),
+        is_rollup = mfa::is_metadata_rollup_key_sql("o.storage_key"),
+        rollup_dir = mfa::metadata_rollup_dir_prefix_sql("o.storage_key"),
     );
     sqlx::query_scalar(&sql)
         .bind(repo_id)
@@ -21804,6 +21836,109 @@ mod apt_validation_tests {
              collected: {collected:?}"
         );
     }
+    /// #3197: deleting a repository must not purge the `maven-metadata.xml`
+    /// rollup (or its sidecars) of a subtree ANOTHER repository is still
+    /// serving.
+    ///
+    /// The GC sweep has carried this anchor since #2668; this collector never
+    /// grew it, so the two delete paths disagreed: GC spared the rollup, the
+    /// repository delete purged it. The rollup is what resolves version ranges
+    /// and `LATEST`/`RELEASE`, so losing it breaks resolution for the surviving
+    /// repository, not merely checksum verification.
+    ///
+    /// The `.sha1` and `.asc` are asserted alongside the document: the shared
+    /// `is_metadata_rollup_key_sql` strips the sidecar suffix before testing,
+    /// so a base-only fix that left the sidecars behind would still leave the
+    /// other repository serving a rollup whose checksum 404s.
+    ///
+    /// TWO positive controls keep the fix honest. The first is the `<> $1`
+    /// scoping: the doomed repository's OWN live artifact under a directory
+    /// must not anchor that directory's rollup, or the object leaks forever.
+    /// The second is a plain unreferenced key. Without them a guard that
+    /// spared every `maven-metadata.xml` would pass.
+    #[tokio::test]
+    async fn collect_repo_maven_flat_keys_spares_rollup_of_foreign_live_subtree_3197() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (owner_repo, _, dir) = tdh::create_repo(&pool, "local", "maven").await;
+        let (other_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let uid = Uuid::new_v4().simple().to_string();
+
+        // Another repository is still serving this subtree...
+        seed_flat_artifact_row(
+            &pool,
+            other_repo,
+            &format!("maven/gav3197/{uid}/lib/1.0/lib-1.0.jar"),
+        )
+        .await;
+        let rollup = format!("maven/gav3197/{uid}/lib/maven-metadata.xml");
+        let rollup_sidecars: Vec<String> = [".sha1", ".md5", ".sha256", ".sha512", ".asc"]
+            .iter()
+            .map(|s| format!("{rollup}{s}"))
+            .collect();
+
+        // ...while the repository being deleted holds only its OWN doomed
+        // artifact under this second directory, so its rollup is collectable.
+        seed_flat_artifact_row(
+            &pool,
+            owner_repo,
+            &format!("maven/gav3197/{uid}/own/1.0/own-1.0.jar"),
+        )
+        .await;
+        let own_rollup = format!("maven/gav3197/{uid}/own/maven-metadata.xml");
+        let own_rollup_sha1 = format!("{own_rollup}.sha1");
+        let orphan_key = format!("maven/gav3197/{uid}/own/1.0/gone-9.9.9.pom");
+
+        // Every claim belongs to the repository being deleted.
+        for key in [&rollup, &own_rollup, &own_rollup_sha1, &orphan_key]
+            .into_iter()
+            .chain(rollup_sidecars.iter())
+        {
+            seed_flat_claim(&pool, owner_repo, key).await;
+        }
+
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let collected = collect_repo_maven_flat_keys(&state, owner_repo).await;
+
+        tdh::cleanup(&pool, other_repo, Uuid::nil()).await;
+        tdh::cleanup(&pool, owner_repo, Uuid::nil()).await;
+
+        assert!(
+            !collected.contains(&rollup),
+            "the maven-metadata.xml of a subtree another repository still has a \
+             live artifact in must NOT be purged by this repository's delete -- \
+             it is what resolves version ranges and LATEST/RELEASE for that \
+             repository (#3197); collected: {collected:?}"
+        );
+        for sidecar in &rollup_sidecars {
+            assert!(
+                !collected.contains(sidecar),
+                "the rollup's sidecars must be spared with it, or the surviving \
+                 repository serves a maven-metadata.xml whose checksum 404s \
+                 (#3197); collected: {collected:?}"
+            );
+        }
+        assert!(
+            collected.contains(&own_rollup),
+            "positive control: only the DOOMED repository's own artifacts sit \
+             under this directory, so its rollup must still be collected -- \
+             otherwise the anchor is unscoped and every rollup leaks forever; \
+             collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&own_rollup_sha1),
+            "positive control: the sidecar of a collectable rollup is collected \
+             with it; collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&orphan_key),
+            "positive control: a key no repository references must still be \
+             collected for purge; collected: {collected:?}"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // #3081: a virtual repository's storage total must not disclose the byte
     // size of member repositories the caller cannot read. Both aggregation

--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -159,6 +159,41 @@ pub(crate) fn sidecar_base_key_sql(key_expr: &str) -> String {
     format!(r"regexp_replace({key_expr}, '\.({alt})$', '')")
 }
 
+/// Trailing filename of a Maven rollup document. The `maven-metadata.xml` at a
+/// group/artifact/version directory is what resolves version ranges and the
+/// `LATEST`/`RELEASE` markers (Maven repository metadata spec, "Repository
+/// Metadata" — `maven-metadata.xml` is the only file name the layout defines
+/// for it), so losing one breaks *resolution*, not merely verification.
+const MAVEN_METADATA_FILENAME: &str = "maven-metadata.xml";
+
+/// SQL predicate: does `key_expr` name a `maven-metadata.xml` rollup document,
+/// or a checksum/signature sidecar of one?
+///
+/// The sidecar suffix is stripped first ([`sidecar_base_key_sql`]), so
+/// `.../maven-metadata.xml.sha1` and `.../maven-metadata.xml.asc` answer the
+/// same as the document itself — a rollup and its sidecars stand or fall
+/// together, which is the #3192 invariant applied to the rollup.
+pub(crate) fn is_metadata_rollup_key_sql(key_expr: &str) -> String {
+    let base = sidecar_base_key_sql(key_expr);
+    format!("{base} LIKE '%/{MAVEN_METADATA_FILENAME}'")
+}
+
+/// SQL expression yielding the directory prefix a `maven-metadata.xml` rollup
+/// summarises (`maven/g/a/` for `maven/g/a/maven-metadata.xml`), for use as the
+/// left operand of a `LIKE ... || '%'` anchor test. Only meaningful for keys
+/// [`is_metadata_rollup_key_sql`] accepts — always gate on it.
+///
+/// The rollup is anchored (spared) while ANY live artifact remains under that
+/// prefix: the document describes the whole groupId/artifactId subtree, so it
+/// is still being served as long as one member of the subtree is. The `LIKE`
+/// operand is a stored key, so SQL wildcards inside it can only make the
+/// pattern match a SUPERSET — i.e. this test can only ever over-PROTECT, which
+/// is the safe direction for a `NOT EXISTS` delete guard.
+pub(crate) fn metadata_rollup_dir_prefix_sql(key_expr: &str) -> String {
+    let base = sidecar_base_key_sql(key_expr);
+    format!("substr({base}, 1, length({base}) - length('{MAVEN_METADATA_FILENAME}'))")
+}
+
 /// Distinct owning repositories of a live parent artifact whose metadata
 /// `files[]` array lists this key (legacy GAV-grouped uploads whose companion
 /// files have no row of their own), restricted to repositories on `$2`. LIMIT 2

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -219,7 +219,23 @@ const ORPHAN_MAVEN_FLAT_SCAN_LIMIT: i64 = 1000;
 /// every live GAV companion (and every checksum sidecar of one) read as
 /// unreferenced and was purged by the sweep while its parent artifact was
 /// still serving it (#3156).
+///
+/// Guards 3, 4 and 5 likewise take their sidecar-suffix regex from
+/// [`crate::services::maven_flat_attribution::GUARDED_SIDECAR_SUFFIXES`] rather
+/// than an inline `(md5|sha1|sha256|sha512)` alternation. The inline copies
+/// omitted `.asc`, which the READ path resolves to its base
+/// (`strip_checksum_suffix`) and which migrations 163 and 170 step (3') both
+/// backfill into `maven_flat_object_owner` -- so a `<base>.asc` the server was
+/// still serving matched neither the verbatim guards (nothing references a
+/// sidecar by name) nor the sidecar arms (the regex did not recognise it as a
+/// sidecar), read as orphan, and was reclaimed while its base stayed live
+/// (#3197). The rollup guard shares
+/// [`crate::services::maven_flat_attribution::is_metadata_rollup_key_sql`] /
+/// [`crate::services::maven_flat_attribution::metadata_rollup_dir_prefix_sql`]
+/// with the repository-delete collector for the same anti-drift reason.
 static ORPHAN_MAVEN_FLAT_PREDICATE_SQL: Lazy<String> = Lazy::new(|| {
+    use crate::services::maven_flat_attribution as mfa;
+    let sidecar_base = mfa::sidecar_base_key_sql("o.storage_key");
     format!(
         r#"
 o.storage_key LIKE 'maven/%'
@@ -240,42 +256,33 @@ AND NOT EXISTS (
 AND NOT EXISTS (
     SELECT 1 FROM artifacts a2
     JOIN repositories r2 ON r2.id = a2.repository_id
-    WHERE regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', '')
-            LIKE '%/maven-metadata.xml'
+    WHERE {is_rollup}
       AND r2.storage_backend = o.storage_backend
       AND a2.is_deleted = false
-      AND a2.storage_key LIKE substr(
-            regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', ''),
-            1,
-            length(regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', ''))
-              - length('maven-metadata.xml')
-          ) || '%'
+      AND a2.storage_key LIKE {rollup_dir} || '%'
 )
 AND NOT EXISTS (
     SELECT 1 FROM artifacts ab
     JOIN repositories rb ON rb.id = ab.repository_id
-    WHERE o.storage_key ~ '\.(md5|sha1|sha256|sha512)$'
-      AND ab.storage_key = regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', '')
+    WHERE {is_sidecar}
+      AND ab.storage_key = {sidecar_base}
       AND rb.storage_backend = o.storage_backend
 )
 AND NOT EXISTS (
     SELECT 1 FROM artifact_metadata am2
     JOIN artifacts pa2 ON pa2.id = am2.artifact_id
     JOIN repositories pr2 ON pr2.id = pa2.repository_id
-    WHERE o.storage_key ~ '\.(md5|sha1|sha256|sha512)$'
+    WHERE {is_sidecar}
       AND pr2.storage_backend = o.storage_backend
       AND {sidecar_base_files_match}
 )
 "#,
-        files_match = crate::services::maven_flat_attribution::metadata_files_name_key_sql(
-            "am.metadata->'files'",
-            "o.storage_key",
-        ),
+        files_match = mfa::metadata_files_name_key_sql("am.metadata->'files'", "o.storage_key"),
+        is_rollup = mfa::is_metadata_rollup_key_sql("o.storage_key"),
+        rollup_dir = mfa::metadata_rollup_dir_prefix_sql("o.storage_key"),
+        is_sidecar = mfa::is_sidecar_key_sql("o.storage_key"),
         sidecar_base_files_match =
-            crate::services::maven_flat_attribution::metadata_files_name_key_sql(
-                "am2.metadata->'files'",
-                r"regexp_replace(o.storage_key, '\.(md5|sha1|sha256|sha512)$', '')",
-            ),
+            mfa::metadata_files_name_key_sql("am2.metadata->'files'", &sidecar_base),
     )
 });
 
@@ -4017,30 +4024,74 @@ mod tests {
     // #2668: row-less Maven sidecar + metadata reclamation
     // -----------------------------------------------------------------------
 
-    /// The sidecar suffix list and the regex alternation embedded (three
-    /// times) in [`ORPHAN_MAVEN_FLAT_PREDICATE_SQL`] must not drift: a suffix
-    /// missing from the SQL would silently exempt that sidecar class from the
-    /// flat-object sweep.
+    /// The sidecar suffix regex embedded (three times) in
+    /// [`ORPHAN_MAVEN_FLAT_PREDICATE_SQL`] must be the one the delete guards
+    /// share — `GUARDED_SIDECAR_SUFFIXES`, not `MAVEN_SIDECAR_SUFFIXES`. A
+    /// suffix missing from the SQL silently exempts that sidecar class from
+    /// guards 3/4/5, and an exempt sidecar in a `NOT EXISTS` guard is a
+    /// PURGED one.
+    ///
+    /// The two lists point in opposite directions and pinning the wrong one is
+    /// how #3197 happened: the predicate was pinned to `MAVEN_SIDECAR_SUFFIXES`
+    /// (the four suffixes GC *derives for deletion*), so `.asc` — which the read
+    /// path resolves to its base and which migrations 163/170 backfill into the
+    /// attribution table — was never recognised as a sidecar here at all.
+    ///
+    /// This is the only check on the `.asc` gap that runs WITHOUT a database;
+    /// `test_orphan_maven_flat_scan_spares_asc_signature_of_live_base_3197`
+    /// skips silently when `DATABASE_URL` is unset.
     #[test]
     fn test_maven_sidecar_suffixes_match_flat_predicate_sql() {
-        for suffix in MAVEN_SIDECAR_SUFFIXES {
+        use crate::services::maven_flat_attribution::GUARDED_SIDECAR_SUFFIXES;
+        for suffix in GUARDED_SIDECAR_SUFFIXES {
             let bare = suffix.trim_start_matches('.');
             assert!(
                 ORPHAN_MAVEN_FLAT_PREDICATE_SQL.contains(bare),
-                "ORPHAN_MAVEN_FLAT_PREDICATE_SQL is missing sidecar suffix {suffix}"
+                "ORPHAN_MAVEN_FLAT_PREDICATE_SQL is missing guarded sidecar \
+                 suffix {suffix}: keys ending in it are not recognised as \
+                 sidecars, so guards 4/5 never fire and the object is purged \
+                 while its base is still served (#3197)"
             );
         }
         let expected_alternation = format!(
             "({})",
-            MAVEN_SIDECAR_SUFFIXES
+            GUARDED_SIDECAR_SUFFIXES
                 .map(|s| s.trim_start_matches('.'))
                 .join("|")
         );
         assert!(
             ORPHAN_MAVEN_FLAT_PREDICATE_SQL.contains(&expected_alternation),
             "the SQL sidecar regex alternation must be built from \
-             MAVEN_SIDECAR_SUFFIXES; expected {expected_alternation}"
+             GUARDED_SIDECAR_SUFFIXES; expected {expected_alternation}"
         );
+        // ...and every suffix GC derives for deletion must be in there too.
+        // `guarded_sidecar_suffixes_are_a_superset_of_the_gc_derived_list`
+        // pins the containment; this states the consequence for the SQL.
+        for suffix in MAVEN_SIDECAR_SUFFIXES {
+            assert!(
+                GUARDED_SIDECAR_SUFFIXES.contains(&suffix),
+                "{suffix} is derived for deletion but not guarded"
+            );
+        }
+    }
+
+    /// Guard 3 (the `maven-metadata.xml` rollup anchor) must be built from the
+    /// fragments the repository-delete collector also uses, so the two delete
+    /// paths cannot disagree about which keys are rollups or which directory a
+    /// rollup covers — the divergence #3197 reported in the other direction.
+    #[test]
+    fn test_flat_predicate_rollup_guard_uses_shared_fragments() {
+        use crate::services::maven_flat_attribution as mfa;
+        for fragment in [
+            mfa::is_metadata_rollup_key_sql("o.storage_key"),
+            mfa::metadata_rollup_dir_prefix_sql("o.storage_key"),
+        ] {
+            assert!(
+                ORPHAN_MAVEN_FLAT_PREDICATE_SQL.contains(&fragment),
+                "the rollup guard must use the shared fragment `{fragment}`, \
+                 not an inline copy"
+            );
+        }
     }
 
     /// #3156: a live parent artifact's metadata `files[]` must anchor its
@@ -4125,6 +4176,97 @@ mod tests {
             collected.contains(&orphan_key),
             "positive control: a key no parent references must still be \
              collected for purge; collected: {collected:?}"
+        );
+    }
+
+    /// #3197: the flat-object sweep must not reclaim a `.asc` signature whose
+    /// base object is still anchored.
+    ///
+    /// Guards 3/4/5 tested `\.(md5|sha1|sha256|sha512)$` — the list GC derives
+    /// keys to DELETE from — while the read path resolves `.asc` to its base
+    /// (`strip_checksum_suffix`) and migrations 163 / 170 step (3') backfill
+    /// `.asc` rows into `maven_flat_object_owner`. So a `.asc` matched neither
+    /// the verbatim guards (nothing references a sidecar by name) nor the
+    /// sidecar arms (it was not recognised as a sidecar), read as orphan, and
+    /// was collected while the server was still serving it.
+    ///
+    /// Both anchoring shapes the `.asc` gap reaches are covered: guard 4 (base
+    /// with a live `artifacts` row) and guard 3 (a `maven-metadata.xml` rollup
+    /// whose subtree is still live).
+    ///
+    /// TWO positive controls keep the fix honest — a `.asc` whose base is
+    /// genuinely unreferenced, and a rollup `.asc` over an empty subtree.
+    /// Without them, sparing every key ending in `.asc` would pass.
+    #[tokio::test]
+    async fn test_orphan_maven_flat_scan_spares_asc_signature_of_live_base_3197() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fixture) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+        let service =
+            StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
+        let uid = Uuid::new_v4().simple().to_string();
+
+        // Guard 4: a live base object; its `.asc` and `.sha1` are row-less.
+        let pom = format!("maven/gav3197/{uid}/lib/1.0/lib-1.0.pom");
+        let pom_asc = format!("{pom}.asc");
+        let pom_sha1 = format!("{pom}.sha1");
+        // Guard 3: the rollup over that still-live subtree, signed.
+        let live_rollup_asc = format!("maven/gav3197/{uid}/lib/maven-metadata.xml.asc");
+        // Positive controls: nothing anchors either of these.
+        let orphan_asc = format!("maven/gav3197/{uid}/lib/9.9.9/gone-9.9.9.pom.asc");
+        let dead_rollup_asc = format!("maven/gav3197/{uid}/dead/maven-metadata.xml.asc");
+
+        insert_maven_artifact_row(&fixture.pool, fixture.repo_id, fixture.user_id, &pom, false)
+            .await;
+        for key in [
+            &pom_asc,
+            &pom_sha1,
+            &live_rollup_asc,
+            &orphan_asc,
+            &dead_rollup_asc,
+        ] {
+            insert_flat_attribution_row(&fixture.pool, fixture.repo_id, key, 2).await;
+        }
+
+        let rows = service
+            .select_orphan_maven_flat_objects(Some(fixture.repo_id))
+            .await;
+        let collected: Vec<String> = rows
+            .expect("scan succeeds")
+            .iter()
+            .map(|r| r.get::<String, _>("storage_key"))
+            .collect();
+        fixture.teardown().await;
+
+        assert!(
+            !collected.contains(&pom_asc),
+            "guard 4: the `.asc` signature of a base with a live artifacts row \
+             must NOT be collected — the read path still serves it off that \
+             base (#3197); collected: {collected:?}"
+        );
+        assert!(
+            !collected.contains(&pom_sha1),
+            "the `.sha1` of the same base must keep being spared too; \
+             collected: {collected:?}"
+        );
+        assert!(
+            !collected.contains(&live_rollup_asc),
+            "guard 3: the `.asc` of a maven-metadata.xml whose subtree is still \
+             live must NOT be collected — losing it breaks signature \
+             verification of the document that resolves version ranges \
+             (#3197); collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&orphan_asc),
+            "positive control: a `.asc` whose BASE nothing anchors is a genuine \
+             orphan and must still be collected — otherwise sparing every \
+             `.asc` unconditionally would pass; collected: {collected:?}"
+        );
+        assert!(
+            collected.contains(&dead_rollup_asc),
+            "positive control: a rollup `.asc` over a subtree with no live \
+             artifact must still be collected; collected: {collected:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #3197

Two further instances of the #3160/#3188 data-loss class. Both were confirmed
in SQL against a freshly migrated schema **before** writing the fix, and both
were revert-proved after.

## The premise, verified

Two repositories on one shared cloud namespace (`s3`), repository **A** holding
every `maven_flat_object_owner` claim, repository **B** serving a live artifact
under `maven/com/acme/lib/`:

| key | GC predicate | `collect_repo_maven_flat_keys(A)` |
|---|---|---|
| `maven/com/acme/lib/maven-metadata.xml` | spared | **PURGED** |
| `maven/com/acme/lib/maven-metadata.xml.sha1` | spared | **PURGED** |
| `maven/com/acme/lib/1.0/lib-1.0.pom.asc` (base row live) | **PURGED** | purged |
| `maven/com/acme/lib/1.0/lib-1.0.pom.sha1` (base row live) | spared | purged |
| `maven/com/acme/gone/9.9.9/gone-9.9.9.pom` (control) | collected | collected |

Both gaps reproduce exactly as reported.

## 1. Repository delete had no `maven-metadata.xml` anchor

The storage-GC predicate has carried this anchor since #2668
(`ORPHAN_MAVEN_FLAT_PREDICATE_SQL` guard 3): a rollup document is spared while
any live artifact remains under its directory prefix. The repository-delete
collector never grew it, so the two delete paths disagreed — GC spared a rollup
another repository was still serving, the repository delete destroyed it along
with its checksums.

`maven-metadata.xml` is the file the Maven repository layout defines for
version-range resolution and the `LATEST`/`RELEASE` markers, so losing it
breaks *resolution* for the surviving repository, not merely checksum
verification.

This is a missing **base** guard, not a missing sidecar arm — the #3192
invariant already holds here, and the shared fragment strips the sidecar suffix
before testing, so the document and its `.sha1`/`.asc` are anchored together.

Two deliberate asymmetries with GC's copy, both documented in the source and
both in the over-PROTECT direction:

* `mb.repository_id <> $1`, matching the four guards it sits beside. The
  collector runs *before* the repository row and its cascading `artifacts` rows
  are deleted, so without the scoping the doomed repository's own artifacts
  would anchor its own rollup and the object would leak forever.
* No `is_deleted` test, also matching its neighbours. A foreign soft-deleted
  artifact under the prefix therefore spares the rollup — a temporary leak, not
  a permanent one, because GC's copy of the guard *does* test `is_deleted` and
  reclaims the key once those rows are hard-deleted. A leak GC later collects is
  recoverable; a purge is not.

## 2. The GC predicate omitted `.asc`

Guards 3/4/5 were pinned to `MAVEN_SIDECAR_SUFFIXES` — the list GC derives keys
*to delete* from, which points in the opposite direction to a guard. Meanwhile
the read path resolves `.asc` to its base (`strip_checksum_suffix`), and
migrations 163 and 170 step (3') both backfill `.asc` rows into
`maven_flat_object_owner`, so these are genuinely tracked, genuinely served
objects.

A `<base>.asc` therefore matched neither the verbatim guards (nothing
references a sidecar by name) nor the sidecar arms (the regex did not recognise
it as a sidecar at all), read as orphan, and was reclaimed while its base
stayed live. The predicate now takes its regex from `GUARDED_SIDECAR_SUFFIXES`,
the list #3192 introduced for exactly this direction.

## Anti-drift

Rather than a second inline copy of the rollup test, both delete paths now
share `is_metadata_rollup_key_sql` / `metadata_rollup_dir_prefix_sql` in
`maven_flat_attribution`, alongside the existing `is_sidecar_key_sql` /
`sidecar_base_key_sql` / `metadata_files_name_key_sql`. That is the same
anti-drift move #3156 and #3192 made, and it is what stops the two sides
diverging a third time.

`MAVEN_SIDECAR_SUFFIXES` is left untouched: it derives keys to delete, so
widening it widens deletion.

## Direction

Every change is to a `NOT EXISTS` anti-join, where a **narrower** anchoring
predicate means **more** rows purged. Both fixes widen the anchoring set:
strictly fewer keys are now collected, never more. No filter was added that
shrinks it, and nothing is scoped by `am.format` (migration 170 backfills on
the key prefix, not on format).

## Tests

Four, all under `--lib` so they score for coverage. The two DB-backed ones were
run with `AK_TESTS_REQUIRE_DB=1` — the siblings in this area skip silently
without a database and report a false green.

* `collect_repo_maven_flat_keys_spares_rollup_of_foreign_live_subtree_3197`
  — the rollup and all five of its sidecars are spared. **Three** positive
  controls: the doomed repository's *own* rollup over its *own* doomed subtree
  must still be collected (this pins the `<> $1` scoping — an unscoped anchor
  would leak every rollup forever), its `.sha1` with it, and a plain
  unreferenced key.
* `test_orphan_maven_flat_scan_spares_asc_signature_of_live_base_3197`
  — both anchoring shapes the `.asc` gap reaches: guard 4 (base with a live
  `artifacts` row) and guard 3 (a rollup whose subtree is still live). The
  `.sha1` of the same base is asserted alongside as the "already worked"
  control. **Two** positive controls: a `.asc` whose base nothing anchors, and
  a rollup `.asc` over an empty subtree — without them, sparing every `.asc`
  unconditionally would pass.
* `test_maven_sidecar_suffixes_match_flat_predicate_sql` (rewritten) — pins the
  predicate's regex to `GUARDED_SIDECAR_SUFFIXES` instead of the deletion list,
  and keeps the containment check. Runs **without** a database, so the `.asc`
  gap is caught even where the DB tests skip.
* `test_flat_predicate_rollup_guard_uses_shared_fragments` — the rollup guard
  must use the shared fragments, not an inline copy.

### Revert-proof

Each production change reverted separately, against the merge-base source.

**Revert 1** — remove the new rollup `NOT EXISTS` from the collector entirely
(the merge-base shape: it had no such guard):

```
FAIL collect_repo_maven_flat_keys_spares_rollup_of_foreign_live_subtree_3197
  the maven-metadata.xml of a subtree another repository still has a live
  artifact in must NOT be purged by this repository's delete [...]
  collected: [".../own/maven-metadata.xml.sha1", ".../own/maven-metadata.xml",
              ".../lib/maven-metadata.xml.asc", ".../lib/maven-metadata.xml.sha512",
              ".../lib/maven-metadata.xml.sha256", ".../lib/maven-metadata.xml.md5",
              ".../lib/maven-metadata.xml.sha1", ".../lib/maven-metadata.xml",
              ".../own/1.0/gone-9.9.9.pom"]
Summary: 2 tests run: 1 passed, 1 failed
```

All three positive controls are present in that list, so it is the negative
assertion that flipped — the test can distinguish the two shapes, it is not
merely failing because nothing was collected.

**Revert 2** — restore the three hardcoded `'\.(md5|sha1|sha256|sha512)$'`
regexes verbatim as the merge base had them:

```
FAIL test_maven_sidecar_suffixes_match_flat_predicate_sql
  ORPHAN_MAVEN_FLAT_PREDICATE_SQL is missing guarded sidecar suffix .asc
FAIL test_flat_predicate_rollup_guard_uses_shared_fragments
FAIL test_orphan_maven_flat_scan_spares_asc_signature_of_live_base_3197
  guard 4: the `.asc` signature of a base with a live artifacts row must NOT be
  collected [...] collected: [".../dead/maven-metadata.xml.asc",
                             ".../lib/1.0/lib-1.0.pom.asc",
                             ".../lib/9.9.9/gone-9.9.9.pom.asc",
                             ".../lib/maven-metadata.xml.asc"]
Summary: 4 tests run: 1 passed, 3 failed
```

Again both positive controls are in the collected list; the live-base `.asc`
and the live-subtree rollup `.asc` are the entries that should not be.

With both fixes in place: `2 tests run: 2 passed`, and the surrounding suites
are green — `141 passed` across `storage_gc_service` + `maven_flat`, and all
three `collect_repo_maven_*` tests including the #3156 and #3160 guards.

`cargo fmt --all -- --check` clean, `cargo clippy --lib --tests` clean,
`SQLX_OFFLINE=true cargo build --lib --tests` clean. No `sqlx::query!` macro
text changed (these are all runtime-checked `sqlx::query`), so no
`sqlx-data.json` regeneration is required.
