### PR TITLE
fix(download): never answer a HEAD with a method-scoped presigned redirect

### DIFF
--- a/backend/src/api/download_response.rs
+++ b/backend/src/api/download_response.rs
@@ -149,6 +149,15 @@ impl IntoResponse for DownloadResponse {
 ///
 /// This helper checks if the storage backend supports redirects and returns
 /// either a 302 redirect to a presigned URL or streams the content directly.
+///
+/// **Method-unaware (#3209).** It has no request context, so it cannot tell a
+/// `GET` from a `HEAD`, and a presigned URL is signed for ONE method (the
+/// method is the first line of the SigV4 canonical request). A caller on a
+/// route registered `get(..)` only — where axum answers `HEAD` by running the
+/// GET handler — must therefore gate the call on `DownloadContext::is_head`
+/// itself, or use a helper that takes the context
+/// ([`try_presigned_redirect`]'s callers in `proxy_helpers` do). This helper
+/// currently has no callers anywhere in the workspace.
 pub async fn serve_from_storage<S: StorageBackend + ?Sized>(
     storage: &S,
     key: &str,
@@ -185,7 +194,10 @@ pub async fn serve_from_storage<S: StorageBackend + ?Sized>(
     })
 }
 
-/// Serve content with custom expiry for presigned URLs
+/// Serve content with custom expiry for presigned URLs.
+///
+/// Method-unaware, with the same #3209 caveat as [`serve_from_storage`]; it too
+/// currently has no callers anywhere in the workspace.
 pub async fn serve_from_storage_with_expiry<S: StorageBackend + ?Sized>(
     storage: &S,
     key: &str,

--- a/backend/src/api/download_response.rs
+++ b/backend/src/api/download_response.rs
@@ -540,11 +540,33 @@ mod tests {
     use crate::storage::PresignedUrl as PU;
     use async_trait::async_trait;
 
-    /// A mock backend that supports presigned URLs.
-    struct RedirectBackend;
+    /// A mock backend whose only variable is whether it can presign.
+    ///
+    /// The two cases previously lived as separate structs whose `put`/`get`/
+    /// `exists`/`delete`/`put_stream` bodies were byte-identical — 24 duplicated
+    /// lines, enough on its own to put this file over the 3% jscpd gate. The
+    /// redirect capability is the single axis these tests vary, so it is a
+    /// field rather than a second impl.
+    struct MockBackend {
+        supports_redirect: bool,
+    }
+
+    impl MockBackend {
+        fn redirecting() -> Self {
+            Self {
+                supports_redirect: true,
+            }
+        }
+
+        fn non_redirecting() -> Self {
+            Self {
+                supports_redirect: false,
+            }
+        }
+    }
 
     #[async_trait]
-    impl StorageBackend for RedirectBackend {
+    impl StorageBackend for MockBackend {
         async fn put(&self, _key: &str, _content: Bytes) -> AppResult<()> {
             Ok(())
         }
@@ -558,13 +580,18 @@ mod tests {
             Ok(())
         }
         fn supports_redirect(&self) -> bool {
-            true
+            self.supports_redirect
         }
         async fn get_presigned_url(
             &self,
             key: &str,
             expires_in: Duration,
         ) -> AppResult<Option<PU>> {
+            // Mirrors the real backends: a backend that cannot redirect does not
+            // hand out a signed URL either.
+            if !self.supports_redirect {
+                return Ok(None);
+            }
             Ok(Some(PU {
                 url: format!("https://s3.example.com/{}", key),
                 expires_in,
@@ -580,35 +607,9 @@ mod tests {
         }
     }
 
-    /// A mock backend that does not support presigned URLs.
-    struct NoRedirectBackend;
-
-    #[async_trait]
-    impl StorageBackend for NoRedirectBackend {
-        async fn put(&self, _key: &str, _content: Bytes) -> AppResult<()> {
-            Ok(())
-        }
-        async fn get(&self, _key: &str) -> AppResult<Bytes> {
-            Ok(Bytes::from_static(b"data"))
-        }
-        async fn exists(&self, _key: &str) -> AppResult<bool> {
-            Ok(true)
-        }
-        async fn delete(&self, _key: &str) -> AppResult<()> {
-            Ok(())
-        }
-        async fn put_stream(
-            &self,
-            key: &str,
-            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
-        ) -> crate::error::Result<crate::storage::PutStreamResult> {
-            crate::storage::buffered_put_stream_fallback(self, key, stream).await
-        }
-    }
-
     #[tokio::test]
     async fn test_try_presigned_redirect_enabled_and_supported() {
-        let backend = RedirectBackend;
+        let backend = MockBackend::redirecting();
         let result = super::try_presigned_redirect(
             &backend,
             "cas/ab/cd/abcdef",
@@ -627,7 +628,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_presigned_redirect_disabled() {
-        let backend = RedirectBackend;
+        let backend = MockBackend::redirecting();
         let result = super::try_presigned_redirect(
             &backend,
             "cas/ab/cd/abcdef",
@@ -644,7 +645,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_presigned_redirect_backend_no_support() {
-        let backend = NoRedirectBackend;
+        let backend = MockBackend::non_redirecting();
         let result = super::try_presigned_redirect(
             &backend,
             "cas/ab/cd/abcdef",
@@ -661,7 +662,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_presigned_redirect_uses_configured_expiry() {
-        let backend = RedirectBackend;
+        let backend = MockBackend::redirecting();
         let result =
             super::try_presigned_redirect(&backend, "test-key", true, Duration::from_secs(600))
                 .await;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -856,7 +856,20 @@ async fn try_member_cache_redirect(
     proxy: &ProxyService,
     member: &Repository,
     path: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Option<Response> {
+    // #3209 (sibling of #3181): a presigned URL is signed for ONE HTTP method —
+    // the method is the FIRST line of the SigV4 canonical request
+    // (`HTTPMethod\nCanonicalURI\n…`), so a URL signed for GET is refused with
+    // 403 when the client re-issues it as HEAD. Every virtual-download route
+    // reaching here is registered `get(..)` only, so axum answers a HEAD by
+    // running the GET handler. Declining routes the HEAD onto the streaming
+    // cache probe, which answers with the cached entry's real
+    // `Content-Type`/`Content-Length`; a HEAD response's body is dropped
+    // unpolled, so no bytes are transferred.
+    if ctx.is_head {
+        return None;
+    }
     if !state.config.presigned_downloads_enabled {
         return None;
     }
@@ -994,6 +1007,8 @@ pub fn stream_fetch_result(
 /// Format handlers can use this as a drop-in replacement for [`proxy_fetch`]
 /// when they want to take advantage of presigned redirects for cached proxy
 /// content.
+///
+/// A `HEAD` is never redirected (#3209) — see the guard below.
 pub async fn proxy_fetch_or_redirect(
     proxy_service: &ProxyService,
     state: &AppState,
@@ -1001,11 +1016,23 @@ pub async fn proxy_fetch_or_redirect(
     repo_key: &str,
     upstream_url: &str,
     path: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let cache_key = ProxyService::cache_storage_key(repo_key, path)
         .map_err(|e| map_proxy_error(repo_key, path, e))?;
     let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
-    let presigned_enabled = state.config.presigned_downloads_enabled;
+    // #3209 (sibling of #3181): a presigned URL is signed for ONE HTTP method —
+    // the method is the FIRST line of the SigV4 canonical request
+    // (`HTTPMethod\nCanonicalURI\n…`), so a GET-signed URL 403s the HEAD a
+    // client re-issues against it. Any route adopting this helper is registered
+    // `get(..)` only, so axum would run it for a HEAD. Suppressing presigning
+    // for a HEAD routes it onto the buffered fetch below, which answers with the
+    // real `Content-Type`/`Content-Length`; the body is dropped unpolled.
+    //
+    // This helper currently has no production caller — it is kept because it is
+    // the documented drop-in for [`proxy_fetch`], and the guard is what stops
+    // the next handler that adopts it from re-opening #3181/#3209.
+    let presigned_enabled = state.config.presigned_downloads_enabled && !ctx.is_head;
 
     // Fast path (#1018): if presigned downloads are enabled and the proxy
     // cache is already fresh, redirect to the signed URL without ever
@@ -2431,7 +2458,7 @@ where
                         // backend is served as a presigned redirect, never
                         // streamed through the backend.
                         if let Some(redirect) =
-                            try_member_cache_redirect(state, proxy, member, path).await
+                            try_member_cache_redirect(state, proxy, member, path, ctx).await
                         {
                             // Remote proxy-cache serve: not our artifact (#1278).
                             (MemberCacheClass::DefiniteHit, Some((redirect, None)))
@@ -3332,6 +3359,27 @@ pub async fn local_fetch_or_redirect(
     // serves those for redirect-capable virtual members, so gate on the key.
     if !ProxyService::is_proxy_cache_key(&artifact.storage_key) {
         crate::services::artifact_service::record_download(db, artifact.id, ctx).await;
+    }
+
+    // #3209 (sibling of #3181): a presigned URL is signed for ONE HTTP method —
+    // the method is the FIRST line of the SigV4 canonical request
+    // (`HTTPMethod\nCanonicalURI\n…`, AWS SigV4 "Create a canonical request"),
+    // so a URL signed for GET is refused with 403 when the client re-issues it
+    // as HEAD. Every route reaching this helper is registered `get(..)` only, so
+    // axum answers a HEAD by running the GET handler and the client would be
+    // handed a signature it cannot use.
+    //
+    // Answer the HEAD from the artifact row instead: `read_local_stream` carries
+    // the row's `content_type` and `size_bytes`, so the response advertises the
+    // same `Content-Type`/`Content-Length` the GET would. The body is opened but
+    // never polled — axum drops a HEAD response's body — so this costs a
+    // metadata round trip rather than a transfer, and (unlike falling through to
+    // the buffered `read_local_content` path below) it never pulls a multi-GiB
+    // artifact into memory just to answer a probe. Status parity with GET is
+    // preserved: a storage miss still errors here exactly as it would for a GET.
+    if ctx.is_head {
+        let result = read_local_stream(db, &artifact, &*storage).await?;
+        return stream_fetch_result(result, &artifact.content_type, None);
     }
 
     // Try presigned redirect before reading content into memory
@@ -11097,6 +11145,119 @@ mod tests {
         db_helpers::cleanup(&pool, member_id, Uuid::nil()).await;
     }
 
+    /// #3209 (systemic sibling of #3181): the virtual-member presigned fast path
+    /// (`try_member_cache_redirect`, inside `resolve_virtual_download_streaming`)
+    /// must never answer a HEAD with a 302.
+    ///
+    /// A presigned URL is signed for exactly ONE HTTP method: the method is the
+    /// first line of the SigV4 canonical request ("Create a canonical request":
+    /// `HTTPMethod\nCanonicalURI\n…`), so an object store refuses a HEAD issued
+    /// against a GET signature. Every format route that funnels here through
+    /// `try_remote_or_virtual_download` is registered `get(..)` only, so axum
+    /// answers a HEAD by running the GET handler.
+    ///
+    /// Both arms run against the SAME proxy-cache double, so the GET arm is a
+    /// negative control in the strong sense: it must still 302 AND sign exactly
+    /// once, and the HEAD must leave that count untouched — proving the decline
+    /// happens before the signer rather than the redirect merely being disabled.
+    #[tokio::test]
+    async fn test_virtual_member_head_is_not_presigned_redirect_3209() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+
+        let (virtual_id, _, _) = db_helpers::create_repo(&pool, "virtual", "pypi").await;
+        let (member_id, _member_key, _) = db_helpers::create_repo(&pool, "remote", "pypi").await;
+        db_helpers::link_member(&pool, virtual_id, member_id, 0).await;
+
+        // A fresh, non-held cache entry on a redirect-capable backend that
+        // counts every presign attempt.
+        let cache = StdArc::new(QuarantineRedirectStorage::new(/* quarantine = */ None));
+        let registry_storage = StdArc::new(RecordingStorage::new(/* supports = */ true));
+        let state =
+            db_helpers::build_state_presigned(pool.clone(), "s3-test", registry_storage.clone());
+        let proxy = ProxyService::new(
+            pool.clone(),
+            StdArc::new(crate::services::storage_service::StorageService::new(
+                cache.clone(),
+            )),
+        );
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let path = format!("pkg/pkg-{}-py3-none-any.whl", Uuid::new_v4());
+
+        let get_resp = resolve_virtual_download_streaming(
+            &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
+            Some(&proxy),
+            virtual_id,
+            &path,
+            "application/octet-stream",
+            None,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                is_head: false,
+                ..Default::default()
+            },
+            |_id, _loc| async {
+                panic!("local_fetch must NOT run: the redirect fast path should win");
+                #[allow(unreachable_code)]
+                Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+            },
+        )
+        .await;
+        let presign_after_get = cache.presign_calls.load(Ordering::SeqCst);
+
+        let head_outcome = resolve_virtual_download_streaming(
+            &state,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
+            Some(&proxy),
+            virtual_id,
+            &path,
+            "application/octet-stream",
+            None,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                is_head: true,
+                ..Default::default()
+            },
+            |_id, _loc| async {
+                // A Remote member never reaches the local fetch on either arm.
+                Err(StatusCode::NOT_FOUND.into_response())
+            },
+        )
+        .await;
+        let presign_after_head = cache.presign_calls.load(Ordering::SeqCst);
+
+        db_helpers::cleanup(&pool, virtual_id, Uuid::nil()).await;
+        db_helpers::cleanup(&pool, member_id, Uuid::nil()).await;
+
+        let get_resp = get_resp.expect("a fresh cache hit must resolve on the GET arm");
+        assert_eq!(
+            get_resp.status(),
+            StatusCode::FOUND,
+            "GET on a fresh proxy-cache hit must still be a presigned 302 (#1555)"
+        );
+        assert_eq!(
+            presign_after_get, 1,
+            "the GET arm must actually sign, or the HEAD assertion proves nothing"
+        );
+
+        let head_status = match head_outcome {
+            Ok(resp) => resp.status(),
+            Err(resp) => resp.status(),
+        };
+        assert_ne!(
+            head_status,
+            StatusCode::FOUND,
+            "#3209: HEAD must not be answered with a 302 to a method-scoped \
+             presigned URL — the signature is bound to GET and the object store \
+             403s the HEAD the client re-issues against it"
+        );
+        assert_eq!(
+            presign_after_head, 1,
+            "the HEAD must decline BEFORE the signer: still exactly one presign, \
+             the GET's"
+        );
+    }
+
     /// Redirect-capable proxy-cache backend for the #2075 quarantine-gate
     /// tests. Serves a single fresh, positive cache entry whose sidecar carries
     /// the supplied Package Age Policy hold (`quarantine_until`), and records
@@ -11221,6 +11382,7 @@ mod tests {
             &repo_key,
             "https://upstream.example.test",
             "lodash",
+            &Default::default(),
         )
         .await
         .expect_err("a held cache entry must not resolve to a redirect");
@@ -11258,6 +11420,7 @@ mod tests {
             &repo_key,
             "https://upstream.example.test",
             "lodash",
+            &Default::default(),
         )
         .await
         .expect("a fresh, non-held entry must resolve to a redirect");
@@ -11271,6 +11434,97 @@ mod tests {
             fresh.presign_calls.load(Ordering::SeqCst),
             1,
             "the non-held fast path must sign exactly once"
+        );
+    }
+
+    /// #3209: `proxy_fetch_or_redirect` — the documented drop-in replacement for
+    /// [`proxy_fetch`] when a handler wants presigned redirects — must not sign
+    /// for a HEAD.
+    ///
+    /// A presigned URL is signed for exactly ONE HTTP method (the method is the
+    /// first line of the SigV4 canonical request), and any route adopting this
+    /// helper is registered `get(..)` only, so axum would run it for a HEAD. The
+    /// helper has no production caller today; this guard is what stops the next
+    /// handler that adopts it from re-opening #3181/#3209.
+    ///
+    /// GET runs first on the SAME backend double as the negative control: it
+    /// must sign exactly once, and the HEAD must leave that count untouched.
+    #[tokio::test]
+    async fn test_proxy_fetch_or_redirect_head_never_presigns_3209() {
+        // A REAL pool, unlike the #2075 siblings above: only the GET arm stops
+        // at the redirect fast path. The HEAD arm falls through to
+        // `proxy_fetch`, which touches the database, and against the lazy
+        // fake-pool those siblings use that costs a 30s connect timeout.
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let fresh = StdArc::new(QuarantineRedirectStorage::new(/* quarantine = */ None));
+        let proxy = ProxyService::new(
+            pool.clone(),
+            StdArc::new(crate::services::storage_service::StorageService::new(
+                fresh.clone(),
+            )),
+        );
+        let registry_storage = StdArc::new(RecordingStorage::new(/* supports = */ true));
+        let state = db_helpers::build_state_presigned(pool, "s3-test", registry_storage.clone());
+
+        // Per-test coordinate isolates the process-global metadata LRU (#2758).
+        let repo_key = format!("npm-proxy-{}", Uuid::new_v4());
+
+        let get_status = super::proxy_fetch_or_redirect(
+            &proxy,
+            &state,
+            Uuid::nil(),
+            &repo_key,
+            // Unroutable: the HEAD fall-through must fail FAST (connection
+            // refused) instead of waiting out a DNS/TLS timeout.
+            "http://127.0.0.1:1",
+            "lodash",
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                is_head: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .map(|r| r.status())
+        .expect("a fresh, non-held entry must resolve to a redirect on GET");
+        let presign_after_get = fresh.presign_calls.load(Ordering::SeqCst);
+
+        let head_status = super::proxy_fetch_or_redirect(
+            &proxy,
+            &state,
+            Uuid::nil(),
+            &repo_key,
+            // Unroutable: the HEAD fall-through must fail FAST (connection
+            // refused) instead of waiting out a DNS/TLS timeout.
+            "http://127.0.0.1:1",
+            "lodash",
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                is_head: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .map_or_else(|e| e.status(), |r| r.status());
+
+        assert_eq!(
+            get_status,
+            StatusCode::FOUND,
+            "GET on a fresh, non-held entry must still 302 to the presigned URL"
+        );
+        assert_eq!(
+            presign_after_get, 1,
+            "the GET arm must actually sign, or the HEAD assertion proves nothing"
+        );
+        assert_ne!(
+            head_status,
+            StatusCode::FOUND,
+            "#3209: HEAD must not be answered with a 302 to a GET-scoped signature"
+        );
+        assert_eq!(
+            fresh.presign_calls.load(Ordering::SeqCst),
+            1,
+            "the HEAD must never reach the signer: still exactly one presign, the GET's"
         );
     }
 
@@ -12468,6 +12722,115 @@ mod tests {
 
         assert!(out.is_none(), "feature disabled must stream, not 302");
         assert_eq!(presign_calls, 0, "no presign when the feature is off");
+    }
+
+    /// #3209 (systemic sibling of #3181): `local_fetch_or_redirect` — the shared
+    /// hosted/virtual-member local serve used by the PyPI file route among
+    /// others — must never answer a HEAD with a presigned 302.
+    ///
+    /// A presigned URL is signed for exactly ONE HTTP method: the method is the
+    /// first line of the SigV4 canonical request ("Create a canonical request":
+    /// `HTTPMethod\nCanonicalURI\n…`), so an object store refuses a HEAD issued
+    /// against a GET signature. Every route reaching this helper is registered
+    /// `get(..)` only, so axum answers HEAD by running the GET handler.
+    ///
+    /// The GET arm is the negative control on the SAME storage double: it must
+    /// still 302 to a signed URL, and the presign counter must show the HEAD
+    /// never reached the signer at all.
+    #[tokio::test]
+    async fn local_fetch_or_redirect_head_is_not_presigned_redirect_3209() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _key, _dir) = db_helpers::create_repo(&pool, "local", "pypi").await;
+
+        let path = "packages/demo-1.0.0-py3-none-any.whl";
+        let storage_key = "artifact-keeper/cas/ab/cd/demo-1.0.0.whl";
+        let _artifact_id = seed_blob_artifact(&pool, repo_id, user_id, path, storage_key).await;
+
+        // One storage double for BOTH arms, so the presign counter measures the
+        // difference between them rather than two unrelated fixtures.
+        let storage = StdArc::new(RecordingStorage::new(/* supports = */ true));
+        let state = db_helpers::build_state_presigned(pool.clone(), "s3-test", storage.clone());
+        let location = crate::storage::StorageLocation {
+            backend: "s3-test".to_string(),
+            path: String::new(),
+        };
+
+        let get_resp = super::local_fetch_or_redirect(
+            &pool,
+            &state,
+            repo_id,
+            &location,
+            path,
+            &ctx_for(user_id, /* is_head = */ false),
+        )
+        .await;
+        let presign_after_get = storage.presigned_calls.load(Ordering::SeqCst);
+
+        let head_resp = super::local_fetch_or_redirect(
+            &pool,
+            &state,
+            repo_id,
+            &location,
+            path,
+            &ctx_for(user_id, /* is_head = */ true),
+        )
+        .await;
+        let presign_after_head = storage.presigned_calls.load(Ordering::SeqCst);
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+
+        let get_resp = get_resp.expect("GET on a hosted artifact must resolve");
+        assert_eq!(
+            get_resp.status(),
+            StatusCode::FOUND,
+            "GET must still be served as a presigned 302"
+        );
+        assert_eq!(
+            presign_after_get, 1,
+            "the GET arm must actually sign, or the HEAD assertion proves nothing"
+        );
+
+        let head_resp = head_resp.expect("HEAD on a hosted artifact must resolve");
+        assert_ne!(
+            head_resp.status(),
+            StatusCode::FOUND,
+            "#3209: HEAD must not be answered with a 302 to a method-scoped \
+             presigned URL — the signature is bound to GET and the object store \
+             403s the HEAD the client re-issues against it"
+        );
+        assert_eq!(
+            head_resp.status(),
+            StatusCode::OK,
+            "HEAD must answer with the artifact's metadata"
+        );
+        assert!(
+            head_resp.headers().get("location").is_none(),
+            "HEAD must carry no Location header"
+        );
+        assert_eq!(
+            head_resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/java-archive"),
+            "HEAD must advertise the artifact row's Content-Type"
+        );
+        assert_eq!(
+            head_resp
+                .headers()
+                .get("content-length")
+                .and_then(|v| v.to_str().ok()),
+            Some("9"),
+            "HEAD must advertise the artifact row's size_bytes as Content-Length"
+        );
+        assert_eq!(
+            presign_after_head, 1,
+            "the HEAD must decline BEFORE the signer: still exactly one presign, \
+             the GET's"
+        );
     }
 
     // ── Cross-format curation enforcement (#2930) ────────────────────────

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -8087,7 +8087,17 @@ pub async fn download_artifact(
     // redirect setting, which controls supports_redirect()).
     let storage = state.storage_for_repo(&repo.storage_location())?;
     let presigned_enabled = state.config.presigned_downloads_enabled && storage.supports_redirect();
-    if presigned_enabled {
+    // #3209 (sibling of #3181): a presigned URL is signed for ONE HTTP method —
+    // the method is the FIRST line of the SigV4 canonical request ("Create a
+    // canonical request", AWS SigV4 reference: `HTTPMethod\nCanonicalURI\n…`),
+    // so a URL signed for GET is rejected with 403 when the client re-issues it
+    // as HEAD. This route is registered `get(..)` only (both as the generic REST
+    // download and as the Generic format route `/general/{key}/*path`), so axum
+    // answers a HEAD by running this GET handler. Handing that HEAD a 302 to a
+    // GET-signed URL hands the client a URL it cannot use. Skip the redirect and
+    // fall through to the streamed path below, which already builds the correct
+    // headers with an empty body for a HEAD.
+    if presigned_enabled && !is_head {
         // Get artifact metadata first using query_as for runtime checking
         #[derive(sqlx::FromRow)]
         struct ArtifactRow {
@@ -17349,6 +17359,135 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("application/x-test"),
             "HEAD must carry the same Content-Type as GET"
+        );
+    }
+
+    /// #3209 (systemic sibling of #3181): a HEAD must never be answered with a
+    /// presigned 302.
+    ///
+    /// A presigned URL is signed for exactly ONE HTTP method — the method is the
+    /// first line of the SigV4 canonical request ("Create a canonical request":
+    /// `HTTPMethod\nCanonicalURI\n…`, where `HTTPMethod` is documented as "The
+    /// HTTP method, such as GET, PUT, HEAD, and DELETE") — so an object store
+    /// rejects a HEAD issued against a GET signature. `download_artifact` is
+    /// registered `get(..)` only, both here and as the Generic format route
+    /// `/general/{key}/*path`, so axum answers a HEAD by running it; before this
+    /// fix that HEAD got a 302 to a URL the client could not use.
+    ///
+    /// The GET arm is the negative control and runs against the SAME router: it
+    /// must still 302 to a signed URL, so a "fix" that simply turned presigning
+    /// off fails here.
+    #[tokio::test]
+    async fn test_download_artifact_head_is_not_presigned_redirect_3209() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "generic").await;
+        sqlx::query(
+            "UPDATE repositories              SET storage_backend = 's3', storage_path = key, is_public = true              WHERE id = $1",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("set cloud backend");
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (state, _mem) = tdh::build_state_with_presigning_cloud(pool.clone(), "s3");
+
+        let blob = Bytes::from_static(b"#3209 generic presigned HEAD marker bytes");
+        let path = "head3209/probe.bin";
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        // The seeding handle must be the SAME cloud backend the handler will
+        // resolve from the repository row, or the bytes land somewhere the
+        // download path cannot see.
+        let repo = crate::api::handlers::proxy_helpers::RepoInfo {
+            storage_backend: "s3".to_string(),
+            storage_path: repo_key.clone(),
+            ..tdh::make_repo_info(
+                repo_id,
+                &repo_key,
+                std::path::Path::new("/tmp/ak-3209-unused"),
+                "local",
+                None,
+            )
+        };
+        tdh::seed_artifact(
+            &state,
+            &pool,
+            &repo,
+            &storage_key,
+            path,
+            "probe",
+            "1.0.0",
+            "application/x-test",
+            blob.clone(),
+            user_id,
+        )
+        .await;
+
+        let router =
+            tdh::router_with_auth(download_router(), state, tdh::make_auth(user_id, &username));
+
+        // Negative control FIRST: presigning really is active on this router, so
+        // the HEAD assertions below cannot pass for the trivial reason.
+        let (get_status, _get_body, get_headers) = tdh::send_with_headers(
+            router.clone(),
+            tdh::get(format!("/{repo_key}/download/{path}")),
+        )
+        .await;
+        let (head_status, head_body, head_headers) =
+            tdh::send_with_headers(router, tdh::head(format!("/{repo_key}/download/{path}"))).await;
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+
+        assert_eq!(
+            get_status,
+            axum::http::StatusCode::FOUND,
+            "GET must still redirect to the presigned URL"
+        );
+        let location = get_headers
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            location.contains("X-Amz-Signature"),
+            "GET must redirect to a signed URL, got {location}"
+        );
+
+        assert_ne!(
+            head_status,
+            axum::http::StatusCode::FOUND,
+            "#3209: HEAD must not be answered with a 302 to a method-scoped \
+             presigned URL — the signature is bound to GET and the object store \
+             403s the HEAD the client re-issues against it"
+        );
+        assert_eq!(
+            head_status,
+            axum::http::StatusCode::OK,
+            "HEAD must answer with the artifact's metadata"
+        );
+        assert!(
+            head_headers.get(header::LOCATION).is_none(),
+            "HEAD must carry no Location header"
+        );
+        assert_eq!(
+            head_headers
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(blob.len().to_string().as_str()),
+            "HEAD must advertise the artifact's real Content-Length"
+        );
+        assert_eq!(
+            head_headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/x-test"),
+            "HEAD must advertise the artifact's Content-Type"
+        );
+        assert!(
+            head_body.is_empty(),
+            "a HEAD response carries no body, got {} bytes",
+            head_body.len()
         );
     }
 


### PR DESCRIPTION
Fixes #3209

## Premise verified before fixing

The issue's core claim holds. The AWS SigV4 reference ("Create a signed AWS API request" → *Create a canonical request*) specifies the canonical request as

```
{{<HTTPMethod>}}\n
{{<CanonicalURI>}}\n
{{<CanonicalQueryString>}}\n
{{<CanonicalHeaders>}}\n
{{<SignedHeaders>}}\n
{{<HashedPayload>}}
```

with `{{HTTPMethod}}` documented as "The HTTP method, such as `GET`, `PUT`, `HEAD`, and `DELETE`". The method is the first line of the string that gets hashed into the signature, so a URL signed for `GET` cannot validate a `HEAD` — which is exactly the `403` #3181 observed live against MinIO. Nothing in the premise was refuted.

## The audit

`DownloadResponse::redirect` is the single 302 builder in the backend, so every presigned redirect funnels through one of five call sites. Only one route in the whole API registers an explicit `head(..)` (`sbt::check_exists`); everything else is `get(..)`-only, so axum answers `HEAD` by running the GET handler.

| Presign call site | Reachable from a GET-only route? | Status |
|---|---|---|
| `try_hosted_blob_redirect` | yes (Maven/Ivy/sbt hosted) | already fixed by #3208 |
| `repositories::download_artifact` | yes — `/api/v1/repositories/{key}/download/*path` **and** `/general/{key}/*path`, which re-exports the same handler | **fixed here** |
| `proxy_helpers::local_fetch_or_redirect` (+ `local_fetch_or_redirect_by_suffix`) | yes — PyPI `serve_file`, and any handler adopting the shared local serve | **fixed here** |
| `proxy_helpers::try_member_cache_redirect` | yes — `resolve_virtual_download_streaming` ← `try_remote_or_virtual_download`, i.e. the virtual-repo download path for rpm / rubygems / puppet / hex / huggingface / cran / ansible / … | **fixed here** |
| `proxy_helpers::proxy_fetch_or_redirect` | **no production caller** (only doc references and its own tests) | guarded anyway |
| `download_response::serve_from_storage{,_with_expiry}` | **no callers anywhere in the workspace** | documented, not changed |

Two of the issue's named suspects therefore split: `try_member_cache_redirect` is live and was broken; `proxy_fetch_or_redirect` is dormant. It is still guarded, because it is the documented drop-in for `proxy_fetch` and an unguarded landmine is how this class propagates — the guard is what stops the next handler that adopts it from re-opening #3181/#3209.

## The fix

Each reachable site declines to presign when `DownloadContext::is_head` is set, and answers with the artifact's real `Content-Type` / `Content-Length` instead.

* `download_artifact` — the redirect branch is skipped and the request falls into the existing streamed path, which already builds GET-identical headers with an empty body for a HEAD (#1782).
* `local_fetch_or_redirect` — answers from `read_local_stream` rather than falling through to the buffered `read_local_content`. Both carry the row's `content_type` and `size_bytes`, so the headers are the same, but the streaming reader means a HEAD probe on a multi-GiB artifact never pulls it into memory. A storage miss still errors exactly as it would for a GET, so HEAD/GET status parity (RFC 9110 §9.3.2, "identical to GET except that the server MUST NOT send content") is preserved.
* `try_member_cache_redirect` — returns `None`, routing the HEAD onto the streaming cache probe. A HEAD response's body is dropped without being polled, so no bytes transfer.

`try_member_cache_redirect` and `proxy_fetch_or_redirect` gain a `ctx: &DownloadContext` parameter; both callers already had one in scope.

## Tests asserting the bug as a requirement

None on these paths. #3208 already corrected the one that existed (`try_hosted_blob_redirect_jar_redirects_and_counts_once`, which asserted `"jar HEAD must 302"`). I checked every HEAD-exercising test that touches these routes — `test_download_artifact_head_returns_headers_no_body` (#1782), `test_virtual_download_artifact_head_declares_same_coding_as_get`, and the `/general/` HEAD download-count guard (#2705) — and each asserts correct HEAD semantics rather than the bug. Existing `proxy_fetch_or_redirect` tests only needed the new argument; no assertion changed.

## New tests (all `--lib`, so they count for coverage)

Each carries its **negative control in the same fixture**: a GET on the identical artifact through the identical storage double must still produce a 302 to a signed URL, so a "fix" that merely disabled presigning fails. Where the double counts signer calls, the HEAD arm additionally asserts the count is unchanged — proving the decline happens *before* the signer rather than the redirect being suppressed afterwards.

* `repositories::tests::test_download_artifact_head_is_not_presigned_redirect_3209` — drives the real router: GET must 302 to an `X-Amz-Signature` URL; HEAD must be 200, no `Location`, real `Content-Type`/`Content-Length`, empty body.
* `proxy_helpers::tests::local_fetch_or_redirect_head_is_not_presigned_redirect_3209` — GET 302 + exactly one presign; HEAD 200 with the row's content type/length and the presign count still at one.
* `proxy_helpers::tests::test_virtual_member_head_is_not_presigned_redirect_3209` — through `resolve_virtual_download_streaming` against a fresh proxy-cache entry: GET 302 + one presign, HEAD not a 302 and no second presign.
* `proxy_helpers::tests::test_proxy_fetch_or_redirect_head_never_presigns_3209` — same shape for the dormant helper.

### Revert check

With the three live guards and the dormant one removed (parameters kept so the tests still compile), all four fail on the #3209 assertion, and every GET-arm control still passes:

```
FAIL api::handlers::proxy_helpers::tests::test_proxy_fetch_or_redirect_head_never_presigns_3209
FAIL api::handlers::proxy_helpers::tests::test_virtual_member_head_is_not_presigned_redirect_3209
FAIL api::handlers::repositories::tests::test_download_artifact_head_is_not_presigned_redirect_3209
FAIL api::handlers::proxy_helpers::tests::local_fetch_or_redirect_head_is_not_presigned_redirect_3209
Summary [0.444s] 4 tests run: 0 passed, 4 failed, 14954 skipped

assertion `left != right` failed: #3209: HEAD must not be answered with a 302 to a
method-scoped presigned URL — the signature is bound to GET and the object store 403s
the HEAD the client re-issues against it
  left: 302
 right: 302

assertion `left != right` failed: #3209: HEAD must not be answered with a 302 to a
GET-scoped signature
  left: 302
 right: 302
```

With the guards restored:

```
PASS [0.239s] api::handlers::proxy_helpers::tests::test_proxy_fetch_or_redirect_head_never_presigns_3209
PASS [0.273s] api::handlers::proxy_helpers::tests::local_fetch_or_redirect_head_is_not_presigned_redirect_3209
PASS [0.316s] api::handlers::proxy_helpers::tests::test_virtual_member_head_is_not_presigned_redirect_3209
PASS [0.362s] api::handlers::repositories::tests::test_download_artifact_head_is_not_presigned_redirect_3209
Summary [0.387s] 4 tests run: 4 passed, 14954 skipped
```

## Gates

* `SQLX_OFFLINE=true cargo build --lib --tests` — clean
* `cargo fmt --all --check` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo nextest run --lib -E 'test(proxy_helpers::) or test(download_response::) or test(general::) or test(pypi::) or test(maven::)'` — 753 passed, 0 failed
* `cargo nextest run --lib -E 'test(repositories::)'` — 489 passed, 0 failed
* No `sqlx::query!` macro text changed, so no `.sqlx` regeneration.

## Left as follow-up

The issue's "adjacent usability" note — `S3_REDIRECT_DOWNLOADS` and `PRESIGNED_DOWNLOADS_ENABLED` being two separately-named switches that must both be set before anything redirects — is a configuration ergonomics change, not part of this bug, and is deliberately not touched here.
