### PR TITLE
fix(pypi): validate the upload project name against PEP 508

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -37,7 +37,7 @@ use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
 use crate::error::AppError;
 use crate::formats::pypi::PypiHandler;
-use crate::formats::pypi_name::NormalizedProjectName;
+use crate::formats::pypi_name::{NormalizedProjectName, PEP508_NAME_PATTERN};
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::age_gate_service::AgeGateService;
 use crate::services::upstream_metadata::metadata_http_client;
@@ -3889,7 +3889,50 @@ async fn upload(
         );
     }
 
-    let normalized = PypiHandler::normalize_name(&pkg_name);
+    // PEP 508 validation on the upload channel (#3198).
+    //
+    // #3196 validated every routed `:project` segment, but twine takes the
+    // project name from a multipart form field, so it never reaches
+    // `parse_project_segment`. What flowed in here instead was
+    // `PypiHandler::normalize_name`, which coerces rather than validates: it
+    // maps every non-ASCII-alphanumeric character to `-`, skips leading
+    // separators and pops one trailing hyphen. So `acme sdk`, `acme!sdk` and
+    // `acme<U+212A>sdk` all published into the namespace of `acme-sdk` -- a
+    // real, valid, possibly someone else's project -- and `---` published under
+    // the EMPTY name, which is stored and charged to quota but reachable at no
+    // URL, because `/simple//` is not a route.
+    //
+    // Deliberately the same constructor as the read paths, not a second
+    // validator: two implementations that must agree about names is the exact
+    // shape of #3186 / #3077 / #3179 / #3183.
+    //
+    // This is NOT a rename for well-formed names. For every PEP 508-valid name
+    // the canonical form and `PypiHandler::normalize_name` agree byte for byte
+    // -- a valid name draws only on `[A-Za-z0-9._-]`, so nothing is dropped,
+    // and it begins and ends alphanumeric, so neither the leading-separator
+    // skip nor the trailing-hyphen pop fires. That equivalence is asserted in
+    // `formats::pypi_name::tests::all_three_normalizers_agree_on_every_valid_name`,
+    // which is what makes this substitution storage-compatible: no existing
+    // artifact path, cache key or index entry changes.
+    //
+    // 400, not the 404 the read paths give: a path segment that is not a
+    // project name names no resource, but an upload that declares one is a
+    // malformed request, and the publisher is the party who can fix it. The
+    // message therefore carries the pattern -- but never the rejected name,
+    // which would make the error a reflection sink for exactly the characters
+    // `normalize_pep503` exists to strip (#1377).
+    let normalized_project = NormalizedProjectName::parse(&pkg_name).ok_or_else(|| {
+        debug!(
+            "rejecting PyPI upload whose 'name' field is not a PEP 508 name (len {})",
+            pkg_name.len()
+        );
+        AppError::Validation(format!(
+            "Invalid project name: a PyPI project name must match the PEP 508 pattern {}",
+            PEP508_NAME_PATTERN
+        ))
+        .into_response()
+    })?;
+    let normalized = normalized_project.as_str().to_string();
 
     // SHA-256 was computed incrementally while the body was spooled to disk.
     let computed_sha256 = digests.sha256.clone();
@@ -4897,7 +4940,22 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(content);
         let sha256 = format!("{:x}", hasher.finalize());
-        let boundary = format!("ak-pypi-test-{}", project.replace('-', "_"));
+        // The boundary must not be derived verbatim from `project`: RFC 2046
+        // §5.1.1 restricts boundary characters, so a project name carrying a
+        // space, a `/` or a non-ASCII character produced a body the multipart
+        // parser rejected outright. That mattered once #3198 started feeding
+        // this helper deliberately-invalid names -- every such case failed with
+        // "Invalid `boundary` for `multipart/form-data` request" before the
+        // handler ever saw the name, which is a 400 for the wrong reason.
+        // Mapping to `_` keeps the boundary byte-identical for the plain
+        // `a-b` names the older tests pass.
+        let boundary = format!(
+            "ak-pypi-test-{}",
+            project
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+                .collect::<String>()
+        );
         let fields = [
             (":action", "file_upload"),
             ("protocol_version", "1"),
@@ -4965,6 +5023,19 @@ mod tests {
     /// ordinary "Package not found" / "File not found" 404 -- which is the
     /// failure mode that would let an over-rejecting fix look like it passes.
     const PROJECT_REJECTED_MESSAGE: &str = "Invalid project name";
+
+    /// The PEP 508 *Names* pattern, as it must appear in the body of a rejected
+    /// upload (#3198).
+    ///
+    /// A literal here rather than a reference to the production constant, on
+    /// purpose and for the same reason as [`PROJECT_REJECTED_MESSAGE`] above:
+    /// the test must still COMPILE against a tree with the fix reverted, so
+    /// that reverting proves the assertion fails rather than that the crate
+    /// stops building. It also makes the message a contract — the pattern is
+    /// what tells a publisher how to spell the name, so silently dropping it
+    /// from the message fails a test.
+    const UPLOAD_NAME_REJECTED_MESSAGE: &str =
+        r"^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])$";
 
     /// PEP 508-valid names, weighted towards the unusual-but-legal.
     ///
@@ -5406,6 +5477,193 @@ mod tests {
             after_control > 0,
             "control failed: a VALID name made no upstream request either, so the \
              zero-request assertion above proves nothing"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3198 — the upload channel
+    // -----------------------------------------------------------------------
+
+    /// PEP 508-invalid names, as they arrive on the *upload* channel.
+    ///
+    /// Deliberately a separate list from [`invalid_route_names`], for two
+    /// reasons. Nothing here is percent-encoded — a twine upload carries the
+    /// project name in a multipart form field, not a path segment, so there is
+    /// no URL layer to encode for. And every entry is a raw field value that a
+    /// `multipart/form-data` body can actually carry, which rules out the CR/LF
+    /// cases: a bare newline in a field value is a *multipart framing* problem,
+    /// so a rejection would prove the parser works rather than that name
+    /// validation does.
+    ///
+    /// Each entry carries the name `PypiHandler::normalize_name` coerces it to,
+    /// which is what the unvalidated upload path stored it under. That column
+    /// is the point of the issue: the coercion is silent, and it is not the
+    /// name the publisher asked for.
+    fn invalid_upload_names() -> Vec<(&'static str, &'static str)> {
+        vec![
+            // The motivating case. `acme sdk` is not a project name, but the
+            // upload path coerced it into the namespace of `acme-sdk`, which
+            // IS one — so the publisher silently squats a different project.
+            ("acme sdk", "acme-sdk"),
+            ("acme!sdk", "acme-sdk"),
+            ("acme@sdk", "acme-sdk"),
+            ("acme/sdk", "acme-sdk"),
+            // Non-ASCII. `normalize_name` keys on `is_ascii_alphanumeric`, so
+            // the `é` is coerced to a separator and swallows the `-` after it:
+            // `acmé-sdk` lands under `acm-sdk`, a third distinct project.
+            ("acmé-sdk", "acm-sdk"),
+            ("acme\u{212A}sdk", "acme-sdk"),
+            // PEP 508 requires an alphanumeric at both ends. `normalize_name`
+            // skips leading separators and pops one trailing hyphen, so these
+            // are silently renamed rather than refused.
+            ("_leading", "leading"),
+            ("-leading", "leading"),
+            (".leading", "leading"),
+            ("trailing_", "trailing"),
+            ("trailing-", "trailing"),
+            // Names made only of separators coerce to the EMPTY string. This is
+            // the shape the issue titles: stored at path `/<version>/<file>`,
+            // counted against quota, and unreachable at any URL, because
+            // `/simple//` is not a route.
+            ("---", ""),
+            ("...", ""),
+            ("", ""),
+            // The stored-XSS payload `normalize_pep503` drops characters for.
+            ("<script>", "script"),
+        ]
+    }
+
+    /// The canonical, PEP 508-valid name every case in this test is measured
+    /// against. It carries a separator on purpose: on a separator-free fixture
+    /// such as `demo` the two legacy coercions cannot diverge, so the squatting
+    /// assertion below would pass on the unfixed tree and report a false all-clear.
+    const UPLOAD_CONTROL_PROJECT: &str = "acme-sdk";
+    const UPLOAD_CONTROL_WHEEL: &str = "acme_sdk-1.0.0-py3-none-any.whl";
+
+    /// The upload path must reject a project name that is not a PEP 508 name,
+    /// with 400 — and a valid one must still publish and resolve.
+    ///
+    /// Three claims in one fixture, because separately each is satisfiable by
+    /// the bug:
+    ///
+    /// 1. **400 on upload.** PEP 508 (*Names*) gives the pattern; an upload
+    ///    naming something outside it is a malformed request, not a missing
+    ///    resource, so it is 400 here and not the 404 the read routes give a
+    ///    path segment (#3196).
+    /// 2. **No squatting.** Rejecting is only half the fix: what made this worth
+    ///    closing is *where the bytes went*. `PypiHandler::normalize_name` maps
+    ///    every non-alphanumeric to `-`, so `acme sdk` was stored under
+    ///    `acme-sdk` — a real, valid, possibly-someone-else's project. The
+    ///    canonical index must not list a distribution uploaded under any of
+    ///    these names.
+    /// 3. **The positive control, in the same fixture and the same response.**
+    ///    `acme-sdk` itself must upload with 200 and be listed by its own simple
+    ///    index. Without it, claim 2 would be satisfied by a repo that serves
+    ///    nothing at all — the failure mode that made an earlier security test
+    ///    on #3179 green while the vulnerability was live.
+    #[tokio::test]
+    async fn pep508_invalid_upload_name_is_rejected_and_cannot_squat_a_valid_project() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let mut failures: Vec<String> = Vec::new();
+
+        // Positive control first: publish the canonical project for real.
+        let (content_type, body) = pypi_upload_multipart(
+            UPLOAD_CONTROL_PROJECT,
+            "1.0.0",
+            UPLOAD_CONTROL_WHEEL,
+            b"fake-wheel-bytes-control",
+            "pep508 upload control",
+            ">=3.8",
+        );
+        let app = fx.router_with_auth(super::router());
+        let (control_status, control_body) = tdh::send(
+            app,
+            tdh::post(format!("/{}/", fx.repo_key), &content_type, body),
+        )
+        .await;
+        if control_status != StatusCode::OK {
+            failures.push(format!(
+                "control upload of {UPLOAD_CONTROL_PROJECT:?} must succeed, got {control_status}; \
+                 body: {}",
+                String::from_utf8_lossy(&control_body)
+            ));
+        }
+
+        // Every PEP 508-invalid name must be refused with 400, and the refusal
+        // must name the pattern so the publisher can act on it.
+        for (index, (raw, coerced_to)) in invalid_upload_names().into_iter().enumerate() {
+            let filename = format!("squatted_{index}-9.9.9-py3-none-any.whl");
+            let (content_type, body) = pypi_upload_multipart(
+                raw,
+                "9.9.9",
+                &filename,
+                b"fake-wheel-bytes-squat",
+                "pep508 upload rejection",
+                ">=3.8",
+            );
+            let app = fx.router_with_auth(super::router());
+            let (status, body) = tdh::send(
+                app,
+                tdh::post(format!("/{}/", fx.repo_key), &content_type, body),
+            )
+            .await;
+            let body = String::from_utf8_lossy(&body).into_owned();
+
+            if status != StatusCode::BAD_REQUEST {
+                failures.push(format!(
+                    "upload named {raw:?} (coerces to {coerced_to:?}): expected 400, got {status}; \
+                     body: {body}"
+                ));
+            } else if !body.contains(UPLOAD_NAME_REJECTED_MESSAGE) {
+                // A 400 alone is not proof — a malformed body, a missing field
+                // or a digest mismatch all produce one. The pattern in the
+                // message is what shows name validation produced it.
+                failures.push(format!(
+                    "upload named {raw:?}: 400 but not from PEP 508 validation; body: {body}"
+                ));
+            }
+        }
+
+        // The canonical index must list its own wheel and nothing that was
+        // uploaded under an invalid name.
+        let app = fx.router_with_auth(super::router());
+        let (index_status, index_body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/simple/{UPLOAD_CONTROL_PROJECT}/", fx.repo_key)),
+        )
+        .await;
+        let index_body = String::from_utf8_lossy(&index_body).into_owned();
+
+        fx.teardown().await;
+
+        if index_status != StatusCode::OK {
+            failures.push(format!(
+                "control index /simple/{UPLOAD_CONTROL_PROJECT}/ must be 200, got {index_status}; \
+                 body: {index_body}"
+            ));
+        }
+        if !index_body.contains(UPLOAD_CONTROL_WHEEL) {
+            failures.push(format!(
+                "control index does not list {UPLOAD_CONTROL_WHEEL}, so the \
+                 'no squatted distribution' assertion below proves nothing; body: {index_body}"
+            ));
+        }
+        if index_body.contains("squatted_") {
+            failures.push(format!(
+                "a distribution uploaded under a PEP 508-invalid name is listed in the \
+                 index of {UPLOAD_CONTROL_PROJECT}; body: {index_body}"
+            ));
+        }
+
+        assert!(
+            failures.is_empty(),
+            "PyPI upload name validation (#3198) failed:\n{}",
+            failures.join("\n")
         );
     }
 

--- a/backend/src/formats/pypi_name.rs
+++ b/backend/src/formats/pypi_name.rs
@@ -93,6 +93,19 @@ static PEP508_NAME_RE: Lazy<Regex> = Lazy::new(|| {
         .expect("PEP 508 name pattern is a valid regex")
 });
 
+/// The PEP 508 *Names* pattern in the spec's own `^`/`$` spelling, for putting
+/// in an error message a publisher will read (#3198).
+///
+/// Spelled out separately from [`PEP508_NAME_RE`] rather than derived from it,
+/// because the two are answering different questions: the regex is anchored
+/// with `\A`/`\z` to close the trailing-newline hole Rust's `$` opens, which is
+/// an implementation detail of *this* engine and would only confuse someone
+/// comparing the message against PEP 508. The character class and the
+/// alternation -- the parts a publisher has to satisfy -- are identical, and
+/// `tests::message_pattern_matches_the_enforced_regex` asserts they stay that
+/// way, so the message cannot drift from what is actually enforced.
+pub const PEP508_NAME_PATTERN: &str = r"^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])$";
+
 /// Does `name` satisfy the PEP 508 project-name pattern?
 ///
 /// This is the *unnormalized* check: `Django`, `zope.interface` and
@@ -414,6 +427,51 @@ mod tests {
             let parsed = NormalizedProjectName::parse(name)
                 .unwrap_or_else(|| panic!("single character {name:?} must be valid"));
             assert_eq!(parsed.as_str(), name.to_ascii_lowercase());
+        }
+    }
+
+    /// The pattern shown to a rejected publisher (#3198) must be the pattern
+    /// actually enforced, differing only in the anchors.
+    ///
+    /// An error message that tells someone how to spell a name is useless --
+    /// worse than useless -- if it drifts from the check. Comparing the two
+    /// with the anchors normalized away catches a change to one that is not
+    /// made to the other, which is the realistic failure.
+    #[test]
+    fn message_pattern_matches_the_enforced_regex() {
+        let enforced = PEP508_NAME_RE
+            .as_str()
+            .trim_start_matches(r"\A")
+            .trim_end_matches(r"\z");
+        let advertised = PEP508_NAME_PATTERN
+            .trim_start_matches('^')
+            .trim_end_matches('$');
+        assert_eq!(
+            enforced, advertised,
+            "the PEP 508 pattern in the error message has drifted from the one enforced"
+        );
+
+        // And the advertised spelling must itself be a regex that accepts and
+        // rejects the same names, so the message is something a publisher can
+        // actually test their name against.
+        let advertised_re = Regex::new(PEP508_NAME_PATTERN).expect("advertised pattern compiles");
+        for name in valid_names() {
+            assert!(
+                advertised_re.is_match(name),
+                "advertised pattern rejects the valid name {name:?}"
+            );
+        }
+        for name in invalid_names() {
+            // `$` in Rust's regex also matches before a trailing newline, which
+            // is the one case where the advertised spelling is deliberately
+            // laxer than the enforced one. Everything else must agree.
+            if name.ends_with('\n') {
+                continue;
+            }
+            assert!(
+                !advertised_re.is_match(name),
+                "advertised pattern accepts the invalid name {name:?}"
+            );
         }
     }
 }

--- a/backend/src/formats/pypi_name.rs
+++ b/backend/src/formats/pypi_name.rs
@@ -430,6 +430,49 @@ mod tests {
         }
     }
 
+    /// Scopes the migration question #3198 raises: which names can a
+    /// deployment that ran the *unvalidated* upload path already be holding?
+    ///
+    /// The answer is narrower than it looks, and this pins it. Whatever
+    /// `PypiHandler::normalize_name` is handed, its output draws only on
+    /// `[a-z0-9-]`, it cannot begin with `-` (separators before the first
+    /// alphanumeric are skipped), and it cannot end with one (runs collapse and
+    /// the single trailing hyphen is popped). So every name it ever stored is
+    /// either a valid PEP 508 name or the EMPTY string.
+    ///
+    /// Two consequences, both stated in the PR:
+    ///
+    /// * The rows that are genuinely unreachable after #3196 are exactly the
+    ///   empty-named ones, so an operator's audit query is a cheap `name = ''`
+    ///   rather than a regex scan.
+    /// * The other invalid uploads are not unreachable, they are *misfiled* --
+    ///   sitting in some other, valid project's namespace. That is the case
+    ///   this change actually prevents, and it is why the fix is not a rename:
+    ///   a server-side rename would have to guess which project those bytes
+    ///   were meant for.
+    #[test]
+    fn legacy_upload_coercion_only_ever_produced_valid_or_empty_names() {
+        let mut saw_empty = false;
+        for name in invalid_names().into_iter().chain(valid_names()) {
+            let coerced = PypiHandler::normalize_name(name);
+            if coerced.is_empty() {
+                saw_empty = true;
+                continue;
+            }
+            assert!(
+                is_valid_project_name(&coerced),
+                "the legacy upload coercion turned {name:?} into {coerced:?}, which is \
+                 neither empty nor a valid PEP 508 name -- the migration scope in #3198 \
+                 is wider than documented"
+            );
+        }
+        assert!(
+            saw_empty,
+            "no input coerced to the empty string, so the empty case above was never \
+             exercised and the 'valid or empty' claim is only half tested"
+        );
+    }
+
     /// The pattern shown to a rejected publisher (#3198) must be the pattern
     /// actually enforced, differing only in the anchors.
     ///


### PR DESCRIPTION
Fixes #3198

## What was wrong

`POST /pypi/{repo_key}/` — the twine upload route — takes the project name from a multipart `name` form field rather than a path segment, so it never reached the `parse_project_segment` validation #3196 added to every routed `:project`. What ran in its place was `PypiHandler::normalize_name`, which **coerces** rather than validates: every non-ASCII-alphanumeric character becomes `-`, leading separators are skipped, and one trailing hyphen is popped.

Coercion without validation silently republishes under a name the publisher did not ask for. Reproduced against the merge-base (`ce7f342`), every one of these was accepted with `200 OK`:

| uploaded `name` | stored under | consequence |
|---|---|---|
| `acme sdk` | `acme-sdk` | lands in another, valid project's namespace |
| `acme!sdk` | `acme-sdk` | ” |
| `acme@sdk` | `acme-sdk` | ” |
| `acme/sdk` | `acme-sdk` | ” |
| `acme\u{212A}sdk` (Kelvin sign) | `acme-sdk` | ” |
| `acmé-sdk` | `acm-sdk` | a *third* distinct project |
| `_leading`, `-leading`, `.leading` | `leading` | silently renamed |
| `trailing_`, `trailing-` | `trailing` | silently renamed |
| `---`, `...`, `` (empty) | `` (empty) | stored at path `/<version>/<file>`, charged to quota, **reachable at no URL** — `/simple//` is not a route |
| `<script>` | `script` | silently renamed |

The issue's title case is the last row. The more consequential one is the first: after uploading `acme!sdk`, `GET /simple/acme-sdk/` listed the uploaded wheel alongside the legitimate `acme-sdk` distribution. That is not "published but unresolvable", it is published into someone else's project.

## The spec position

**PEP 503** ("Simple Repository API", *Normalized Names*) defines normalization as exactly:

```
re.sub(r"[-_.]+", "-", name).lower()
```

That is the whole rule. It says nothing about any other character — not because others are permitted, but because it presupposes a name that is already valid.

**PEP 508** ("Dependency specification for Python Software Packages", *Names*) supplies that precondition:

> The format of a name is:
> ```
> ^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
> ```
> with `re.IGNORECASE`.

So `acme sdk` is not a project name, and there is no correct normalization for it — it is outside the input domain of PEP 503's rule. Coercing it into one is the bug.

## The fix

Validate the multipart `name` field with `NormalizedProjectName::parse` — deliberately **the same constructor the read paths use**, not a second validator. Two implementations that must agree about names is the exact shape of #3186 (and of #3077 / #3179 / #3183 before it).

**400, not the read paths' 404.** A path segment that is not a project name names no resource, which is why #3196 returns 404 there and why pypi.org does too. An upload *declaring* an invalid project is a malformed request, and the publisher is the party who can fix it — so it gets a 400 carrying the PEP 508 pattern. The message never echoes the rejected name: that would make it a reflection sink for exactly the characters `normalize_pep503` exists to strip (#1377).

**This is not a rename for well-formed names.** For every PEP 508-valid name the canonical form and `PypiHandler::normalize_name` agree byte for byte — a valid name draws only on `[A-Za-z0-9._-]`, so nothing is dropped, and it begins and ends alphanumeric, so neither the leading-separator skip nor the trailing-hyphen pop fires. That equivalence is already asserted by `all_three_normalizers_agree_on_every_valid_name`, which is what makes the substitution storage-compatible: no existing artifact path, cache key or index entry changes.

`normalize_pep503` is untouched. Its character-dropping remains the XSS boundary for names scraped out of upstream HTML, which are not route input.

## The migration question, answered

The issue asks to settle this before enforcing. The scope is narrower than it looks, and `legacy_upload_coercion_only_ever_produced_valid_or_empty_names` now pins it: `PypiHandler::normalize_name` emits only `[a-z0-9-]`, can never emit a leading `-` (leading separators are skipped) and never a trailing one (runs collapse, the trailing hyphen is popped). **Every name already stored is therefore either a valid PEP 508 name or the empty string.**

So:

* The rows genuinely unreachable after #3196 are exactly the empty-named ones. An operator audit is a cheap equality check, not a regex scan:

  ```sql
  SELECT r.key AS repository, a.path, a.version, a.size_bytes, a.created_at
  FROM artifacts a
  JOIN repositories r ON r.id = a.repository_id
  WHERE r.format = 'pypi' AND a.is_deleted = false AND a.name = ''
  ORDER BY r.key, a.created_at;
  ```

* **Recommendation: report, do not rename.** The other invalid uploads are not unreachable, they are *misfiled* — sitting in some other valid project's namespace. A server-side rename would have to guess which project those bytes were meant for, and for the empty-named rows there is no candidate at all; worse, renaming toward a "canonical form" is the same silent-relocation behaviour this change exists to stop, and it can collide with a legitimate project of the target name. Operators should be told what they hold and decide.

This wants a line in the 1.7.2 release notes, since the failure it introduces is a *new* 400 on a publish that previously returned 200.

## Behaviour change

A `twine upload` whose `name` is not a PEP 508 name now gets `400` with `Invalid project name: a PyPI project name must match the PEP 508 pattern ^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])$`. Previously it returned `200 OK` and published somewhere else. No valid publish changes.

## Tests

`pep508_invalid_upload_name_is_rejected_and_cannot_squat_a_valid_project` (in-file `#[cfg(test)] mod tests`, so it counts toward `--lib` coverage) makes three claims in one fixture, because separately each is satisfiable by the bug:

1. every name in the table above is refused with 400, and the body carries the PEP 508 pattern — a 400 alone proves nothing, since a malformed body or a digest mismatch produces one too;
2. no distribution uploaded under an invalid name appears in `/simple/acme-sdk/`;
3. **positive control, in the same fixture and the same response**: `acme-sdk` itself uploads with 200 and its own wheel *is* listed. Without it, claim 2 would be satisfied by a repo that serves nothing — the failure mode that kept an earlier security test on #3179 green while the vulnerability was live.

The fixture name carries a separator on purpose. On a separator-free name such as `demo` the two legacy coercions cannot diverge, so claim 2 would pass on the unfixed tree and report a false all-clear.

Also fixed: the shared `pypi_upload_multipart` test helper derived the multipart boundary from the project name, so any name carrying a character RFC 2046 §5.1.1 excludes produced a body the parser rejected outright — a 400 for the wrong reason on exactly the inputs this change is about. It is byte-identical for the names the existing tests pass.

### Revert-proof

The enforcement was faithfully reverted to the merge-base shape (`let normalized = PypiHandler::normalize_name(&pkg_name);`, `ce7f342:backend/src/api/handlers/pypi.rs:3892`), keeping the test. It fails, on the claim rather than on a compile error or a fixture barrier — the message constant is a test-local literal precisely so the reverted tree still builds:

```
FAIL [ 0.965s] pep508_invalid_upload_name_is_rejected_and_cannot_squat_a_valid_project
  upload named "acme sdk" (coerces to "acme-sdk"): expected 400, got 200 OK; body: OK
  upload named "acme!sdk" (coerces to "acme-sdk"): expected 400, got 200 OK; body: OK
  ... (all 15 names accepted) ...
  a distribution uploaded under a PEP 508-invalid name is listed in the index of acme-sdk
```

With the fix restored:

```
PASS [ 0.603s] pep508_invalid_upload_name_is_rejected_and_cannot_squat_a_valid_project
Summary: 413 pypi tests run, 413 passed
```
