### PR TITLE
fix(formats): derive /api/v1/formats from the compiled-in handler registry

### DIFF
--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -292,6 +292,41 @@ pub async fn path_stats_serial_lock() -> PathStatsSerialGuard {
     }
 }
 
+/// Advisory-lock key for [`format_registry_serial_lock`] (#3157).
+///
+/// Distinct from the other test lock keys and from the application advisory
+/// locks, so the format-registry test cluster serializes only against itself.
+const FORMAT_REGISTRY_TEST_LOCK_KEY: i64 = 0x4652_3157; // "FR" + issue #3157
+
+/// Cross-process serialization guard for the DB-backed core-format-registry
+/// tests (#3157).
+///
+/// `WasmPluginService::sync_core_format_handlers` upserts EVERY compiled-in
+/// handler row, so two of these tests running concurrently would each observe
+/// the other's rows: the test that deletes a handler row to reproduce the
+/// pre-fix state would see it reappear under a peer's sync, and the test that
+/// asserts a WASM-owned row survives a sync would race the same statement.
+/// A Postgres *session* advisory lock — mirroring [`scan_dedup_serial_lock`] —
+/// makes every such test contend for one key, so only one runs its
+/// arrange → sync → assert → restore critical section at a time. The lock
+/// releases when the guard drops (connection closes), including on panic.
+pub struct FormatRegistrySerialGuard {
+    _conn: Option<sqlx::PgConnection>,
+}
+
+/// Acquire the process-wide format-registry test lock, blocking until it is
+/// free.
+///
+/// Returns an inert guard (no lock held) when `DATABASE_URL` is unset or the
+/// database is unreachable, mirroring [`try_pool`] so DB-free environments
+/// still no-op cleanly. Call this as the first line of a DB-backed
+/// format-registry test and bind the result for the whole test body.
+pub async fn format_registry_serial_lock() -> FormatRegistrySerialGuard {
+    FormatRegistrySerialGuard {
+        _conn: serial_lock_session(FORMAT_REGISTRY_TEST_LOCK_KEY).await,
+    }
+}
+
 /// Refresh the materialized storage stats for a test, absorbing transient
 /// cross-suite interference.
 ///

--- a/backend/src/formats/format_tests.rs
+++ b/backend/src/formats/format_tests.rs
@@ -7,8 +7,11 @@
 mod tests {
     use bytes::Bytes;
 
-    use crate::formats::{get_core_handler, get_handler_for_format, list_core_formats};
+    use crate::formats::{
+        core_format_handlers, get_core_handler, get_handler_for_format, list_core_formats,
+    };
     use crate::models::repository::RepositoryFormat;
+    use crate::services::repository_service::parse_format_str;
 
     /// All format keys that should be resolved by get_core_handler.
     const ALL_FORMAT_KEYS: &[&str] = &[
@@ -65,59 +68,14 @@ mod tests {
     /// Additional alias keys that get_core_handler should also resolve.
     const ALIAS_FORMAT_KEYS: &[&str] = &["oci", "cursor", "windsurf", "kiro"];
 
-    /// All RepositoryFormat enum variants.
+    /// Every built-in format variant.
+    ///
+    /// Derived from `RepositoryFormat::ALL` rather than re-listed here: the
+    /// hand-written copy this replaces had drifted and was missing
+    /// `protobuf`, `incus` and `lxc`, so those three never went through any of
+    /// the handler-registry tests below (#3157).
     fn all_repository_formats() -> Vec<RepositoryFormat> {
-        vec![
-            RepositoryFormat::Maven,
-            RepositoryFormat::Gradle,
-            RepositoryFormat::Npm,
-            RepositoryFormat::Pypi,
-            RepositoryFormat::Nuget,
-            RepositoryFormat::Go,
-            RepositoryFormat::Rubygems,
-            RepositoryFormat::Docker,
-            RepositoryFormat::Helm,
-            RepositoryFormat::Rpm,
-            RepositoryFormat::Debian,
-            RepositoryFormat::Conan,
-            RepositoryFormat::Cargo,
-            RepositoryFormat::Generic,
-            RepositoryFormat::Podman,
-            RepositoryFormat::Buildx,
-            RepositoryFormat::Oras,
-            RepositoryFormat::WasmOci,
-            RepositoryFormat::HelmOci,
-            RepositoryFormat::Poetry,
-            RepositoryFormat::Conda,
-            RepositoryFormat::Yarn,
-            RepositoryFormat::Bower,
-            RepositoryFormat::Pnpm,
-            RepositoryFormat::Chocolatey,
-            RepositoryFormat::Powershell,
-            RepositoryFormat::Terraform,
-            RepositoryFormat::Opentofu,
-            RepositoryFormat::Alpine,
-            RepositoryFormat::CondaNative,
-            RepositoryFormat::Composer,
-            RepositoryFormat::Hex,
-            RepositoryFormat::Cocoapods,
-            RepositoryFormat::Swift,
-            RepositoryFormat::Pub,
-            RepositoryFormat::Sbt,
-            RepositoryFormat::Chef,
-            RepositoryFormat::Puppet,
-            RepositoryFormat::Ansible,
-            RepositoryFormat::Gitlfs,
-            RepositoryFormat::Vscode,
-            RepositoryFormat::Jetbrains,
-            RepositoryFormat::Huggingface,
-            RepositoryFormat::Mlmodel,
-            RepositoryFormat::Cran,
-            RepositoryFormat::Vagrant,
-            RepositoryFormat::Opkg,
-            RepositoryFormat::P2,
-            RepositoryFormat::Bazel,
-        ]
+        RepositoryFormat::ALL.to_vec()
     }
 
     #[test]
@@ -722,5 +680,171 @@ mod tests {
             "Conda native validate failed: {:?}",
             result.err()
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Compiled-in format handler registry (#3157)
+    //
+    // `GET /api/v1/formats` reported only the 13 handlers migration 014
+    // seeded; ~24 shipped handlers including `pub` were missing, and a format
+    // with no row can never be disabled, so those were also silently exempt
+    // from the enable/disable control surface. The registry below is what the
+    // endpoint is now synchronised from, so these tests check it against
+    // sources that are NOT the registry itself: `get_core_handler` (the actual
+    // dispatch table) and `ALL_FORMAT_KEYS` (this module's own list).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_core_format_handlers_all_resolve_to_a_compiled_in_handler() {
+        // Independent oracle: get_core_handler is the real dispatch table, so
+        // a registry entry with no handler behind it would be advertising a
+        // format the backend cannot actually serve.
+        for entry in core_format_handlers() {
+            assert!(
+                get_core_handler(entry.format_key).is_some(),
+                "registry advertises '{}' but get_core_handler() has no handler for it",
+                entry.format_key
+            );
+            assert!(
+                !entry.display_name.is_empty(),
+                "registry entry '{}' has an empty display name",
+                entry.format_key
+            );
+        }
+    }
+
+    #[test]
+    fn test_core_format_handlers_cover_every_format_key() {
+        // Every format the product supports must be served by a registered
+        // handler. ALL_FORMAT_KEYS is maintained independently of the registry
+        // (it predates it), so this catches a format whose handler key never
+        // made it into the registry.
+        let registered: std::collections::HashSet<&str> = core_format_handlers()
+            .iter()
+            .map(|h| h.format_key)
+            .collect();
+
+        for key in ALL_FORMAT_KEYS.iter().chain(ALIAS_FORMAT_KEYS.iter()) {
+            // `cursor`/`windsurf`/`kiro` are client aliases of the vscode
+            // handler and are not repository formats, so they have no
+            // RepositoryFormat variant to derive an entry from.
+            if matches!(*key, "cursor" | "windsurf" | "kiro") {
+                continue;
+            }
+            let handler_key = parse_format_str(key)
+                .map(|f| f.handler_key())
+                .unwrap_or(key);
+            assert!(
+                registered.contains(handler_key),
+                "format '{}' resolves to handler '{}', which the core registry does not list",
+                key,
+                handler_key
+            );
+        }
+    }
+
+    #[test]
+    fn test_core_format_handlers_include_handlers_added_after_the_014_seed() {
+        // The 13 handlers migration 014 seeded, verbatim from
+        // `backend/migrations/014_wasm_plugins.sql`.
+        const SEEDED_BY_MIGRATION_014: &[&str] = &[
+            "maven", "npm", "pypi", "nuget", "cargo", "go", "oci", "helm", "debian", "rpm",
+            "rubygems", "conan", "generic",
+        ];
+
+        let registered: std::collections::HashSet<&str> = core_format_handlers()
+            .iter()
+            .map(|h| h.format_key)
+            .collect();
+
+        // Positive control: the originally seeded handlers are still listed,
+        // so a registry that lost everything cannot satisfy the assertions
+        // below by being empty.
+        for key in SEEDED_BY_MIGRATION_014 {
+            assert!(
+                registered.contains(key),
+                "registry lost originally seeded handler '{}'",
+                key
+            );
+        }
+
+        // The gap reported in #3157: handlers shipped after the seed. `pub`
+        // is the one the issue was raised against.
+        for key in [
+            "pub",
+            "composer",
+            "cocoapods",
+            "swift",
+            "hex",
+            "sbt",
+            "cran",
+            "terraform",
+            "alpine",
+            "protobuf",
+            "incus",
+            "conda_native",
+            "gitlfs",
+            "vscode",
+            "jetbrains",
+            "huggingface",
+            "mlmodel",
+            "vagrant",
+            "opkg",
+            "p2",
+            "bazel",
+            "chef",
+            "puppet",
+            "ansible",
+        ] {
+            assert!(
+                registered.contains(key),
+                "core format registry is missing '{}' (added after the migration 014 seed)",
+                key
+            );
+        }
+
+        assert!(
+            registered.len() > SEEDED_BY_MIGRATION_014.len(),
+            "registry has not grown past the 13 handlers seeded in 2024"
+        );
+    }
+
+    #[test]
+    fn test_core_format_handlers_are_deduplicated_by_handler() {
+        // Aliases share a handler (gradle -> maven, lxc -> incus, every OCI
+        // alias -> oci). The table is keyed by format_key, so a duplicate
+        // entry would make the startup sync fight itself.
+        let mut seen = std::collections::HashSet::new();
+        for entry in core_format_handlers() {
+            assert!(
+                seen.insert(entry.format_key),
+                "duplicate registry entry for '{}'",
+                entry.format_key
+            );
+        }
+        // The alias collapse must actually happen: `docker` and `lxc` are
+        // formats, not handlers.
+        assert!(
+            !seen.contains("docker"),
+            "'docker' should collapse onto 'oci'"
+        );
+        assert!(seen.contains("oci"));
+        assert!(!seen.contains("lxc"), "'lxc' should collapse onto 'incus'");
+        assert!(seen.contains("incus"));
+    }
+
+    #[test]
+    fn test_list_core_formats_resolves_every_key_to_a_handler() {
+        // list_core_formats() is now derived from RepositoryFormat::ALL, so
+        // this is the check that the derivation cannot advertise a format the
+        // dispatch table does not know — it is what caught `gradle` missing
+        // from get_core_handler().
+        for key in list_core_formats() {
+            assert!(
+                get_core_handler(key).is_some(),
+                "list_core_formats() advertises '{}' but get_core_handler() returns None",
+                key
+            );
+        }
     }
 }

--- a/backend/src/formats/mod.rs
+++ b/backend/src/formats/mod.rs
@@ -68,60 +68,7 @@ pub trait FormatHandler: Send + Sync {
     /// For core handlers, this matches the RepositoryFormat enum value.
     /// For WASM plugins, this is the custom format key from the manifest.
     fn format_key(&self) -> &str {
-        match self.format() {
-            RepositoryFormat::Maven => "maven",
-            RepositoryFormat::Gradle => "gradle",
-            RepositoryFormat::Npm => "npm",
-            RepositoryFormat::Pypi => "pypi",
-            RepositoryFormat::Nuget => "nuget",
-            RepositoryFormat::Go => "go",
-            RepositoryFormat::Rubygems => "rubygems",
-            RepositoryFormat::Docker => "docker",
-            RepositoryFormat::Helm => "helm",
-            RepositoryFormat::Rpm => "rpm",
-            RepositoryFormat::Debian => "debian",
-            RepositoryFormat::Conan => "conan",
-            RepositoryFormat::Cargo => "cargo",
-            RepositoryFormat::Generic => "generic",
-            RepositoryFormat::Podman => "podman",
-            RepositoryFormat::Buildx => "buildx",
-            RepositoryFormat::Oras => "oras",
-            RepositoryFormat::WasmOci => "wasm_oci",
-            RepositoryFormat::HelmOci => "helm_oci",
-            RepositoryFormat::Poetry => "poetry",
-            RepositoryFormat::Conda => "conda",
-            RepositoryFormat::Yarn => "yarn",
-            RepositoryFormat::Bower => "bower",
-            RepositoryFormat::Pnpm => "pnpm",
-            RepositoryFormat::Chocolatey => "chocolatey",
-            RepositoryFormat::Powershell => "powershell",
-            RepositoryFormat::Terraform => "terraform",
-            RepositoryFormat::Opentofu => "opentofu",
-            RepositoryFormat::Alpine => "alpine",
-            RepositoryFormat::CondaNative => "conda_native",
-            RepositoryFormat::Composer => "composer",
-            RepositoryFormat::Hex => "hex",
-            RepositoryFormat::Cocoapods => "cocoapods",
-            RepositoryFormat::Swift => "swift",
-            RepositoryFormat::Pub => "pub",
-            RepositoryFormat::Sbt => "sbt",
-            RepositoryFormat::Chef => "chef",
-            RepositoryFormat::Puppet => "puppet",
-            RepositoryFormat::Ansible => "ansible",
-            RepositoryFormat::Gitlfs => "gitlfs",
-            RepositoryFormat::Vscode => "vscode",
-            RepositoryFormat::Jetbrains => "jetbrains",
-            RepositoryFormat::Huggingface => "huggingface",
-            RepositoryFormat::Mlmodel => "mlmodel",
-            RepositoryFormat::Cran => "cran",
-            RepositoryFormat::Vagrant => "vagrant",
-            RepositoryFormat::Opkg => "opkg",
-            RepositoryFormat::P2 => "p2",
-            RepositoryFormat::Bazel => "bazel",
-            RepositoryFormat::Protobuf => "protobuf",
-            RepositoryFormat::Incus => "incus",
-            RepositoryFormat::Lxc => "lxc",
-        }
+        self.format().as_key()
     }
 
     /// Check if this handler is backed by a WASM plugin.
@@ -145,7 +92,7 @@ pub trait FormatHandler: Send + Sync {
 /// use the WasmFormatHandlerFactory instead.
 pub fn get_core_handler(format_key: &str) -> Option<Box<dyn FormatHandler>> {
     match format_key {
-        "maven" => Some(Box::new(maven::MavenHandler::new())),
+        "maven" | "gradle" => Some(Box::new(maven::MavenHandler::new())),
         "npm" => Some(Box::new(npm::NpmHandler::new())),
         "pypi" => Some(Box::new(pypi::PypiHandler::new())),
         "nuget" => Some(Box::new(nuget::NugetHandler::new())),
@@ -251,60 +198,133 @@ pub fn get_handler_for_format(format: &RepositoryFormat) -> Box<dyn FormatHandle
 }
 
 /// List all supported core format keys.
+///
+/// Derived from [`RepositoryFormat::ALL`] rather than hand-maintained: the
+/// previous literal list had silently lost `gradle` (#3157).
 pub fn list_core_formats() -> Vec<&'static str> {
-    vec![
-        "maven",
-        "npm",
-        "pypi",
-        "nuget",
-        "go",
-        "rubygems",
-        "docker",
-        "helm",
-        "rpm",
-        "debian",
-        "conan",
-        "cargo",
-        "generic",
-        "podman",
-        "buildx",
-        "oras",
-        "wasm_oci",
-        "helm_oci",
-        "poetry",
-        "conda",
-        "yarn",
-        "bower",
-        "pnpm",
-        "chocolatey",
-        "powershell",
-        "terraform",
-        "opentofu",
-        "alpine",
-        "conda_native",
-        "composer",
-        "hex",
-        "cocoapods",
-        "swift",
-        "pub",
-        "sbt",
-        "chef",
-        "puppet",
-        "ansible",
-        "gitlfs",
-        "vscode",
-        "jetbrains",
-        "huggingface",
-        "mlmodel",
-        "cran",
-        "vagrant",
-        "opkg",
-        "p2",
-        "bazel",
-        "protobuf",
-        "incus",
-        "lxc",
-    ]
+    RepositoryFormat::ALL.iter().map(|f| f.as_key()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Compiled-in format handler registry (#3157)
+// ---------------------------------------------------------------------------
+
+/// A compiled-in ("core") format handler, as advertised by
+/// `GET /api/v1/formats`.
+///
+/// One entry per *handler*, not per format alias: `gradle` is served by the
+/// Maven handler and every OCI alias by the `oci` handler, so those collapse
+/// onto a single entry — the same granularity the `format_handlers` table is
+/// keyed by and the same granularity the enable/disable gate acts on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoreFormatHandler {
+    /// Handler key, e.g. `"pub"`. Matches `format_handlers.format_key`.
+    pub format_key: &'static str,
+    /// Human-readable name for the API/UI.
+    pub display_name: &'static str,
+    /// One-line description of the format.
+    pub description: &'static str,
+    /// File extensions the handler recognises. Advisory/display only.
+    pub extensions: &'static [&'static str],
+}
+
+/// Every format handler compiled into this binary.
+///
+/// This is the authoritative answer to "which formats does the running
+/// backend provide?" — it is *derived* from [`RepositoryFormat::ALL`] via
+/// [`RepositoryFormat::handler_key`], so a format cannot be added to the
+/// product without appearing here. `format_handlers` rows are synchronised
+/// from this registry at startup
+/// (`WasmPluginService::sync_core_format_handlers`), which makes the table an
+/// enablement overlay on top of the registry instead of a second, hand-written
+/// copy of it. Migration 014 seeded that table once with the 13 handlers that
+/// existed at the time and it was never extended, so `GET /api/v1/formats` hid
+/// ~24 shipped handlers including `pub` (#3157).
+pub fn core_format_handlers() -> Vec<CoreFormatHandler> {
+    let mut seen = std::collections::HashSet::new();
+    let mut handlers = Vec::new();
+    for format in RepositoryFormat::ALL {
+        let key = format.handler_key();
+        if seen.insert(key) {
+            let (display_name, description, extensions) = core_handler_metadata(key);
+            handlers.push(CoreFormatHandler {
+                format_key: key,
+                display_name,
+                description,
+                extensions,
+            });
+        }
+    }
+    handlers
+}
+
+/// Presentation metadata for a core handler key.
+///
+/// Deliberately total: an unrecognised key falls back to the key itself rather
+/// than being dropped, so forgetting to add a line here can only cost a format
+/// its pretty name — never its presence in the registry. Membership is decided
+/// by [`RepositoryFormat::ALL`] alone.
+fn core_handler_metadata(
+    format_key: &'static str,
+) -> (&'static str, &'static str, &'static [&'static str]) {
+    match format_key {
+        "maven" => (
+            "Maven",
+            "Maven repository format for Java artifacts",
+            &[".jar", ".pom", ".war", ".ear"],
+        ),
+        "npm" => ("npm", "Node.js package manager", &[".tgz"]),
+        "pypi" => ("PyPI", "Python Package Index", &[".whl", ".tar.gz"]),
+        "nuget" => ("NuGet", ".NET package manager", &[".nupkg"]),
+        "cargo" => ("Cargo", "Rust package manager", &[".crate"]),
+        "go" => ("Go Modules", "Go module proxy", &[".zip", ".mod"]),
+        "oci" => ("OCI/Docker", "Container images (OCI format)", &[]),
+        "helm" => ("Helm", "Kubernetes package manager", &[".tgz"]),
+        "debian" => ("Debian", "Debian packages", &[".deb"]),
+        "rpm" => ("RPM", "Red Hat packages", &[".rpm"]),
+        "rubygems" => ("RubyGems", "Ruby gems", &[".gem"]),
+        "conan" => ("Conan", "C/C++ package manager", &[".tgz"]),
+        "generic" => ("Generic", "Generic artifact storage", &[]),
+        "terraform" => (
+            "Terraform/OpenTofu",
+            "Terraform and OpenTofu modules and providers",
+            &[".zip"],
+        ),
+        "alpine" => ("Alpine", "Alpine Linux apk packages", &[".apk"]),
+        "conda_native" => (
+            "Conda",
+            "Conda packages (native channel layout)",
+            &[".conda", ".tar.bz2"],
+        ),
+        "composer" => ("Composer", "PHP package manager", &[".zip", ".tar"]),
+        "hex" => ("Hex", "Elixir/Erlang package manager", &[".tar"]),
+        "cocoapods" => ("CocoaPods", "Swift and Objective-C dependency manager", &[]),
+        "swift" => ("Swift", "Swift Package Manager registry", &[".zip"]),
+        "pub" => ("Pub", "Dart and Flutter package registry", &[".tar.gz"]),
+        "sbt" => ("sbt", "Scala build tool plugins and artifacts", &[".jar"]),
+        "chef" => ("Chef", "Chef cookbooks", &[".tar.gz"]),
+        "puppet" => ("Puppet", "Puppet modules", &[".tar.gz"]),
+        "ansible" => ("Ansible", "Ansible collections and roles", &[".tar.gz"]),
+        "gitlfs" => ("Git LFS", "Git Large File Storage objects", &[]),
+        "vscode" => (
+            "VS Code Extensions",
+            "Visual Studio Code compatible extensions",
+            &[".vsix"],
+        ),
+        "jetbrains" => ("JetBrains Plugins", "JetBrains IDE plugins", &[".zip"]),
+        "huggingface" => ("Hugging Face", "Hugging Face models and datasets", &[]),
+        "mlmodel" => ("ML Models", "Machine-learning model artifacts", &[]),
+        "cran" => ("CRAN", "R packages", &[".tar.gz"]),
+        "vagrant" => ("Vagrant", "Vagrant boxes", &[".box"]),
+        "opkg" => ("opkg", "OpenWrt/embedded Linux packages", &[".ipk"]),
+        "p2" => ("Eclipse P2", "Eclipse P2 update sites", &[".jar"]),
+        "bazel" => ("Bazel", "Bazel modules and rulesets", &[".tar.gz"]),
+        "protobuf" => ("Protobuf", "Protocol Buffer schema registry", &[".proto"]),
+        "incus" => ("Incus/LXC", "Incus and LXC container images", &[".tar.xz"]),
+        // Total fallback -- see the doc comment. A format that reaches this
+        // arm is still listed, it just shows its raw key as the display name.
+        other => (other, "Compiled-in format handler", &[]),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1374,6 +1374,19 @@ async fn initialize_wasm_plugins(
     // Ensure plugins directory exists
     wasm_service.ensure_plugins_dir().await?;
 
+    // Project the compiled-in format handler registry into `format_handlers`
+    // so the table describes the handlers this binary actually provides
+    // (#3157). Idempotent; never overwrites an operator's enable/disable
+    // choice or a WASM plugin's own row.
+    match wasm_service.sync_core_format_handlers().await {
+        Ok(rows) => tracing::info!("Core format handlers synchronized ({} rows)", rows),
+        Err(e) => {
+            // The registry listing degrades to whatever is already in the
+            // table; that is not a reason to refuse to serve traffic.
+            tracing::error!("Failed to synchronize core format handlers: {}", e);
+        }
+    }
+
     // Load active plugins from database
     let active_plugins = load_active_plugins(&db_pool).await?;
 

--- a/backend/src/models/repository.rs
+++ b/backend/src/models/repository.rs
@@ -79,6 +79,170 @@ pub enum RepositoryFormat {
     Lxc,
 }
 
+impl RepositoryFormat {
+    /// Every built-in repository format, in declaration order.
+    ///
+    /// This is the single enumeration of the variant set: `list_core_formats`,
+    /// the compiled-in format-handler registry
+    /// ([`crate::formats::core_format_handlers`]) and the test helpers all
+    /// derive from it instead of keeping their own copies. Before #3157 there
+    /// were four separate hand-written lists of formats and three of them had
+    /// silently drifted (the `format_handlers` seed in migration 014 stopped at
+    /// the original 13, `list_core_formats` was missing `gradle`, and the test
+    /// helper was missing `protobuf`/`incus`/`lxc`).
+    ///
+    /// A new variant must be added here as well. That is checked, not trusted:
+    /// `as_key`/`handler_key` are exhaustive matches (a new variant fails the
+    /// build until they are extended), and `test_all_matches_database_enum`
+    /// compares this list against `enum_range(NULL::repository_format)` — the
+    /// label set the migrations create — so an omission fails CI against an
+    /// independently maintained source rather than drifting silently.
+    pub const ALL: &'static [RepositoryFormat] = &[
+        RepositoryFormat::Maven,
+        RepositoryFormat::Gradle,
+        RepositoryFormat::Npm,
+        RepositoryFormat::Pypi,
+        RepositoryFormat::Nuget,
+        RepositoryFormat::Go,
+        RepositoryFormat::Rubygems,
+        RepositoryFormat::Docker,
+        RepositoryFormat::Helm,
+        RepositoryFormat::Rpm,
+        RepositoryFormat::Debian,
+        RepositoryFormat::Conan,
+        RepositoryFormat::Cargo,
+        RepositoryFormat::Generic,
+        RepositoryFormat::Podman,
+        RepositoryFormat::Buildx,
+        RepositoryFormat::Oras,
+        RepositoryFormat::WasmOci,
+        RepositoryFormat::HelmOci,
+        RepositoryFormat::Poetry,
+        RepositoryFormat::Conda,
+        RepositoryFormat::Yarn,
+        RepositoryFormat::Bower,
+        RepositoryFormat::Pnpm,
+        RepositoryFormat::Chocolatey,
+        RepositoryFormat::Powershell,
+        RepositoryFormat::Terraform,
+        RepositoryFormat::Opentofu,
+        RepositoryFormat::Alpine,
+        RepositoryFormat::CondaNative,
+        RepositoryFormat::Composer,
+        RepositoryFormat::Hex,
+        RepositoryFormat::Cocoapods,
+        RepositoryFormat::Swift,
+        RepositoryFormat::Pub,
+        RepositoryFormat::Sbt,
+        RepositoryFormat::Chef,
+        RepositoryFormat::Puppet,
+        RepositoryFormat::Ansible,
+        RepositoryFormat::Gitlfs,
+        RepositoryFormat::Vscode,
+        RepositoryFormat::Jetbrains,
+        RepositoryFormat::Huggingface,
+        RepositoryFormat::Mlmodel,
+        RepositoryFormat::Cran,
+        RepositoryFormat::Vagrant,
+        RepositoryFormat::Opkg,
+        RepositoryFormat::P2,
+        RepositoryFormat::Bazel,
+        RepositoryFormat::Protobuf,
+        RepositoryFormat::Incus,
+        RepositoryFormat::Lxc,
+    ];
+
+    /// The canonical snake_case key for this format.
+    ///
+    /// This is the label used by the `repository_format` Postgres enum and by
+    /// the `FormatHandler::format_key()` contract, so it is deliberately NOT
+    /// the lowercased `Debug` form: that drops the underscore in multi-word
+    /// variants (`CondaNative` would become `condanative`).
+    pub fn as_key(&self) -> &'static str {
+        match self {
+            Self::Maven => "maven",
+            Self::Gradle => "gradle",
+            Self::Npm => "npm",
+            Self::Pypi => "pypi",
+            Self::Nuget => "nuget",
+            Self::Go => "go",
+            Self::Rubygems => "rubygems",
+            Self::Docker => "docker",
+            Self::Helm => "helm",
+            Self::Rpm => "rpm",
+            Self::Debian => "debian",
+            Self::Conan => "conan",
+            Self::Cargo => "cargo",
+            Self::Generic => "generic",
+            Self::Podman => "podman",
+            Self::Buildx => "buildx",
+            Self::Oras => "oras",
+            Self::WasmOci => "wasm_oci",
+            Self::HelmOci => "helm_oci",
+            Self::Poetry => "poetry",
+            Self::Conda => "conda",
+            Self::Yarn => "yarn",
+            Self::Bower => "bower",
+            Self::Pnpm => "pnpm",
+            Self::Chocolatey => "chocolatey",
+            Self::Powershell => "powershell",
+            Self::Terraform => "terraform",
+            Self::Opentofu => "opentofu",
+            Self::Alpine => "alpine",
+            Self::CondaNative => "conda_native",
+            Self::Composer => "composer",
+            Self::Hex => "hex",
+            Self::Cocoapods => "cocoapods",
+            Self::Swift => "swift",
+            Self::Pub => "pub",
+            Self::Sbt => "sbt",
+            Self::Chef => "chef",
+            Self::Puppet => "puppet",
+            Self::Ansible => "ansible",
+            Self::Gitlfs => "gitlfs",
+            Self::Vscode => "vscode",
+            Self::Jetbrains => "jetbrains",
+            Self::Huggingface => "huggingface",
+            Self::Mlmodel => "mlmodel",
+            Self::Cran => "cran",
+            Self::Vagrant => "vagrant",
+            Self::Opkg => "opkg",
+            Self::P2 => "p2",
+            Self::Bazel => "bazel",
+            Self::Protobuf => "protobuf",
+            Self::Incus => "incus",
+            Self::Lxc => "lxc",
+        }
+    }
+
+    /// The key of the *handler* that serves this format.
+    ///
+    /// Aliases collapse onto the handler they share, mirroring
+    /// [`crate::formats::get_handler_for_format`]: `gradle` is served by the
+    /// Maven handler, every OCI alias by the `oci` handler, `lxc` by `incus`,
+    /// and so on. This is the identity the `format_handlers` table is keyed by
+    /// — the enablement gate in `RepositoryService::create` looks the row up by
+    /// this key, so it is also the correct granularity for the
+    /// enable/disable control surface.
+    pub fn handler_key(&self) -> &'static str {
+        match self {
+            Self::Gradle => "maven",
+            Self::Yarn | Self::Bower | Self::Pnpm => "npm",
+            Self::Poetry | Self::Conda => "pypi",
+            Self::Chocolatey | Self::Powershell => "nuget",
+            Self::Docker
+            | Self::Podman
+            | Self::Buildx
+            | Self::Oras
+            | Self::WasmOci
+            | Self::HelmOci => "oci",
+            Self::Opentofu => "terraform",
+            Self::Lxc => "incus",
+            other => other.as_key(),
+        }
+    }
+}
+
 /// Repository type enum
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "repository_type", rename_all = "lowercase")]

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -302,82 +302,16 @@ fn is_debian_flat_or_mirrorlist(url: &str) -> bool {
 /// formatting followed by `to_lowercase()` is insufficient because it
 /// drops underscores from multi-word variants (e.g., `CondaNative` becomes
 /// `"condanative"` instead of `"conda_native"`).
+///
+/// The mapping itself lives on [`RepositoryFormat::as_key`] so the format
+/// registry has one definition rather than one per consumer (#3157).
 pub(crate) fn derive_format_key(format: &RepositoryFormat) -> String {
-    match format {
-        RepositoryFormat::Maven => "maven",
-        RepositoryFormat::Gradle => "gradle",
-        RepositoryFormat::Npm => "npm",
-        RepositoryFormat::Pypi => "pypi",
-        RepositoryFormat::Nuget => "nuget",
-        RepositoryFormat::Go => "go",
-        RepositoryFormat::Rubygems => "rubygems",
-        RepositoryFormat::Docker => "docker",
-        RepositoryFormat::Helm => "helm",
-        RepositoryFormat::Rpm => "rpm",
-        RepositoryFormat::Debian => "debian",
-        RepositoryFormat::Conan => "conan",
-        RepositoryFormat::Cargo => "cargo",
-        RepositoryFormat::Generic => "generic",
-        RepositoryFormat::Podman => "podman",
-        RepositoryFormat::Buildx => "buildx",
-        RepositoryFormat::Oras => "oras",
-        RepositoryFormat::WasmOci => "wasm_oci",
-        RepositoryFormat::HelmOci => "helm_oci",
-        RepositoryFormat::Poetry => "poetry",
-        RepositoryFormat::Conda => "conda",
-        RepositoryFormat::Yarn => "yarn",
-        RepositoryFormat::Bower => "bower",
-        RepositoryFormat::Pnpm => "pnpm",
-        RepositoryFormat::Chocolatey => "chocolatey",
-        RepositoryFormat::Powershell => "powershell",
-        RepositoryFormat::Terraform => "terraform",
-        RepositoryFormat::Opentofu => "opentofu",
-        RepositoryFormat::Alpine => "alpine",
-        RepositoryFormat::CondaNative => "conda_native",
-        RepositoryFormat::Composer => "composer",
-        RepositoryFormat::Hex => "hex",
-        RepositoryFormat::Cocoapods => "cocoapods",
-        RepositoryFormat::Swift => "swift",
-        RepositoryFormat::Pub => "pub",
-        RepositoryFormat::Sbt => "sbt",
-        RepositoryFormat::Chef => "chef",
-        RepositoryFormat::Puppet => "puppet",
-        RepositoryFormat::Ansible => "ansible",
-        RepositoryFormat::Gitlfs => "gitlfs",
-        RepositoryFormat::Vscode => "vscode",
-        RepositoryFormat::Jetbrains => "jetbrains",
-        RepositoryFormat::Huggingface => "huggingface",
-        RepositoryFormat::Mlmodel => "mlmodel",
-        RepositoryFormat::Cran => "cran",
-        RepositoryFormat::Vagrant => "vagrant",
-        RepositoryFormat::Opkg => "opkg",
-        RepositoryFormat::P2 => "p2",
-        RepositoryFormat::Bazel => "bazel",
-        RepositoryFormat::Protobuf => "protobuf",
-        RepositoryFormat::Incus => "incus",
-        RepositoryFormat::Lxc => "lxc",
-    }
-    .to_string()
+    format.as_key().to_string()
 }
 
 /// Handler key a format gates on; aliases collapse to their core handler (mirrors get_handler_for_format).
 pub(crate) fn format_handler_key(format: &RepositoryFormat) -> String {
-    let key = match format {
-        RepositoryFormat::Gradle => "maven",
-        RepositoryFormat::Yarn | RepositoryFormat::Bower | RepositoryFormat::Pnpm => "npm",
-        RepositoryFormat::Poetry | RepositoryFormat::Conda => "pypi",
-        RepositoryFormat::Chocolatey | RepositoryFormat::Powershell => "nuget",
-        RepositoryFormat::Docker
-        | RepositoryFormat::Podman
-        | RepositoryFormat::Buildx
-        | RepositoryFormat::Oras
-        | RepositoryFormat::WasmOci
-        | RepositoryFormat::HelmOci => "oci",
-        RepositoryFormat::Opentofu => "terraform",
-        RepositoryFormat::Lxc => "incus",
-        other => return derive_format_key(other),
-    };
-    key.to_string()
+    format.handler_key().to_string()
 }
 
 /// Build a SQL LIKE search pattern from a user query string.

--- a/backend/src/services/wasm_plugin_service.rs
+++ b/backend/src/services/wasm_plugin_service.rs
@@ -189,6 +189,78 @@ impl WasmPluginService {
     // T013: Format Handler CRUD Operations
     // =========================================================================
 
+    /// Synchronise `format_handlers` with the format handlers actually
+    /// compiled into this binary (#3157).
+    ///
+    /// `format_handlers` was seeded exactly once, by migration
+    /// `014_wasm_plugins.sql`, with the 13 handlers that existed at the time.
+    /// Every format added since — `pub`, `composer`, `swift`, `hex`,
+    /// `terraform`, `protobuf`, `incus` and ~17 more — extended only the
+    /// `repository_format` enum, so `GET /api/v1/formats` under-reported the
+    /// running backend by two thirds and those formats had no row to toggle,
+    /// which silently exempted them from the enable/disable control surface
+    /// the other 13 had. Because migrations are the same on a fresh install as
+    /// on an upgrade, this was never an upgrade-only gap.
+    ///
+    /// Running the sync at startup — rather than adding another static seed
+    /// migration — makes [`crate::formats::core_format_handlers`] the source
+    /// of truth and the table an *enablement overlay* on it: whatever the
+    /// binary compiles in has a row, so the two cannot drift again.
+    ///
+    /// The upsert is deliberately narrow:
+    ///
+    /// * `is_enabled` is never written on conflict — an operator who disabled
+    ///   a handler keeps it disabled across restarts.
+    /// * rows owned by a WASM plugin (`handler_type = 'wasm'`) are left
+    ///   untouched, so a plugin that claimed a key keeps its own metadata.
+    ///
+    /// Idempotent and safe to run concurrently from several replicas.
+    pub async fn sync_core_format_handlers(&self) -> Result<u64> {
+        let mut synced = 0u64;
+        for handler in crate::formats::core_format_handlers() {
+            let extensions: Vec<String> =
+                handler.extensions.iter().map(|e| e.to_string()).collect();
+            // `generic` is the catch-all fallback handler and was seeded at
+            // priority 0 in migration 014; keep it last in the listing.
+            let priority: i32 = if handler.format_key == "generic" {
+                0
+            } else {
+                100
+            };
+
+            let result = sqlx::query(
+                r#"
+                INSERT INTO format_handlers
+                    (format_key, handler_type, display_name, description, extensions, is_enabled, priority)
+                VALUES ($1, 'core', $2, $3, $4, true, $5)
+                ON CONFLICT (format_key) DO UPDATE SET
+                    display_name = EXCLUDED.display_name,
+                    description  = EXCLUDED.description,
+                    extensions   = EXCLUDED.extensions
+                WHERE format_handlers.handler_type = 'core'
+                "#,
+            )
+            .bind(handler.format_key)
+            .bind(handler.display_name)
+            .bind(handler.description)
+            .bind(&extensions)
+            .bind(priority)
+            .execute(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            synced += result.rows_affected();
+        }
+
+        info!(
+            "Core format handler registry synced: {} rows written across {} compiled-in handlers",
+            synced,
+            crate::formats::core_format_handlers().len()
+        );
+
+        Ok(synced)
+    }
+
     /// List all format handlers with optional filters.
     pub async fn list_format_handlers(
         &self,
@@ -1915,6 +1987,8 @@ impl WasmPluginService {
 mod tests {
     use super::*;
 
+    use crate::models::repository::RepositoryFormat;
+
     // -----------------------------------------------------------------------
     // Pure helper functions (moved from module scope — test-only)
     // -----------------------------------------------------------------------
@@ -2900,5 +2974,230 @@ timeout_secs = 30
     #[test]
     fn test_signature_gate_required_valid_sig_ok() {
         assert!(signature_gate(true, Some("key"), true, true).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Core format handler registry sync (#3157)
+    //
+    // `format_handlers` was seeded once by migration 014 with 13 handlers and
+    // never extended, so `GET /api/v1/formats` under-reported the running
+    // backend by ~24 handlers (including `pub`) and those handlers had no row
+    // to enable/disable. `sync_core_format_handlers` projects the compiled-in
+    // registry into the table at startup.
+    // -----------------------------------------------------------------------
+
+    /// Connect to the test database when `DATABASE_URL` is set; otherwise
+    /// return `None` so the test skips cleanly. A connect failure under
+    /// `AK_TESTS_REQUIRE_DB` panics rather than fiction-greening (#2924).
+    async fn try_pool() -> Option<PgPool> {
+        crate::testing::try_pool_with(3).await
+    }
+
+    /// Build a service bound to `pool`. The plugin registry is real but no
+    /// WASM plugin is loaded, which is exactly the shape a fresh install has.
+    fn format_sync_service(pool: PgPool) -> WasmPluginService {
+        let registry = Arc::new(PluginRegistry::new().expect("plugin registry"));
+        WasmPluginService::new(
+            pool,
+            registry,
+            std::env::temp_dir().join("ak-3157-plugins"),
+            false,
+            None,
+        )
+    }
+
+    /// Format keys present in the listing.
+    async fn listed_keys(svc: &WasmPluginService) -> std::collections::HashSet<String> {
+        svc.list_format_handlers(None, None)
+            .await
+            .expect("list format handlers")
+            .into_iter()
+            .map(|h| h.format_key)
+            .collect()
+    }
+
+    /// Restore the pre-fix state for `keys`: delete the core rows so the table
+    /// holds only what migration 014 seeded.
+    async fn delete_core_rows(pool: &PgPool, keys: &[&str]) {
+        for key in keys {
+            sqlx::query(
+                "DELETE FROM format_handlers WHERE format_key = $1 AND handler_type = 'core'",
+            )
+            .bind(key)
+            .execute(pool)
+            .await
+            .expect("delete core format handler row");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_repository_format_all_matches_the_database_enum() {
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+
+        // Independent oracle: the `repository_format` labels are created by
+        // the migrations, a source maintained separately from the Rust enum.
+        // If a format is added to one and not the other, this fails — which is
+        // the drift that produced #3157 in the first place.
+        let db_labels: Vec<String> = sqlx::query_scalar(
+            "SELECT e.enumlabel::text FROM pg_enum e \
+             JOIN pg_type t ON t.oid = e.enumtypid \
+             WHERE t.typname = 'repository_format'",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("read repository_format enum labels");
+
+        let db: std::collections::HashSet<String> = db_labels.into_iter().collect();
+        let rust: std::collections::HashSet<String> = RepositoryFormat::ALL
+            .iter()
+            .map(|f| f.as_key().to_string())
+            .collect();
+
+        assert!(!db.is_empty(), "repository_format enum has no labels");
+        let missing_in_rust: Vec<_> = db.difference(&rust).collect();
+        let missing_in_db: Vec<_> = rust.difference(&db).collect();
+        assert!(
+            missing_in_rust.is_empty(),
+            "repository_format labels absent from RepositoryFormat::ALL: {:?}",
+            missing_in_rust
+        );
+        assert!(
+            missing_in_db.is_empty(),
+            "RepositoryFormat::ALL entries with no repository_format label: {:?}",
+            missing_in_db
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_core_format_handlers_lists_formats_the_014_seed_missed() {
+        let _guard = crate::api::handlers::test_db_helpers::format_registry_serial_lock().await;
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let svc = format_sync_service(pool.clone());
+
+        // Arrange: the pre-fix state — only what migration 014 seeded.
+        let after_seed = ["pub", "composer", "swift", "protobuf", "incus", "terraform"];
+        delete_core_rows(&pool, &after_seed).await;
+
+        let before = listed_keys(&svc).await;
+        // Positive control in the same fixture: the listing itself works, so
+        // the absence below is a real gap and not an empty/failing endpoint.
+        assert!(
+            before.contains("maven"),
+            "listing is broken: even the seeded 'maven' handler is missing"
+        );
+        for key in after_seed {
+            assert!(
+                !before.contains(key),
+                "fixture did not reproduce the bug: '{}' is already listed",
+                key
+            );
+        }
+
+        // Act.
+        svc.sync_core_format_handlers()
+            .await
+            .expect("sync core format handlers");
+
+        // Assert: every compiled-in handler is now listed.
+        let after = listed_keys(&svc).await;
+        for key in after_seed {
+            assert!(
+                after.contains(key),
+                "'{}' is compiled in but still missing from GET /api/v1/formats",
+                key
+            );
+        }
+        // The originally seeded handlers survive the sync.
+        for key in ["maven", "npm", "oci", "generic"] {
+            assert!(after.contains(key), "sync dropped seeded handler '{}'", key);
+        }
+        assert!(
+            after.len() >= crate::formats::core_format_handlers().len(),
+            "listing ({}) is smaller than the compiled-in registry ({})",
+            after.len(),
+            crate::formats::core_format_handlers().len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_core_format_handlers_preserves_operator_disable() {
+        let _guard = crate::api::handlers::test_db_helpers::format_registry_serial_lock().await;
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let svc = format_sync_service(pool.clone());
+
+        svc.sync_core_format_handlers().await.expect("initial sync");
+
+        // A format added after the 014 seed had no row, so it could not be
+        // disabled at all. It must be togglable now...
+        let disabled = svc
+            .disable_format_handler("cran")
+            .await
+            .expect("disable a handler that the 014 seed never created");
+        assert!(!disabled.is_enabled);
+
+        // ...and the choice must survive the next restart's sync.
+        svc.sync_core_format_handlers()
+            .await
+            .expect("re-sync after disable");
+        let after = svc
+            .get_format_handler("cran")
+            .await
+            .expect("handler still present");
+        assert!(
+            !after.is_enabled,
+            "sync re-enabled a handler the operator had disabled"
+        );
+
+        // Restore.
+        svc.enable_format_handler("cran")
+            .await
+            .expect("re-enable handler");
+    }
+
+    #[tokio::test]
+    async fn test_sync_core_format_handlers_leaves_wasm_owned_rows_alone() {
+        let _guard = crate::api::handlers::test_db_helpers::format_registry_serial_lock().await;
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let svc = format_sync_service(pool.clone());
+
+        // A WASM plugin that claimed a key must keep its own metadata: the
+        // sync only owns rows it created.
+        delete_core_rows(&pool, &["hex"]).await;
+        sqlx::query(
+            "INSERT INTO format_handlers (format_key, handler_type, display_name, description, extensions, is_enabled, priority) \
+             VALUES ('hex', 'wasm', 'Plugin Hex', 'installed by a plugin', ARRAY[]::TEXT[], true, 10) \
+             ON CONFLICT (format_key) DO NOTHING",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed wasm-owned row");
+
+        svc.sync_core_format_handlers()
+            .await
+            .expect("sync core format handlers");
+
+        let row = svc.get_format_handler("hex").await.expect("hex row");
+        assert_eq!(
+            row.display_name, "Plugin Hex",
+            "sync overwrote a WASM-owned format handler row"
+        );
+        assert_eq!(row.handler_type, FormatHandlerType::Wasm);
+
+        // Restore the core row for the rest of the suite.
+        sqlx::query("DELETE FROM format_handlers WHERE format_key = 'hex'")
+            .execute(&pool)
+            .await
+            .expect("drop test row");
+        svc.sync_core_format_handlers()
+            .await
+            .expect("restore core rows");
     }
 }


### PR DESCRIPTION
Fixes #3157

## The gap

`format_handlers` is seeded exactly once — `backend/migrations/014_wasm_plugins.sql:57`, 13 rows — and every format added since extended only the `repository_format` enum. `GET /api/v1/formats` therefore reported 13 of the 37 handlers this binary actually provides; `pub`, `composer`, `swift`, `hex`, `sbt`, `cocoapods`, `cran`, `terraform`, `alpine`, `protobuf`, `incus` and the rest were absent.

The second half of the issue matters as much as the listing: `should_reject_disabled_format` rejects only an explicit `false`, so a format with **no row** is not merely unlisted — it can never be disabled. ~24 handlers were silently exempt from the enable/disable surface the other 13 had. `POST /api/v1/formats/pub/disable` returned 404.

Reproduced on a fresh database at the tip of `main`:

```
$ psql -c "SELECT count(*) FROM format_handlers"
 13
$ psql -tAc "SELECT string_agg(format_key, ',' ORDER BY format_key) FROM format_handlers"
cargo,conan,debian,generic,go,helm,maven,npm,nuget,oci,pypi,rpm,rubygems
```

As the issue notes, this is not upgrade-only: migrations behave identically on a fresh install.

## Direction: registry-authoritative, no new seed migration

The issue offered two options. This takes the second — deriving the answer from the compiled-in registry and treating `format_handlers` as an enablement overlay — because a static seed is what drifted, and the evidence that it drifts is not hypothetical. Three separate hand-written lists of formats existed in this codebase and **all three had already diverged**:

| List | State on `main` |
|---|---|
| migration 014 seed | stopped at 13 (the reported bug) |
| `formats::list_core_formats()` | missing `gradle` |
| `all_repository_formats()` (test helper) | missing `protobuf`, `incus`, `lxc` — so those three were exercised by no handler-registry test |

Adding a fourth would have been a fourth thing to forget.

### What changed

* **`RepositoryFormat::ALL` / `as_key()` / `handler_key()`** (`models/repository.rs`) — the enumeration and the key mappings now live next to the enum. `as_key`/`handler_key` absorb three *already duplicated* exhaustive matches (`derive_format_key`, `format_handler_key`, `FormatHandler::format_key`), which now delegate; each was 51 identical arms.
* **`formats::core_format_handlers()`** — derives one entry per *handler* from `ALL`, collapsing aliases exactly as `get_handler_for_format` does (`gradle`→`maven`, every OCI alias→`oci`, `lxc`→`incus`). That is the granularity `format_handlers` is keyed by and the granularity the enablement gate in `RepositoryService::create` reads, so listing `lxc` separately would have offered a toggle that does nothing. Display metadata is a lookup with a **total fallback** to the raw key: forgetting a line there can cost a format its pretty name, never its presence.
* **`WasmPluginService::sync_core_format_handlers()`** — projects the registry into `format_handlers` at startup (called from `initialize_wasm_plugins`). Deliberately narrow:
  * `is_enabled` is never written on conflict, so an operator's disable survives restarts;
  * `ON CONFLICT ... WHERE format_handlers.handler_type = 'core'` leaves rows a WASM plugin owns untouched;
  * idempotent and safe from several replicas booting at once;
  * a failure is logged, not fatal — the listing degrades to whatever is already in the table rather than refusing traffic.
* **The two drifted lists are now derived** from the same source, which is what surfaced `get_core_handler("gradle") == None` (fixed: `"maven" | "gradle"`).

No migration, so no ledger number to collide with in-flight PRs. Deployments running `SKIP_MIGRATIONS=true` get the sync too, since it is application code.

### Behaviour change worth calling out

Existing deployments gain ~24 rows and therefore ~24 new toggles at once, and "no row" stops being an implicit permanent allow. That is the semantic the issue flagged as a maintainer decision; it is the one that makes the endpoint and the control surface honest, and it is strictly additive — every new row is created enabled, so nothing that worked before stops working. One narrow consequence: a WASM plugin can no longer claim a format key a core handler already owns (it would now conflict). That looks correct — the core handler owns the key — but it is a change.

## Verification

`main` at `ce7f342`, dedicated Postgres, migrations applied.

**Green with the fix** (`cargo nextest run --lib`, the coverage gate's runner):

```
Summary [1.570s] 57 tests run: 57 passed, 14906 skipped
```

Table after the sync: 37 rows, `pub` present and enabled.

**Revert-proof.** The revert restores the pre-fix registry faithfully: before this change the *only* enumeration of format handlers anywhere was migration 014's 13-row `VALUES` list, so `core_format_handlers()` was made to iterate exactly that list, and the database was reset to those 13 rows.

```
FAIL formats::format_tests::tests::test_core_format_handlers_cover_every_format_key
FAIL formats::format_tests::tests::test_core_format_handlers_are_deduplicated_by_handler
FAIL formats::format_tests::tests::test_core_format_handlers_include_handlers_added_after_the_014_seed
FAIL services::wasm_plugin_service::tests::test_sync_core_format_handlers_lists_formats_the_014_seed_missed
FAIL services::wasm_plugin_service::tests::test_sync_core_format_handlers_preserves_operator_disable
Summary [9.526s] 11 tests run: 6 passed, 5 failed, 14952 skipped

panicked at wasm_plugin_service.rs:3102:
  'pub' is compiled in but still missing from GET /api/v1/formats
panicked at wasm_plugin_service.rs:3137:
  disable a handler that the 014 seed never created: NotFound("Format handler 'cran' not found")
```

The `gradle` arm is proved separately — reverting `"maven" | "gradle"` to `"maven"`:

```
panicked at format_tests.rs:840:
  list_core_formats() advertises 'gradle' but get_core_handler() returns None
```

**The assertions are not tautological.** Comparing the endpoint against the registry it is synced from would prove nothing, so each guard uses a source that is *not* the registry:

* `get_core_handler` — the real dispatch table — must have a handler behind every advertised entry.
* `ALL_FORMAT_KEYS`, this module's pre-existing independent list, must map into the registry.
* `test_repository_format_all_matches_the_database_enum` compares `RepositoryFormat::ALL` against `enum_range(NULL::repository_format)`, i.e. the labels the **migrations** create. That is the check that makes the next added format fail CI rather than drift: it is maintained in a different file, in a different language, by a different mechanism.
* The DB test asserts `pub` specifically, per the issue.

**Positive controls**, since three of these are absence assertions on a fixture that deletes rows: the same fixture asserts `maven` *is* listed before the sync (a broken or empty listing cannot satisfy the "pub is missing" arm), and that the 13 originally seeded handlers survive it. The disable test asserts the *round trip* — disable `cran`, re-sync, still disabled, re-enable — so an `is_enabled` clobber and a no-op sync both fail it.

The three DB tests share a `pg_advisory_lock` guard (`format_registry_serial_lock`, following the existing `scan_dedup_serial_lock` pattern), because nextest runs each test in its own process against one database and a peer's sync would otherwise restore the row a test just deleted.

**Regression:** 1345 tests across `repository_service`, `wasm_plugin_service`, `formats::*`, `plugin_registry`, `handlers::plugins` — all pass; 488 `handlers::repositories` tests (the enablement gate's callers) — all pass. `cargo fmt --all` clean, `cargo clippy --lib --tests` clean, `SQLX_OFFLINE=true cargo build --lib --tests` clean (no `sqlx::query!` macro text changed, so `.sqlx` needs no regeneration).
