### PR TITLE
fix(sso): reject empty NameID / empty sub before the external_id lookup

### DIFF
--- a/backend/.sqlx/query-0ad0c56e6850c91ee5dab6835aeb1f3b84d22fbfdfdef2b691e813630edc1999.json
+++ b/backend/.sqlx/query-0ad0c56e6850c91ee5dab6835aeb1f3b84d22fbfdfdef2b691e813630edc1999.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM users WHERE auth_provider = 'saml' AND username LIKE $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0ad0c56e6850c91ee5dab6835aeb1f3b84d22fbfdfdef2b691e813630edc1999"
+}

--- a/backend/.sqlx/query-b89697b5a41226973daf36a9147b7133f0d45e96fe8b58141a1cd7894e6f4048.json
+++ b/backend/.sqlx/query-b89697b5a41226973daf36a9147b7133f0d45e96fe8b58141a1cd7894e6f4048.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM users WHERE auth_provider = 'oidc' AND username LIKE $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b89697b5a41226973daf36a9147b7133f0d45e96fe8b58141a1cd7894e6f4048"
+}

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -518,6 +518,23 @@ impl OidcService {
 
     /// Get or create a user from OIDC information
     pub async fn get_or_create_user(&self, oidc_user: &OidcUserInfo) -> Result<User> {
+        // #3204 (OIDC arm): `sub` is the account key — it is stored in
+        // `users.external_id` and looked up by below. OIDC Core 1.0 §2
+        // REQUIRES a non-empty `sub`, but nothing upstream enforces that a
+        // misbehaving IdP sent one: an empty `sub` deserializes fine and
+        // both the ID-token and userinfo extraction paths pass it through.
+        // Two users resolving to `external_id = ''` would then silently
+        // merge into one account, exactly like the SAML empty-NameID
+        // collapse. Reject before the key can reach the lookup.
+        if oidc_user.sub.trim().is_empty() {
+            return Err(AppError::Authentication(
+                "refusing to resolve an OIDC user with an empty 'sub' claim: the \
+                 subject is the account key (users.external_id), and an empty key \
+                 would collapse distinct federated identities into a single account"
+                    .into(),
+            ));
+        }
+
         // Check if user already exists by external_id (sub)
         let existing_user = sqlx::query_as!(
             User,
@@ -1610,5 +1627,78 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+    }
+
+    /// #3204 (OIDC arm): `sub` is the account key (`users.external_id`), and
+    /// OIDC Core 1.0 §2 requires it to be non-empty — but nothing upstream
+    /// enforces that. The extraction path deliberately passes an empty `sub`
+    /// through (asserted below as a fixture guard), so `get_or_create_user`
+    /// must refuse it before the `WHERE external_id = $1` lookup can collapse
+    /// two such users into one account. DB-backed; no-ops without DATABASE_URL.
+    #[tokio::test]
+    async fn empty_sub_never_reaches_the_external_id_lookup() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let svc = OidcService::with_config(pool.clone(), test_oidc_config());
+        let run = Uuid::new_v4().simple().to_string();
+
+        // Fixture guard: the real ID-token extraction path yields an empty
+        // sub rather than rejecting it — which is exactly why the lookup
+        // layer must be the one to refuse the key.
+        let mut evil = user_from_token("", &format!("sub3204_{run}_evil"), None);
+        assert_eq!(evil.sub, "", "fixture guard: extraction passed '' through");
+        // The email placeholder derives from the sub; make it unique so this
+        // test cannot trip over users_email_key instead of the guard.
+        evil.email = format!("sub3204_{run}_evil@no-email.oidc.invalid");
+
+        let result = svc.get_or_create_user(&evil).await;
+
+        // Cleanup before asserting, in case the guard is absent and the row
+        // was created (scoped to this run's username prefix).
+        sqlx::query!(
+            "DELETE FROM users WHERE auth_provider = 'oidc' AND username LIKE $1",
+            format!("sub3204\\_{}\\_%", run)
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_err(),
+            "an empty OIDC 'sub' must never be used as external_id: the first \
+             such login provisions the '' row every later empty-sub login \
+             resolves to (identity collapse)"
+        );
+
+        // Positive control: two distinct subs provision two distinct accounts.
+        let alice = svc
+            .get_or_create_user(&user_from_token(
+                &format!("sub-{run}-alice"),
+                &format!("sub3204_{run}_alice"),
+                None,
+            ))
+            .await
+            .expect("a real sub must still provision");
+        let bob = svc
+            .get_or_create_user(&user_from_token(
+                &format!("sub-{run}-bob"),
+                &format!("sub3204_{run}_bob"),
+                None,
+            ))
+            .await
+            .expect("a second, distinct sub must still provision");
+        let collapsed = alice.id == bob.id;
+
+        for id in [alice.id, bob.id] {
+            let _ = sqlx::query!("DELETE FROM users WHERE id = $1", id)
+                .execute(&pool)
+                .await;
+        }
+
+        assert!(
+            !collapsed,
+            "distinct subs must resolve to distinct accounts"
+        );
     }
 }

--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -20,6 +20,13 @@ use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
 use crate::services::federated_email::{resolve_federated_email, SAML_NO_EMAIL_DOMAIN};
 
+/// The SAML 2.0 transient NameID format URI (SAML 2.0 Core §8.3.8).
+///
+/// A transient NameID "SHOULD be treated as an opaque and temporary value by
+/// the relying party" — it is a per-session handle, not a stable identifier,
+/// so it can never serve as `users.external_id` (see `extract_user_info`).
+const TRANSIENT_NAME_ID_FORMAT: &str = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient";
+
 /// SAML configuration
 #[derive(Clone)]
 pub struct SamlConfig {
@@ -958,6 +965,47 @@ impl SamlService {
 
     /// Extract user information from assertion
     fn extract_user_info(&self, assertion: &SamlAssertion) -> Result<SamlUserInfo> {
+        // The NameID is the account key: `get_or_create_user` stores it in
+        // `users.external_id` and looks accounts up by it. An empty (or
+        // missing, or whitespace-only — the parser trims text nodes) NameID
+        // therefore is not "a user with no identifier", it is THE SAME
+        // lookup key for every such assertion: the first login provisions a
+        // row with `external_id = ''` and every later empty-NameID login —
+        // any other person at the same IdP — silently resolves to that row
+        // (#3204). Reject at the parse boundary, before any identity is
+        // derived from the assertion.
+        if assertion.name_id.trim().is_empty() {
+            return Err(AppError::Authentication(
+                "SAML assertion has an empty or missing NameID. The NameID is the \
+                 federated account key, so an empty value cannot identify a user; \
+                 configure the IdP to release a stable NameID (persistent or \
+                 emailAddress format)"
+                    .into(),
+            ));
+        }
+
+        // A transient-format NameID is, per SAML 2.0 Core §8.3.8, "an
+        // identifier with transient semantics and SHOULD be treated as an
+        // opaque and temporary value by the relying party". A temporary
+        // per-session value cannot key the durable `users.external_id` row:
+        // at best every login provisions a fresh orphan account, and reuse of
+        // a handle across its validity windows resolves to whichever user
+        // happened to log in under it first. Reject it with a configuration
+        // error instead of provisioning garbage. Absent/unspecified formats
+        // stay accepted: §8.3.1 leaves their interpretation "to individual
+        // implementations", and AK's own AuthnRequest NameIDPolicy requests
+        // the unspecified format.
+        if assertion.name_id_format.as_deref() == Some(TRANSIENT_NAME_ID_FORMAT) {
+            return Err(AppError::Authentication(
+                "SAML assertion NameID uses the transient format \
+                 (urn:oasis:names:tc:SAML:2.0:nameid-format:transient), which is a \
+                 temporary per-session value (SAML 2.0 Core §8.3.8) and cannot be \
+                 used as a stable account identifier; configure the IdP to release \
+                 a persistent or emailAddress NameID"
+                    .into(),
+            ));
+        }
+
         // Get username from configured attribute or NameID
         let username = if self.config.username_attr == "NameID" {
             assertion.name_id.clone()
@@ -1031,6 +1079,21 @@ impl SamlService {
 
     /// Get or create a user from SAML information
     pub async fn get_or_create_user(&self, saml_user: &SamlUserInfo) -> Result<User> {
+        // Defense in depth for #3204: `extract_user_info` already rejects an
+        // empty NameID at the parse boundary, but this method is `pub` and is
+        // the layer where the collapse would actually happen — an empty
+        // `external_id` matches (or provisions) the SAME row for every caller,
+        // merging distinct federated identities into one account. Never let an
+        // empty key reach the lookup.
+        if saml_user.name_id.trim().is_empty() {
+            return Err(AppError::Authentication(
+                "refusing to resolve a SAML user with an empty NameID: the NameID \
+                 is the account key (users.external_id), and an empty key would \
+                 collapse distinct federated identities into a single account"
+                    .into(),
+            ));
+        }
+
         // Check if user already exists by external_id (NameID)
         let existing_user = sqlx::query_as!(
             User,
@@ -4231,5 +4294,247 @@ mod tests {
                 .await
                 .unwrap();
         }
+    }
+
+    // =======================================================================
+    // #3204: an empty NameID must never become the account key
+    // =======================================================================
+
+    /// An empty or whitespace-only NameID is rejected at the parse boundary
+    /// (`extract_user_info`), before any identity is derived. The positive
+    /// control in the same fixture proves a normal assertion still extracts —
+    /// a "fix" that rejected every assertion would fail here too.
+    #[tokio::test]
+    async fn empty_name_id_rejected_at_extraction() {
+        let svc = make_test_saml_service();
+
+        for bad in ["", "   ", "\t\n"] {
+            let result = svc.extract_user_info(&assertion_with(bad, "eve", None));
+            let err = result.expect_err(&format!(
+                "an assertion whose NameID is {bad:?} must be rejected: it would \
+                 become external_id = '' and collapse identities"
+            ));
+            assert!(
+                err.to_string().contains("NameID"),
+                "rejection must name the NameID so operators can act on it: {err}"
+            );
+        }
+
+        // Positive control: the same fixture with a real NameID extracts fine.
+        let ok = svc
+            .extract_user_info(&assertion_with("urn:idp:nameid:real-user", "eve", None))
+            .expect("a normal assertion must still extract");
+        assert_eq!(ok.name_id, "urn:idp:nameid:real-user");
+    }
+
+    /// The three XML shapes that all left `name_id` as `""` in the parsed
+    /// assertion — element absent, element empty, element self-closing — must
+    /// each fail extraction. Parsed through the real parser so the guard sees
+    /// exactly what a live response produces.
+    #[tokio::test]
+    async fn empty_name_id_xml_shapes_all_rejected() {
+        let svc = make_test_saml_service();
+        let real = r#"<saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">john.doe@example.com</saml:NameID>"#;
+        let base = valid_saml_response_xml(Some("_req"));
+        assert!(base.contains(real), "fixture guard: NameID line present");
+
+        for (shape, replacement) in [
+            ("empty element", "<saml:NameID></saml:NameID>"),
+            ("self-closing element", "<saml:NameID/>"),
+            ("whitespace only", "<saml:NameID>   </saml:NameID>"),
+            ("element absent", ""),
+        ] {
+            let xml = base.replace(real, replacement);
+            let assertion = svc
+                .parse_saml_response(&xml)
+                .expect("response parses")
+                .assertion
+                .expect("assertion present");
+            assert!(
+                assertion.name_id.trim().is_empty(),
+                "fixture guard ({shape}): parser must yield an empty name_id, \
+                 or this variant is not exercising the bug"
+            );
+            assert!(
+                svc.extract_user_info(&assertion).is_err(),
+                "{shape}: an assertion with no usable NameID must not extract"
+            );
+        }
+
+        // Positive control: the unmodified response still extracts.
+        let assertion = svc
+            .parse_saml_response(&base)
+            .expect("response parses")
+            .assertion
+            .expect("assertion present");
+        let info = svc
+            .extract_user_info(&assertion)
+            .expect("the unmodified fixture must still extract");
+        assert_eq!(info.name_id, "john.doe@example.com");
+    }
+
+    /// A transient-format NameID is "an opaque and temporary value"
+    /// (SAML 2.0 Core §8.3.8) — a per-session handle that cannot key the
+    /// durable `users.external_id` row. It must be rejected with an error
+    /// naming the format. Persistent (§8.3.7), emailAddress, and absent
+    /// formats (§8.3.1 leaves unspecified "to individual implementations",
+    /// and AK's own NameIDPolicy requests unspecified) all stay accepted.
+    #[tokio::test]
+    async fn transient_name_id_format_rejected_stable_formats_accepted() {
+        let svc = make_test_saml_service();
+
+        let with_format = |format: Option<&str>| SamlAssertion {
+            name_id_format: format.map(String::from),
+            ..assertion_with("urn:idp:nameid:someone", "someone", None)
+        };
+
+        let err = svc
+            .extract_user_info(&with_format(Some(
+                "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+            )))
+            .expect_err("a transient NameID is not a stable account identifier");
+        assert!(
+            err.to_string().contains("transient"),
+            "rejection must name the transient format: {err}"
+        );
+
+        // Positive controls: every stable format still extracts.
+        for ok_format in [
+            Some("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"),
+            Some("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"),
+            Some("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"),
+            None,
+        ] {
+            svc.extract_user_info(&with_format(ok_format))
+                .unwrap_or_else(|e| panic!("format {ok_format:?} must extract: {e}"));
+        }
+    }
+
+    /// The lookup-layer guard: `get_or_create_user` is `pub` and is where the
+    /// collapse physically happens (`WHERE external_id = $1`), so it must
+    /// refuse an empty key even when handed a `SamlUserInfo` that bypassed
+    /// `extract_user_info`. Before the fix this test provisioned a row with
+    /// `external_id = ''` and a second empty-NameID "user" resolved to the
+    /// SAME row — identity collapse. DB-backed; no-ops without DATABASE_URL.
+    #[tokio::test]
+    async fn empty_name_id_never_reaches_the_external_id_lookup() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let svc = SamlService::with_config(pool.clone(), make_test_saml_config());
+        let run = Uuid::new_v4().simple().to_string();
+
+        let info_with = |name_id: &str, tag: &str| SamlUserInfo {
+            name_id: name_id.to_string(),
+            name_id_format: None,
+            session_index: None,
+            username: format!("nameid3204_{run}_{tag}"),
+            email: format!("nameid3204_{run}_{tag}@no-email.saml.invalid"),
+            display_name: None,
+            groups: Vec::new(),
+            attributes: HashMap::new(),
+        };
+
+        // Two DIFFERENT people whose assertions both lost their NameID.
+        let first = svc.get_or_create_user(&info_with("", "first")).await;
+        let second = svc.get_or_create_user(&info_with("  ", "second")).await;
+
+        // Cleanup before asserting, in case the guard is absent and rows were
+        // created (scoped to this run's username prefix, never a real user).
+        sqlx::query!(
+            "DELETE FROM users WHERE auth_provider = 'saml' AND username LIKE $1",
+            format!("nameid3204\\_{}\\_%", run)
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            first.is_err(),
+            "an empty NameID must never be used as external_id: the first such \
+             login provisions the '' row every later empty-NameID login resolves to"
+        );
+        assert!(
+            second.is_err(),
+            "a whitespace-only NameID is the same empty key and must be rejected"
+        );
+
+        // Positive control: two DISTINCT NameIDs provision two DISTINCT
+        // accounts — a guard that simply rejected everything fails here.
+        let alice = svc
+            .get_or_create_user(&info_with(&format!("urn:idp:nameid:{run}-a"), "alice"))
+            .await
+            .expect("a real NameID must still provision");
+        let bob = svc
+            .get_or_create_user(&info_with(&format!("urn:idp:nameid:{run}-b"), "bob"))
+            .await
+            .expect("a second, distinct NameID must still provision");
+        let collapsed = alice.id == bob.id;
+
+        for id in [alice.id, bob.id] {
+            let _ = sqlx::query!("DELETE FROM users WHERE id = $1", id)
+                .execute(&pool)
+                .await;
+        }
+
+        assert!(
+            !collapsed,
+            "distinct NameIDs must resolve to distinct accounts"
+        );
+    }
+
+    /// End to end through the real login path (`authenticate`): a response
+    /// whose assertion carries an empty NameID must fail after the
+    /// InResponseTo session is validated — proving the rejection comes from
+    /// the NameID guard, not from session machinery — and a normal response
+    /// on a second session must still succeed. DB-backed.
+    #[tokio::test]
+    async fn authenticate_rejects_empty_name_id_end_to_end() {
+        use crate::api::handlers::test_db_helpers as db_helpers;
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let service = make_db_saml_service(pool.clone());
+        let real = r#"<saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">john.doe@example.com</saml:NameID>"#;
+
+        // Attack arm: valid session, empty NameID.
+        let request_id = format!("_id{}", Uuid::new_v4());
+        crate::services::auth_config_service::AuthConfigService::create_sso_session_with_state(
+            &pool,
+            "saml",
+            Uuid::new_v4(),
+            &request_id,
+        )
+        .await
+        .expect("create sso session");
+        let xml =
+            valid_saml_response_xml(Some(&request_id)).replace(real, "<saml:NameID></saml:NameID>");
+        assert!(!xml.contains("john.doe"), "fixture guard: NameID emptied");
+        let err = service
+            .authenticate(&base64_encode(xml.as_bytes()))
+            .await
+            .expect_err("an assertion with an empty NameID must not authenticate");
+        assert!(
+            err.to_string().contains("NameID"),
+            "failure must be the NameID guard, not session machinery: {err}"
+        );
+
+        // Positive control: a normal response on a fresh session still logs in.
+        let request_id2 = format!("_id{}", Uuid::new_v4());
+        crate::services::auth_config_service::AuthConfigService::create_sso_session_with_state(
+            &pool,
+            "saml",
+            Uuid::new_v4(),
+            &request_id2,
+        )
+        .await
+        .expect("create second sso session");
+        let ok = service
+            .authenticate(&base64_encode(
+                valid_saml_response_xml(Some(&request_id2)).as_bytes(),
+            ))
+            .await
+            .expect("a normal federated login must still succeed");
+        assert_eq!(ok.name_id, "john.doe@example.com");
     }
 }


### PR DESCRIPTION
Fixes #3204

## The bug

Nothing validated that a SAML assertion's `NameID` was non-empty. The NameID is the account key — `get_or_create_user` stores it in `users.external_id` and resolves accounts by `WHERE external_id = $1 AND auth_provider = 'saml'`. An empty NameID is therefore not "a user with no identifier": it is the **same lookup key for every such assertion**. The first empty-NameID login provisions a row with `external_id = ''`, and every later one — any other person at the same IdP — silently resolves to that same account. Identity collapse, one layer earlier than anything #3202 touched.

All four XML shapes reached the lookup as `""` (asserted as fixture guards in the new tests): element absent, `<NameID></NameID>`, self-closing `<NameID/>`, and whitespace-only content (the parser trims text nodes).

## The fix

Reject at the boundary instead of normalizing into a lookup key:

1. **`extract_user_info` rejects an empty or whitespace-only NameID** at the parse boundary, before any identity is derived from the assertion. Login fails with a clear error naming the NameID; nothing is provisioned.
2. **`extract_user_info` rejects transient-format NameIDs.** Per SAML 2.0 Core §8.3.8, a transient identifier "SHOULD be treated as an opaque and temporary value by the relying party" — a per-session handle can never key the durable `users.external_id` row (at best a fresh orphan account per login; at worst a reused handle resolves to whichever user logged in under it first). Absent/unspecified formats stay accepted: §8.3.1 leaves their interpretation "to individual implementations", and AK's own AuthnRequest `NameIDPolicy` requests the unspecified format, so rejecting it would break the default flow. Persistent (§8.3.7) and emailAddress remain the recommended formats and are covered by positive controls.
3. **`get_or_create_user` (SAML *and* OIDC) refuses an empty account key outright** — defense in depth at the layer where the collapse physically happens. The OIDC arm closes the equivalent hole the issue flagged: OIDC Core 1.0 §2 requires a non-empty `sub`, but nothing upstream enforced it — an empty `sub` deserializes fine and both the ID-token and userinfo extraction paths pass it through (the new OIDC test asserts that pass-through as a fixture guard).

No migration; no schema change; patch-sized for the 1.7.x line.

## Tests (all in-file `#[cfg(test)]`, count for the `--lib` coverage gate)

| Test | What it proves |
|---|---|
| `empty_name_id_rejected_at_extraction` | `""`, `"   "`, `"\t\n"` all rejected; real NameID still extracts (positive control) |
| `empty_name_id_xml_shapes_all_rejected` | the four XML shapes, through the real parser, each fail extraction; unmodified fixture still extracts |
| `transient_name_id_format_rejected_stable_formats_accepted` | transient rejected naming the format; persistent / emailAddress / unspecified / absent all accepted |
| `empty_name_id_never_reaches_the_external_id_lookup` (DB) | empty + whitespace keys refused at the lookup layer even when handed a `SamlUserInfo` directly; two distinct NameIDs still provision two distinct accounts |
| `authenticate_rejects_empty_name_id_end_to_end` (DB) | full login path: valid InResponseTo session + empty-NameID response fails **on the NameID guard** (error text asserted), and a normal response on a second session still logs in |
| `empty_sub_never_reaches_the_external_id_lookup` (DB, OIDC) | extraction passes `sub=""` through (fixture guard), lookup layer refuses it; two distinct subs provision distinct accounts |

**Revert-proof** (run with `DATABASE_URL` set and `AK_TESTS_REQUIRE_DB=1`; DB tests at 0.25–0.44s, i.e. genuinely executed): with the four guard blocks removed the remaining diff vs the merge base is 315 pure insertions inside the two test modules and zero deletions — production code byte-identical to pre-fix. Result: all 6 new tests **FAIL** (`9 tests run: 3 passed, 6 failed` — the 3 passes are unrelated conda tests matched by the name filter), e.g. `panicked at backend/src/services/oidc_service.rs:1650: an empty OIDC 'sub' must never be used as external_id`. With the fix restored: `9 tests run: 9 passed`. Full SSO surface (`saml`/`oidc`/`sso`/`federated`, 453 tests) green; clippy `-D warnings` and fmt clean; `.sqlx` regenerated and `SQLX_OFFLINE=true` build verified.

## Operator remediation — existing collapsed accounts

Deployments that already took empty-NameID (or empty-`sub`) logins may hold a collapsed account: one `users` row with `external_id = ''` carrying several people's history (tokens, uploads, group memberships). This fix stops future logins from reaching it but does not repair it. Release notes for the version shipping this should instruct operators to check:

```sql
SELECT id, username, email, auth_provider, created_at, last_login_at
FROM users
WHERE auth_provider IN ('saml', 'oidc') AND btrim(coalesce(external_id, '')) = '';
```

Any hit should be **deactivated** (`UPDATE users SET is_active = false WHERE id = ...`) rather than deleted — 11 FKs to `users(id)` cascade, and the merged history may be needed for audit. Affected humans re-provision cleanly on next login once the IdP releases a real NameID/`sub`; the row's mixed history cannot be split mechanically and is best reviewed by hand.

## Deliberately out of scope

- `ldap_service.rs` keys `external_id` on the bind DN, which comes from the server's own search result for a successfully authenticated bind — an empty DN is not producible by a client. The third `{username}@unknown` placeholder variant at `ldap_service.rs:637` (noted in the issue) remains for whenever LDAP is next touched, per the issue's own suggestion.
