### PR TITLE
fix(scan-policy): apply the download gate on virtual-repository member downloads

### DIFF
--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -531,7 +531,7 @@ async fn download_chart_via_index(
         for member in &members {
             if member.repo_type != RepositoryType::Remote {
                 // Hosted / staging member: check local storage.
-                if let Ok(result) = proxy_helpers::local_fetch_by_path_suffix(
+                match proxy_helpers::local_fetch_by_path_suffix(
                     &state.db,
                     state,
                     member.id,
@@ -540,12 +540,25 @@ async fn download_chart_via_index(
                 )
                 .await
                 {
-                    return proxy_helpers::stream_fetch_result(
-                        result,
-                        content_type,
-                        Some(filename),
-                    )
-                    .map(Some);
+                    Ok(result) => {
+                        return proxy_helpers::stream_fetch_result(
+                            result,
+                            content_type,
+                            Some(filename),
+                        )
+                        .map(Some);
+                    }
+                    // #3220: this member HAS the chart and its download gate
+                    // (quarantine hold / scan policy) refuses to serve it. Fail
+                    // closed — `continue`ing would fall through to another
+                    // member or upstream and serve the blocked chart with a 200,
+                    // which is how the direct `/helm/<hosted>/charts/<f>` route's
+                    // 403 was bypassable through any virtual listing that repo.
+                    Err(resp) if proxy_helpers::is_member_policy_block_response(&resp) => {
+                        return Err(resp);
+                    }
+                    // Ordinary miss (404) or infrastructure failure: next member.
+                    Err(_) => {}
                 }
                 continue;
             }
@@ -1650,6 +1663,132 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
             StatusCode::OK,
             "negative control: removing the policy must restore the download"
         );
+    }
+
+    /// #3220: the VIRTUAL-member arm of the Helm download must apply the
+    /// resolving member's scan policy, exactly as the direct hosted route does
+    /// (pinned by `test_hosted_chart_download_already_applies_scan_policy_3143`
+    /// immediately above).
+    ///
+    /// `download_chart_via_index` walks members by hand and resolved hosted
+    /// ones through `local_fetch_by_path_suffix` under `if let Ok(..)`, so both
+    /// halves of the bug are exercised here: the helper applied no scan policy,
+    /// and the loop's `continue` would have swallowed the rejection as "this
+    /// member does not have the chart".
+    ///
+    /// The same request against the same member repository is a 403 on
+    /// `/helm/<member>/charts/<f>` — so this test is the bypass in one file:
+    /// direct route refuses, virtual route serves.
+    ///
+    /// POSITIVE CONTROLS in this fixture: the virtual route serves 200 with the
+    /// real chart bytes before the policy exists and again after it is removed.
+    #[tokio::test]
+    async fn test_virtual_member_chart_download_applies_scan_policy_3220() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let blob = bytes::Bytes::from_static(b"helm-virtual-gate-chart-bytes");
+        let filename = "vgatechart-0.2.0.tgz";
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &f.repo_info("local", None),
+            filename,
+            filename,
+            "vgatechart",
+            "0.2.0",
+            "application/gzip",
+            blob.clone(),
+            f.user_id,
+        )
+        .await;
+
+        // A virtual Helm repo whose only member is the fixture's hosted repo.
+        let (virtual_id, virtual_key, _vdir) = tdh::create_repo(&f.pool, "virtual", "helm").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(virtual_id)
+        .bind(f.repo_id)
+        .execute(&f.pool)
+        .await
+        .expect("link virtual member");
+
+        // `download_chart_via_index` early-returns when no proxy service is
+        // wired, so the member loop would never run on the bare fixture state.
+        let storage_path = f.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(f.pool.clone(), &storage_path);
+        let state = tdh::build_state_with_proxy(f.pool.clone(), &storage_path, proxy);
+        let app = || tdh::router_anon(super::router(), state.clone());
+
+        let virtual_uri = format!("/{}/charts/{}", virtual_key, filename);
+        let direct_uri = format!("/{}/charts/{}", f.repo_key, filename);
+
+        // POSITIVE CONTROL: no policy -> the virtual route serves the chart.
+        let (before_status, before_body) = tdh::send(app(), tdh::get(virtual_uri.clone())).await;
+
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3220-helm-{}", f.repo_id))
+        .bind(f.repo_id)
+        .execute(&f.pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let (virtual_blocked, virtual_blocked_body) =
+            tdh::send(app(), tdh::get(virtual_uri.clone())).await;
+        // The direct route on the SAME repository, under the SAME policy: this
+        // is the comparison the bug is defined by.
+        let (direct_blocked, _) = tdh::send(app(), tdh::get(direct_uri)).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(f.repo_id)
+            .execute(&f.pool)
+            .await;
+
+        // NEGATIVE CONTROL: policy removed -> the virtual route serves again.
+        let (after_status, after_body) = tdh::send(app(), tdh::get(virtual_uri)).await;
+
+        tdh::cleanup(&f.pool, virtual_id, f.user_id).await;
+        f.teardown().await;
+
+        assert_eq!(
+            before_status,
+            StatusCode::OK,
+            "positive control: with no scan policy the virtual route must serve the chart"
+        );
+        assert_eq!(
+            &before_body[..],
+            &blob[..],
+            "positive control: the virtual route must serve the seeded chart bytes"
+        );
+        assert_eq!(
+            direct_blocked,
+            StatusCode::FORBIDDEN,
+            "control: the direct hosted route must refuse under this policy"
+        );
+        assert_eq!(
+            virtual_blocked,
+            StatusCode::FORBIDDEN,
+            "#3220: the virtual-member route must refuse the same chart under the same \
+             policy, got {virtual_blocked} body={:?}",
+            String::from_utf8_lossy(&virtual_blocked_body)
+        );
+        assert_ne!(
+            &virtual_blocked_body[..],
+            &blob[..],
+            "#3220: the blocked chart's bytes must not be served through the virtual repo"
+        );
+        assert_eq!(
+            after_status,
+            StatusCode::OK,
+            "negative control: removing the policy must restore the virtual download"
+        );
+        assert_eq!(&after_body[..], &blob[..]);
     }
 
     /// Regression guard for #3150: OCI manifest rows written into a classic

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -326,9 +326,21 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     .map_err(|e| internal_error("Database", e))?
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
-    // Gate 3: Honor quarantine on the primary. A quarantined primary
+    // Gate 3: Honor the primary's full download gate. A quarantined primary
     // means the whole GAV is gated; do not leak its companion files.
+    //
+    // #3220: the scan-policy half (`block_unscanned` / `block_on_fail` /
+    // `max_severity`) is applied here too, for the same reason the quarantine
+    // half is. The companions have no artifact row of their own, so the anchor
+    // primary's verdict is the only verdict there is — and without this a
+    // policy-blocked jar's `.pom` / `-sources.jar` / checksums stayed
+    // downloadable, on the direct hosted route as well as through a virtual.
+    // This mirrors `proxy_helpers::local_lookup_artifact`, which applies the
+    // same two halves to rows that DO exist.
     check_quarantine_row(&primary)?;
+    crate::services::quarantine_service::enforce_scan_policy_gate(db, primary.id, repo_id)
+        .await
+        .map_err(|e| e.into_response())?;
 
     // Gates passed — read the secondary bytes from storage. A storage
     // backend error (transient S3 5xx, network) is mapped to a real
@@ -693,6 +705,92 @@ mod tests {
         }
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    /// #3220: Gate 3 must honour the anchor primary's SCAN POLICY, not only its
+    /// quarantine state.
+    ///
+    /// A row-less companion (`.pom`, `-sources.jar`, `.sha1`, …) has no artifact
+    /// row of its own, so the anchor primary's verdict is the only verdict
+    /// available. Gate 3 called `check_quarantine_row` alone, so a jar that the
+    /// download routes 403 still had its whole companion set served — through a
+    /// virtual repo and on the direct hosted route alike.
+    ///
+    /// POSITIVE CONTROL in the same fixture: the identical fetch serves the
+    /// companion bytes before the policy exists and again after it is removed.
+    #[tokio::test]
+    async fn test_storage_fallback_applies_anchor_scan_policy_3220() {
+        let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
+            return;
+        };
+        let _primary = insert_primary_jar(
+            &pool,
+            repo_id,
+            user_id,
+            "com/example/foo/1.0/foo-1.0.jar",
+            "maven/com/example/foo/1.0/foo-1.0.jar",
+        )
+        .await;
+        let pom_path = "com/example/foo/1.0/foo-1.0.pom";
+        let pom = Bytes::from_static(b"<project>gate-3220-pom</project>");
+        put_artifact_bytes(&state, &repo, &format!("maven/{pom_path}"), pom.clone())
+            .await
+            .expect("put companion");
+        let location = repo.storage_location();
+
+        // POSITIVE CONTROL: no policy -> the companion serves.
+        let before =
+            maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, pom_path)
+                .await
+                .expect("positive control: companion must serve with no scan policy");
+        let before_bytes = before.collect().await.expect("collect companion bytes");
+
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3220-maven-{repo_id}"))
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let blocked =
+            maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, pom_path)
+                .await
+                .err()
+                .map(|resp| resp.status());
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+
+        // NEGATIVE CONTROL: policy removed -> the companion serves again.
+        let after = maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, pom_path)
+            .await
+            .map(|_| ())
+            .map_err(|resp| resp.status());
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+
+        assert_eq!(
+            &before_bytes[..],
+            &pom[..],
+            "positive control: companion bytes"
+        );
+        assert_eq!(
+            blocked,
+            Some(StatusCode::FORBIDDEN),
+            "#3220: a row-less companion must be refused while its anchor primary is \
+             blocked by the repository's scan policy"
+        );
+        assert_eq!(
+            after,
+            Ok(()),
+            "negative control: removing the policy must restore the companion serve"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -810,7 +810,7 @@ pub async fn proxy_fetch_streaming_with_disposition(
 /// produce. Builds a ready-to-serve [`Response`]; errors are mapped to a
 /// [`Response`] exactly as [`proxy_fetch_streaming_with_disposition`] does, so
 /// the streaming virtual-download path can detect a quarantine block via
-/// [`is_quarantine_block_response`].
+/// [`is_member_policy_block_response`].
 async fn proxy_fetch_streaming_member(
     proxy_service: &ProxyService,
     member: &Repository,
@@ -1818,11 +1818,29 @@ pub(crate) enum MemberCacheClass {
 pub(crate) enum MemberResolveOutcome<T, E> {
     /// The member produced the artifact.
     Hit(T),
-    /// The member returned a deliberate Package-Age-Policy quarantine block
-    /// (409/403, #1770) that must surface rather than fall through.
+    /// The member refused to serve: a Package-Age-Policy quarantine block
+    /// (409/403, #1770), or — since #3220 — the member's own download gate
+    /// (quarantine hold / scan policy) rejecting an artifact it *does* hold.
+    /// Either way it must surface rather than fall through to another member.
     Quarantine(E),
     /// The member does not have the artifact; try the next by priority.
     Miss,
+}
+
+impl<T, E> MemberResolveOutcome<T, E> {
+    /// Transform the success payload, leaving `Quarantine` / `Miss` untouched.
+    ///
+    /// Lets a resolver reuse the shared `classify_*` helpers (which produce a
+    /// bare payload) when its own `T` is a tuple carrying extra per-member data
+    /// — e.g. `resolve_virtual_download_streaming` threading the resolved local
+    /// `artifact_id` alongside the built `Response` for #2260 accounting.
+    pub(crate) fn map_hit<U>(self, f: impl FnOnce(T) -> U) -> MemberResolveOutcome<U, E> {
+        match self {
+            MemberResolveOutcome::Hit(t) => MemberResolveOutcome::Hit(f(t)),
+            MemberResolveOutcome::Quarantine(e) => MemberResolveOutcome::Quarantine(e),
+            MemberResolveOutcome::Miss => MemberResolveOutcome::Miss,
+        }
+    }
 }
 
 /// Indices of the members that must be resolved against upstream in Pass 2,
@@ -1873,7 +1891,19 @@ pub(crate) const MAX_VIRTUAL_FANOUT: usize = 16;
 /// Pass 1 calls `probe` on members in priority order, stopping at the first
 /// [`MemberCacheClass::DefiniteHit`] (a cache hit or local artifact). `probe`
 /// must NOT contact upstream — it returns the member's [`MemberCacheClass`]
-/// together with the already-built success payload for a `DefiniteHit`.
+/// together with the already-resolved [`MemberResolveOutcome`] for a
+/// `DefiniteHit`.
+///
+/// That outcome is a full `MemberResolveOutcome`, not just a success payload,
+/// so Pass 1 can express **"this member holds the artifact and refuses to serve
+/// it"** ([`MemberResolveOutcome::Quarantine`]) as distinct from "this member
+/// does not have it" ([`MemberCacheClass::DefiniteMiss`]) — the distinction
+/// #3220 needs for the local download gate. A Pass-1 `Quarantine` is classified
+/// `DefiniteHit`, which is exactly the fail-closed semantic wanted: Pass 1 stops
+/// there, members ranked BELOW it are never probed (so a lower-priority member's
+/// copy of the same coordinate cannot be substituted for a blocked one), and
+/// only members ranked ABOVE it — which legitimately outrank it — can still win
+/// in Pass 2.
 /// Members ranked below the first hit are never probed: they can never win
 /// (`upstream_candidate_indices` only considers members above the first hit),
 /// so this preserves the old sequential loop's warm-path short-circuit —
@@ -1921,7 +1951,7 @@ pub(crate) async fn resolve_members_two_phase<'a, T, E, P, PFut, U, UFut>(
 ) -> Option<MemberResolveOutcome<T, E>>
 where
     P: Fn(&'a Repository) -> PFut,
-    PFut: std::future::Future<Output = (MemberCacheClass, Option<T>)> + 'a,
+    PFut: std::future::Future<Output = (MemberCacheClass, Option<MemberResolveOutcome<T, E>>)> + 'a,
     U: Fn(&'a Repository) -> UFut,
     UFut: std::future::Future<Output = MemberResolveOutcome<T, E>> + 'a,
 {
@@ -1931,7 +1961,7 @@ where
     // so probing the rest would be wasted work (and, for the streaming/metadata
     // resolvers, wasted storage round-trips / body reads on the warm path).
     let mut classes: Vec<MemberCacheClass> = Vec::with_capacity(members.len());
-    let mut pass1_hits: Vec<Option<T>> = Vec::with_capacity(members.len());
+    let mut pass1_hits: Vec<Option<MemberResolveOutcome<T, E>>> = Vec::with_capacity(members.len());
     for member in members {
         let (class, hit) = probe(member).await;
         let is_definite_hit = class == MemberCacheClass::DefiniteHit;
@@ -1942,13 +1972,12 @@ where
         }
     }
 
-    // The highest-priority Pass-1 cache hit is the fallback winner used when
-    // every upstream candidate misses. By construction every candidate index is
-    // higher priority than (below) the first DefiniteHit, so any candidate hit
+    // The highest-priority Pass-1 outcome (a cache hit, or a #3220 terminal
+    // policy rejection) is the fallback winner used when every upstream
+    // candidate misses. By construction every candidate index is higher
+    // priority than (below) the first DefiniteHit, so any candidate hit
     // outranks this fallback.
-    let pass1_winner: Option<MemberResolveOutcome<T, E>> = pass1_hits
-        .into_iter()
-        .find_map(|hit| hit.map(MemberResolveOutcome::Hit));
+    let pass1_winner: Option<MemberResolveOutcome<T, E>> = pass1_hits.into_iter().flatten().next();
 
     let candidates = upstream_candidate_indices(&classes);
     let Some((&first, rest)) = candidates.split_first() else {
@@ -2038,11 +2067,14 @@ where
 /// (A transient sidecar read/parse error is mapped to `Ok(None)` upstream of
 /// this in `read_cached_with_revalidation_streaming`, so it falls through to an
 /// upstream fetch rather than being suppressed here.)
-pub(crate) fn classify_cache_probe<T>(
+pub(crate) fn classify_cache_probe<T, E>(
     probe: Result<Option<T>, crate::error::AppError>,
-) -> (MemberCacheClass, Option<T>) {
+) -> (MemberCacheClass, Option<MemberResolveOutcome<T, E>>) {
     match probe {
-        Ok(Some(hit)) => (MemberCacheClass::DefiniteHit, Some(hit)),
+        Ok(Some(hit)) => (
+            MemberCacheClass::DefiniteHit,
+            Some(MemberResolveOutcome::Hit(hit)),
+        ),
         Ok(None) => (MemberCacheClass::NeedsUpstream, None),
         // A quarantine block must surface (#1770): re-resolve in Pass 2.
         Err(e) if is_quarantine_block(&e) => (MemberCacheClass::NeedsUpstream, None),
@@ -2079,14 +2111,20 @@ pub(crate) fn classify_streaming_cache_probe(
     probe: Result<Option<StreamingFetchResult>, crate::error::AppError>,
     default_content_type: &str,
     content_disposition_filename: Option<&str>,
-) -> (MemberCacheClass, Option<Response>) {
+) -> (
+    MemberCacheClass,
+    Option<MemberResolveOutcome<Response, Response>>,
+) {
     match probe {
         Ok(Some(result)) => match build_streaming_response_with_disposition(
             result,
             default_content_type,
             content_disposition_filename,
         ) {
-            Ok(response) => (MemberCacheClass::DefiniteHit, Some(response)),
+            Ok(response) => (
+                MemberCacheClass::DefiniteHit,
+                Some(MemberResolveOutcome::Hit(response)),
+            ),
             Err(_) => (MemberCacheClass::NeedsUpstream, None),
         },
         Ok(None) => (MemberCacheClass::NeedsUpstream, None),
@@ -2099,23 +2137,43 @@ pub(crate) fn classify_streaming_cache_probe(
 /// Classify a Local/Staging member's buffered fetch for the streaming resolver
 /// (#2069): build the streaming response on a hit (or serve a 500 if header
 /// building fails — that member still "wins" with an error), else a miss.
+///
+/// #3220: a 403/409 from `local_fetch` is the member's own download gate
+/// (quarantine hold or scan policy) refusing an artifact it DOES hold — see
+/// [`local_lookup_artifact`]. That is terminal, not a miss: classifying it
+/// `DefiniteMiss` would let resolution continue to a lower-priority member or
+/// upstream and serve the very bytes the policy blocked, with no 403 anywhere
+/// in the response. It is returned as [`MemberResolveOutcome::Quarantine`]
+/// under `DefiniteHit` so Pass 1 stops here and the block surfaces.
 pub(crate) fn classify_streaming_local(
     fetched: Result<StreamingFetchResult, Response>,
     default_content_type: &str,
     content_disposition_filename: Option<&str>,
-) -> (MemberCacheClass, Option<Response>) {
+) -> (
+    MemberCacheClass,
+    Option<MemberResolveOutcome<Response, Response>>,
+) {
     match fetched {
         Ok(result) => match build_streaming_response_with_disposition(
             result,
             default_content_type,
             content_disposition_filename,
         ) {
-            Ok(response) => (MemberCacheClass::DefiniteHit, Some(response)),
+            Ok(response) => (
+                MemberCacheClass::DefiniteHit,
+                Some(MemberResolveOutcome::Hit(response)),
+            ),
             Err(e) => (
                 MemberCacheClass::DefiniteHit,
-                Some((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()),
+                Some(MemberResolveOutcome::Hit(
+                    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+                )),
             ),
         },
+        Err(resp) if is_member_policy_block_response(&resp) => (
+            MemberCacheClass::DefiniteHit,
+            Some(MemberResolveOutcome::Quarantine(resp)),
+        ),
         Err(_) => (MemberCacheClass::DefiniteMiss, None),
     }
 }
@@ -2128,7 +2186,9 @@ pub(crate) fn classify_streaming_upstream(
 ) -> MemberResolveOutcome<Response, Response> {
     match result {
         Ok(response) => MemberResolveOutcome::Hit(response),
-        Err(resp) if is_quarantine_block_response(&resp) => MemberResolveOutcome::Quarantine(resp),
+        Err(resp) if is_member_policy_block_response(&resp) => {
+            MemberResolveOutcome::Quarantine(resp)
+        }
         Err(_) => MemberResolveOutcome::Miss,
     }
 }
@@ -2254,7 +2314,20 @@ where
             ) {
                 VirtualMemberFetchStrategy::Local => {
                     match local_fetch(member.id, member.storage_location()).await {
-                        Ok(result) => (MemberCacheClass::DefiniteHit, Some(result)),
+                        Ok(result) => (
+                            MemberCacheClass::DefiniteHit,
+                            Some(MemberResolveOutcome::Hit(result)),
+                        ),
+                        // #3220: the member's own download gate (quarantine /
+                        // scan policy) refused an artifact it HOLDS. Terminal,
+                        // not a miss — otherwise the block silently falls
+                        // through to the next member or upstream and the client
+                        // gets the bytes anyway. Fail closed on the member that
+                        // would have served.
+                        Err(resp) if is_member_policy_block_response(&resp) => (
+                            MemberCacheClass::DefiniteHit,
+                            Some(MemberResolveOutcome::Quarantine(resp)),
+                        ),
                         Err(_) => (MemberCacheClass::DefiniteMiss, None),
                     }
                 }
@@ -2307,12 +2380,23 @@ fn is_quarantine_block(e: &crate::error::AppError) -> bool {
     )
 }
 
-/// `Response`-level sibling of [`is_quarantine_block`] for the streaming
-/// virtual-download path, where the member fetch has already mapped its
-/// [`AppError`] to a [`Response`] (#1770). A 409 Conflict (held) or 403
-/// Forbidden (rejected) is a quarantine block that must surface from
-/// virtual-repo resolution rather than fall through to the next member.
-fn is_quarantine_block_response(resp: &Response) -> bool {
+/// `Response`-level sibling of [`is_quarantine_block`]: does this member-fetch
+/// failure mean "the member refuses to serve" rather than "the member does not
+/// have it"?
+///
+/// A 409 Conflict (Package Age Policy hold / quarantine hold) or a 403 Forbidden
+/// (quarantine rejected, or — since #3220 — the repository's scan policy) is a
+/// deliberate block that MUST surface from virtual-repo resolution rather than
+/// fall through to the next member. Every other failure is a miss: a 404 from
+/// the row lookup, a 500 from storage or the database, a 507 from the
+/// coordinated-retry hydration path. `local_lookup_artifact` produces 403/409
+/// from the download gate ALONE — the surrounding steps map their failures to
+/// 400/404/500/507 (see `map_storage_err`) — so this cannot mistake an outage
+/// for a policy decision.
+///
+/// Used by both two-phase resolvers and by the hand-rolled member loops in
+/// `helm::download_chart_via_index` and `pypi::serve_file`.
+pub(crate) fn is_member_policy_block_response(resp: &Response) -> bool {
     matches!(resp.status(), StatusCode::CONFLICT | StatusCode::FORBIDDEN)
 }
 
@@ -2418,12 +2502,19 @@ where
                     // Capture the local artifact id before `fetched` is consumed
                     // into a Response by `classify_streaming_local`.
                     let artifact_id = fetched.as_ref().ok().and_then(|r| r.artifact_id);
-                    let (class, hit) = classify_streaming_local(
+                    let (class, outcome) = classify_streaming_local(
                         fetched,
                         default_content_type,
                         content_disposition_filename,
                     );
-                    (class, hit.map(|resp| (resp, artifact_id)))
+                    // #3220: `classify_streaming_local` may return a terminal
+                    // Quarantine here (the member's download gate refusing an
+                    // artifact it holds); `map_hit` threads the artifact id onto
+                    // the success arm only, leaving that rejection intact.
+                    (
+                        class,
+                        outcome.map(|o| o.map_hit(|resp| (resp, artifact_id))),
+                    )
                 }
                 VirtualMemberFetchStrategy::Proxy => match proxy_service {
                     Some(proxy) => {
@@ -2434,14 +2525,17 @@ where
                             try_member_cache_redirect(state, proxy, member, path).await
                         {
                             // Remote proxy-cache serve: not our artifact (#1278).
-                            (MemberCacheClass::DefiniteHit, Some((redirect, None)))
+                            (
+                                MemberCacheClass::DefiniteHit,
+                                Some(MemberResolveOutcome::Hit((redirect, None))),
+                            )
                         } else {
-                            let (class, hit) = classify_streaming_cache_probe(
+                            let (class, outcome) = classify_streaming_cache_probe(
                                 proxy.streaming_cached_artifact_by_path(member, path).await,
                                 default_content_type,
                                 content_disposition_filename,
                             );
-                            (class, hit.map(|resp| (resp, None)))
+                            (class, outcome.map(|o| o.map_hit(|resp| (resp, None))))
                         }
                     }
                     None => (MemberCacheClass::DefiniteMiss, None),
@@ -2539,7 +2633,10 @@ where
             // than served raw. A fresh hit is transformed into the response.
             match proxy.cached_metadata_if_servable(member, path).await {
                 Ok(Some((bytes, _ct, _enc))) => match transform(bytes, member.key.clone()).await {
-                    Ok(response) => (MemberCacheClass::DefiniteHit, Some(response)),
+                    Ok(response) => (
+                        MemberCacheClass::DefiniteHit,
+                        Some(MemberResolveOutcome::Hit(response)),
+                    ),
                     // The cached bytes failed to transform (e.g. corrupt cached
                     // metadata). Don't treat the member as a definite miss —
                     // fall through to an upstream re-fetch in Pass 2 so a good
@@ -3012,9 +3109,48 @@ impl LocalLookup<'_> {
 }
 
 /// Shared skeleton step 1: resolve the artifact row for `lookup`, enforce the
-/// quarantine policy, and resolve the repo's storage backend. Returns the row
+/// FULL download gate, and resolve the repo's storage backend. Returns the row
 /// and storage so callers can either read bytes or short-circuit (e.g. the
 /// presigned redirect in [`local_fetch_or_redirect`]) before reading.
+///
+/// # The gate (#3220)
+///
+/// This applies both halves of `quarantine_service::enforce_download_gate` —
+/// quarantine AND the repository's scan policy (`block_unscanned` /
+/// `block_on_fail` / `max_severity`). Until #3220 it applied only
+/// [`check_quarantine_row`], the raw quarantine predicate. Since every
+/// `local_fetch_*` helper funnels through here, and those helpers are the
+/// per-member `local_fetch` closures for the ~24 formats that aggregate hosted
+/// repositories behind a Virtual repo, the scan policy was enforced on the
+/// DIRECT hosted route and skipped on the virtual-member route: an artifact
+/// that 403s at `/<format>/hosted/...` was served with a 200 at
+/// `/<format>/virtual/...` whenever the virtual listed that hosted repo as a
+/// member.
+///
+/// It is gated HERE, in the one helper they share, rather than at each of the
+/// ~24 member arms. A hand-repeated check is what produced the gap in the first
+/// place (#3143 closed two arms by hand and the other ~24 stayed open), and a
+/// per-arm check silently omits itself again for the next format added.
+///
+/// The two halves are applied separately rather than by calling
+/// `enforce_download_gate`: [`LocalLookup::select_sql`] already returns the
+/// quarantine columns, so `check_quarantine_row` costs no query, and
+/// `enforce_scan_policy_gate` is the identical policy half `enforce_download_gate`
+/// runs. `repo_id` is the artifact's owning repository — it is the value this
+/// lookup's own `WHERE repository_id = $1` matched on.
+///
+/// # Callers must not swallow the rejection
+///
+/// A gate rejection is a 403 (scan policy / rejected) or 409 (quarantine hold),
+/// distinguishable from a miss (404) or an infrastructure failure (500/507) by
+/// [`is_member_policy_block_response`]. Virtual-member resolution treats an
+/// `Err` from `local_fetch` as "this member does not have it, try the next
+/// one", so a caller that iterates members MUST classify a policy block as a
+/// terminal outcome; otherwise the block degrades into a silent fallback to
+/// another member or to upstream, which serves the bytes anyway and surfaces
+/// nothing. [`resolve_virtual_download_from_members`],
+/// [`resolve_virtual_download_streaming`] and the two hand-rolled member loops
+/// (`helm::download_chart_via_index`, `pypi::serve_file`) all do this.
 async fn local_lookup_artifact(
     db: &PgPool,
     state: &AppState,
@@ -3030,6 +3166,9 @@ async fn local_lookup_artifact(
 > {
     let artifact = lookup.fetch_row(db, repo_id).await?;
     check_quarantine_row(&artifact)?;
+    crate::services::quarantine_service::enforce_scan_policy_gate(db, artifact.id, repo_id)
+        .await
+        .map_err(|e| e.into_response())?;
     let storage = state.storage_for_repo_or_500(location)?;
     Ok((artifact, storage))
 }
@@ -6090,7 +6229,10 @@ mod tests {
             &members,
             |m| {
                 let class = if m.key == "m0" {
-                    (MemberCacheClass::DefiniteHit, Some("cache0".to_string()))
+                    (
+                        MemberCacheClass::DefiniteHit,
+                        Some(MemberResolveOutcome::Hit("cache0".to_string())),
+                    )
                 } else {
                     (MemberCacheClass::NeedsUpstream, None)
                 };
@@ -6122,7 +6264,10 @@ mod tests {
                 let class = if m.key == "m0" {
                     (MemberCacheClass::NeedsUpstream, None)
                 } else {
-                    (MemberCacheClass::DefiniteHit, Some("cache1".to_string()))
+                    (
+                        MemberCacheClass::DefiniteHit,
+                        Some(MemberResolveOutcome::Hit("cache1".to_string())),
+                    )
                 };
                 async move { class }
             },
@@ -6144,7 +6289,10 @@ mod tests {
                 let class = if m.key == "m0" {
                     (MemberCacheClass::NeedsUpstream, None)
                 } else {
-                    (MemberCacheClass::DefiniteHit, Some("cache1".to_string()))
+                    (
+                        MemberCacheClass::DefiniteHit,
+                        Some(MemberResolveOutcome::Hit("cache1".to_string())),
+                    )
                 };
                 async move { class }
             },
@@ -6289,7 +6437,12 @@ mod tests {
             &members,
             move |_m| {
                 p.fetch_add(1, Ordering::SeqCst);
-                async move { (MemberCacheClass::DefiniteHit, Some("hit0".to_string())) }
+                async move {
+                    (
+                        MemberCacheClass::DefiniteHit,
+                        Some(MemberResolveOutcome::Hit("hit0".to_string())),
+                    )
+                }
             },
             move |_m| {
                 u.fetch_add(1, Ordering::SeqCst);
@@ -6384,26 +6537,28 @@ mod tests {
     #[test]
     fn classify_cache_probe_maps_hit_miss_negative() {
         use crate::error::AppError;
-        let (class, hit) = classify_cache_probe::<i32>(Ok(Some(7)));
+        let (class, hit) = classify_cache_probe::<i32, String>(Ok(Some(7)));
         assert_eq!(class, MemberCacheClass::DefiniteHit);
-        assert_eq!(hit, Some(7));
+        assert!(matches!(hit, Some(MemberResolveOutcome::Hit(7))));
 
-        let (class, hit) = classify_cache_probe::<i32>(Ok(None));
+        let (class, hit) = classify_cache_probe::<i32, String>(Ok(None));
         assert_eq!(class, MemberCacheClass::NeedsUpstream);
         assert!(hit.is_none());
 
         // A negative-cached 404 surfaces as Err -> definite miss (no re-fetch).
-        let (class, hit) = classify_cache_probe::<i32>(Err(AppError::NotFound("neg".into())));
+        let (class, hit) =
+            classify_cache_probe::<i32, String>(Err(AppError::NotFound("neg".into())));
         assert_eq!(class, MemberCacheClass::DefiniteMiss);
         assert!(hit.is_none());
 
         // A quarantine block (#1770) from a *cached* held entry must NOT be
         // dropped: it is re-resolved in Pass 2 (which surfaces the 409/403),
         // so it classifies NeedsUpstream, not DefiniteMiss.
-        let (class, _) = classify_cache_probe::<i32>(Err(AppError::Conflict("held".into())));
+        let (class, _) =
+            classify_cache_probe::<i32, String>(Err(AppError::Conflict("held".into())));
         assert_eq!(class, MemberCacheClass::NeedsUpstream);
         let (class, _) =
-            classify_cache_probe::<i32>(Err(AppError::Authorization("rejected".into())));
+            classify_cache_probe::<i32, String>(Err(AppError::Authorization("rejected".into())));
         assert_eq!(class, MemberCacheClass::NeedsUpstream);
     }
 
@@ -6459,12 +6614,65 @@ mod tests {
         let (class, resp) =
             classify_streaming_local(Ok(empty_stream_result()), "application/json", Some("f.bin"));
         assert_eq!(class, MemberCacheClass::DefiniteHit);
-        assert!(resp.is_some());
+        assert!(matches!(resp, Some(MemberResolveOutcome::Hit(_))));
 
         let miss = Err((StatusCode::NOT_FOUND, "missing").into_response());
         let (class, resp) = classify_streaming_local(miss, "application/json", None);
         assert_eq!(class, MemberCacheClass::DefiniteMiss);
         assert!(resp.is_none());
+    }
+
+    /// #3220: a local member's download-gate rejection is a TERMINAL outcome,
+    /// not a member miss.
+    ///
+    /// The distinction is the whole fix: `DefiniteMiss` means "try the next
+    /// member / upstream", which converts a 403 into a silent fallback that
+    /// serves the blocked bytes anyway. `DefiniteHit` + `Quarantine` stops
+    /// Pass 1 (so no lower-priority member is even probed) and surfaces the
+    /// status the gate produced.
+    ///
+    /// The 404/500 arms are the control: they must STAY `DefiniteMiss`, or a
+    /// member that genuinely lacks the artifact would fail the whole virtual
+    /// request instead of deferring to a sibling that has it.
+    #[test]
+    fn classify_streaming_local_policy_block_is_terminal_3220() {
+        for status in [StatusCode::FORBIDDEN, StatusCode::CONFLICT] {
+            let blocked = Err((status, "blocked by policy").into_response());
+            let (class, outcome) = classify_streaming_local(blocked, "application/json", None);
+            assert_eq!(
+                class,
+                MemberCacheClass::DefiniteHit,
+                "#3220: a {status} download-gate block must stop Pass 1, not read as a miss"
+            );
+            match outcome {
+                Some(MemberResolveOutcome::Quarantine(resp)) => assert_eq!(
+                    resp.status(),
+                    status,
+                    "#3220: the gate's own status must be the one surfaced"
+                ),
+                other => panic!("#3220: expected a terminal Quarantine outcome, got {other:?}"),
+            }
+        }
+
+        // Controls: a real miss and a real infrastructure failure must still
+        // defer to the next member.
+        for status in [
+            StatusCode::NOT_FOUND,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INSUFFICIENT_STORAGE,
+        ] {
+            let (class, outcome) = classify_streaming_local(
+                Err((status, "not a policy decision").into_response()),
+                "application/json",
+                None,
+            );
+            assert_eq!(
+                class,
+                MemberCacheClass::DefiniteMiss,
+                "a {status} is not a policy block and must remain a member miss"
+            );
+            assert!(outcome.is_none());
+        }
     }
 
     #[test]
@@ -6621,7 +6829,7 @@ mod tests {
             ),
         );
         assert_eq!(resp.status(), StatusCode::CONFLICT);
-        assert!(is_quarantine_block_response(&resp));
+        assert!(is_member_policy_block_response(&resp));
     }
 
     #[test]
@@ -6632,7 +6840,7 @@ mod tests {
             crate::error::AppError::Authorization("Artifact was rejected".into()),
         );
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-        assert!(is_quarantine_block_response(&resp));
+        assert!(is_member_policy_block_response(&resp));
     }
 
     #[test]
@@ -6643,7 +6851,7 @@ mod tests {
             crate::error::AppError::Storage("connection reset".into()),
         );
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
-        assert!(!is_quarantine_block_response(&resp));
+        assert!(!is_member_policy_block_response(&resp));
     }
 
     // ── promotion_only direct-upload gate ───────────────────────────
@@ -11861,6 +12069,326 @@ mod tests {
         assert_eq!(
             recorded, 1,
             "a virtual-member local resolve must record exactly one download"
+        );
+    }
+
+    // ── #3220: the download gate on virtual-member local serves ─────────
+
+    /// Seed `content` into a member repo's storage and insert its `artifacts`
+    /// row. Returns the artifact id.
+    #[allow(clippy::too_many_arguments)]
+    async fn seed_member_artifact_3220(
+        state: &crate::api::SharedState,
+        pool: &PgPool,
+        member_id: Uuid,
+        member_key: &str,
+        member_dir: &std::path::Path,
+        path: &str,
+        content: &'static [u8],
+        user_id: Uuid,
+    ) -> Uuid {
+        let info = crate::api::handlers::test_db_helpers::make_repo_info(
+            member_id, member_key, member_dir, "local", None,
+        );
+        let storage_key = format!("{member_key}/{path}");
+        put_artifact_bytes(state, &info, &storage_key, Bytes::from_static(content))
+            .await
+            .expect("seed member payload on disk");
+        insert_artifact(
+            pool,
+            NewArtifact {
+                repository_id: member_id,
+                path,
+                name: "gate3220",
+                version: "1.0.0",
+                size_bytes: content.len() as i64,
+                checksum_sha256: "test-3220",
+                content_type: "application/octet-stream",
+                storage_key: &storage_key,
+                uploaded_by: user_id,
+            },
+        )
+        .await
+        .expect("seed member artifact row")
+    }
+
+    /// Enable `block_unscanned` on `repo_id`. Seeded artifacts have no
+    /// `scan_results` rows at all, so they are unscanned and the policy blocks
+    /// them — the same policy shape #3143 used for the direct routes.
+    async fn enable_block_unscanned_3220(pool: &PgPool, repo_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3220-{repo_id}"))
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("insert block_unscanned policy");
+    }
+
+    async fn drop_scan_policies_3220(pool: &PgPool, repo_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+    }
+
+    /// Resolve `path` through the buffered virtual-download resolver exactly as
+    /// the ~24 format handlers do — `local_fetch_by_path` as the per-member
+    /// `local_fetch` closure, `proxy_service: None` so only Local members can
+    /// win. Returns the served status and body.
+    async fn virtual_download_3220(
+        state: &crate::api::SharedState,
+        pool: &PgPool,
+        virtual_id: Uuid,
+        path: &str,
+    ) -> (StatusCode, Bytes) {
+        let db = pool.clone();
+        let st = state.clone();
+        let p = path.to_string();
+        let resolved = resolve_virtual_download(
+            pool,
+            crate::api::handlers::test_db_helpers::admin_auth_ext().as_ref(),
+            None,
+            virtual_id,
+            path,
+            move |mid, loc| {
+                let db = db.clone();
+                let st = st.clone();
+                let p = p.clone();
+                async move { local_fetch_by_path(&db, &st, mid, &loc, &p).await }
+            },
+        )
+        .await;
+        let response = match resolved {
+            Ok(result) => match stream_fetch_result(result, "application/octet-stream", None) {
+                Ok(r) => r,
+                Err(e) => e,
+            },
+            Err(e) => e,
+        };
+        let (status, body, _) =
+            crate::api::handlers::test_db_helpers::collect_response(response).await;
+        (status, body)
+    }
+
+    /// #3220: a virtual repo must apply its resolving member's scan policy to
+    /// the bytes it serves on that member's behalf.
+    ///
+    /// `local_lookup_artifact` — the helper every `local_fetch_*` funnels
+    /// through, and hence every virtual-member arm across ~24 formats — applied
+    /// only `check_quarantine_row`, the raw quarantine predicate.
+    /// `block_unscanned` / `block_on_fail` / `max_severity` were never
+    /// consulted, so an artifact the direct hosted route 403s was served with a
+    /// 200 through any virtual repo that listed its repository as a member.
+    ///
+    /// POSITIVE CONTROLS, both in this fixture:
+    ///   * the identical request serves 200 with the real bytes BEFORE the
+    ///     policy exists, and again AFTER it is removed — so the 403 is
+    ///     attributable to the policy, not to a resolver that stopped working;
+    ///   * a sibling member with NO policy keeps serving its own artifact with
+    ///     a 200 while the block is in force — so a "fix" that fails the whole
+    ///     virtual, or blocks unconditionally, fails this test.
+    #[tokio::test]
+    async fn test_virtual_member_download_applies_scan_policy_3220() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (virtual_id, _vkey, _vdir) = db_helpers::create_repo(&pool, "virtual", "generic").await;
+        let (gated_id, gated_key, gated_dir) =
+            db_helpers::create_repo(&pool, "local", "generic").await;
+        let (clean_id, clean_key, clean_dir) =
+            db_helpers::create_repo(&pool, "local", "generic").await;
+        db_helpers::link_member(&pool, virtual_id, gated_id, 0).await;
+        db_helpers::link_member(&pool, virtual_id, clean_id, 1).await;
+
+        let state = db_helpers::build_state(pool.clone(), gated_dir.to_str().unwrap());
+        let clean_state = db_helpers::build_state(pool.clone(), clean_dir.to_str().unwrap());
+
+        let gated_bytes: &[u8] = b"#3220 gated member payload";
+        let clean_bytes: &[u8] = b"#3220 sibling member payload";
+        let gated_path = "gate3220/gate3220-1.0.0.bin";
+        let clean_path = "gate3220/sibling-1.0.0.bin";
+        seed_member_artifact_3220(
+            &state,
+            &pool,
+            gated_id,
+            &gated_key,
+            &gated_dir,
+            gated_path,
+            gated_bytes,
+            user_id,
+        )
+        .await;
+        seed_member_artifact_3220(
+            &clean_state,
+            &pool,
+            clean_id,
+            &clean_key,
+            &clean_dir,
+            clean_path,
+            clean_bytes,
+            user_id,
+        )
+        .await;
+
+        // POSITIVE CONTROL: no policy anywhere -> the virtual serves the bytes.
+        let (before_status, before_body) =
+            virtual_download_3220(&state, &pool, virtual_id, gated_path).await;
+
+        enable_block_unscanned_3220(&pool, gated_id).await;
+
+        let (blocked_status, blocked_body) =
+            virtual_download_3220(&state, &pool, virtual_id, gated_path).await;
+        // POSITIVE CONTROL, policy in force: the un-policied sibling still serves.
+        let (sibling_status, sibling_body) =
+            virtual_download_3220(&clean_state, &pool, virtual_id, clean_path).await;
+
+        drop_scan_policies_3220(&pool, gated_id).await;
+
+        // NEGATIVE CONTROL: removing the policy restores the download.
+        let (after_status, after_body) =
+            virtual_download_3220(&state, &pool, virtual_id, gated_path).await;
+
+        db_helpers::cleanup(&pool, gated_id, user_id).await;
+        db_helpers::cleanup(&pool, clean_id, user_id).await;
+        db_helpers::cleanup(&pool, virtual_id, user_id).await;
+
+        assert_eq!(
+            before_status,
+            StatusCode::OK,
+            "positive control: with no scan policy the virtual member must serve"
+        );
+        assert_eq!(
+            before_body.as_ref(),
+            gated_bytes,
+            "positive control: the served bytes must be the seeded artifact"
+        );
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "#3220: an unscanned artifact under block_unscanned must be refused with 403 \
+             through the virtual repo, got {blocked_status} body={:?}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_ne!(
+            blocked_body.as_ref(),
+            gated_bytes,
+            "#3220: the blocked artifact's bytes must not be served"
+        );
+        assert_eq!(
+            sibling_status,
+            StatusCode::OK,
+            "positive control: a member with no policy must keep serving while another \
+             member's artifact is blocked"
+        );
+        assert_eq!(sibling_body.as_ref(), clean_bytes);
+        assert_eq!(
+            after_status,
+            StatusCode::OK,
+            "negative control: removing the policy must restore the download"
+        );
+        assert_eq!(after_body.as_ref(), gated_bytes);
+    }
+
+    /// #3220, the fall-through half: a policy block on the winning member must
+    /// FAIL CLOSED, not silently resolve to a lower-priority member's copy of
+    /// the same coordinate.
+    ///
+    /// This is the shape the bypass actually took. `resolve_virtual_download`'s
+    /// Pass-1 probe mapped every `Err` from `local_fetch` to `DefiniteMiss` —
+    /// "this member does not have it, try the next one" — so gating inside
+    /// `local_lookup_artifact` without also giving the resolver a terminal
+    /// outcome would have converted the 403 into a silent fallback: the client
+    /// still gets bytes, and nothing surfaces the block.
+    ///
+    /// The pre-fix behaviour here is a 200 carrying the FALLBACK member's
+    /// bytes, so this assertion cannot be satisfied by a change that merely
+    /// makes everything fail — and the positive control (same fixture, no
+    /// policy) pins that the higher-priority member is the one that wins.
+    #[tokio::test]
+    async fn test_virtual_member_policy_block_does_not_fall_through_3220() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (virtual_id, _vkey, _vdir) = db_helpers::create_repo(&pool, "virtual", "generic").await;
+        let (top_id, top_key, top_dir) = db_helpers::create_repo(&pool, "local", "generic").await;
+        let (fallback_id, fallback_key, fallback_dir) =
+            db_helpers::create_repo(&pool, "local", "generic").await;
+        // Same coordinate held by BOTH members; `top` outranks `fallback`.
+        db_helpers::link_member(&pool, virtual_id, top_id, 0).await;
+        db_helpers::link_member(&pool, virtual_id, fallback_id, 1).await;
+
+        let top_state = db_helpers::build_state(pool.clone(), top_dir.to_str().unwrap());
+        let fallback_state = db_helpers::build_state(pool.clone(), fallback_dir.to_str().unwrap());
+
+        let path = "gate3220/shared-1.0.0.bin";
+        let top_bytes: &[u8] = b"#3220 blocked copy from the top member";
+        let fallback_bytes: &[u8] = b"#3220 unblocked copy from the fallback member";
+        seed_member_artifact_3220(
+            &top_state, &pool, top_id, &top_key, &top_dir, path, top_bytes, user_id,
+        )
+        .await;
+        seed_member_artifact_3220(
+            &fallback_state,
+            &pool,
+            fallback_id,
+            &fallback_key,
+            &fallback_dir,
+            path,
+            fallback_bytes,
+            user_id,
+        )
+        .await;
+
+        // POSITIVE CONTROL: with no policy the higher-priority member wins.
+        let (before_status, before_body) =
+            virtual_download_3220(&top_state, &pool, virtual_id, path).await;
+
+        // Block ONLY the winning member. The fallback stays freely servable, so
+        // a resolver that treats the block as a miss will happily serve it.
+        enable_block_unscanned_3220(&pool, top_id).await;
+
+        let (blocked_status, blocked_body) =
+            virtual_download_3220(&top_state, &pool, virtual_id, path).await;
+
+        drop_scan_policies_3220(&pool, top_id).await;
+
+        db_helpers::cleanup(&pool, top_id, user_id).await;
+        db_helpers::cleanup(&pool, fallback_id, user_id).await;
+        db_helpers::cleanup(&pool, virtual_id, user_id).await;
+
+        assert_eq!(
+            before_status,
+            StatusCode::OK,
+            "positive control: with no policy the virtual must resolve this coordinate"
+        );
+        assert_eq!(
+            before_body.as_ref(),
+            top_bytes,
+            "positive control: the higher-priority member must be the one that wins"
+        );
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "#3220: a policy block on the winning member must fail closed with 403, \
+             got {blocked_status} body={:?}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_ne!(
+            blocked_body.as_ref(),
+            fallback_bytes,
+            "#3220: the block must NOT silently fall through to a lower-priority member's \
+             copy of the same coordinate — that is the bypass, with a 200 and no signal"
+        );
+        assert_ne!(
+            blocked_body.as_ref(),
+            top_bytes,
+            "#3220: the blocked member's own bytes must not be served either"
         );
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2680,6 +2680,20 @@ async fn serve_file(
                         Ok(response) => {
                             return Ok(response);
                         }
+                        // #3220: this member HAS the distribution and its
+                        // download gate (quarantine hold / scan policy) refuses
+                        // to serve it. Fail closed — falling through would try
+                        // the member's own upstream, or the next member, and
+                        // serve the blocked file with a 200, which is how the
+                        // direct hosted route's 403 was bypassable through any
+                        // virtual listing that repo. Note this deliberately
+                        // differs from the per-member curation skip above: a
+                        // curation rule says "this member must not supply this
+                        // package" (a sibling still may), whereas the download
+                        // gate says "these bytes must not be served".
+                        Err(e) if proxy_helpers::is_member_policy_block_response(&e) => {
+                            return Err(e);
+                        }
                         Err(e) => {
                             debug!(
                                 member_key = %member.key,
@@ -12798,6 +12812,144 @@ mod tests {
                 "vulnerable-via-virtual pypi serve must be 403"
             ),
         }
+    }
+
+    /// Buffer a `serve_file` outcome (Ok or Err) into (status, body) for the
+    /// #3220 gate assertions below.
+    async fn collect_serve_3220(r: Result<Response, Response>) -> (StatusCode, Bytes) {
+        let resp = match r {
+            Ok(resp) => resp,
+            Err(resp) => resp,
+        };
+        let (status, body, _) = crate::api::handlers::test_db_helpers::collect_response(resp).await;
+        (status, body)
+    }
+
+    /// #3220: `serve_file`'s virtual-member loop must apply the resolving
+    /// member's DOWNLOAD gate (quarantine + scan policy) to the bytes it serves
+    /// from that member's local row, and must fail closed when it blocks.
+    ///
+    /// Two independent defects met on this path. `local_fetch_or_redirect_by_suffix`
+    /// applied only the raw quarantine predicate, so `block_unscanned` /
+    /// `block_on_fail` / `max_severity` were never consulted. And the loop's
+    /// `Err(e) => debug!(...)` arm treated any failure as "this member does not
+    /// have it", so even once the gate existed its 403 would have fallen through
+    /// to the member's own upstream — which happily returns the wheel.
+    ///
+    /// The upstream mock therefore serves DIFFERENT bytes from the cached copy:
+    /// a fall-through is observable as a 200 carrying the upstream bytes, not
+    /// merely as "not a 403". The positive control (no policy -> 200 with the
+    /// CACHED bytes) is in the same fixture, so a change that blocks everything,
+    /// or that stops resolving the member at all, fails this test.
+    #[tokio::test]
+    async fn test_virtual_serve_file_applies_member_download_gate_3220() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::MockServer;
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pypi").await else {
+            return;
+        };
+        let project = "gatepkg";
+        let version = "1.0.0";
+        let filename = "gatepkg-1.0.0-py3-none-any.whl";
+        // Distinct from `seed_member_wheel`'s cached payload on purpose.
+        let upstream_wheel: &[u8] = b"PK\x03\x04 gatepkg-from-UPSTREAM-not-cache";
+        let cached_wheel: &[u8] = b"PK\x03\x04 virtual-member-wheel";
+
+        let upstream = MockServer::start().await;
+        mount_scan_upstream(&upstream, project, filename, upstream_wheel).await;
+
+        let (member_id, member_key, member_dir, state) =
+            setup_virtual_pypi_member(&fx, false, &upstream.uri()).await;
+        seed_member_wheel(
+            &state,
+            &fx.pool,
+            fx.user_id,
+            member_id,
+            &member_key,
+            &member_dir,
+            &upstream.uri(),
+            project,
+            version,
+            filename,
+        )
+        .await;
+
+        let virtual_info = fx.repo_info("virtual", None);
+        let project_name = proj(project);
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext::default();
+        let serve = || {
+            super::serve_file(
+                &state,
+                &virtual_info,
+                &fx.repo_key,
+                &project_name,
+                filename,
+                None,
+                &ctx,
+            )
+        };
+
+        // POSITIVE CONTROL: no policy -> the cached member copy is served.
+        let (before_status, before_body) = collect_serve_3220(serve().await).await;
+
+        sqlx::query(
+            "INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, \
+                                        block_on_fail, is_enabled) \
+             VALUES ($1, $2, 'critical', true, false, true)",
+        )
+        .bind(format!("gate-3220-pypi-{member_id}"))
+        .bind(member_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert block_unscanned policy");
+
+        let (blocked_status, blocked_body) = collect_serve_3220(serve().await).await;
+
+        let _ = sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+            .bind(member_id)
+            .execute(&fx.pool)
+            .await;
+
+        // NEGATIVE CONTROL: policy removed -> serving resumes.
+        let (after_status, after_body) = collect_serve_3220(serve().await).await;
+
+        cleanup_virtual_member(&fx.pool, member_id, &member_dir).await;
+        fx.teardown().await;
+
+        assert_eq!(
+            before_status,
+            StatusCode::OK,
+            "positive control: with no scan policy the virtual member must serve"
+        );
+        assert_eq!(
+            &before_body[..],
+            cached_wheel,
+            "positive control: the member's cached copy is what serves"
+        );
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "#3220: an unscanned wheel under block_unscanned must be refused with 403 \
+             through the virtual repo, got {blocked_status}"
+        );
+        assert_ne!(
+            &blocked_body[..],
+            cached_wheel,
+            "#3220: the blocked wheel's bytes must not be served"
+        );
+        assert_ne!(
+            &blocked_body[..],
+            upstream_wheel,
+            "#3220: the block must not fall through to the member's upstream — that is the \
+             silent fallback that turns a policy block into a 200"
+        );
+        assert_eq!(
+            after_status,
+            StatusCode::OK,
+            "negative control: removing the policy must restore the download"
+        );
+        assert_eq!(&after_body[..], cached_wheel);
     }
 
     /// Clean via virtual -> 200 (no over-block).

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -655,6 +655,31 @@ pub async fn enforce_download_gate(db: &PgPool, artifact_id: Uuid) -> Result<()>
     check_download_allowed(status.as_deref(), until, Utc::now())?;
 
     // Scan-policy gate. No-op (allowed) when no enabled policy matches the repo.
+    enforce_scan_policy_gate(db, artifact_id, repository_id).await
+}
+
+/// The scan-policy half of [`enforce_download_gate`], for callers that have
+/// ALREADY applied the quarantine half from a row they hold (#3220).
+///
+/// `proxy_helpers::local_lookup_artifact` selects `quarantine_status` /
+/// `quarantine_until` in the same round trip that resolves the artifact, so it
+/// evaluates quarantine in-process via `check_quarantine_row` and only needs
+/// this half — calling the whole of [`enforce_download_gate`] there would
+/// re-read the quarantine columns it already has, once per probed virtual
+/// member. Splitting it (rather than open-coding `PolicyService` at the second
+/// call site) keeps ONE implementation of "what the scan policy decides and how
+/// a block is rendered": the hand-repeated variant is exactly what left the
+/// virtual-member paths quarantine-only while the direct paths were gated.
+///
+/// `repository_id` must be the artifact's owning repository. Both callers
+/// satisfy this by construction: [`enforce_download_gate`] reads it from the
+/// artifact row, and `local_lookup_artifact` passes the `repository_id` its own
+/// `WHERE` clause matched on.
+pub async fn enforce_scan_policy_gate(
+    db: &PgPool,
+    artifact_id: Uuid,
+    repository_id: Uuid,
+) -> Result<()> {
     let policy_result = crate::services::policy_service::PolicyService::new(db.clone())
         .evaluate_artifact(artifact_id, repository_id)
         .await?;


### PR DESCRIPTION
## Problem

`enforce_download_gate` (#2954) is the shared download choke point: quarantine **and** the repository's scan policy (`block_unscanned` / `block_on_fail` / `max_severity`). Every format's **direct hosted** route reaches it. The **virtual-member** route of ~24 formats did not.

Every virtual-member local serve funnels through `proxy_helpers::local_lookup_artifact`, whose only gate was `check_quarantine_row` — the raw quarantine predicate. So a scan-policy block on a hosted repository was bypassable by pulling the same artifact through any virtual repository that listed it as a member.

Reproduced at the merge base, in one fixture — same repository, same policy, two routes:

```
control: the direct hosted route must refuse under this policy   -> 403 ✔
assertion `left == right` failed: #3220: the virtual-member route must refuse the
same chart under the same policy, got 200 OK body="helm-virtual-gate-chart-bytes"
  left: 200
 right: 403
```

## Affected paths, verified against source

Two families reach `local_lookup_artifact`, and both were open.

**A. The two-phase virtual resolvers** (`resolve_virtual_download`, `resolve_virtual_download_from_members`, `resolve_virtual_download_streaming`), whose per-member `local_fetch` closures are `local_fetch_by_path` / `_by_name_version` / `_by_name_version_and_suffix` / `_by_path_suffix` / `local_fetch_or_redirect`:

`alpine`, `cargo`, `chef`, `cocoapods`, `composer`, `conan`, `conda`, `debian`, `gitlfs`, `goproxy`, `hex`, `huggingface`, `jetbrains`, `maven`, `npm`, `nuget`, `protobuf`, `pub`, `sbt`, `swift`, `terraform`, `vscode`, plus the generic `repositories` virtual arm.

Note the issue's list understates the reach: the Virtual arm of `try_remote_or_virtual_download` routes through `resolve_virtual_download_streaming` too, so `ansible`, `cran`, `puppet`, `rpm` and `rubygems` were also affected through it.

**B. Two hand-rolled member loops** that do not use the resolvers:

* `helm::download_chart_via_index` — `if let Ok(..) { .. } continue;` over `local_fetch_by_path_suffix`
* `pypi::serve_file` — `match ..local_fetch_or_redirect_by_suffix { Err(e) => debug!(..) }`, then falls on to the member's own upstream

Also fixed, from the issue's "plus `maven_proxy.rs:268/331`": `maven_local_fetch_storage_fallback`'s Gate 3 checked the anchor primary's quarantine but not its scan policy. Row-less companions (`.pom`, `-sources.jar`, `.sha1`, …) have no artifact row, so the anchor's verdict is the only verdict there is — a policy-blocked jar still had its whole companion set served, on the direct hosted route as well as through a virtual.

**Not** in scope, matching the issue's own split: `oci_v2::handle_get_blob` and `rpm::serve_version_package` serve bytes with no `artifacts` row, so there is no `artifact_id` to gate on. Unchanged.

## Fix: at the shared helper, not per path

Gated in `local_lookup_artifact`, the one helper all ~24 member arms share, rather than at each arm. Hand-repeating the check is what produced this gap: #3143 closed two arms by hand and the other ~24 stayed open, and a per-arm check silently omits itself again for the next format added.

That required resolving the design question the issue raised, because gating there alone would have been **worse than the bug**.

### 1. The gate (`local_lookup_artifact`)

Both halves of `enforce_download_gate` now apply. The scan-policy half is factored out as `quarantine_service::enforce_scan_policy_gate` and reused, so there is exactly one implementation of what the policy decides and how a block renders. The quarantine half stays in-process on the row the lookup already selected (`LocalLookup::select_sql` returns the quarantine columns), so **no extra query is added** — the change costs one policy evaluation, not a re-read.

`repo_id` is the artifact's owning repository by construction: it is the value the lookup's own `WHERE repository_id = $1` matched on.

### 2. The rejection is terminal, not a member miss

Virtual resolution treats an `Err` from `local_fetch` as *"this member does not have it, try the next one"*. Gating without changing that converts a policy block into a **silent fallback** — the client still gets bytes and nothing surfaces the block. Measured, with the gate in place and this half reverted:

```
assertion `left == right` failed: #3220: a policy block on the winning member must
fail closed with 403, got 200 OK body="#3220 unblocked copy from the fallback member"
```

`resolve_members_two_phase`'s Pass-1 probe now returns a full `MemberResolveOutcome` instead of a bare success payload, so a member can report *"holds it, refuses to serve"* (`Quarantine`) as distinct from *"does not have it"* (`DefiniteMiss`). The `Quarantine` variant already existed for the #1770 Package-Age-Policy block on Remote members; this gives it a Pass-1 meaning.

Answering the issue's three questions:

1. **Distinguishable?** Yes — `is_member_policy_block_response` (403/409). `local_lookup_artifact` produces 403/409 from the download gate *alone*; every surrounding step maps its failures to 400/404/500/507 (`map_storage_err`), so an outage cannot be mistaken for a policy decision. There is a unit test pinning both directions.
2. **Fail-closed or skip the member?** **Fail closed.** A Pass-1 rejection is classified `DefiniteHit`, which gives exactly that shape for free: Pass 1 stops there, members ranked *below* are never probed (so a lower-priority copy of the same coordinate cannot be substituted), and only members that legitimately *outrank* it can still win in Pass 2.
3. **Probe-time or winner-only?** Probe time, but bounded: Pass 1 stops at the first terminal outcome and never probes below it, so the cost is O(rank of the winner) policy evaluations — one in the ordinary case — not N per request.

The two hand-rolled loops fail closed the same way, via the same predicate.

## Verification

Every guard revert-proved, each half **independently**, against the merge-base shape of the code (not a plausible-looking mutation). Exact output:

**Both halves reverted** — the bug, verbatim:

```
FAIL classify_streaming_local_policy_block_is_terminal_3220
  #3220: a 403 Forbidden download-gate block must stop Pass 1, not read as a miss
    left: DefiniteMiss     right: DefiniteHit
FAIL test_virtual_member_download_applies_scan_policy_3220
  ... got 200 OK body="#3220 gated member payload"
    left: 200              right: 403
FAIL test_virtual_member_policy_block_does_not_fall_through_3220
  ... got 200 OK body="#3220 blocked copy from the top member"
    left: 200              right: 403
FAIL test_virtual_member_chart_download_applies_scan_policy_3220
  ... got 200 OK body="helm-virtual-gate-chart-bytes"
    left: 200              right: 403
```

**Gate reverted, terminal-outcome kept** — no rejection is ever produced, so all three byte-level tests serve 200 (output as above; the pure classifier test still passes, correctly, since it tests the resolver half).

**Terminal-outcome reverted, gate kept** — the silent fallback the issue predicted:

```
FAIL test_virtual_member_policy_block_does_not_fall_through_3220
  ... got 200 OK body="#3220 unblocked copy from the fallback member"
    left: 200              right: 403
FAIL test_virtual_member_download_applies_scan_policy_3220
  ... got 404 Not Found body="Artifact not found in any member repository"
    left: 404              right: 403
```

**Helm loop guard reverted, gate kept:** `got 404 Not Found body="Chart not found"` — the `continue` swallows the rejection.

**PyPI loop guard reverted, gate kept:** `got 200 OK` — falls through to the member's upstream.

**Maven anchor gate reverted:** `left: None  right: Some(403)` — the companion serves.

### Positive controls, in the same fixture as every negative assertion

A negative assertion that the bug also satisfies is not a guard, so each fixture proves it can succeed:

* every byte-level test serves **200 with the real bytes** before the policy exists and **again after it is removed**, so the 403 is attributable to the policy and not to a route that stopped working or blocks unconditionally;
* `test_virtual_member_download_applies_scan_policy_3220` keeps a **second member with no policy serving 200 while the block is in force** — over-blocking is an outage, and a fix that fails the whole virtual fails here;
* `test_virtual_member_policy_block_does_not_fall_through_3220` seeds the **same coordinate on two members with different bytes**. The pre-fix result is a 200 carrying the *fallback member's* bytes, so this cannot be satisfied by a change that merely makes everything fail; the control pins that the higher-priority member is the one that wins;
* the PyPI upstream mock serves **different bytes from the cached copy**, so a fall-through is observable as the upstream bytes rather than merely as "not a 403";
* the Helm test asserts the **direct route 403s in the same run** — the bypass and its closure in one file;
* `classify_streaming_local_policy_block_is_terminal_3220` asserts 404/500/507 **stay** `DefiniteMiss`, so the terminal classification cannot creep into "any error fails the virtual".

### Gates

Against Postgres 16, on a freshly migrated database:

* `cargo nextest run --workspace --lib` — **14961 passed, 0 failed** (6 skipped)
* `cargo fmt --all --check` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* No `sqlx::query!` macro text changed (the new queries are runtime `sqlx::query` / `query_as`); `SQLX_OFFLINE=true cargo build --lib --tests` with `DATABASE_URL` unset — clean

Fixes #3220
