### PR TITLE
fix(s3): copy objects >5GiB server-side via UploadPartCopy instead of restreaming through the app

### DIFF
--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -27,6 +27,10 @@
 //!   CopyObject (default: 1800). Control-plane calls (head/list/delete/exists)
 //!   keep a short [`S3_CONTROL_TIMEOUT`] so a wedged endpoint still fails fast.
 //!   Set to 0 to disable the bulk timeout entirely.
+//! - S3_MAX_SINGLE_COPY_BYTES: Largest object copied with one server-side
+//!   CopyObject (default: 5 GiB, AWS's cap). Larger sources are copied via
+//!   multipart UploadPartCopy in slices of this size. Clamped into
+//!   [5 MiB, 5 GiB]. Lever for S3-compatible stores with lower copy limits.
 //!
 //! For redirect downloads (302 to presigned URLs):
 //! - S3_REDIRECT_DOWNLOADS: Enable 302 redirects (default: false)
@@ -67,6 +71,13 @@ const S3_MULTIPART_CHUNK_SIZE: usize = 5 * 1024 * 1024;
 /// this regardless of how large the object is.
 const S3_MULTIPART_MAX_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
 const S3_MULTIPART_MAX_IN_FLIGHT_PARTS: usize = 4;
+/// AWS's ceiling for a single copy operation (5 GiB): "You create a copy of
+/// your object up to 5 GB in size in a single atomic action using this API.
+/// However, to copy an object greater than 5 GB, you must use the multipart
+/// upload Upload Part - Copy (UploadPartCopy) API" (Amazon S3 API Reference,
+/// CopyObject). Default for the configurable
+/// [`S3Config::max_single_copy_bytes`]; also the hard upper clamp, since no
+/// single copy — `CopyObject` or one `UploadPartCopy` part — may exceed it.
 const S3_MAX_SINGLE_COPY_SIZE: u64 = 5 * 1024 * 1024 * 1024;
 /// Overall HTTP request timeout for control-plane S3 calls: head, exists, list,
 /// delete, multipart create/abort. These are all small, fixed-cost round trips,
@@ -367,17 +378,19 @@ impl Drop for MultipartAbortGuard {
 /// Each range becomes one `UploadPartCopy`'s `x-amz-copy-source-range` header,
 /// which the S3 API Reference (UploadPartCopy, `x-amz-copy-source-range`)
 /// defines as "the form bytes=first-last, where the first and last are the
-/// zero-based byte offsets to copy". Every part is
-/// [`S3_MULTIPART_MAX_PART_SIZE`] (5 GiB, S3's per-part ceiling) except a
-/// shorter final part; maximal parts keep the count minimal — S3's 5 TiB
-/// object ceiling needs 1,024 parts, far under [`S3_MULTIPART_MAX_PARTS`].
-/// Every non-final part is 5 GiB, so the 5 MiB minimum-part-size rule is
-/// trivially satisfied for the `> 5 GiB` objects this path handles.
-fn copy_part_ranges(size: u64) -> Vec<(u64, u64)> {
+/// zero-based byte offsets to copy". Every part is `part_size` except a
+/// shorter final part. `part_size` is the (clamped) single-copy ceiling — each
+/// `UploadPartCopy` is itself a single copy operation bound by the same limit
+/// — so maximal parts keep the count minimal: at the default 5 GiB ceiling,
+/// S3's 5 TiB object ceiling needs 1,024 parts, far under
+/// [`S3_MULTIPART_MAX_PARTS`]. Callers guarantee `part_size >= 5 MiB`
+/// (see [`S3Backend::effective_single_copy_ceiling`]), satisfying the
+/// minimum-part-size rule for every non-final part.
+fn copy_part_ranges(size: u64, part_size: u64) -> Vec<(u64, u64)> {
     let mut ranges = Vec::new();
     let mut start = 0u64;
     while start < size {
-        let end = (start + S3_MULTIPART_MAX_PART_SIZE).min(size) - 1;
+        let end = (start + part_size).min(size) - 1;
         ranges.push((start, end));
         start = end + 1;
     }
@@ -401,8 +414,14 @@ fn s3_copy_source_value(bucket: &str, full_key: &str) -> String {
 /// A successful response is `<CopyPartResult><ETag>...</ETag></CopyPartResult>`
 /// (S3 API Reference, UploadPartCopy response syntax). S3 copy operations can
 /// return `200 OK` with an embedded `<Error>` document instead, so a 200
-/// status alone is not success — only a parseable ETag is. The ETag's XML
-/// entity escapes are undone (S3 wraps ETags in `&quot;`).
+/// status alone is not success — only a parseable ETag is.
+///
+/// The ETag's XML entity escapes are undone: implementations differ on how
+/// they escape the quotes around the ETag — AWS emits the named entity
+/// (`&quot;`), MinIO (Go's `encoding/xml`) the decimal reference (`&#34;`) —
+/// and a passed-through entity poisons `CompleteMultipartUpload` with
+/// `InvalidPart` ("the specified entity tag may not match"), caught live
+/// against MinIO by `test_large_copy_upload_part_copy_live_3164`.
 fn parse_copy_part_etag(body: &str) -> Option<String> {
     if body.contains("<Error") {
         return None;
@@ -412,6 +431,10 @@ fn parse_copy_part_etag(body: &str) -> Option<String> {
     let etag = body[start..end]
         .trim()
         .replace("&quot;", "\"")
+        .replace("&#34;", "\"")
+        .replace("&#x22;", "\"")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&amp;", "&");
@@ -468,6 +491,15 @@ pub struct S3Config {
     /// so this stays short to fail fast on a wedged endpoint. `0` disables it.
     /// Default: [`S3_CONTROL_TIMEOUT`] (30s).
     pub control_timeout_secs: u64,
+    /// Largest object copied with a single server-side `CopyObject`; larger
+    /// sources use the multipart `UploadPartCopy` path, whose per-part slice
+    /// size is this same value (each part copy is a single copy operation
+    /// under the same ceiling). Operator lever for S3-compatible stores with
+    /// a lower single-copy limit than AWS's. Clamped at use into
+    /// [5 MiB, 5 GiB]: a range copy requires a source over 5 MB, and no
+    /// single copy may exceed AWS's 5 GiB cap. Default:
+    /// [`S3_MAX_SINGLE_COPY_SIZE`] (5 GiB).
+    pub max_single_copy_bytes: u64,
 }
 
 /// CloudFront CDN configuration for signed URLs
@@ -532,6 +564,10 @@ impl S3Config {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(S3_CONTROL_TIMEOUT.as_secs());
+        let max_single_copy_bytes: u64 = std::env::var("S3_MAX_SINGLE_COPY_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(S3_MAX_SINGLE_COPY_SIZE);
 
         Ok(Self {
             bucket,
@@ -551,6 +587,7 @@ impl S3Config {
             pool_idle_timeout_secs,
             bulk_timeout_secs,
             control_timeout_secs,
+            max_single_copy_bytes,
         })
     }
 
@@ -616,6 +653,7 @@ impl S3Config {
             pool_idle_timeout_secs: 90,
             bulk_timeout_secs: S3_DEFAULT_BULK_TIMEOUT_SECS,
             control_timeout_secs: S3_CONTROL_TIMEOUT.as_secs(),
+            max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
         }
     }
 
@@ -677,6 +715,13 @@ impl S3Config {
     /// Override the control-plane request timeout (seconds). `0` disables it.
     pub fn with_control_timeout_secs(mut self, timeout_secs: u64) -> Self {
         self.control_timeout_secs = timeout_secs;
+        self
+    }
+
+    /// Override the single-copy ceiling in bytes (see
+    /// [`Self::max_single_copy_bytes`]). Clamped at use into [5 MiB, 5 GiB].
+    pub fn with_max_single_copy_bytes(mut self, bytes: u64) -> Self {
+        self.max_single_copy_bytes = bytes;
         self
     }
 }
@@ -834,6 +879,11 @@ pub struct S3Backend {
     /// does not expose (ranged `UploadPartCopy`, #3164). Built with the same
     /// custom-CA / insecure-TLS options as the object_store clients.
     raw_http: reqwest::Client,
+    /// Single-copy ceiling (already clamped into [5 MiB, 5 GiB], see
+    /// [`Self::effective_single_copy_ceiling`]): sources at or under it use
+    /// native `CopyObject`; larger ones use multipart `UploadPartCopy` with
+    /// parts of this size.
+    max_single_copy_bytes: u64,
     prefix: Option<String>,
     redirect_downloads: bool,
     cloudfront: Option<CloudFrontConfig>,
@@ -873,6 +923,19 @@ impl S3Backend {
         let timeout =
             (config.bulk_timeout_secs > 0).then(|| Duration::from_secs(config.bulk_timeout_secs));
         Self::build_store_with_timeout(config, access_key, secret_key, timeout)
+    }
+
+    /// Clamp the configured single-copy ceiling into what the S3 API can
+    /// honor: at least 5 MiB ("You can copy a range only if the source object
+    /// is greater than 5 MB" — S3 API Reference, UploadPartCopy — and 5 MiB
+    /// is the minimum non-final part size) and at most
+    /// [`S3_MAX_SINGLE_COPY_SIZE`] (no single copy may exceed AWS's 5 GiB
+    /// cap). Used for both the CopyObject-vs-multipart threshold and the
+    /// multipart part slice size.
+    fn effective_single_copy_ceiling(config: &S3Config) -> u64 {
+        config
+            .max_single_copy_bytes
+            .clamp(S3_MULTIPART_CHUNK_SIZE as u64, S3_MAX_SINGLE_COPY_SIZE)
     }
 
     /// HTTP client for hand-rolled S3 API calls that `object_store` does not
@@ -1147,6 +1210,7 @@ impl S3Backend {
             bulk_timeout: (config.bulk_timeout_secs > 0)
                 .then(|| Duration::from_secs(config.bulk_timeout_secs)),
             raw_http,
+            max_single_copy_bytes: Self::effective_single_copy_ceiling(&config),
             prefix: config.prefix,
             redirect_downloads: config.redirect_downloads,
             cloudfront: config.cloudfront,
@@ -1829,7 +1893,7 @@ impl S3Backend {
     /// Copy content from one key to another
     pub async fn copy(&self, source: &str, dest: &str) -> Result<()> {
         let size = self.size(source).await?;
-        if size > S3_MAX_SINGLE_COPY_SIZE {
+        if size > self.max_single_copy_bytes {
             tracing::debug!(
                 source = %source,
                 dest = %dest,
@@ -1853,8 +1917,10 @@ impl S3Backend {
         Ok(())
     }
 
-    /// Copy an object larger than [`S3_MAX_SINGLE_COPY_SIZE`] entirely
-    /// server-side via multipart `UploadPartCopy` (#3164).
+    /// Copy an object larger than the single-copy ceiling
+    /// ([`S3Config::max_single_copy_bytes`], default
+    /// [`S3_MAX_SINGLE_COPY_SIZE`]) entirely server-side via multipart
+    /// `UploadPartCopy` (#3164).
     ///
     /// AWS caps single copies at 5 GiB: "You create a copy of your object up
     /// to 5 GB in size in a single atomic action using this API. However, to
@@ -1876,7 +1942,7 @@ impl S3Backend {
     /// earlier failure aborts the upload and leaves an existing `dest`
     /// object untouched.
     async fn multipart_server_side_copy(&self, source: &str, dest: &str, size: u64) -> Result<()> {
-        let ranges = copy_part_ranges(size);
+        let ranges = copy_part_ranges(size, self.max_single_copy_bytes);
         if ranges.len() > S3_MULTIPART_MAX_PARTS {
             // Unreachable for real S3 (5 TiB object ceiling / 5 GiB parts =
             // 1,024), but fail fast rather than opaquely at part 10,001 if an
@@ -3703,6 +3769,7 @@ mod tests {
             region: config.region.clone(),
             bulk_timeout: Some(Duration::from_secs(S3_DEFAULT_BULK_TIMEOUT_SECS)),
             raw_http: reqwest::Client::new(),
+            max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
             prefix: None,
             redirect_downloads: false,
             cloudfront: None,
@@ -3980,6 +4047,7 @@ mod tests {
                 bulk_timeout: (config.bulk_timeout_secs > 0)
                     .then(|| Duration::from_secs(config.bulk_timeout_secs)),
                 raw_http: reqwest::Client::new(),
+                max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
                 prefix: None,
                 redirect_downloads: false,
                 cloudfront: None,
@@ -4058,6 +4126,7 @@ mod tests {
             bulk_timeout: (config.bulk_timeout_secs > 0)
                 .then(|| Duration::from_secs(config.bulk_timeout_secs)),
             raw_http: reqwest::Client::new(),
+            max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
             prefix: None,
             redirect_downloads: false,
             cloudfront: None,
@@ -4372,10 +4441,13 @@ mod tests {
             ))
             .mount(&server)
             .await;
+        // MinIO-style decimal quote entities (`&#34;`); the failure-path test
+        // below uses AWS-style `&quot;` so both real-world encodings are
+        // covered (see `parse_copy_part_etag`).
         let part_copy_guard = Mock::given(method("PUT"))
             .and(query_param("uploadId", "copy-upload-id"))
             .respond_with(ResponseTemplate::new(200).set_body_string(
-                "<CopyPartResult><ETag>&quot;part-copy-etag&quot;</ETag></CopyPartResult>",
+                "<CopyPartResult><ETag>&#34;part-copy-etag&#34;</ETag></CopyPartResult>",
             ))
             .mount_as_scoped(&server)
             .await;
@@ -5065,5 +5137,96 @@ mod integration_tests {
 
         let _ = StorageBackendTrait::delete(&backend, key).await;
         println!("#1555 no-prefix presign live test OK");
+    }
+
+    /// #3164 live: prove the hand-rolled, SigV4-signed `UploadPartCopy`
+    /// request is actually ACCEPTED by a real S3-compatible server (MinIO).
+    /// The wiremock suite asserts the request shape but cannot validate the
+    /// signature — a signing bug there would pass every double and then fail
+    /// in production on the first over-ceiling copy.
+    ///
+    /// Shrinks the single-copy ceiling via the `S3_MAX_SINGLE_COPY_BYTES`
+    /// env lever (the operator-facing knob this PR adds) so the multipart
+    /// path triggers on a 16 MiB object instead of a >5 GiB one, then
+    /// asserts: (1) the copy succeeds against the live server — the
+    /// signature validation; (2) destination bytes equal source bytes —
+    /// position-dependent content, so a range mix-up changes the result;
+    /// (3) the multipart path was really taken: a multipart-completed
+    /// object's ETag carries a `-<parts>` suffix (md5-of-part-md5s), while
+    /// a native `CopyObject` fallback would carry the source's plain ETag.
+    ///
+    ///   AK_S3_E2E=1 S3_BUCKET=ak-test S3_REGION=us-east-1 \
+    ///   S3_ENDPOINT=http://127.0.0.1:39164 S3_ACCESS_KEY_ID=... \
+    ///   S3_SECRET_ACCESS_KEY=... cargo test \
+    ///   test_large_copy_upload_part_copy_live_3164 -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn test_large_copy_upload_part_copy_live_3164() {
+        if std::env::var("AK_S3_E2E").ok().as_deref() != Some("1") {
+            println!("Skipping: set AK_S3_E2E=1 to run");
+            return;
+        }
+
+        // 6 MiB ceiling -> a 16 MiB source needs three ranged part copies
+        // (6 + 6 + 4 MiB). Set via env so this exercises the exact
+        // config-surface path an operator would use.
+        std::env::set_var("S3_MAX_SINGLE_COPY_BYTES", (6u64 * 1024 * 1024).to_string());
+        let config = S3Config::from_env().expect("S3Config::from_env");
+        let backend = S3Backend::new(config).await.expect("S3Backend::new");
+
+        let source_key = format!("large-copy-3164/src-{}", uuid::Uuid::new_v4());
+        let dest_key = format!("large-copy-3164/dst-{}", uuid::Uuid::new_v4());
+
+        // Position-dependent bytes: reassembling the parts in the wrong
+        // order, at the wrong offsets, or dropping a slice changes the
+        // content, so the equality check below validates the ranges too.
+        let len = 16 * 1024 * 1024_usize;
+        let content = Bytes::from(
+            (0..len)
+                .map(|i| (i.wrapping_mul(2654435761) >> 7) as u8)
+                .collect::<Vec<u8>>(),
+        );
+        StorageBackendTrait::put(&backend, &source_key, content.clone())
+            .await
+            .expect("seed source object");
+
+        // (1) Signature validation: the copy must be accepted by the live
+        // server. Every part is a hand-rolled UploadPartCopy request.
+        backend.copy(&source_key, &dest_key).await.expect(
+            "#3164: server-side multipart copy must be accepted by a real \
+             S3-compatible store (SigV4 of the hand-rolled UploadPartCopy)",
+        );
+
+        // (2) The copied bytes must equal the source bytes.
+        let copied = StorageBackendTrait::get(&backend, &dest_key)
+            .await
+            .expect("read copied object");
+        assert_eq!(copied.len(), content.len(), "copied length must match");
+        assert!(
+            copied == content,
+            "#3164: destination bytes must equal source bytes"
+        );
+
+        // (3) The multipart path must actually have been taken. 16 MiB at a
+        // 6 MiB ceiling = 3 parts -> ETag like "abc...-3". A native
+        // CopyObject fallback yields a plain single-part ETag with no
+        // dash-suffix (MD5 hex contains no '-').
+        let dest_path: ObjectPath = backend.full_key(&dest_key).into();
+        let meta = backend.store.head(&dest_path).await.expect("head dest");
+        let etag = meta.e_tag.clone().expect("dest object must have an ETag");
+        assert!(
+            etag.contains("-3"),
+            "#3164: dest ETag {:?} does not carry the 3-part multipart \
+             suffix; the copy did not take the UploadPartCopy path",
+            etag
+        );
+
+        let _ = StorageBackendTrait::delete(&backend, &source_key).await;
+        let _ = StorageBackendTrait::delete(&backend, &dest_key).await;
+        println!(
+            "#3164 live multipart copy OK: len={} dest_etag={}",
+            copied.len(),
+            etag
+        );
     }
 }

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -737,6 +737,23 @@ fn anonymous_s3_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Whether the store built by [`S3Backend::build_store_with_timeout`] will sign
+/// its requests, mirroring that function's credential branch exactly.
+///
+/// It is `false` only on the one arm that calls `with_skip_signature(true)`:
+/// no explicit key pair from any source, and `S3_ALLOW_ANONYMOUS` set. Kept
+/// beside [`anonymous_s3_enabled`] so the two stay in step — the hand-rolled
+/// `UploadPartCopy` path signs its own request and must refuse when this is
+/// `false` (see [`S3Backend::sign_requests`]).
+fn s3_requests_are_signed(access_key: Option<&str>, secret_key: Option<&str>) -> bool {
+    let explicit_pair = (access_key.is_some() && secret_key.is_some())
+        || (std::env::var("S3_ACCESS_KEY_ID").is_ok()
+            && std::env::var("S3_SECRET_ACCESS_KEY").is_ok())
+        || (std::env::var("AWS_ACCESS_KEY_ID").is_ok()
+            && std::env::var("AWS_SECRET_ACCESS_KEY").is_ok());
+    explicit_pair || !anonymous_s3_enabled()
+}
+
 /// Classify an `object_store::Error` from S3 into a human-readable
 /// diagnostic. Used by both the runtime `health_check` and the boot
 /// `startup_probe` so the operator sees the same actionable message in
@@ -884,6 +901,16 @@ pub struct S3Backend {
     /// native `CopyObject`; larger ones use multipart `UploadPartCopy` with
     /// parts of this size.
     max_single_copy_bytes: u64,
+    /// False when the store was built unsigned (`S3_ALLOW_ANONYMOUS` with no
+    /// credentials — `build_store` calls `with_skip_signature(true)`).
+    ///
+    /// The hand-rolled `UploadPartCopy` path signs its own request, so it
+    /// cannot honour `skip_signature`: `signed_url` and
+    /// `credentials().get_credential()` both resolve credentials
+    /// unconditionally, and with nothing configured object_store's chain falls
+    /// through to the IMDS provider. Recording the decision here lets the
+    /// multipart copy refuse legibly instead of stalling on a link-local probe.
+    sign_requests: bool,
     prefix: Option<String>,
     redirect_downloads: bool,
     cloudfront: Option<CloudFrontConfig>,
@@ -1211,6 +1238,7 @@ impl S3Backend {
                 .then(|| Duration::from_secs(config.bulk_timeout_secs)),
             raw_http,
             max_single_copy_bytes: Self::effective_single_copy_ceiling(&config),
+            sign_requests: s3_requests_are_signed(None, None),
             prefix: config.prefix,
             redirect_downloads: config.redirect_downloads,
             cloudfront: config.cloudfront,
@@ -1942,18 +1970,43 @@ impl S3Backend {
     /// earlier failure aborts the upload and leaves an existing `dest`
     /// object untouched.
     async fn multipart_server_side_copy(&self, source: &str, dest: &str, size: u64) -> Result<()> {
-        let ranges = copy_part_ranges(size, self.max_single_copy_bytes);
-        if ranges.len() > S3_MULTIPART_MAX_PARTS {
+        // `UploadPartCopy` is signed per request: the method and every `x-amz-*`
+        // header go into the SigV4 canonical request, so an anonymous store has
+        // nothing to sign with. `build_store` sets `with_skip_signature(true)`
+        // when no credentials are configured, but object_store still populates
+        // its credential chain, which falls through to the IMDS provider — so
+        // reaching the signing path on an anonymous store stalls on a
+        // link-local probe (up to the 180s retry_timeout) and then fails with
+        // an error naming 169.254.169.254, which reads like a network fault
+        // rather than a configuration one. Refuse legibly instead.
+        if !self.sign_requests {
+            return Err(AppError::Storage(format!(
+                "Server-side copy of '{source}' ({size} bytes) exceeds the \
+                 single-copy ceiling and requires S3 credentials to sign an \
+                 UploadPartCopy request, but this backend is running \
+                 unsigned (S3_ALLOW_ANONYMOUS). Configure credentials, or \
+                 lower S3_MAX_SINGLE_COPY_BYTES so this object copies with a \
+                 single unsigned CopyObject."
+            )));
+        }
+
+        // Bound the part count BEFORE materialising the range vector. `size`
+        // comes from a HEAD Content-Length, so an S3-compatible endpoint
+        // reporting a bogus length would otherwise have us push one 16-byte
+        // tuple per part first: `copy_part_ranges(u64::MAX/2, 5 GiB)` builds
+        // 1.7e9 ranges (~27 GiB resident) and completes rather than erroring.
+        // The ceiling is clamped to >= 5 MiB at construction, so it is never 0.
+        let part_count = size.div_ceil(self.max_single_copy_bytes);
+        if part_count > S3_MULTIPART_MAX_PARTS as u64 {
             // Unreachable for real S3 (5 TiB object ceiling / 5 GiB parts =
             // 1,024), but fail fast rather than opaquely at part 10,001 if an
             // S3-compatible provider reports a larger object.
             return Err(AppError::Storage(format!(
                 "Multipart copy of '{}' would need {} parts, exceeding S3's {}-part limit",
-                source,
-                ranges.len(),
-                S3_MULTIPART_MAX_PARTS,
+                source, part_count, S3_MULTIPART_MAX_PARTS,
             )));
         }
+        let ranges = copy_part_ranges(size, self.max_single_copy_bytes);
         let copy_source = s3_copy_source_value(&self.bucket, &self.full_key(source));
         let dest_path: ObjectPath = self.full_key(dest).into();
 
@@ -3770,6 +3823,7 @@ mod tests {
             bulk_timeout: Some(Duration::from_secs(S3_DEFAULT_BULK_TIMEOUT_SECS)),
             raw_http: reqwest::Client::new(),
             max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
+            sign_requests: true,
             prefix: None,
             redirect_downloads: false,
             cloudfront: None,
@@ -4048,6 +4102,7 @@ mod tests {
                     .then(|| Duration::from_secs(config.bulk_timeout_secs)),
                 raw_http: reqwest::Client::new(),
                 max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
+                sign_requests: true,
                 prefix: None,
                 redirect_downloads: false,
                 cloudfront: None,
@@ -4127,6 +4182,7 @@ mod tests {
                 .then(|| Duration::from_secs(config.bulk_timeout_secs)),
             raw_http: reqwest::Client::new(),
             max_single_copy_bytes: S3_MAX_SINGLE_COPY_SIZE,
+            sign_requests: true,
             prefix: None,
             redirect_downloads: false,
             cloudfront: None,

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -47,7 +47,7 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
-use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::aws::{AmazonS3, AmazonS3Builder, AwsAuthorizer};
 use object_store::multipart::{MultipartStore, PartId};
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
@@ -362,28 +362,60 @@ impl Drop for MultipartAbortGuard {
     }
 }
 
-/// Cross-check a streamed large-object copy against the source content.
+/// Inclusive byte ranges for a server-side multipart copy (#3164).
 ///
-/// The `>5 GiB` copy path streams the source through [`S3Backend::put_stream`],
-/// which returns the SHA-256 of the bytes it wrote. `put_stream`'s result is
-/// otherwise discarded, so a truncated or corrupted transfer would go unnoticed.
-/// This compares that digest against the SHA-256 computed independently over the
-/// source stream and rejects any mismatch. Pure so the mismatch branch is
-/// unit-testable without S3.
-fn ensure_copy_digest_matches(
-    source: &str,
-    dest: &str,
-    source_sha256: &str,
-    result: &PutStreamResult,
-) -> Result<()> {
-    if result.checksum_sha256 != source_sha256 {
-        return Err(AppError::Storage(format!(
-            "S3 streamed copy of '{}' -> '{}' failed integrity check: source SHA-256 {} \
-             but copied object hashed to {}",
-            source, dest, source_sha256, result.checksum_sha256
-        )));
+/// Each range becomes one `UploadPartCopy`'s `x-amz-copy-source-range` header,
+/// which the S3 API Reference (UploadPartCopy, `x-amz-copy-source-range`)
+/// defines as "the form bytes=first-last, where the first and last are the
+/// zero-based byte offsets to copy". Every part is
+/// [`S3_MULTIPART_MAX_PART_SIZE`] (5 GiB, S3's per-part ceiling) except a
+/// shorter final part; maximal parts keep the count minimal — S3's 5 TiB
+/// object ceiling needs 1,024 parts, far under [`S3_MULTIPART_MAX_PARTS`].
+/// Every non-final part is 5 GiB, so the 5 MiB minimum-part-size rule is
+/// trivially satisfied for the `> 5 GiB` objects this path handles.
+fn copy_part_ranges(size: u64) -> Vec<(u64, u64)> {
+    let mut ranges = Vec::new();
+    let mut start = 0u64;
+    while start < size {
+        let end = (start + S3_MULTIPART_MAX_PART_SIZE).min(size) - 1;
+        ranges.push((start, end));
+        start = end + 1;
     }
-    Ok(())
+    ranges
+}
+
+/// Build the `x-amz-copy-source` header value: "the name of the source bucket
+/// and key of the source object, separated by a slash (/). ... The value must
+/// be URL-encoded" (S3 API Reference, UploadPartCopy). Each key segment is
+/// percent-encoded; the `/` separators are structural and stay literal.
+fn s3_copy_source_value(bucket: &str, full_key: &str) -> String {
+    let encoded: Vec<String> = full_key
+        .split('/')
+        .map(|segment| urlencoding::encode(segment).into_owned())
+        .collect();
+    format!("{}/{}", bucket, encoded.join("/"))
+}
+
+/// Extract the part ETag from an `UploadPartCopy` response body.
+///
+/// A successful response is `<CopyPartResult><ETag>...</ETag></CopyPartResult>`
+/// (S3 API Reference, UploadPartCopy response syntax). S3 copy operations can
+/// return `200 OK` with an embedded `<Error>` document instead, so a 200
+/// status alone is not success — only a parseable ETag is. The ETag's XML
+/// entity escapes are undone (S3 wraps ETags in `&quot;`).
+fn parse_copy_part_etag(body: &str) -> Option<String> {
+    if body.contains("<Error") {
+        return None;
+    }
+    let start = body.find("<ETag>")? + "<ETag>".len();
+    let end = body[start..].find("</ETag>")? + start;
+    let etag = body[start..end]
+        .trim()
+        .replace("&quot;", "\"")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&");
+    (!etag.is_empty()).then_some(etag)
 }
 
 /// S3 storage backend configuration
@@ -790,6 +822,18 @@ pub struct S3Backend {
     /// payloads instead of the control-plane cliff. Used only by `get`/`put`,
     /// `get_stream`/`put_stream`, and `copy`.
     bulk_store: AmazonS3,
+    /// Bucket name, kept for the `x-amz-copy-source` header of hand-rolled
+    /// `UploadPartCopy` requests (#3164).
+    bucket: String,
+    /// Region used to SigV4-sign hand-rolled requests.
+    region: String,
+    /// Bulk-transfer request timeout, applied per-request to hand-rolled
+    /// part-copy calls (mirrors `bulk_store`'s ceiling). `None` = disabled.
+    bulk_timeout: Option<Duration>,
+    /// Plain HTTP client for hand-rolled S3 API calls that `object_store`
+    /// does not expose (ranged `UploadPartCopy`, #3164). Built with the same
+    /// custom-CA / insecure-TLS options as the object_store clients.
+    raw_http: reqwest::Client,
     prefix: Option<String>,
     redirect_downloads: bool,
     cloudfront: Option<CloudFrontConfig>,
@@ -829,6 +873,32 @@ impl S3Backend {
         let timeout =
             (config.bulk_timeout_secs > 0).then(|| Duration::from_secs(config.bulk_timeout_secs));
         Self::build_store_with_timeout(config, access_key, secret_key, timeout)
+    }
+
+    /// HTTP client for hand-rolled S3 API calls that `object_store` does not
+    /// expose (ranged `UploadPartCopy`, #3164). Honors the same custom-CA and
+    /// insecure-TLS options as the object_store clients; each request is
+    /// SigV4-signed per-call with [`AwsAuthorizer`], reusing the store's
+    /// credential chain.
+    fn build_raw_http_client(config: &S3Config) -> Result<reqwest::Client> {
+        let mut builder = reqwest::Client::builder();
+        if let Some(ca_path) = &config.ca_cert_path {
+            let pem = std::fs::read(ca_path).map_err(|e| {
+                AppError::Config(format!("Failed to read CA cert '{}': {}", ca_path, e))
+            })?;
+            let certs = reqwest::Certificate::from_pem_bundle(&pem).map_err(|e| {
+                AppError::Config(format!("Invalid CA cert PEM '{}': {}", ca_path, e))
+            })?;
+            for cert in certs {
+                builder = builder.add_root_certificate(cert);
+            }
+        }
+        if config.insecure_tls {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+        builder
+            .build()
+            .map_err(|e| AppError::Config(format!("Failed to build raw S3 HTTP client: {}", e)))
     }
 
     fn build_store_with_timeout(
@@ -1067,9 +1137,16 @@ impl S3Backend {
             );
         }
 
+        let raw_http = Self::build_raw_http_client(&config)?;
+
         Ok(Self {
             store,
             bulk_store,
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            bulk_timeout: (config.bulk_timeout_secs > 0)
+                .then(|| Duration::from_secs(config.bulk_timeout_secs)),
+            raw_http,
             prefix: config.prefix,
             redirect_downloads: config.redirect_downloads,
             cloudfront: config.cloudfront,
@@ -1757,39 +1834,9 @@ impl S3Backend {
                 source = %source,
                 dest = %dest,
                 size,
-                "S3 source is too large for CopyObject; streaming through multipart upload"
+                "S3 source is too large for CopyObject; copying server-side via UploadPartCopy"
             );
-            let stream = <Self as super::StorageBackend>::get_stream(self, source).await?;
-
-            // Hash the source bytes as they stream past so the copied object's
-            // digest (returned by `put_stream`) can be cross-checked end-to-end
-            // instead of silently discarded. The hasher is shared with the
-            // stream adapter and read back after the transfer completes.
-            let source_hasher = std::sync::Arc::new(std::sync::Mutex::new(Sha256::new()));
-            let tap = source_hasher.clone();
-            let hashing_stream = stream
-                .map(move |chunk| {
-                    if let Ok(ref bytes) = chunk {
-                        tap.lock()
-                            .expect("source hash mutex poisoned")
-                            .update(bytes);
-                    }
-                    chunk
-                })
-                .boxed();
-
-            let result =
-                <Self as super::StorageBackend>::put_stream(self, dest, hashing_stream).await?;
-            let source_sha256 = format!(
-                "{:x}",
-                source_hasher
-                    .lock()
-                    .expect("source hash mutex poisoned")
-                    .clone()
-                    .finalize()
-            );
-            ensure_copy_digest_matches(source, dest, &source_sha256, &result)?;
-            return Ok(());
+            return self.multipart_server_side_copy(source, dest, size).await;
         }
 
         let source_key = self.full_key(source);
@@ -1804,6 +1851,211 @@ impl S3Backend {
 
         tracing::debug!(source = %source, dest = %dest, "S3 copy object successful");
         Ok(())
+    }
+
+    /// Copy an object larger than [`S3_MAX_SINGLE_COPY_SIZE`] entirely
+    /// server-side via multipart `UploadPartCopy` (#3164).
+    ///
+    /// AWS caps single copies at 5 GiB: "You create a copy of your object up
+    /// to 5 GB in size in a single atomic action using this API. However, to
+    /// copy an object greater than 5 GB, you must use the multipart upload
+    /// Upload Part - Copy (UploadPartCopy) API" (Amazon S3 API Reference,
+    /// CopyObject). The previous fallback restreamed the object through the
+    /// application (`get_stream` -> `put_stream`) and only compared digests
+    /// *after* `put_stream` had already completed the multipart upload — by
+    /// the time a mismatch could be detected, the corrupt bytes were live at
+    /// `dest`, and #3153 deliberately rules out a reactive delete (it could
+    /// clobber a concurrent writer's just-published good object).
+    ///
+    /// Copying server-side removes both problems at once: no payload byte
+    /// passes through the application, and `dest` is not touched until
+    /// `CompleteMultipartUpload` — every part must have been copied
+    /// successfully (S3 validates the supplied part ETags at completion)
+    /// before the destination becomes visible, matching the atomicity the
+    /// native `CopyObject` already gives objects below the threshold. Any
+    /// earlier failure aborts the upload and leaves an existing `dest`
+    /// object untouched.
+    async fn multipart_server_side_copy(&self, source: &str, dest: &str, size: u64) -> Result<()> {
+        let ranges = copy_part_ranges(size);
+        if ranges.len() > S3_MULTIPART_MAX_PARTS {
+            // Unreachable for real S3 (5 TiB object ceiling / 5 GiB parts =
+            // 1,024), but fail fast rather than opaquely at part 10,001 if an
+            // S3-compatible provider reports a larger object.
+            return Err(AppError::Storage(format!(
+                "Multipart copy of '{}' would need {} parts, exceeding S3's {}-part limit",
+                source,
+                ranges.len(),
+                S3_MULTIPART_MAX_PARTS,
+            )));
+        }
+        let copy_source = s3_copy_source_value(&self.bucket, &self.full_key(source));
+        let dest_path: ObjectPath = self.full_key(dest).into();
+
+        let upload_id = self.store.create_multipart(&dest_path).await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to start multipart copy of '{}' -> '{}': {}",
+                source, dest, e
+            ))
+        })?;
+        // Aborts the upload if this future is dropped mid-copy, mirroring
+        // `put_stream`; defused on completion or by the inline aborts below.
+        let mut abort_guard =
+            MultipartAbortGuard::new(self.store.clone(), dest_path.clone(), dest.to_string());
+        abort_guard.arm(upload_id.clone());
+
+        let mut parts = Vec::with_capacity(ranges.len());
+        for (part_idx, range) in ranges.iter().enumerate() {
+            match self
+                .upload_part_copy(&copy_source, &dest_path, &upload_id, part_idx, *range)
+                .await
+            {
+                Ok(part) => parts.push(part),
+                Err(e) => {
+                    abort_guard.abort_now().await;
+                    return Err(e);
+                }
+            }
+        }
+
+        // CompleteMultipartUpload is the publish point: `dest` only becomes
+        // visible here, after every server-side part copy succeeded. It rides
+        // the bulk client because S3 assembles the object server-side and can
+        // hold the connection well past the control-plane cliff (#3180).
+        if let Err(e) = self
+            .bulk_store
+            .complete_multipart(&dest_path, &upload_id, parts)
+            .await
+        {
+            abort_guard.abort_now().await;
+            return Err(AppError::Storage(format!(
+                "Failed to complete multipart copy of '{}' -> '{}': {}",
+                source, dest, e
+            )));
+        }
+        abort_guard.disarm();
+
+        tracing::debug!(
+            source = %source,
+            dest = %dest,
+            size,
+            parts = ranges.len(),
+            "S3 server-side multipart copy successful"
+        );
+        Ok(())
+    }
+
+    /// Issue one server-side `UploadPartCopy` request.
+    ///
+    /// `object_store` 0.13 does not expose ranged `UploadPartCopy`, so this is
+    /// a hand-rolled request against the S3 REST API
+    /// (`PUT /{key}?partNumber=N&uploadId=ID` with `x-amz-copy-source` and
+    /// `x-amz-copy-source-range`), signed with the crate's own SigV4 signer
+    /// ([`AwsAuthorizer`]) and the store's credential chain, so IRSA /
+    /// container credentials keep working. The URL shape (path-style vs
+    /// virtual-hosted, custom endpoints) is derived from the configured store
+    /// via [`object_store::signer::Signer::signed_url`] rather than rebuilt
+    /// here. "All headers with the `x-amz-` prefix, including
+    /// `x-amz-copy-source`, must be signed" (S3 API Reference,
+    /// UploadPartCopy), which header-based SigV4 does and a presigned URL
+    /// cannot.
+    async fn upload_part_copy(
+        &self,
+        copy_source: &str,
+        dest_path: &ObjectPath,
+        upload_id: &str,
+        part_idx: usize,
+        range: (u64, u64),
+    ) -> Result<PartId> {
+        use object_store::signer::Signer;
+
+        let display = dest_path.as_ref();
+        // "Part number of part being copied. This is a positive integer
+        // between 1 and 10,000" (S3 API Reference, UploadPartCopy).
+        let part_number = part_idx + 1;
+
+        let mut url = self
+            .store
+            .signed_url(http::Method::PUT, dest_path, Duration::from_secs(300))
+            .await
+            .map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to build UploadPartCopy URL for '{}': {}",
+                    display, e
+                ))
+            })?;
+        url.set_query(None);
+        url.query_pairs_mut()
+            .append_pair("partNumber", &part_number.to_string())
+            .append_pair("uploadId", upload_id);
+
+        let credential = self
+            .bulk_store
+            .credentials()
+            .get_credential()
+            .await
+            .map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to resolve S3 credentials for UploadPartCopy of '{}': {}",
+                    display, e
+                ))
+            })?;
+
+        // "The range value must use the form bytes=first-last, where the
+        // first and last are the zero-based byte offsets to copy" (S3 API
+        // Reference, UploadPartCopy, x-amz-copy-source-range). Inclusive.
+        let range_value = format!("bytes={}-{}", range.0, range.1);
+        let mut request = http::Request::builder()
+            .method(http::Method::PUT)
+            .uri(url.as_str())
+            .header("x-amz-copy-source", copy_source)
+            .header("x-amz-copy-source-range", &range_value)
+            .body(object_store::client::HttpRequestBody::empty())
+            .map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to build UploadPartCopy request for '{}': {}",
+                    display, e
+                ))
+            })?;
+        AwsAuthorizer::new(&credential, "s3", &self.region).authorize(&mut request, None);
+
+        let mut send = self
+            .raw_http
+            .put(url.as_str())
+            .headers(request.headers().clone());
+        if let Some(timeout) = self.bulk_timeout {
+            // A 5 GiB server-side copy is bulk work: give it the bulk
+            // ceiling, not reqwest's unbounded default.
+            send = send.timeout(timeout);
+        }
+        let response = send.send().await.map_err(|e| {
+            AppError::Storage(format!(
+                "UploadPartCopy part {} for '{}' failed to send: {}",
+                part_number, display, e
+            ))
+        })?;
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(AppError::Storage(format!(
+                "UploadPartCopy part {} for '{}' failed: {} {}: {}",
+                part_number,
+                display,
+                status.as_u16(),
+                status.canonical_reason().unwrap_or(""),
+                body
+            )));
+        }
+        let etag = parse_copy_part_etag(&body).ok_or_else(|| {
+            AppError::Storage(format!(
+                "UploadPartCopy part {} for '{}' returned {} without a CopyPartResult ETag: {}",
+                part_number,
+                display,
+                status.as_u16(),
+                body
+            ))
+        })?;
+        Ok(PartId { content_id: etag })
     }
 
     /// Get content size without fetching full content
@@ -3447,6 +3699,10 @@ mod tests {
         S3Backend {
             store,
             bulk_store,
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            bulk_timeout: Some(Duration::from_secs(S3_DEFAULT_BULK_TIMEOUT_SECS)),
+            raw_http: reqwest::Client::new(),
             prefix: None,
             redirect_downloads: false,
             cloudfront: None,
@@ -3719,6 +3975,11 @@ mod tests {
                 store: S3Backend::build_store(&config, Some("AKIA"), Some("secret")).unwrap(),
                 bulk_store: S3Backend::build_bulk_store(&config, Some("AKIA"), Some("secret"))
                     .unwrap(),
+                bucket: config.bucket.clone(),
+                region: config.region.clone(),
+                bulk_timeout: (config.bulk_timeout_secs > 0)
+                    .then(|| Duration::from_secs(config.bulk_timeout_secs)),
+                raw_http: reqwest::Client::new(),
                 prefix: None,
                 redirect_downloads: false,
                 cloudfront: None,
@@ -3792,6 +4053,11 @@ mod tests {
         let backend = S3Backend {
             store: S3Backend::build_store(&config, Some("AKIA"), Some("secret")).unwrap(),
             bulk_store: S3Backend::build_bulk_store(&config, Some("AKIA"), Some("secret")).unwrap(),
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            bulk_timeout: (config.bulk_timeout_secs > 0)
+                .then(|| Duration::from_secs(config.bulk_timeout_secs)),
+            raw_http: reqwest::Client::new(),
             prefix: None,
             redirect_downloads: false,
             cloudfront: None,
@@ -4072,25 +4338,31 @@ mod tests {
         );
     }
 
+    // ---- #3164: >5 GiB copies must be server-side UploadPartCopy, and the
+    // destination must never be published before the copy fully succeeds ----
+
+    /// A copy of an object over `S3_MAX_SINGLE_COPY_SIZE` must be performed
+    /// entirely server-side: CreateMultipartUpload, one ranged
+    /// `UploadPartCopy` per 5 GiB slice, CompleteMultipartUpload — and no
+    /// payload byte through the application. No GET mock is mounted, so a
+    /// regression to the restream shape fails immediately on the source read.
     #[tokio::test]
-    async fn test_copy_streams_large_source_instead_of_single_copy_object() {
+    async fn test_copy_over_5gib_is_server_side_upload_part_copy() {
         use wiremock::matchers::{method, query_param, query_param_is_missing};
         use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // 10 GiB + 1 byte -> exactly three parts: two full 5 GiB slices and a
+        // final 1-byte slice. Never materialized; only a Content-Length.
+        let size = 2 * 5_u64 * 1024 * 1024 * 1024 + 1;
 
         let server = MockServer::start().await;
         Mock::given(method("HEAD"))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .insert_header(
-                        "Content-Length",
-                        (5_u64 * 1024 * 1024 * 1024 + 1).to_string(),
-                    )
+                    .insert_header("Content-Length", size.to_string())
+                    .insert_header("last-modified", "Fri, 07 Aug 2026 18:09:54 GMT")
                     .insert_header("ETag", "\"large-source\""),
             )
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(Vec::from(&b"large-copy"[..])))
             .mount(&server)
             .await;
         Mock::given(method("POST"))
@@ -4100,70 +4372,264 @@ mod tests {
             ))
             .mount(&server)
             .await;
-        Mock::given(method("PUT"))
+        let part_copy_guard = Mock::given(method("PUT"))
             .and(query_param("uploadId", "copy-upload-id"))
-            .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"copy-part\""))
-            .mount(&server)
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "<CopyPartResult><ETag>&quot;part-copy-etag&quot;</ETag></CopyPartResult>",
+            ))
+            .mount_as_scoped(&server)
             .await;
-        Mock::given(method("POST"))
+        let complete_guard = Mock::given(method("POST"))
             .and(query_param("uploadId", "copy-upload-id"))
             .respond_with(ResponseTemplate::new(200).set_body_string(
                 "<CompleteMultipartUploadResult><ETag>\"complete-copy\"</ETag></CompleteMultipartUploadResult>",
             ))
-            .mount(&server)
+            .mount_as_scoped(&server)
             .await;
 
         let backend = mock_s3_backend(&server.uri(), false).await;
         S3Backend::copy(&backend, "source-object", "dest-object")
             .await
-            .expect("large copy should stream through multipart upload");
+            .expect("#3164: a >5 GiB copy must succeed via server-side UploadPartCopy");
 
         let requests = server.received_requests().await.unwrap_or_default();
         assert!(
-            requests
-                .iter()
-                .any(|request| request.method.as_str() == "GET"
-                    && request.url.path().ends_with("/source-object")),
-            "large copy should read the source as a stream"
+            !requests.iter().any(|r| r.method.as_str() == "GET"),
+            "#3164: a >5 GiB copy must not read the source back through the \
+             application (no GET restream)"
         );
-        assert!(
-            requests.iter().any(|request| request
-                .url
+
+        // Every part must be a ranged server-side copy: empty body (no bytes
+        // through the app), the copy-source header, and 1-based part numbers
+        // whose ranges exactly partition [0, size-1] in 5 GiB slices.
+        let mut part_requests = part_copy_guard.received_requests().await;
+        part_requests.sort_by_key(|r| {
+            r.url
                 .query_pairs()
-                .any(|(key, value)| key == "uploadId" && value == "copy-upload-id")),
-            "large copy should write the destination via multipart upload"
+                .find_map(|(k, v)| (k == "partNumber").then(|| v.parse::<usize>().unwrap()))
+                .expect("UploadPartCopy must carry partNumber")
+        });
+        let observed: Vec<(usize, String, String, usize)> = part_requests
+            .iter()
+            .map(|r| {
+                let part_number = r
+                    .url
+                    .query_pairs()
+                    .find_map(|(k, v)| (k == "partNumber").then(|| v.parse().unwrap()))
+                    .unwrap();
+                let source = r
+                    .headers
+                    .get("x-amz-copy-source")
+                    .expect("part copy must name its server-side source")
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                let range = r
+                    .headers
+                    .get("x-amz-copy-source-range")
+                    .expect("part copy must be ranged")
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                (part_number, source, range, r.body.len())
+            })
+            .collect();
+        assert_eq!(
+            observed,
+            vec![
+                (
+                    1,
+                    "test-bucket/source-object".to_string(),
+                    "bytes=0-5368709119".to_string(),
+                    0
+                ),
+                (
+                    2,
+                    "test-bucket/source-object".to_string(),
+                    "bytes=5368709120-10737418239".to_string(),
+                    0
+                ),
+                (
+                    3,
+                    "test-bucket/source-object".to_string(),
+                    "bytes=10737418240-10737418240".to_string(),
+                    0
+                ),
+            ],
+            "#3164: the copy must be exactly three ranged, bodyless \
+             UploadPartCopy requests partitioning the object"
+        );
+        assert_eq!(
+            complete_guard.received_requests().await.len(),
+            1,
+            "the multipart copy must be completed exactly once"
+        );
+    }
+
+    /// The integrity half of #3164: with the old restream shape, `dest` was
+    /// already fully published (multipart upload completed) before any
+    /// verification could run. With server-side part copies the publish point
+    /// is CompleteMultipartUpload, so a failed part copy must surface as an
+    /// error, abort the upload, and never complete it — the destination keeps
+    /// whatever it held before.
+    ///
+    /// The fixture deliberately lets the OLD shape succeed end to end (the
+    /// source GET and un-ranged part PUTs are all mocked green), so on the
+    /// unfixed code `copy()` returns Ok and publishes dest — this test can
+    /// only pass when the publish is actually gated on the part copies.
+    #[tokio::test]
+    async fn test_copy_over_5gib_failed_part_copy_never_publishes_dest() {
+        use wiremock::matchers::{header, method, query_param, query_param_is_missing};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // 5 GiB + 1 byte -> two parts; the second (1-byte) part copy fails.
+        let size = 5_u64 * 1024 * 1024 * 1024 + 1;
+
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Length", size.to_string())
+                    .insert_header("last-modified", "Fri, 07 Aug 2026 18:09:54 GMT")
+                    .insert_header("ETag", "\"large-source\""),
+            )
+            .mount(&server)
+            .await;
+        // Keep the pre-fix path viable so the test discriminates: the source
+        // is readable...
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"restream-bytes".to_vec()))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(query_param_is_missing("uploadId"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "<InitiateMultipartUploadResult><UploadId>copy-upload-id</UploadId></InitiateMultipartUploadResult>",
+            ))
+            .mount(&server)
+            .await;
+        // The second ranged part copy fails server-side.
+        Mock::given(method("PUT"))
+            .and(query_param("uploadId", "copy-upload-id"))
+            .and(header(
+                "x-amz-copy-source-range",
+                "bytes=5368709120-5368709120",
+            ))
+            .respond_with(ResponseTemplate::new(500).set_body_string("InternalError"))
+            .mount(&server)
+            .await;
+        // ...and every other part upload succeeds, whether it is the first
+        // ranged copy (fixed shape) or an un-ranged data PUT (old shape reads
+        // the ETag header; new shape parses the CopyPartResult body).
+        Mock::given(method("PUT"))
+            .and(query_param("uploadId", "copy-upload-id"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ETag", "\"part-etag\"")
+                    .set_body_string(
+                        "<CopyPartResult><ETag>&quot;part-etag&quot;</ETag></CopyPartResult>",
+                    ),
+            )
+            .mount(&server)
+            .await;
+        let complete_guard = Mock::given(method("POST"))
+            .and(query_param("uploadId", "copy-upload-id"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "<CompleteMultipartUploadResult><ETag>\"complete-copy\"</ETag></CompleteMultipartUploadResult>",
+            ))
+            .mount_as_scoped(&server)
+            .await;
+        let abort_guard = Mock::given(method("DELETE"))
+            .and(query_param("uploadId", "copy-upload-id"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount_as_scoped(&server)
+            .await;
+
+        let backend = mock_s3_backend(&server.uri(), false).await;
+        let result = S3Backend::copy(&backend, "source-object", "dest-object").await;
+
+        assert!(
+            result.is_err(),
+            "#3164: a failed server-side part copy must fail the whole copy \
+             (the old restream shape returned Ok here)"
+        );
+        assert_eq!(
+            complete_guard.received_requests().await.len(),
+            0,
+            "#3164: dest must never be published (CompleteMultipartUpload) \
+             when a part copy failed — bad bytes must not go live"
+        );
+        assert_eq!(
+            abort_guard.received_requests().await.len(),
+            1,
+            "a failed part copy must abort the pending multipart upload"
+        );
+    }
+
+    /// Positive control for #3164: copies at or below the 5 GiB threshold must
+    /// keep using the single atomic `CopyObject` ("You create a copy of your
+    /// object up to 5 GB in size in a single atomic action using this API" —
+    /// S3 API Reference, CopyObject), whose atomicity is itself the integrity
+    /// guarantee: a failure never touches `dest`. A "fix" that pushed the
+    /// common path into multipart machinery or a restream fails these counts.
+    #[tokio::test]
+    async fn test_copy_at_or_under_threshold_stays_single_native_copy_object() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Exactly the 5 GiB boundary: the largest size the atomic path serves.
+        let size = 5_u64 * 1024 * 1024 * 1024;
+
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Length", size.to_string())
+                    .insert_header("last-modified", "Fri, 07 Aug 2026 18:09:54 GMT")
+                    .insert_header("ETag", "\"small-source\""),
+            )
+            .mount(&server)
+            .await;
+        let copy_guard = Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "<CopyObjectResult><ETag>\"copy-dst-etag\"</ETag></CopyObjectResult>",
+            ))
+            .mount_as_scoped(&server)
+            .await;
+
+        let backend = mock_s3_backend(&server.uri(), false).await;
+        S3Backend::copy(&backend, "source-object", "dest-object")
+            .await
+            .expect("a copy at the 5 GiB boundary must still succeed");
+
+        let puts = copy_guard.received_requests().await;
+        assert_eq!(
+            puts.len(),
+            1,
+            "an at-threshold copy must be exactly one native CopyObject"
+        );
+        let put = &puts[0];
+        assert!(
+            put.headers.contains_key("x-amz-copy-source"),
+            "the single PUT must be a server-side CopyObject"
         );
         assert!(
-            !requests
-                .iter()
-                .any(|request| request.headers.contains_key("x-amz-copy-source")),
-            "large copy must not use single-request S3 CopyObject"
+            !put.headers.contains_key("x-amz-copy-source-range"),
+            "a native CopyObject is not ranged"
         );
-    }
-
-    // ---- ensure_copy_digest_matches (pure large-copy integrity check) ----
-
-    #[test]
-    fn test_ensure_copy_digest_matches_ok_when_equal() {
-        let result = PutStreamResult {
-            checksum_sha256: "deadbeef".to_string(),
-            bytes_written: 42,
-        };
-        ensure_copy_digest_matches("src", "dst", "deadbeef", &result)
-            .expect("matching digests must pass the integrity check");
-    }
-
-    #[test]
-    fn test_ensure_copy_digest_matches_errors_on_mismatch() {
-        let result = PutStreamResult {
-            checksum_sha256: "0000".to_string(),
-            bytes_written: 42,
-        };
-        let err = ensure_copy_digest_matches("src", "dst", "ffff", &result)
-            .expect_err("a digest mismatch must be rejected");
-        let msg = err.to_string();
-        assert!(msg.contains("integrity check"), "unexpected error: {msg}");
-        assert!(msg.contains("ffff") && msg.contains("0000"), "err: {msg}");
+        assert!(
+            !put.url.query_pairs().any(|(k, _)| k == "uploadId"),
+            "an at-threshold copy must not open a multipart upload"
+        );
+        let requests = server.received_requests().await.unwrap_or_default();
+        assert!(
+            !requests.iter().any(|r| r.method.as_str() == "GET"),
+            "an at-threshold copy must not restream the source"
+        );
+        assert!(
+            !requests.iter().any(|r| r.method.as_str() == "POST"),
+            "an at-threshold copy must not touch the multipart API"
+        );
     }
 
     // ---- MultipartAbortGuard (abort-on-drop for cancelled multipart copies) ----


### PR DESCRIPTION
Fixes #3164

## What was actually wrong (verified against source before fixing)

Both halves of the issue are real, confirmed on current `main` (`929c0bb`, on top of #3222's client split):

1. **Restream**: `S3Backend::copy` for objects over `S3_MAX_SINGLE_COPY_SIZE` (5 GiB) fell back to `get_stream(source)` + `put_stream(dest)` (`backend/src/storage/s3.rs:1753-1792` at merge-base) — every byte of a >5 GiB object came back through the application and was re-uploaded.
2. **Integrity ordering (the part that matters)**: `ensure_copy_digest_matches` ran only **after** `put_stream` returned — i.e. after `CompleteMultipartUpload` had already published `dest`. On a mismatch the corrupt bytes were already live, and #3153 deliberately rules out a reactive delete (it could clobber a concurrent writer's just-published good object). Worse, the check compared the tap hasher against `put_stream`'s hasher — **two SHA-256s of the same in-process byte stream** — so it was structurally unable to detect a transfer that diverged from the source at all. The check was theater; this PR fixes the ordering problem by removing the window entirely rather than reordering the theater.

## Fix

Copy `>5 GiB` objects **entirely server-side** via ranged `UploadPartCopy`, per the issue's suggested direction. AWS caps single copies at 5 GiB:

> "You create a copy of your object up to 5 GB in size in a single atomic action using this API. However, to copy an object greater than 5 GB, you must use the multipart upload Upload Part - Copy (UploadPartCopy) API." — *Amazon S3 API Reference, CopyObject*

- One `UploadPartCopy` per 5 GiB slice (`x-amz-copy-source` + `x-amz-copy-source-range`, "the form bytes=first-last, where the first and last are the zero-based byte offsets to copy" — *S3 API Reference, UploadPartCopy*). Maximal slices keep the count minimal: S3's 5 TiB object ceiling needs 1,024 parts, far under the 10,000-part cap.
- **No payload byte passes through the application**, and `dest` only becomes visible at `CompleteMultipartUpload`, after every part copied successfully (S3 validates the supplied part ETags at completion) — the same publish-is-the-last-step atomicity native `CopyObject` gives the ≤5 GiB path, which is exactly the property #3153's staging-key publish relies on.
- Failures abort the multipart upload (inline on error paths, `MultipartAbortGuard` on future drop), leaving an existing `dest` untouched.

`object_store` 0.13 implements `UploadPartCopy` internally only as the un-ranged whole-object variant behind `copy_if_not_exists`, so the ranged call is hand-rolled against the S3 REST API — but signed with the crate's **own public SigV4 signer** (`AwsAuthorizer`) and the store's own credential chain (`AmazonS3::credentials()`), so static keys, IRSA, ECS/EKS container credentials and session tokens all keep working ("All headers with the `x-amz-` prefix, including `x-amz-copy-source`, must be signed" — *S3 API Reference, UploadPartCopy*; a presigned URL cannot satisfy that, header signing does). The request URL is derived from the configured store via `Signer::signed_url` rather than rebuilt, so path-style/virtual-hosted/custom-endpoint shapes carry over. The raw client honors `S3_CA_CERT_PATH` / `S3_INSECURE_TLS`. `partNumber` is 1-based per the API reference; a `200 OK` body is only accepted with a parseable `<CopyPartResult><ETag>` (S3 can embed an `<Error>` document in a 200 for copy operations).

`ensure_copy_digest_matches` and its tests are removed with the restream they guarded (see the tautology note above — there is nothing app-side left to hash, by design).

## Tests (in-file `#[cfg(test)]`, count toward the `--lib` coverage gate)

All wiremock storage doubles; large sizes are `Content-Length` headers only — **no multi-GB buffers are materialized**.

- `test_copy_over_5gib_is_server_side_upload_part_copy` — 10 GiB + 1 B copy: asserts **zero GET requests** (no restream), **exactly three bodyless ranged part copies** whose `(partNumber, x-amz-copy-source, x-amz-copy-source-range, body length)` tuples exactly partition `[0, size-1]`, and exactly one `CompleteMultipartUpload`. No GET mock is mounted, so the old shape fails on the first source read.
- `test_copy_over_5gib_failed_part_copy_never_publishes_dest` — the integrity claim. Second part copy 500s; asserts the copy errors, `CompleteMultipartUpload` count == **0** (dest never published), abort count == 1. The fixture deliberately keeps the *old* shape fully green (source GET + un-ranged part PUTs + complete all mocked OK), so pre-fix code returns `Ok` and publishes — the test cannot pass unless the publish is actually gated on the part copies.
- `test_copy_at_or_under_threshold_stays_single_native_copy_object` — positive control at exactly 5 GiB: exactly one native `CopyObject` PUT (`x-amz-copy-source`, no range header, no `uploadId`), zero GET/POST — a fix that degraded or multipart-ified the common path fails these counts.

The prior `test_copy_streams_large_source_instead_of_single_copy_object` asserted the bug as a requirement ("large copy should read the source as a stream", "must not use \[x-amz-copy-source\]") and is replaced by the above.

## Revert-proof (faithful, insertions-only)

Production `s3.rs` restored byte-identical to `main`, keeping only the new tests:

```
$ git diff main --shortstat
 1 file changed, 294 insertions(+)
$ git diff main -U0 | grep ^@@
@@ -4168,0 +4169,294 @@ mod tests {
```

(single hunk, entirely inside `mod tests`). Result on merge-base production code:

```
PASS test_copy_at_or_under_threshold_stays_single_native_copy_object   (control)
FAIL test_copy_over_5gib_is_server_side_upload_part_copy
     -> NotFound("Storage key not found: source-object")  [old code restreams the source]
FAIL test_copy_over_5gib_failed_part_copy_never_publishes_dest
     -> "#3164: a failed server-side part copy must fail the whole copy
         (the old restream shape returned Ok here)"       [old code published dest]
```

With the fix restored: all 424 `storage::` `--lib` tests pass; `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean. No `sqlx::query!` text touched.


## Live validation against real MinIO (SigV4 proof)

The wiremock suite asserts request *shape* but cannot validate signatures, so the multipart-copy path is also proven against a live server. To make that testable without moving 5 GiB, the single-copy ceiling is now configurable — `S3Config::max_single_copy_bytes` + `with_max_single_copy_bytes()` + `S3_MAX_SINGLE_COPY_BYTES` env (the `bulk_timeout_secs` shape from #3222), defaulting to AWS's 5 GiB cap and clamped into [5 MiB, 5 GiB] (a range copy requires a source over 5 MB, and no single copy may exceed 5 GiB). The multipart part slice follows the same knob, since each `UploadPartCopy` is itself a single copy operation under the same ceiling. Defensible on its own: it is the operator lever for S3-compatible stores with lower copy limits.

`test_large_copy_upload_part_copy_live_3164` (`AK_S3_E2E`-gated + `#[ignore]`, same pattern as #3180's roundtrip test) sets a 6 MiB ceiling via the env lever, copies a 16 MiB object of position-dependent bytes against live MinIO, and asserts: (1) the copy is **accepted** — real SigV4 validation of the hand-rolled requests; (2) destination bytes equal source bytes — a range mix-up would change the content; (3) the dest ETag carries the `-3` multipart suffix, so the `UploadPartCopy` path demonstrably ran rather than a native-copy fallback.

**The live run immediately caught a real bug the doubles could not:** the part-copy requests were signed correctly and accepted, but `CompleteMultipartUpload` failed with `InvalidPart` — MinIO (Go `encoding/xml`) escapes the ETag quotes as decimal entities (`&#34;`) where AWS uses `&quot;`, and the parser passed the entity through literally. `parse_copy_part_etag` now decodes both; the two wiremock fixtures use one encoding each. Fixed output:

```
#3164 live multipart copy OK: len=16777216 dest_etag="c59bad0d7b9c262935d141050bf39bf9-3"
test result: ok. 1 passed; 0 failed
```

MinIO's server-side API trace (`mc admin trace --call s3`) for the same run shows the exact call sequence, confirming the hand-rolled requests were accepted and executed server-side — each `CopyObjectPart` (MinIO's name for `UploadPartCopy`) uploads ~131 B of headers and no payload:

```
[200 OK] s3.NewMultipartUpload   .../large-copy-3164/dst-...?uploads=
[200 OK] s3.CopyObjectPart       .../large-copy-3164/dst-...?partNumber=1&uploadId=...  ↑ 131 B ↓ 228 B
[200 OK] s3.CopyObjectPart       .../large-copy-3164/dst-...?partNumber=2&uploadId=...  ↑ 131 B ↓ 228 B
[200 OK] s3.CopyObjectPart       .../large-copy-3164/dst-...?partNumber=3&uploadId=...  ↑ 131 B ↓ 228 B
[200 OK] s3.CompleteMultipartUpload .../large-copy-3164/dst-...?uploadId=...
```

**Note for reviewers:** this live test is `AK_S3_E2E`-gated and `#[ignore]`d, so it does **not** run in CI — it is a deliberate-invocation check, the same pattern as `test_oci_blob_roundtrip_live_3180`. A green CI run does not constitute signature validation; the validation is the recorded run above (executed 2026-08-09/10 against MinIO at `http://127.0.0.1:39164`, path-style, static `S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY` credentials).

Revert-proof was re-run for the full test set (production restored byte-identical to main, now 387 insertions / 0 deletions across the two test modules — `@@ mod tests` and `@@ mod integration_tests`): both wiremock #3164 tests fail as before, and the live test fails on assertion (3) with `dest ETag "\"bccf03b2...\"" does not carry the 3-part multipart suffix` — on merge-base the env lever is ignored, the 16 MiB copy silently rides native `CopyObject`, and copies (1) and (2) alone cannot distinguish the shapes. The control still passes.

## Behavior notes

- ≤5 GiB copies are byte-for-byte unchanged (native `CopyObject` on the bulk client, #3222 timeouts intact).
- Part copies run sequentially; each rides the bulk timeout (`S3_BULK_TIMEOUT_SECS`) since a 5 GiB server-side copy is bulk work. Parallelizing part copies is possible later but irrelevant to correctness.
- S3-compatible stores that lack `UploadPartCopy` would now fail the >5 GiB copy loudly instead of silently restreaming; every mainstream target (AWS, MinIO, Ceph RGW, R2, OBS) implements it.
