### PR TITLE
fix(oci): keep digest-addressed proxied manifests immutable in the proxy cache; add pull-through regression guards

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -27362,14 +27362,12 @@ mod remote_pull_through_cache_tests {
         let raw = std::fs::read(sidecar)
             .unwrap_or_else(|e| panic!("sidecar {} must exist: {e}", sidecar.display()));
         let v: serde_json::Value = serde_json::from_slice(&raw).expect("sidecar JSON");
-        let cached_at = chrono::DateTime::parse_from_rfc3339(
-            v["cached_at"].as_str().expect("cached_at"),
-        )
-        .expect("cached_at rfc3339");
-        let expires_at = chrono::DateTime::parse_from_rfc3339(
-            v["expires_at"].as_str().expect("expires_at"),
-        )
-        .expect("expires_at rfc3339");
+        let cached_at =
+            chrono::DateTime::parse_from_rfc3339(v["cached_at"].as_str().expect("cached_at"))
+                .expect("cached_at rfc3339");
+        let expires_at =
+            chrono::DateTime::parse_from_rfc3339(v["expires_at"].as_str().expect("expires_at"))
+                .expect("expires_at rfc3339");
         (expires_at - cached_at).num_seconds()
     }
 
@@ -27605,14 +27603,9 @@ mod remote_pull_through_cache_tests {
             (&config_digest, &config, "warm GET config blob (outage)"),
             (&layer_digest, &layer, "warm GET layer blob (outage)"),
         ] {
-            let resp = super::handle_get_blob(
-                &state,
-                &anon_headers(),
-                "http://ak.test",
-                &image,
-                digest,
-            )
-            .await;
+            let resp =
+                super::handle_get_blob(&state, &anon_headers(), "http://ak.test", &image, digest)
+                    .await;
             let (status, body, _h) = tdh::collect_response(resp).await;
             results.push((what.to_string(), status, body.to_vec(), expect.to_vec()));
         }
@@ -27683,10 +27676,7 @@ mod remote_pull_through_cache_tests {
                 .and(wm_path(path))
                 .respond_with(
                     ResponseTemplate::new(200)
-                        .insert_header(
-                            "content-type",
-                            "application/vnd.oci.image.manifest.v1+json",
-                        )
+                        .insert_header("content-type", "application/vnd.oci.image.manifest.v1+json")
                         .set_body_bytes(manifest.clone()),
                 )
                 .mount(&server)

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -3123,6 +3123,10 @@ pub async fn resolve_virtual_manifest(
                             &upstream_path,
                             accept,
                             proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                            // #3206 / #2069 bug 1: the member's REAL format, so
+                            // its digest-addressed manifest cache entries keep
+                            // the immutable TTL (parity with the blob arm).
+                            member.format.clone(),
                         )
                         .await
                     {
@@ -3481,6 +3485,9 @@ async fn try_upstream_fetch_with_accept(
     // `_with_accept` sibling that could forward the content-negotiation `Accept`
     // header. Blob downloads no longer flow through here: the Remote GET-blob
     // path streams via `try_upstream_fetch_streaming_blob`.
+    // #3206: pass the real Docker format so digest-addressed manifests
+    // (`v2/<image>/manifests/sha256:...`) classify immutable in the proxy
+    // cache instead of inheriting Generic's 5-minute mutable TTL.
     proxy_helpers::proxy_fetch_capped_with_accept(
         proxy,
         repo.id,
@@ -3489,6 +3496,7 @@ async fn try_upstream_fetch_with_accept(
         &upstream_path,
         accept,
         proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        RepositoryFormat::Docker,
     )
     .await
     .ok()
@@ -27266,5 +27274,529 @@ mod content_encoding_forwarding_tests {
         );
         assert_eq!(&get_body[..], &coded[..], "GET must stream the coded layer");
         assert!(head_body.is_empty(), "HEAD must carry no body");
+    }
+}
+
+/// #3206: a Docker Remote repository must behave as a pull-through cache.
+///
+/// Three guards, matching the failure modes behind the issue:
+///
+/// * a layer blob pulled once through the proxy must be PERSISTED locally and
+///   a second pull of the same digest served from the cache without another
+///   upstream fetch (the issue's headline symptom);
+/// * a previously pulled image (manifests + config + layers) must remain
+///   retrievable when the upstream registry is DOWN (the issue's stated
+///   operational requirement);
+/// * the persisted cache entries must carry the TTL class the OCI spec
+///   implies — content-addressed blob/manifest paths immutable, tag paths
+///   mutable. The 1.5.x root cause of #3206 was exactly this classification:
+///   every handler-synthesized proxy repo was `Generic`, so
+///   `cache_classifier::classify` fell back to the 5-minute mutable TTL and
+///   every cached layer expired minutes after the pull (fixed for the
+///   streaming blob arm by #2312; the buffered manifest arm is fixed here).
+#[cfg(test)]
+mod remote_pull_through_cache_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn insert_public_remote_repo(pool: &sqlx::PgPool, upstream: &str) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("ocptc{}", &id.to_string()[..8]);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, \
+             upstream_url, is_public) \
+             VALUES ($1, $2, $2, $3, 'remote'::repository_type, 'docker'::repository_format, \
+             $4, true)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(format!("/tmp/oci-ptc-{}", id))
+        .bind(upstream)
+        .execute(pool)
+        .await
+        .expect("insert repo");
+        (id, key)
+    }
+
+    fn anon_headers() -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            AUTHORIZATION,
+            axum::http::HeaderValue::from_static("Bearer anonymous"),
+        );
+        h
+    }
+
+    fn sha_of(bytes: &[u8]) -> String {
+        format!(
+            "sha256:{}",
+            crate::api::handlers::proxy_helpers::sha256_hex(&bytes::Bytes::copy_from_slice(bytes))
+        )
+    }
+
+    async fn drain_ok(resp: Response, what: &str) -> Vec<u8> {
+        let (status, body, _h) = tdh::collect_response(resp).await;
+        assert_eq!(status, StatusCode::OK, "{what} must succeed");
+        body.to_vec()
+    }
+
+    /// Bounded wait for the background cache writer to commit `sidecar`.
+    ///
+    /// Presence is polled, never asserted: BOTH the fixed and the pre-fix
+    /// code write the sidecar (they differ in its TTL / in what a later pull
+    /// does), so this barrier is reachable under either shape and a revert
+    /// fails on the claim under test, not on the barrier.
+    async fn await_sidecar(sidecar: &std::path::Path) {
+        for _ in 0..100 {
+            if sidecar.exists() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Parse a cache sidecar and return `expires_at - cached_at` in seconds.
+    fn sidecar_ttl_secs(sidecar: &std::path::Path) -> i64 {
+        let raw = std::fs::read(sidecar)
+            .unwrap_or_else(|e| panic!("sidecar {} must exist: {e}", sidecar.display()));
+        let v: serde_json::Value = serde_json::from_slice(&raw).expect("sidecar JSON");
+        let cached_at = chrono::DateTime::parse_from_rfc3339(
+            v["cached_at"].as_str().expect("cached_at"),
+        )
+        .expect("cached_at rfc3339");
+        let expires_at = chrono::DateTime::parse_from_rfc3339(
+            v["expires_at"].as_str().expect("expires_at"),
+        )
+        .expect("expires_at rfc3339");
+        (expires_at - cached_at).num_seconds()
+    }
+
+    /// The issue's headline symptom: a pulled layer must be served from the
+    /// local cache on the next pull, without a second upstream fetch. The
+    /// mock's `.expect(1)` plus the explicit received-request count are the
+    /// positive control — a "fix" that re-fetched every time would fail here,
+    /// and a broken serve path would fail the body assertions.
+    #[tokio::test]
+    async fn remote_blob_second_pull_is_served_from_cache_without_upstream_refetch() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let layer: Vec<u8> = b"pull-through layer payload #3206. ".repeat(64);
+        let digest = sha_of(&layer);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(layer.clone()),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (repo_id, repo_key) = insert_public_remote_repo(&pool, &server.uri()).await;
+        let tmp = std::env::temp_dir().join(format!("oci-ptc-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+        let image = format!("{repo_key}/myimage");
+
+        // First pull: cache miss, streamed from upstream (teed into the cache).
+        let first = drain_ok(
+            super::handle_get_blob(&state, &anon_headers(), "http://ak.test", &image, &digest)
+                .await,
+            "first blob pull",
+        )
+        .await;
+        assert_eq!(&first[..], &layer[..], "first pull must stream the layer");
+
+        await_sidecar(&tmp.join(format!(
+            "proxy-cache/{repo_key}/v2/myimage/blobs/{digest}/__cache_meta__.json"
+        )))
+        .await;
+
+        // Second pull of the same digest: must come from the local cache.
+        let second = drain_ok(
+            super::handle_get_blob(&state, &anon_headers(), "http://ak.test", &image, &digest)
+                .await,
+            "second blob pull",
+        )
+        .await;
+
+        let received = server.received_requests().await.unwrap_or_default();
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(&second[..], &layer[..], "second pull must serve the layer");
+        assert_eq!(
+            received.len(),
+            1,
+            "second pull must be served from the local cache without an upstream fetch"
+        );
+    }
+
+    /// The issue's operational requirement: after one full `docker pull`
+    /// (HEAD tag, GET index by tag, GET child manifest by digest, GET config
+    /// + layer blobs), the SAME pull must succeed with the upstream registry
+    /// dead — every piece served from local persistence.
+    #[tokio::test]
+    async fn full_docker_pull_survives_upstream_outage() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let layer: Vec<u8> = b"layer bytes for the outage guard. ".repeat(64);
+        let config: Vec<u8> = br#"{"architecture":"amd64","os":"linux"}"#.to_vec();
+        let layer_digest = sha_of(&layer);
+        let config_digest = sha_of(&config);
+        let child = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config_digest,
+                "size": config.len(),
+            },
+            "layers": [{
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": layer_digest,
+                "size": layer.len(),
+            }],
+        })
+        .to_string()
+        .into_bytes();
+        let child_digest = sha_of(&child);
+        let index = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [{
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": child_digest,
+                "size": child.len(),
+                "platform": {"architecture": "amd64", "os": "linux"},
+            }],
+        })
+        .to_string()
+        .into_bytes();
+
+        let server = MockServer::start().await;
+        for (path, body, ct) in [
+            (
+                "/v2/myimage/manifests/v1".to_string(),
+                index.clone(),
+                "application/vnd.oci.image.index.v1+json",
+            ),
+            (
+                format!("/v2/myimage/manifests/{child_digest}"),
+                child.clone(),
+                "application/vnd.oci.image.manifest.v1+json",
+            ),
+            (
+                format!("/v2/myimage/blobs/{config_digest}"),
+                config.clone(),
+                "application/octet-stream",
+            ),
+            (
+                format!("/v2/myimage/blobs/{layer_digest}"),
+                layer.clone(),
+                "application/octet-stream",
+            ),
+        ] {
+            Mock::given(method("GET"))
+                .and(wm_path(path))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header("content-type", ct)
+                        .set_body_bytes(body),
+                )
+                .mount(&server)
+                .await;
+        }
+
+        let (repo_id, repo_key) = insert_public_remote_repo(&pool, &server.uri()).await;
+        let tmp = std::env::temp_dir().join(format!("oci-ptc-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+        let image = format!("{repo_key}/myimage");
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext::default();
+
+        // ---- Cold pull (upstream up), the sequence a docker client issues.
+        let head =
+            super::handle_head_manifest(&state, &anon_headers(), "http://ak.test", &image, "v1")
+                .await;
+        assert_eq!(head.status(), StatusCode::OK, "cold HEAD tag");
+        for (reference, expect, what) in [
+            ("v1", &index, "cold GET index by tag"),
+            (child_digest.as_str(), &child, "cold GET child manifest"),
+        ] {
+            let body = drain_ok(
+                super::handle_get_manifest(
+                    &state,
+                    &anon_headers(),
+                    "http://ak.test",
+                    &image,
+                    reference,
+                    &ctx,
+                )
+                .await,
+                what,
+            )
+            .await;
+            assert_eq!(&body[..], &expect[..], "{what}: bytes");
+        }
+        for (digest, expect, what) in [
+            (&config_digest, &config, "cold GET config blob"),
+            (&layer_digest, &layer, "cold GET layer blob"),
+        ] {
+            let body = drain_ok(
+                super::handle_get_blob(&state, &anon_headers(), "http://ak.test", &image, digest)
+                    .await,
+                what,
+            )
+            .await;
+            assert_eq!(&body[..], &expect[..], "{what}: bytes");
+        }
+
+        for digest in [&config_digest, &layer_digest] {
+            await_sidecar(&tmp.join(format!(
+                "proxy-cache/{repo_key}/v2/myimage/blobs/{digest}/__cache_meta__.json"
+            )))
+            .await;
+        }
+
+        // ---- Upstream outage.
+        drop(server);
+
+        // ---- Same pull again: everything must be served locally.
+        let head2 =
+            super::handle_head_manifest(&state, &anon_headers(), "http://ak.test", &image, "v1")
+                .await;
+        let mut results: Vec<(String, StatusCode, Vec<u8>, Vec<u8>)> = Vec::new();
+        for (reference, expect, what) in [
+            ("v1", &index, "warm GET index by tag (outage)"),
+            (
+                child_digest.as_str(),
+                &child,
+                "warm GET child manifest (outage)",
+            ),
+        ] {
+            let resp = super::handle_get_manifest(
+                &state,
+                &anon_headers(),
+                "http://ak.test",
+                &image,
+                reference,
+                &ctx,
+            )
+            .await;
+            let (status, body, _h) = tdh::collect_response(resp).await;
+            results.push((what.to_string(), status, body.to_vec(), expect.to_vec()));
+        }
+        for (digest, expect, what) in [
+            (&config_digest, &config, "warm GET config blob (outage)"),
+            (&layer_digest, &layer, "warm GET layer blob (outage)"),
+        ] {
+            let resp = super::handle_get_blob(
+                &state,
+                &anon_headers(),
+                "http://ak.test",
+                &image,
+                digest,
+            )
+            .await;
+            let (status, body, _h) = tdh::collect_response(resp).await;
+            results.push((what.to_string(), status, body.to_vec(), expect.to_vec()));
+        }
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(
+            head2.status(),
+            StatusCode::OK,
+            "warm HEAD tag (outage) must resolve locally"
+        );
+        for (what, status, body, expect) in results {
+            assert_eq!(status, StatusCode::OK, "{what} must succeed");
+            assert_eq!(&body[..], &expect[..], "{what}: bytes");
+        }
+    }
+
+    /// TTL-classification pin — the root cause of #3206.
+    ///
+    /// Content-addressed cache entries (blobs and digest-addressed manifests,
+    /// OCI distribution-spec content-addressable identities) must be written
+    /// with the immutable TTL; the tag-addressed manifest must keep a short
+    /// mutable TTL (tags move — this arm is the negative control that a
+    /// blanket "everything immutable" bug cannot satisfy).
+    ///
+    /// Pre-#2312 (≤ v1.5.8) every handler-synthesized proxy repo was Generic,
+    /// so blob entries expired after 300 s and every later pull re-downloaded
+    /// every layer from the upstream — the reported behavior. The digest-
+    /// manifest arm pins the same fix on the buffered manifest path.
+    #[tokio::test]
+    async fn proxied_oci_content_addressed_entries_cache_as_immutable() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        const IMMUTABLE_FLOOR_SECS: i64 = 30 * 24 * 3600; // >= 30 days
+        const MUTABLE_CEIL_SECS: i64 = 24 * 3600; // <= 1 day
+
+        let layer: Vec<u8> = b"ttl classification layer #3206. ".repeat(64);
+        let layer_digest = sha_of(&layer);
+        let manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": sha_of(b"{}"),
+                "size": 2,
+            },
+            "layers": [{
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": layer_digest,
+                "size": layer.len(),
+            }],
+        })
+        .to_string()
+        .into_bytes();
+        let manifest_digest = sha_of(&manifest);
+
+        let server = MockServer::start().await;
+        for path in [
+            format!("/v2/myimage/manifests/{manifest_digest}"),
+            "/v2/myimage/manifests/v1".to_string(),
+        ] {
+            Mock::given(method("GET"))
+                .and(wm_path(path))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header(
+                            "content-type",
+                            "application/vnd.oci.image.manifest.v1+json",
+                        )
+                        .set_body_bytes(manifest.clone()),
+                )
+                .mount(&server)
+                .await;
+        }
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{layer_digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(layer.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let (repo_id, repo_key) = insert_public_remote_repo(&pool, &server.uri()).await;
+        let tmp = std::env::temp_dir().join(format!("oci-ptc-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+        let image = format!("{repo_key}/myimage");
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext::default();
+
+        // Digest-addressed manifest FIRST: once a tag pull has cached the
+        // manifest locally, a later by-digest GET resolves locally and never
+        // writes the proxy-cache entry under test.
+        drain_ok(
+            super::handle_get_manifest(
+                &state,
+                &anon_headers(),
+                "http://ak.test",
+                &image,
+                &manifest_digest,
+                &ctx,
+            )
+            .await,
+            "cold GET manifest by digest",
+        )
+        .await;
+        drain_ok(
+            super::handle_get_manifest(
+                &state,
+                &anon_headers(),
+                "http://ak.test",
+                &image,
+                "v1",
+                &ctx,
+            )
+            .await,
+            "cold GET manifest by tag",
+        )
+        .await;
+        drain_ok(
+            super::handle_get_blob(
+                &state,
+                &anon_headers(),
+                "http://ak.test",
+                &image,
+                &layer_digest,
+            )
+            .await,
+            "cold GET layer blob",
+        )
+        .await;
+
+        let digest_manifest_sidecar = tmp.join(format!(
+            "proxy-cache/{repo_key}/v2/myimage/manifests/{manifest_digest}/__cache_meta__.json"
+        ));
+        let tag_manifest_sidecar = tmp.join(format!(
+            "proxy-cache/{repo_key}/v2/myimage/manifests/v1/__cache_meta__.json"
+        ));
+        let blob_sidecar = tmp.join(format!(
+            "proxy-cache/{repo_key}/v2/myimage/blobs/{layer_digest}/__cache_meta__.json"
+        ));
+        for sidecar in [
+            &digest_manifest_sidecar,
+            &tag_manifest_sidecar,
+            &blob_sidecar,
+        ] {
+            await_sidecar(sidecar).await;
+        }
+
+        let digest_manifest_ttl = sidecar_ttl_secs(&digest_manifest_sidecar);
+        let tag_manifest_ttl = sidecar_ttl_secs(&tag_manifest_sidecar);
+        let blob_ttl = sidecar_ttl_secs(&blob_sidecar);
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            blob_ttl >= IMMUTABLE_FLOOR_SECS,
+            "a content-addressed blob cache entry must be immutable \
+             (OCI distribution-spec content addressability); got {blob_ttl}s — \
+             the 5-minute TTL is the ≤1.5.8 regression behind #3206"
+        );
+        assert!(
+            digest_manifest_ttl >= IMMUTABLE_FLOOR_SECS,
+            "a digest-addressed manifest cache entry must be immutable \
+             (OCI distribution-spec content addressability); got \
+             {digest_manifest_ttl}s — the buffered manifest arm still \
+             synthesizing a Generic-format repo reintroduces the #3206 class"
+        );
+        assert!(
+            tag_manifest_ttl <= MUTABLE_CEIL_SECS,
+            "a tag-addressed manifest must stay mutable (tags move); got \
+             {tag_manifest_ttl}s — this negative control keeps the immutable \
+             assertions honest"
+        );
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -621,6 +621,17 @@ pub async fn proxy_fetch_capped(
 
 /// Byte-ceiling-bounded sibling of [`proxy_fetch_with_accept`] (#1608 Phase 4b /
 /// #2181). See [`proxy_fetch_capped`] for the `max` semantics.
+///
+/// Takes the repository's real `format` (#3206, completing #2312 for the
+/// buffered arm): this helper serves the OCI manifest proxy paths, whose
+/// digest-addressed cache paths (`v2/<image>/manifests/sha256:...`) are
+/// content-addressed and classify immutable — but only when the synthesized
+/// [`Repository`] carries the real format. The pre-#2312 `Generic` synthesis
+/// made `cache_classifier::classify` fall back to the mutable 5-minute TTL,
+/// which on the (then-unthreaded) blob path was the root cause of #3206:
+/// every cached OCI layer expired 5 minutes after the pull and each later
+/// pull re-downloaded every layer from the upstream registry.
+#[allow(clippy::too_many_arguments)]
 pub async fn proxy_fetch_capped_with_accept(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -629,13 +640,13 @@ pub async fn proxy_fetch_capped_with_accept(
     path: &str,
     accept: Option<&str>,
     max: usize,
+    format: RepositoryFormat,
 ) -> Result<(Bytes, Option<String>), Response> {
-    with_proxy_repo(repo_id, repo_key, upstream_url, path, |repo| async move {
-        proxy_service
-            .fetch_artifact_with_accept_capped(&repo, path, accept, max)
-            .await
-    })
-    .await
+    let repo = build_remote_repo_with_format(repo_id, repo_key, upstream_url, format);
+    proxy_service
+        .fetch_artifact_with_accept_capped(&repo, path, accept, max)
+        .await
+        .map_err(|e| map_proxy_error(repo_key, path, e))
 }
 
 /// Budget-reserving sibling of [`proxy_fetch_capped`] (#2684).


### PR DESCRIPTION
Fixes #3206

## What the issue reports

Docker Remote repositories do not behave as pull-through caches: image layers pulled through the proxy are re-fetched from the upstream registry on later pulls, and the storage volume does not appear to retain layer content. Reported against backend **1.5.1**.

## Root cause (verified live)

Reproduced against a live **v1.5.1** build pulling `library/alpine:3.20` from Docker Hub through a Docker remote repository (real bearer-token exchange and CDN redirects):

* The layer and config blobs **were** written to `proxy-cache/<repo>/v2/<image>/blobs/<digest>/__content__` — but their metadata sidecars carried `expires_at = cached_at + 300s`.
* Five minutes later, repeating the same pull re-downloaded **every blob** from Docker Hub (server log upstream-fetch count 4 → 6, both re-fetches being `blobs/sha256:...` streams). Manifests kept resolving locally via their `oci_tags` rows — matching the report's "manifests appear stored, layers don't persist" shape.

Mechanism: before #2312, every handler-driven proxy fetch synthesized its temporary `Repository` with `format: Generic` (`proxy_helpers::build_remote_repo`), so `cache_classifier::classify` never reached the OCI rules — content-addressed `v2/<image>/blobs/<digest>` paths fell to the **mutable 5-minute default TTL** instead of the immutable 10-year TTL. Expired entries fail revalidation (no usable validator flow on the blob path) and refill from upstream on every pull. That is exactly the reported behavior: the cache never *holds* anything for more than 5 minutes, upstream is re-hit for every layer, and the volume never grows past one TTL window's worth of content.

**#2312 (shipped in v1.6.0) fixed this for the streaming blob arm.** Verified live against current `main`: blob sidecars now carry the 10-year immutable TTL, a warm pull performs **zero** upstream fetches, and a fully pulled image (index, child manifest, config, layer) stays retrievable with the upstream registry down. So the issue as reported is resolved by upgrading to ≥ 1.6.0; for the reporter's 1.5.1 the answer to "is there a known issue where layers are streamed without being (durably) cached" is yes — this classification bug.

## What this PR fixes

The same classification gap was still live on `main` in the **buffered manifest arm**: `try_upstream_fetch_with_accept` (direct Remote manifest GET/HEAD fallback, also reached by the remote HEAD-blob probe) and the virtual-member manifest fallback both call `proxy_fetch_capped_with_accept`, which still synthesized a `Generic` repo. Observed live on a `main` build: `proxy-cache/.../manifests/sha256:<digest>/__cache_meta__.json` with a 300-second TTL — a digest-addressed manifest, which the OCI distribution spec makes content-addressable and therefore immutable. On direct Remote pulls this is masked by the local `oci-manifests/` + `oci_tags` store, but the virtual-member digest-manifest path re-fetches upstream after every 5-minute window, and any regression in the local manifest store would silently fall back onto a 5-minute cache.

Change: thread `RepositoryFormat` through `proxy_fetch_capped_with_accept` (its only two callers are the OCI manifest paths) and pass the real format at both call sites — `Docker` on the direct Remote arm, the member's own format on the virtual arm (parity with the #2069 bug-1 member-format fix on the blob arm).

Spec grounding: OCI distribution-spec, *Content Digests* — a digest reference is content-addressable ("the byte stream MUST be verified against the digest"), so a digest-addressed manifest or blob can never change; RFC 9111 §4.2 freshness for the mutable tag path (tags move, so they keep the conservative 5-minute TTL — unchanged).

## Regression guards added (`--lib`, DB-backed)

1. `remote_blob_second_pull_is_served_from_cache_without_upstream_refetch` — the issue's headline symptom, with a positive control: the wiremock upstream is pinned to **exactly one** request (`.expect(1)` plus an explicit received-request count), so a "fix" that re-fetched every pull fails, and body-equality assertions catch a broken serve path.
2. `full_docker_pull_survives_upstream_outage` — full docker-pull sequence (HEAD tag, GET index by tag, GET child manifest by digest, GET config + layer blobs), then the same pull with the upstream dead; everything must serve locally with matching bytes.
3. `proxied_oci_content_addressed_entries_cache_as_immutable` — TTL pin on the persisted sidecars: blob and digest-addressed manifest entries must be immutable-classified (≥ 30 days), while the tag-manifest entry must stay mutable (≤ 1 day) as the negative control that a blanket "everything immutable" bug cannot satisfy.

Barrier discipline: the tests wait on sidecar *presence*, which both the fixed and pre-fix code produce (they differ only in TTL / later-pull behavior), so a revert fails on the claim, not on the barrier.

## Revert-proof

Production code reverted faithfully to the merge-base shape (both call sites restored to the 7-argument call; `proxy_helpers.rs` restored byte-identical via `git checkout main --`):

* `git diff main --shortstat` → **`1 file changed, 524 insertions(+)`** — zero deletions, single appended hunk, all inside the new `#[cfg(test)] mod remote_pull_through_cache_tests`. Production byte-identical to merge-base.
* Test run (with `DATABASE_URL` + `AK_TESTS_REQUIRE_DB=1`; failing test ran 0.43 s, i.e. a real DB-backed run, not a skip):

```
FAIL proxied_oci_content_addressed_entries_cache_as_immutable
  a digest-addressed manifest cache entry must be immutable (OCI
  distribution-spec content addressability); got 300s — the buffered
  manifest arm still synthesizing a Generic-format repo reintroduces the
  #3206 class
```

Mutation check on the historical arm: flipping `try_upstream_fetch_streaming_blob`'s `RepositoryFormat::Docker` back to `Generic` — the faithful ≤ 1.5.8 shape that produced this issue — fails the same test on its **blob** assertion (`got 300s`), so the pin guards the original #3206 regression too, not just the manifest arm.

## Verification

* `cargo nextest run --lib -E 'test(oci_v2) or test(proxy_helpers)'` — 771/771 pass.
* `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `SQLX_OFFLINE=true cargo build --lib --tests` clean (no query-macro changes).
* Live end-to-end on `main` + this fix: cold pull of `library/alpine:3.20` from Docker Hub persists all four objects; warm pull performs zero upstream fetches; digest-addressed manifest sidecar now immutable.

## Note for the reporter

On 1.5.1 the layers *are* written to `proxy-cache/<repo>/...` but expire 300 s after each pull; upgrading to ≥ 1.6.0 (current: 1.7.x) makes blob cache entries durable and pulls survive upstream outages. Also note `tree -shL 3` cannot show this either way — level 3 is the per-repo cache directory, blob files live at level 6+, and `tree -s` prints the directory inode size (4.0K), not recursive content size; `du -sh` / unrestricted `find -type f` are the reliable probes.
