### PR TITLE
fix(pypi): enforce distribution metadata matches declared name/version on upload (#3107)

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3934,6 +3934,41 @@ async fn upload(
     })?;
     let normalized = normalized_project.as_str().to_string();
 
+    // Distribution/metadata consistency (#3107).
+    //
+    // `PypiHandler::validate` held name/version-vs-metadata checks but had no
+    // call site, so a wheel/sdist whose embedded METADATA/PKG-INFO named a
+    // DIFFERENT project (or version) than the twine `name`/`version` fields was
+    // published into the declared project's namespace unchecked — the bytes and
+    // the identity they resolve under could disagree. Bind them here.
+    //
+    // The body was streamed to a bounded scratch file (up to
+    // `max_upload_size_bytes`, 10 GiB by default); re-open that file and read
+    // only the metadata entry rather than buffering the whole distribution.
+    // ZIP/tar parsing is blocking, so it runs on the blocking pool.
+    {
+        let staged_path = staged_content.path().to_path_buf();
+        let expected_name = normalized.clone();
+        let expected_version = pkg_version.clone();
+        let dist_filename = filename.clone();
+        tokio::task::spawn_blocking(move || {
+            let file = std::fs::File::open(&staged_path).map_err(|e| {
+                AppError::Internal(format!("re-open staged upload for validation: {e}"))
+            })?;
+            PypiHandler::validate_upload_file(
+                &expected_name,
+                &expected_version,
+                &dist_filename,
+                file,
+            )
+        })
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!("upload validation task failed: {e}")).into_response()
+        })?
+        .map_err(|e| e.into_response())?;
+    }
+
     // SHA-256 was computed incrementally while the body was spooled to disk.
     let computed_sha256 = digests.sha256.clone();
 
@@ -5663,6 +5698,255 @@ mod tests {
         assert!(
             failures.is_empty(),
             "PyPI upload name validation (#3198) failed:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #3107 -- distribution/metadata consistency on the upload channel
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal but *real* wheel (a ZIP carrying `.dist-info/METADATA`)
+    /// whose declared `Name`/`Version` are `meta_name`/`meta_version`. Used to
+    /// drive the #3107 consistency check, which reads the archive's real
+    /// metadata rather than trusting the multipart form fields.
+    fn build_test_wheel(meta_name: &str, meta_version: &str) -> Vec<u8> {
+        use std::io::Write;
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut cursor);
+            let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            zip.start_file(
+                format!("{meta_name}-{meta_version}.dist-info/METADATA"),
+                options,
+            )
+            .expect("start METADATA");
+            write!(
+                zip,
+                "Metadata-Version: 2.1\nName: {meta_name}\nVersion: {meta_version}\n"
+            )
+            .expect("write METADATA");
+            zip.finish().expect("finish wheel zip");
+        }
+        cursor.into_inner()
+    }
+
+    /// Build a minimal but *real* sdist (a gzip'd tar carrying `PKG-INFO`) whose
+    /// declared `Name`/`Version` are `meta_name`/`meta_version`.
+    fn build_test_sdist(meta_name: &str, meta_version: &str) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let pkg_info =
+            format!("Metadata-Version: 2.1\nName: {meta_name}\nVersion: {meta_version}\n");
+        let mut tar_builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header
+            .set_path(format!("{meta_name}-{meta_version}/PKG-INFO"))
+            .expect("set PKG-INFO path");
+        header.set_size(pkg_info.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar_builder
+            .append(&header, pkg_info.as_bytes())
+            .expect("append PKG-INFO");
+        let tar_bytes = tar_builder.into_inner().expect("finish tar");
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar_bytes).expect("gzip write");
+        encoder.finish().expect("gzip finish")
+    }
+
+    /// `PypiHandler::validate` (formats/pypi.rs) held name/version-vs-metadata
+    /// checks but had no call site, so a distribution whose embedded metadata
+    /// named a *different* project or version than the twine `name`/`version`
+    /// fields published unchecked into the declared namespace (#3107). Wiring
+    /// the check must:
+    ///
+    /// 1. **Positive control, same fixture.** A wheel and an sdist whose
+    ///    metadata matches the declared identity upload with 200 and are listed
+    ///    by their own simple index — without this a validator that rejects
+    ///    everything would satisfy every negative assertion below (the #3179
+    ///    failure mode).
+    /// 2. **Reject name confusion.** A wheel/sdist whose `METADATA`/`PKG-INFO`
+    ///    `Name` disagrees with the declared project is 400 and never lands in
+    ///    that project's index.
+    /// 3. **Reject version confusion.** A wheel whose `METADATA` `Version`
+    ///    disagrees with the declared version is 400.
+    /// 4. **PEP 440 equivalence is not a mismatch.** Declaring `1.0` for a wheel
+    ///    whose metadata says `1.0.0` still succeeds — the guard must not
+    ///    over-reject versions PEP 440 considers equal.
+    ///
+    /// The 400s must carry the word `mismatch`: a 400 alone proves nothing
+    /// (a malformed body, a missing field or a digest error all produce one).
+    #[tokio::test]
+    async fn pypi_upload_rejects_distribution_metadata_mismatch_but_allows_consistent_ones() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let mut failures: Vec<String> = Vec::new();
+
+        // Helper: POST an upload, return (status, body).
+        async fn upload(
+            fx: &tdh::Fixture,
+            project: &str,
+            version: &str,
+            filename: &str,
+            content: &[u8],
+        ) -> (StatusCode, String) {
+            use crate::api::handlers::test_db_helpers as tdh;
+            let (content_type, body) = pypi_upload_multipart(
+                project,
+                version,
+                filename,
+                content,
+                "#3107 consistency",
+                ">=3.8",
+            );
+            let app = fx.router_with_auth(super::router());
+            let (status, body) = tdh::send(
+                app,
+                tdh::post(format!("/{}/", fx.repo_key), &content_type, body),
+            )
+            .await;
+            (status, String::from_utf8_lossy(&body).into_owned())
+        }
+
+        // Helper: GET a project's simple index, return (status, body).
+        async fn simple_index(fx: &tdh::Fixture, project: &str) -> (StatusCode, String) {
+            use crate::api::handlers::test_db_helpers as tdh;
+            let app = fx.router_with_auth(super::router());
+            let (status, body) =
+                tdh::send(app, tdh::get(format!("/{}/simple/{project}/", fx.repo_key))).await;
+            (status, String::from_utf8_lossy(&body).into_owned())
+        }
+
+        // (1) Positive control: a consistent wheel publishes and resolves.
+        let good_wheel = "goodpkg-1.0.0-py3-none-any.whl";
+        let (st, body) = upload(
+            &fx,
+            "goodpkg",
+            "1.0.0",
+            good_wheel,
+            &build_test_wheel("goodpkg", "1.0.0"),
+        )
+        .await;
+        if st != StatusCode::OK {
+            failures.push(format!(
+                "consistent wheel must upload (200), got {st}; body: {body}"
+            ));
+        }
+        let (st, body) = simple_index(&fx, "goodpkg").await;
+        if st != StatusCode::OK || !body.contains(good_wheel) {
+            failures.push(format!(
+                "consistent wheel must be listed at /simple/goodpkg/ (200 + lists {good_wheel}); \
+                 got {st}; body: {body}"
+            ));
+        }
+
+        // (1) Positive control: a consistent sdist publishes and resolves.
+        let good_sdist = "goodsdist-2.0.0.tar.gz";
+        let (st, body) = upload(
+            &fx,
+            "goodsdist",
+            "2.0.0",
+            good_sdist,
+            &build_test_sdist("goodsdist", "2.0.0"),
+        )
+        .await;
+        if st != StatusCode::OK {
+            failures.push(format!(
+                "consistent sdist must upload (200), got {st}; body: {body}"
+            ));
+        }
+        let (st, body) = simple_index(&fx, "goodsdist").await;
+        if st != StatusCode::OK || !body.contains(good_sdist) {
+            failures.push(format!(
+                "consistent sdist must be listed at /simple/goodsdist/; got {st}; body: {body}"
+            ));
+        }
+
+        // (4) PEP 440 equivalence: declared `1.0` vs metadata `1.0.0` -> 200.
+        let canon_wheel = "canonpkg-1.0-py3-none-any.whl";
+        let (st, body) = upload(
+            &fx,
+            "canonpkg",
+            "1.0",
+            canon_wheel,
+            &build_test_wheel("canonpkg", "1.0.0"),
+        )
+        .await;
+        if st != StatusCode::OK {
+            failures.push(format!(
+                "PEP 440-equivalent version (declared 1.0, metadata 1.0.0) must NOT be rejected; \
+                 got {st}; body: {body}"
+            ));
+        }
+
+        // (2) Name confusion in a wheel -> 400 mismatch, and nothing squats.
+        let (st, body) = upload(
+            &fx,
+            "realclaim",
+            "1.0.0",
+            "realclaim-1.0.0-py3-none-any.whl",
+            &build_test_wheel("evilpkg", "1.0.0"),
+        )
+        .await;
+        if st != StatusCode::BAD_REQUEST || !body.to_lowercase().contains("mismatch") {
+            failures.push(format!(
+                "wheel whose metadata names a different project must be 400 with 'mismatch'; \
+                 got {st}; body: {body}"
+            ));
+        }
+        let (_st, body) = simple_index(&fx, "realclaim").await;
+        if body.contains("realclaim-1.0.0-py3-none-any.whl") {
+            failures.push(format!(
+                "a name-mismatched wheel must not land in /simple/realclaim/; body: {body}"
+            ));
+        }
+
+        // (3) Version confusion in a wheel -> 400 mismatch.
+        let (st, body) = upload(
+            &fx,
+            "verpkg",
+            "1.0.0",
+            "verpkg-1.0.0-py3-none-any.whl",
+            &build_test_wheel("verpkg", "9.9.9"),
+        )
+        .await;
+        if st != StatusCode::BAD_REQUEST || !body.to_lowercase().contains("mismatch") {
+            failures.push(format!(
+                "wheel whose metadata version disagrees must be 400 with 'mismatch'; \
+                 got {st}; body: {body}"
+            ));
+        }
+
+        // (2) Name confusion in an sdist -> 400 mismatch.
+        let (st, body) = upload(
+            &fx,
+            "sdistclaim",
+            "1.0.0",
+            "sdistclaim-1.0.0.tar.gz",
+            &build_test_sdist("othersdist", "1.0.0"),
+        )
+        .await;
+        if st != StatusCode::BAD_REQUEST || !body.to_lowercase().contains("mismatch") {
+            failures.push(format!(
+                "sdist whose metadata names a different project must be 400 with 'mismatch'; \
+                 got {st}; body: {body}"
+            ));
+        }
+
+        fx.teardown().await;
+
+        assert!(
+            failures.is_empty(),
+            "PyPI upload metadata-consistency (#3107) failed:\n{}",
             failures.join("\n")
         );
     }

--- a/backend/src/formats/pypi.rs
+++ b/backend/src/formats/pypi.rs
@@ -8,12 +8,18 @@ use bytes::Bytes;
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Read;
+use std::io::{Read, Seek};
 use tar::Archive;
 
 use crate::error::{AppError, Result};
 use crate::formats::FormatHandler;
 use crate::models::repository::RepositoryFormat;
+
+/// Upper bound on the bytes read from a wheel `METADATA` / sdist `PKG-INFO`
+/// entry (#3107). Those files are a few KiB in practice; capping the read keeps
+/// a hostile archive whose metadata entry is a decompression bomb from turning
+/// the upload-time consistency check into an unbounded read.
+const MAX_PKG_INFO_BYTES: u64 = 4 * 1024 * 1024;
 
 /// PyPI format handler
 pub struct PypiHandler;
@@ -300,24 +306,36 @@ impl PypiHandler {
 
     /// Extract metadata from PKG-INFO or METADATA file in sdist
     pub fn extract_sdist_metadata(content: &[u8]) -> Result<PkgInfo> {
-        let gz = GzDecoder::new(content);
+        Self::extract_sdist_metadata_reader(content)
+    }
+
+    /// Streaming variant of [`Self::extract_sdist_metadata`] that reads the
+    /// gzip'd tar straight from any [`Read`] (e.g. the staged upload scratch
+    /// file) instead of a fully-buffered slice, so a multi-gigabyte body is
+    /// never held in memory (#3107). The `PKG-INFO` read is capped at
+    /// [`MAX_PKG_INFO_BYTES`].
+    pub fn extract_sdist_metadata_reader<R: Read>(reader: R) -> Result<PkgInfo> {
+        let gz = GzDecoder::new(reader);
         let mut archive = Archive::new(gz);
 
         for entry in archive
             .entries()
             .map_err(|e| AppError::Validation(format!("Invalid tarball: {}", e)))?
         {
-            let mut entry =
+            let entry =
                 entry.map_err(|e| AppError::Validation(format!("Invalid tarball entry: {}", e)))?;
 
-            let path = entry
-                .path()
-                .map_err(|e| AppError::Validation(format!("Invalid path in tarball: {}", e)))?;
-
             // Look for PKG-INFO in the root of the package
-            if path.ends_with("PKG-INFO") {
+            let is_pkg_info = {
+                let path = entry
+                    .path()
+                    .map_err(|e| AppError::Validation(format!("Invalid path in tarball: {}", e)))?;
+                path.ends_with("PKG-INFO")
+            };
+            if is_pkg_info {
                 let mut content = String::new();
                 entry
+                    .take(MAX_PKG_INFO_BYTES)
                     .read_to_string(&mut content)
                     .map_err(|e| AppError::Validation(format!("Failed to read PKG-INFO: {}", e)))?;
 
@@ -332,13 +350,20 @@ impl PypiHandler {
 
     /// Extract METADATA from wheel file
     pub fn extract_wheel_metadata(content: &[u8]) -> Result<PkgInfo> {
-        // Wheels are ZIP files
-        let cursor = std::io::Cursor::new(content);
-        let mut archive = zip::ZipArchive::new(cursor)
+        Self::extract_wheel_metadata_reader(std::io::Cursor::new(content))
+    }
+
+    /// Streaming variant of [`Self::extract_wheel_metadata`]. A wheel is a ZIP,
+    /// so the reader must be [`Seek`]: the ZIP central directory lives at the
+    /// end of the file and only the single `METADATA` entry is inflated, so
+    /// this reads a bounded amount regardless of the (up to 10 GiB) body size
+    /// (#3107). The `METADATA` read is capped at [`MAX_PKG_INFO_BYTES`].
+    pub fn extract_wheel_metadata_reader<R: Read + Seek>(reader: R) -> Result<PkgInfo> {
+        let mut archive = zip::ZipArchive::new(reader)
             .map_err(|e| AppError::Validation(format!("Invalid wheel file: {}", e)))?;
 
         for i in 0..archive.len() {
-            let mut file = archive
+            let file = archive
                 .by_index(i)
                 .map_err(|e| AppError::Validation(format!("Failed to read wheel entry: {}", e)))?;
 
@@ -347,7 +372,8 @@ impl PypiHandler {
             // Look for METADATA file in .dist-info directory
             if name.contains(".dist-info/") && name.ends_with("METADATA") {
                 let mut content = String::new();
-                file.read_to_string(&mut content)
+                file.take(MAX_PKG_INFO_BYTES)
+                    .read_to_string(&mut content)
                     .map_err(|e| AppError::Validation(format!("Failed to read METADATA: {}", e)))?;
 
                 return Self::parse_pkg_info(&content);
@@ -357,6 +383,108 @@ impl PypiHandler {
         Err(AppError::Validation(
             "METADATA not found in wheel file".to_string(),
         ))
+    }
+
+    /// Enforce that a distribution's embedded `METADATA`/`PKG-INFO` agrees with
+    /// the name (and, for wheels, version) it is being published under.
+    ///
+    /// Shared by [`FormatHandler::validate`] (buffered) and
+    /// [`Self::validate_upload_file`] (streaming) so the two entry points can
+    /// never disagree about what a match is — the recurring failure mode when
+    /// PyPI name/version logic is duplicated (#3077 / #3179 / #3183 / #3186).
+    ///
+    /// * Names are compared in PEP 503 normalized form (`expected_name` is
+    ///   already normalized; the metadata name is normalized here).
+    /// * Versions match on either byte equality or PEP 440 equivalence
+    ///   ([`Self::canonical_version`]), so `1.0` and `1.0.0`, or a metadata
+    ///   `1.0+abc` and its filename-escaped form, are not spuriously rejected.
+    fn enforce_declared_identity(
+        expected_name: Option<&str>,
+        expected_version: Option<&str>,
+        pkg_info: &PkgInfo,
+    ) -> Result<()> {
+        if let Some(expected_name) = expected_name {
+            let metadata_name = Self::normalize_name(&pkg_info.name);
+            if metadata_name != expected_name {
+                return Err(AppError::Validation(format!(
+                    "Package name mismatch: declared '{}' but distribution metadata says '{}'",
+                    expected_name, pkg_info.name
+                )));
+            }
+        }
+
+        if let Some(expected_version) = expected_version {
+            if !Self::versions_match(&pkg_info.version, expected_version) {
+                return Err(AppError::Validation(format!(
+                    "Version mismatch: declared '{}' but distribution metadata says '{}'",
+                    expected_version, pkg_info.version
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Two PyPI versions are the same iff they are byte-equal or PEP 440 equal.
+    fn versions_match(a: &str, b: &str) -> bool {
+        a == b
+            || matches!(
+                (Self::canonical_version(a), Self::canonical_version(b)),
+                (Some(x), Some(y)) if x == y
+            )
+    }
+
+    /// Validate an uploaded PyPI distribution against the name/version it is
+    /// being published under, reading the archive metadata directly from the
+    /// staged scratch file (#3107).
+    ///
+    /// This is the check `FormatHandler::validate` was written for but which had
+    /// no call site. It is expressed over a streaming [`Read`]/[`Seek`] rather
+    /// than `&Bytes` because a twine upload body can be up to
+    /// `max_upload_size_bytes` (10 GiB by default) and is spooled to disk, never
+    /// buffered — so the trait's `&Bytes` signature cannot be the literal call
+    /// site. Both paths funnel through [`Self::enforce_declared_identity`].
+    ///
+    /// A body that does not parse as the declared archive type carries no
+    /// metadata to contradict its declared identity, so it is passed through
+    /// here: malformed content is the scan/quarantine pipeline's concern, and
+    /// rejecting it is a separate policy from this name/version-consistency
+    /// gate. Only a distribution that *does* carry metadata and disagrees with
+    /// its declared name/version is rejected.
+    ///
+    /// Specs: wheel filename + `.dist-info/METADATA` (PEP 427), sdist filename +
+    /// `PKG-INFO` (PEP 625 / PEP 643), name normalization (PEP 503), version
+    /// equivalence (PEP 440).
+    pub fn validate_upload_file<R: Read + Seek>(
+        expected_name: &str,
+        expected_version: &str,
+        filename: &str,
+        reader: R,
+    ) -> Result<()> {
+        if filename.ends_with(".whl") {
+            match Self::extract_wheel_metadata_reader(reader) {
+                Ok(pkg_info) => Self::enforce_declared_identity(
+                    Some(expected_name),
+                    Some(expected_version),
+                    &pkg_info,
+                ),
+                // Unparseable / metadata-less wheel: nothing to contradict.
+                Err(_) => Ok(()),
+            }
+        } else if filename.ends_with(".tar.gz") {
+            match Self::extract_sdist_metadata_reader(reader) {
+                // Sdist filenames do not carry a build/python tag, but the
+                // PKG-INFO version is authoritative; the name is the field a
+                // confusion upload gets wrong, so — matching the historical
+                // `validate()` behaviour — the sdist path checks the name.
+                Ok(pkg_info) => {
+                    Self::enforce_declared_identity(Some(expected_name), None, &pkg_info)
+                }
+                Err(_) => Ok(()),
+            }
+        } else {
+            Ok(())
+        }
     }
 
     /// Parse PKG-INFO or METADATA content (RFC 822 format)
@@ -811,46 +939,17 @@ impl FormatHandler for PypiHandler {
 
         // Validate package files
         if let Some(filename) = info.filename.as_ref().filter(|_| !content.is_empty()) {
-            // Validate wheel files
+            // Wheels carry a name and a version to check; sdists carry a name.
             if filename.ends_with(".whl") {
                 let pkg_info = Self::extract_wheel_metadata(content)?;
-
-                // Verify name matches
-                if let Some(path_name) = &info.name {
-                    let normalized_pkg_name = Self::normalize_name(&pkg_info.name);
-                    if &normalized_pkg_name != path_name {
-                        return Err(AppError::Validation(format!(
-                            "Package name mismatch: path says '{}' but metadata says '{}'",
-                            path_name, pkg_info.name
-                        )));
-                    }
-                }
-
-                // Verify version matches
-                if let Some(path_version) = &info.version {
-                    if &pkg_info.version != path_version {
-                        return Err(AppError::Validation(format!(
-                            "Version mismatch: path says '{}' but metadata says '{}'",
-                            path_version, pkg_info.version
-                        )));
-                    }
-                }
-            }
-
-            // Validate sdist files
-            if filename.ends_with(".tar.gz") {
+                Self::enforce_declared_identity(
+                    info.name.as_deref(),
+                    info.version.as_deref(),
+                    &pkg_info,
+                )?;
+            } else if filename.ends_with(".tar.gz") {
                 let pkg_info = Self::extract_sdist_metadata(content)?;
-
-                // Verify name matches
-                if let Some(path_name) = &info.name {
-                    let normalized_pkg_name = Self::normalize_name(&pkg_info.name);
-                    if &normalized_pkg_name != path_name {
-                        return Err(AppError::Validation(format!(
-                            "Package name mismatch: path says '{}' but metadata says '{}'",
-                            path_name, pkg_info.name
-                        )));
-                    }
-                }
+                Self::enforce_declared_identity(info.name.as_deref(), None, &pkg_info)?;
             }
         }
 


### PR DESCRIPTION
## What

`PypiHandler::validate()` (`backend/src/formats/pypi.rs`) carried
name/version-vs-metadata consistency checks but **had no call site** — the upload
handler never invoked it. As a result a wheel or sdist whose embedded
`METADATA`/`PKG-INFO` declared a **different project name or version** than the
twine `name`/`version` form fields was published, unchecked, into the declared
project's namespace. The stored bytes and the identity they resolve under could
disagree — e.g. an archive whose metadata says `evilpkg` accepted and served
from `/simple/realclaim/`.

The sibling filename path-traversal guard already shipped in #3104; this PR
closes the remaining half of #3107 (the dead `validate()` hook).

## Fix

- **Wire the check into the upload path.** After the project name is validated
  (PEP 508, #3198) the handler now binds the declared `name`/`version` to what
  the archive actually contains before the artifact is stored.
- **Stream, don't buffer.** A twine body can be up to `max_upload_size_bytes`
  (10 GiB default) and is spooled to a scratch file. The check re-opens that
  file and reads only the metadata entry via new streaming reader-based
  extractors (`extract_wheel_metadata_reader` / `extract_sdist_metadata_reader`,
  ZIP central directory + single inflated entry / gzip'd-tar scan); the existing
  `&[u8]` extractors now delegate to them. The `METADATA`/`PKG-INFO` read is
  capped (`MAX_PKG_INFO_BYTES`) so a hostile archive cannot turn the check into
  an unbounded read. ZIP/tar parsing runs on the blocking pool.
- **One implementation, two entry points.** `validate()` and the upload path now
  funnel through a single `enforce_declared_identity` helper, so they cannot
  drift — the recurring PyPI-normalizer divergence failure mode (#3077 / #3179 /
  #3183 / #3186). Version comparison accepts PEP 440 equivalence
  (`canonical_version`), so declaring `1.0` for a `1.0.0` metadata version is not
  a false mismatch.

## Deliberate scope

A body that does **not** parse as the declared archive type carries no metadata
to contradict its declared identity, so it is passed through (a malformed archive
is the scan/quarantine pipeline's concern; per PEP 427 / PEP 625 a conformant
distribution always carries `METADATA`/`PKG-INFO`, and a client that cannot read
it cannot install the artifact anyway). Only a distribution that *does* carry
metadata and *disagrees* with its declared name/version is rejected (`400`). This
is exactly the behaviour change the issue anticipated — it rejects uploads that
currently succeed **only** when their metadata lies about their identity, and
leaves every legitimate twine upload (where `name`/`version` are derived from the
same metadata) untouched.

## Tests

`pypi_upload_rejects_distribution_metadata_mismatch_but_allows_consistent_ones`
(DB-backed, in-crate `--lib`) builds **real** wheels/sdists and, in one fixture:

- **positive control** — a consistent wheel *and* sdist upload `200` and are
  listed at `/simple/<name>/` (so the negative assertions cannot be satisfied by
  a validator that rejects everything);
- a wheel/sdist whose metadata **name** disagrees → `400 mismatch`, and it never
  lands in the declared project's index;
- a wheel whose metadata **version** disagrees → `400 mismatch`;
- a **PEP 440-equivalent** version (declared `1.0`, metadata `1.0.0`) still
  succeeds (no over-rejection).

Revert-proof: with the production wiring reverted to merge-base (tests kept, a
242-insertion test-only diff), the name-mismatched wheel returns `200` and squats
`/simple/realclaim/` and the test **fails**; with the fix it passes. Existing
fake-content upload tests (name round-trip, PEP 508 squat, peer replication) stay
green.

## Specs

PEP 427 (wheel filename + `.dist-info/METADATA`), PEP 625 / PEP 643 (sdist
filename + `PKG-INFO`), PEP 503 (name normalization), PEP 440 (version
equivalence), PEP 508 (name grammar, already enforced by #3198).

Fixes #3107
