### PR TITLE
fix(maven): declare upstream Content-Encoding on download_root verbatim forwards

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -915,17 +915,15 @@ async fn download_root(
             // under the non-empty sentinel key "_root_" to satisfy the cache-
             // path validation that rejects empty strings.
             let remote = proxy_helpers::build_remote_repo(repo.id, &repo_key, upstream_url);
-            let (content, content_type) = proxy
+            let (content, content_type, content_encoding) = proxy
                 .fetch_artifact_with_cache_path(&remote, "", "_root_")
                 .await
                 .map_err(|e| e.into_response())?;
-            let ct = content_type.unwrap_or_else(|| "text/html".to_string());
-            return Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(CONTENT_TYPE, ct)
-                .header(CONTENT_LENGTH, content.len().to_string())
-                .body(Body::from(content))
-                .unwrap());
+            return Ok(forward_root_verbatim(
+                content,
+                content_type,
+                content_encoding,
+            ));
         }
     }
 
@@ -938,17 +936,15 @@ async fn download_root(
                 {
                     let remote =
                         proxy_helpers::build_remote_repo(member.id, &member.key, upstream_url);
-                    if let Ok((content, content_type)) = proxy
+                    if let Ok((content, content_type, content_encoding)) = proxy
                         .fetch_artifact_with_cache_path(&remote, "", "_root_")
                         .await
                     {
-                        let ct = content_type.unwrap_or_else(|| "text/html".to_string());
-                        return Ok(Response::builder()
-                            .status(StatusCode::OK)
-                            .header(CONTENT_TYPE, ct)
-                            .header(CONTENT_LENGTH, content.len().to_string())
-                            .body(Body::from(content))
-                            .unwrap());
+                        return Ok(forward_root_verbatim(
+                            content,
+                            content_type,
+                            content_encoding,
+                        ));
                     }
                 }
             }
@@ -956,6 +952,31 @@ async fn download_root(
     }
 
     Err(AppError::NotFound("Repository root not available".to_string()).into_response())
+}
+
+/// Build the response for an upstream root body that is forwarded VERBATIM.
+///
+/// The bytes are sent exactly as the upstream (or the proxy cache) produced
+/// them, so the upstream `Content-Encoding` must be re-declared when present
+/// (RFC 9110 §8.4 — the representation header describes the coding applied to
+/// the bytes as transferred), and `Content-Length` is the length of those
+/// coded bytes (RFC 9110 §8.6). Dropping the coding while keeping the coded
+/// bytes was #3211: clients stored a compressed root document as if it were
+/// plain.
+fn forward_root_verbatim(
+    content: Bytes,
+    content_type: Option<String>,
+    content_encoding: Option<String>,
+) -> Response {
+    let ct = content_type.unwrap_or_else(|| "text/html".to_string());
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, ct)
+        .header(CONTENT_LENGTH, content.len().to_string());
+    if let Some(enc) = content_encoding {
+        builder = builder.header(CONTENT_ENCODING, enc);
+    }
+    builder.body(Body::from(content)).unwrap()
 }
 
 // ---------------------------------------------------------------------------
@@ -4778,6 +4799,160 @@ mod tests {
 
         // cleanup (members cascade on repo delete).
         for id in [virtual_id, remote_id, local_id] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await;
+        }
+    }
+
+    /// #3211: `download_root` forwards the upstream root body VERBATIM, so it
+    /// must re-declare the upstream `Content-Encoding` (RFC 9110 §8.4 — the
+    /// header describes the coding of the bytes as transferred) and its
+    /// `Content-Length` must describe the coded bytes actually sent
+    /// (RFC 9110 §8.6). Before the fix the handler copied `Content-Type` and
+    /// recomputed `Content-Length` from the coded bytes but dropped the
+    /// coding, so clients stored a compressed document as if it were plain.
+    ///
+    /// Uses a NON-gzip coding (deflate) so a handler hardcoding `"gzip"`
+    /// cannot pass, and an uncoded upstream in the SAME fixture so hardcoding
+    /// `"deflate"` cannot pass either (the control must carry no
+    /// `Content-Encoding` at all). Covers BOTH arms that had the bug: the
+    /// Remote repo arm and the Virtual-member arm.
+    #[tokio::test]
+    async fn test_download_root_forwards_upstream_content_encoding_verbatim() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Path, State};
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (plain, coded) = tdh::coded_fixture("deflate", b"maven-root-index-3211 ");
+
+        // Coded upstream: root index served deflate-coded, coding declared.
+        let coded_mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .insert_header("content-encoding", "deflate")
+                    .set_body_bytes(coded.clone()),
+            )
+            .mount(&coded_mock)
+            .await;
+
+        // Positive control in the same fixture: same document, no coding.
+        let plain_mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_bytes(plain.clone()),
+            )
+            .mount(&plain_mock)
+            .await;
+
+        let (coded_id, coded_key, dir) = tdh::create_repo(&pool, "remote", "maven").await;
+        let (plain_id, plain_key, _pdir) = tdh::create_repo(&pool, "remote", "maven").await;
+        for (id, uri) in [(coded_id, coded_mock.uri()), (plain_id, plain_mock.uri())] {
+            sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+                .bind(uri)
+                .bind(id)
+                .execute(&pool)
+                .await
+                .expect("point remote upstream at mock");
+        }
+
+        // Virtual repo whose only member is the coded remote — the second arm
+        // of `download_root` that dropped the coding.
+        let (virtual_id, virtual_key, _vdir) = tdh::create_repo(&pool, "virtual", "maven").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(virtual_id)
+        .bind(coded_id)
+        .execute(&pool)
+        .await
+        .expect("link coded remote as virtual member");
+
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), dir.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), dir.to_str().unwrap(), proxy);
+
+        async fn probe(
+            state: crate::api::SharedState,
+            key: &str,
+        ) -> (Option<String>, Option<String>, bytes::Bytes) {
+            let resp = download_root(State(state), Path(key.to_string()))
+                .await
+                .expect("root probe must proxy 200");
+            assert_eq!(resp.status(), axum::http::StatusCode::OK);
+            // Fully qualified (not the handler-module import) so this test
+            // compiles unchanged against the pre-fix production code.
+            let enc = resp
+                .headers()
+                .get(axum::http::header::CONTENT_ENCODING)
+                .map(|v| v.to_str().unwrap().to_string());
+            let len = resp
+                .headers()
+                .get(CONTENT_LENGTH)
+                .map(|v| v.to_str().unwrap().to_string());
+            let body = axum::body::to_bytes(resp.into_body(), 1 << 20)
+                .await
+                .expect("read body");
+            (enc, len, body)
+        }
+
+        // REMOTE arm, coded upstream: the UPSTREAM's coding is declared, the
+        // bytes are the coded bytes untouched, and Content-Length describes
+        // those coded bytes (§8.6).
+        let (enc, len, body) = probe(state.clone(), &coded_key).await;
+        assert_eq!(
+            enc.as_deref(),
+            Some("deflate"),
+            "remote root must re-declare the upstream Content-Encoding (#3211)"
+        );
+        assert_eq!(len.as_deref(), Some(coded.len().to_string().as_str()));
+        assert_eq!(
+            &body[..],
+            &coded[..],
+            "coded bytes must pass through verbatim"
+        );
+        assert_eq!(
+            tdh::inflate_deflate(&body),
+            plain,
+            "client must be able to decode the body with the declared coding"
+        );
+
+        // VIRTUAL arm, coded member: identical contract.
+        let (enc, len, body) = probe(state.clone(), &virtual_key).await;
+        assert_eq!(
+            enc.as_deref(),
+            Some("deflate"),
+            "virtual root must re-declare the member upstream's Content-Encoding (#3211)"
+        );
+        assert_eq!(len.as_deref(), Some(coded.len().to_string().as_str()));
+        assert_eq!(&body[..], &coded[..]);
+        assert_eq!(tdh::inflate_deflate(&body), plain);
+
+        // CONTROL, uncoded upstream: byte-identical body, NO spurious coding.
+        let (enc, len, body) = probe(state.clone(), &plain_key).await;
+        assert_eq!(
+            enc, None,
+            "an uncoded upstream must not grow a Content-Encoding header"
+        );
+        assert_eq!(len.as_deref(), Some(plain.len().to_string().as_str()));
+        assert_eq!(
+            &body[..],
+            &plain[..],
+            "uncoded body must be forwarded byte-identically"
+        );
+
+        // cleanup (members cascade on repo delete).
+        for id in [virtual_id, coded_id, plain_id] {
             let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
                 .bind(id)
                 .execute(&pool)

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1415,6 +1415,11 @@ pub(crate) async fn coordinated_retry_get(
 /// Fetch from upstream using `fetch_path` for the URL but `cache_path` for
 /// the proxy cache key. This lets callers store content under a predictable
 /// local path even when the upstream download URL varies between requests.
+///
+/// Returns `(body, content_type, content_encoding)` (#3211): an adopter that
+/// forwards the buffered body verbatim must declare the coding (RFC 9110
+/// §8.4); one that parses/rewrites the body must decode it and drop the
+/// coding.
 pub async fn proxy_fetch_with_cache_key(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -1422,7 +1427,7 @@ pub async fn proxy_fetch_with_cache_key(
     upstream_url: &str,
     fetch_path: &str,
     cache_path: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<(Bytes, Option<String>, Option<String>), Response> {
     with_proxy_repo(
         repo_id,
         repo_key,
@@ -1442,6 +1447,9 @@ pub async fn proxy_fetch_with_cache_key(
 /// the PEP 691 JSON representation while keying the cache on a format-qualified
 /// `cache_path`, so the JSON and HTML forms of the same index never collide in
 /// the proxy cache.
+///
+/// Returns `(body, content_type, content_encoding)` (#3211) — same contract
+/// as [`proxy_fetch_with_cache_key`].
 pub async fn proxy_fetch_with_cache_key_and_accept(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -1450,7 +1458,7 @@ pub async fn proxy_fetch_with_cache_key_and_accept(
     fetch_path: &str,
     cache_path: &str,
     accept: Option<&str>,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<(Bytes, Option<String>, Option<String>), Response> {
     with_proxy_repo(
         repo_id,
         repo_key,

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2674,12 +2674,22 @@ impl ProxyService {
 
     /// Fetch artifact from upstream if not cached or cache expired.
     /// Returns (content, content_type) tuple.
+    ///
+    /// As [`Self::fetch_artifact_with_cache_path`], but DROPS the upstream
+    /// `Content-Encoding` (#3211). Kept for the callers that parse or rewrite
+    /// the body themselves (virtual metadata merge closures, the pub registry
+    /// JSON rewriter) rather than forwarding it verbatim. A caller that passes
+    /// the buffered bytes through to the client must use the widened
+    /// cache-path form and declare the coding, or it reproduces #3149.
     pub async fn fetch_artifact(
         &self,
         repo: &Repository,
         path: &str,
     ) -> Result<(Bytes, Option<String>)> {
-        self.fetch_artifact_with_cache_path(repo, path, path).await
+        let (content, content_type, _encoding) = self
+            .fetch_artifact_with_cache_path(repo, path, path)
+            .await?;
+        Ok((content, content_type))
     }
 
     /// Byte-ceiling-aware sibling of [`Self::fetch_artifact`] (#1608 Phase 4b /
@@ -2771,14 +2781,19 @@ impl ProxyService {
     /// Blob fetches do NOT need this (blobs are content-addressable opaque
     /// bytes), but routing them through this path with `accept = None` is
     /// a no-op so the buffered fast path stays a single function.
+    ///
+    /// DROPS the upstream `Content-Encoding` (#3211) — kept for parse-only
+    /// callers, same stance as [`Self::fetch_artifact`].
     pub async fn fetch_artifact_with_accept(
         &self,
         repo: &Repository,
         path: &str,
         accept: Option<&str>,
     ) -> Result<(Bytes, Option<String>)> {
-        self.fetch_artifact_with_cache_path_and_accept(repo, path, path, accept)
-            .await
+        let (content, content_type, _encoding) = self
+            .fetch_artifact_with_cache_path_and_accept(repo, path, path, accept)
+            .await?;
+        Ok((content, content_type))
     }
 
     /// Check whether an artifact is already present in the proxy cache
@@ -2910,18 +2925,26 @@ impl ProxyService {
     /// locally-computed cache key so that subsequent requests can hit the
     /// cache without rediscovering the upstream URL.
     ///
-    /// DROPS the upstream `Content-Encoding`, and is exactly equivalent to
+    /// Exactly equivalent to
     /// [`Self::fetch_artifact_with_cache_path_capped`] at
-    /// [`DEFAULT_METADATA_MAX_BYTES`] otherwise. A caller that forwards the
-    /// buffered body verbatim, or that PARSES it (a coded body is not a
-    /// parseable zip/tar/JSON — #3193), must use the capped form and handle the
-    /// coding, or it reproduces #3149.
+    /// [`DEFAULT_METADATA_MAX_BYTES`].
+    ///
+    /// Returns a [`CachedBody`] — `(body, content_type, content_encoding)` —
+    /// rather than the `(body, content_type)` pair it used to (#3211, the
+    /// uncapped sibling of the #3184 widening). The coding was previously
+    /// dropped right here, which is how Maven `download_root` served a coded
+    /// upstream root with no `Content-Encoding` declared. Widened IN PLACE
+    /// rather than via a `_with_encoding` sibling — deliberately, so every
+    /// caller breaks at compile time and must state whether it forwards the
+    /// bytes verbatim (must declare the coding, RFC 9110 §8.4) or
+    /// parses/transforms them (must drop it), instead of a new caller silently
+    /// reintroducing #3149.
     pub async fn fetch_artifact_with_cache_path(
         &self,
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
-    ) -> Result<(Bytes, Option<String>)> {
+    ) -> Result<CachedBody> {
         self.fetch_artifact_with_cache_path_and_accept(repo, fetch_path, cache_path, None)
             .await
     }
@@ -2932,23 +2955,25 @@ impl ProxyService {
     /// simple-index proxy requesting the PEP 691 JSON representation under a
     /// format-qualified `cache_path`. Pass `None` to preserve the buffered
     /// fetch behaviour exactly.
+    ///
+    /// Returns a [`CachedBody`] — the upstream `Content-Encoding` is part of
+    /// the result (#3211), same contract as
+    /// [`Self::fetch_artifact_with_cache_path`].
     pub async fn fetch_artifact_with_cache_path_and_accept(
         &self,
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
         accept: Option<&str>,
-    ) -> Result<(Bytes, Option<String>)> {
-        let (content, content_type, _encoding) = self
-            .fetch_artifact_with_cache_path_and_accept_capped(
-                repo,
-                fetch_path,
-                cache_path,
-                accept,
-                DEFAULT_METADATA_MAX_BYTES,
-            )
-            .await?;
-        Ok((content, content_type))
+    ) -> Result<CachedBody> {
+        self.fetch_artifact_with_cache_path_and_accept_capped(
+            repo,
+            fetch_path,
+            cache_path,
+            accept,
+            DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await
     }
 
     /// Byte-ceiling-aware sibling of
@@ -14824,7 +14849,7 @@ mod tests {
         let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
         let repo = wiremock_remote_repo("s8-cachepath", &server.uri(), tmp.to_str().unwrap());
 
-        let (b1, ct1) = proxy
+        let (b1, ct1, _enc1) = proxy
             .fetch_artifact_with_cache_path(&repo, "dl/pkg.tgz", "stable/pkg.tgz")
             .await
             .expect("first fetch hits upstream and caches");
@@ -14833,7 +14858,7 @@ mod tests {
 
         // Second call: upstream mock is exhausted (up_to_n_times(1)); a cache
         // hit is the only way this can succeed.
-        let (b2, _ct2) = proxy
+        let (b2, _ct2, _enc2) = proxy
             .fetch_artifact_with_cache_path(&repo, "dl/pkg.tgz", "stable/pkg.tgz")
             .await
             .expect("second fetch must be served from the proxy cache");
@@ -14988,7 +15013,7 @@ mod tests {
             Some("\"v1\""),
         );
 
-        let (body, _ct) = proxy
+        let (body, _ct, _enc) = proxy
             .fetch_artifact_with_cache_path(&repo, "meta.xml", "meta.xml")
             .await
             .expect("304 revalidation must serve the cached body");
@@ -15034,7 +15059,7 @@ mod tests {
             Some("\"v1\""),
         );
 
-        let (body, _ct) = proxy
+        let (body, _ct, _enc) = proxy
             .fetch_artifact_with_cache_path(&repo, "meta.xml", "meta.xml")
             .await
             .expect("changed upstream must refill");
@@ -15110,7 +15135,7 @@ mod tests {
             Some("\"v1\""),
         );
 
-        let (body, _ct) = proxy
+        let (body, _ct, _enc) = proxy
             .fetch_artifact_with_cache_path(&repo, "meta.xml", "meta.xml")
             .await
             .expect("stale-if-error must serve the stale body when upstream is down");
@@ -15155,14 +15180,14 @@ mod tests {
         let jar = "com/example/app/1.0.0/app-1.0.0.jar";
 
         // First fetch hits upstream once and caches with the immutable TTL.
-        let (b1, _) = proxy
+        let (b1, _, _) = proxy
             .fetch_artifact_with_cache_path(&repo, jar, jar)
             .await
             .expect("first immutable fetch hits upstream and caches forever");
         assert_eq!(&b1[..], b"jar-bytes");
 
         // Second fetch must be served from cache with ZERO upstream contact.
-        let (b2, _) = proxy
+        let (b2, _, _) = proxy
             .fetch_artifact_with_cache_path(&repo, jar, jar)
             .await
             .expect("immutable hit must serve from cache without upstream");


### PR DESCRIPTION
Fixes #3211

## The bug

`maven.rs::download_root` — both the Remote arm and the Virtual-member arm — forwards the upstream root body **verbatim**: it copies the upstream `Content-Type`, recomputes `Content-Length` from `content.len()`, and streams the bytes untouched. But it fetched through `ProxyService::fetch_artifact_with_cache_path`, which dropped the upstream `Content-Encoding` (the primitive's own doc said so, left as a visible seam by #3210).

Per RFC 9110 **§8.4**, `Content-Encoding` is a representation header describing the coding of the bytes *as transferred*; per **§8.6**, `Content-Length` must describe the octets actually sent. The handler sent the coded octets with a matching (coded) `Content-Length` but no coding declaration — so a client receives compressed bytes it has no reason to decode and stores a compressed document under an identity implying it is plain. Same class as #3149, in a different handler.

Verified against source before fixing: `Content-Type` survived the forward, `Content-Length` was recomputed from the coded bytes (and therefore *matched* what was sent — §8.6 was satisfied; the only violation was the missing §8.4 declaration). `Content-Encoding` was the one header dropped.

## The fix

Followed the in-place-widening pattern established by #3194 / #3210 / #3184: **no `_with_encoding` sibling**, so every caller breaks at compile time and must classify itself.

* `ProxyService::fetch_artifact_with_cache_path` and `fetch_artifact_with_cache_path_and_accept` now return `CachedBody` (`body, content_type, content_encoding`), delegating to the already-widened capped primitive. The cache sidecar already persists the coding, so cache hits re-emit it identically to cold fetches.
* `maven.rs::download_root` (both arms) — **verbatim forwarders, the bug** — now re-declare the upstream coding via a shared `forward_root_verbatim` builder: `Content-Encoding` set iff the upstream (or cache sidecar) reported one; `Content-Length` remains the coded length, which is correct because the coded bytes are what is sent (§8.6).

### Caller audit (the full blast radius — nothing silently widened)

Every caller of the two widened methods, classified per the issue:

| Caller | Classification | Action |
|---|---|---|
| `maven.rs::download_root` Remote arm | forwards verbatim | re-declares the coding (**the fix**) |
| `maven.rs::download_root` Virtual arm | forwards verbatim | re-declares the coding (**the fix**) |
| `ProxyService::fetch_artifact` | convenience wrapper for parse/rewrite callers (virtual-metadata merge closures, pub registry JSON rewriter) | keeps its `(Bytes, Option<String>)` shape, now explicitly destructures-and-drops with a doc stating so (mirrors `fetch_artifact_capped`) |
| `ProxyService::fetch_artifact_with_accept` | same stance | same |
| `proxy_helpers::proxy_fetch_with_cache_key` | **no callers in-tree** | widened to the triple + doc, so a future adopter sees the coding instead of silently reintroducing #3149 |
| `proxy_helpers::proxy_fetch_with_cache_key_and_accept` | **no callers in-tree** | same |
| in-file `proxy_service.rs` tests (8 destructures) | test call sites | third element added |

So the *behavioral* change is Maven-only (`download_root`); the *seam* change is shared, and no other format's serving behavior changes in this PR.

### Known residuals (documented, deliberately out of scope)

* `proxy_helpers::proxy_fetch_or_redirect` (no production caller, per its own comment) forwards verbatim through `fetch_artifact` and would drop a coding if adopted; its buffered fallback arm carries the same latent class.
* `pub_registry.rs::proxy_pub_meta_get` has a verbatim pass-through fallback for non-JSON upstream bodies.

Both go through `fetch_artifact`, which is documented as dropping; fixing them means the decode-or-declare treatment per caller and belongs to a follow-up, not riding along here.

## Tests

DB-backed `--lib` test in `maven.rs` (counts toward the coverage gate), `test_download_root_forwards_upstream_content_encoding_verbatim`, per the issue's test requirement:

* **Non-gzip coding** (`tdh::coded_fixture("deflate", …)`) — a handler hardcoding `"gzip"` cannot pass.
* **Uncoded upstream control in the same fixture** — no spurious `Content-Encoding`, body byte-identical — so hardcoding `"deflate"` cannot pass either.
* Asserts the actual bytes received (verbatim coded bytes, `Content-Length` == coded length) and **decodes the served body** with `tdh::inflate_deflate`, proving the declared coding matches the bytes.
* Covers **both** arms that had the bug (Remote, and Virtual via a member), plus the control.

### Revert-proof (faithful, DB-backed)

Production files restored byte-identical to merge-base `757eb9f`, tests kept. On the reverted tree:

```
$ git diff 757eb9f --shortstat
 1 file changed, 154 insertions(+)      # single hunk, @@ mod tests — insertions only, all in the test module
```

```
FAIL api::handlers::maven::tests::test_download_root_forwards_upstream_content_encoding_verbatim   [0.31s]
  assertion `left == right` failed: remote root must re-declare the upstream Content-Encoding (#3211)
    left: None
    right: Some("deflate")
PASS api::handlers::maven::tests::test_download_root_forwards_remote_and_virtual_but_404s_local    [0.39s]
```

Run with `DATABASE_URL` + `AK_TESTS_REQUIRE_DB=1` (timings show real DB execution, not the try_pool skip). With the fix applied the test passes; full `cargo nextest run --workspace --lib`, `cargo fmt --all --check`, and `cargo clippy --workspace --all-targets -- -D warnings` are green locally.
