### PR TITLE
fix(security): neutral not_applicable arm in rollup_scan_status; correct block_on_policy_violation docs (#3144)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -6515,6 +6515,17 @@ async fn list_artifacts_grouped_by_docker_tag(
 ///    plus a failed incus scan now surfaces as `partial`, not
 ///    `completed`.
 ///
+/// `not_applicable` rows are neutral (#3144): a scanner that declined an
+/// artifact it does not cover (the #2324 degrade path — e.g. OpenSCAP on
+/// anything that is not a container/rpm/deb) neither completes nor fails
+/// the rollup, mirroring how `PolicyService::evaluate_artifact` (#3142)
+/// and the #2471 scan-list collapse treat the status. Pre-#3144 the
+/// status fell into the unknown bucket, so the default shape for most
+/// formats — completed grype + `not_applicable` OpenSCAP — rendered as
+/// `partial`. A set that is *entirely* `not_applicable` collapses to
+/// `not_applicable` (no configured scanner covered the artifact; calling
+/// that `completed` would overstate coverage).
+///
 /// Unknown status strings are pessimistically treated as a failure for
 /// the all-completed check (they will not collapse to `completed`).
 pub(crate) fn rollup_scan_status(statuses: &[String]) -> Option<String> {
@@ -6526,6 +6537,7 @@ pub(crate) fn rollup_scan_status(statuses: &[String]) -> Option<String> {
     let mut has_pending = false;
     let mut has_completed = false;
     let mut has_failed = false;
+    let mut has_not_applicable = false;
     let mut has_unknown = false;
 
     for s in statuses {
@@ -6534,6 +6546,7 @@ pub(crate) fn rollup_scan_status(statuses: &[String]) -> Option<String> {
             "pending" => has_pending = true,
             "completed" => has_completed = true,
             "failed" => has_failed = true,
+            "not_applicable" => has_not_applicable = true,
             _ => has_unknown = true,
         }
     }
@@ -6549,6 +6562,9 @@ pub(crate) fn rollup_scan_status(statuses: &[String]) -> Option<String> {
     }
     if has_failed && !has_completed && !has_unknown {
         return Some("failed".to_string());
+    }
+    if has_not_applicable && !has_completed && !has_failed && !has_unknown {
+        return Some("not_applicable".to_string());
     }
     Some("partial".to_string())
 }
@@ -12473,6 +12489,65 @@ mod tests {
         // future scanner that writes a status value the rollup does not
         // yet know about.
         let statuses = vec![s("completed"), s("weird-state")];
+        assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("partial"));
+    }
+
+    #[test]
+    fn test_rollup_scan_status_completed_plus_not_applicable_is_completed() {
+        // #3144: the default shape for most formats — grype completed plus an
+        // OpenSCAP `not_applicable` row (the #2324 degrade path) — must roll
+        // up as `completed`, not `partial`. Pre-fix `not_applicable` fell into
+        // the unknown bucket and blocked the all-completed collapse.
+        let statuses = vec![s("completed"), s("not_applicable")];
+        assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn test_rollup_scan_status_failed_plus_not_applicable_is_failed() {
+        // #3144: a declined scanner must not soften a hard failure to
+        // `partial` — every scanner that actually ran errored out.
+        let statuses = vec![s("failed"), s("not_applicable")];
+        assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("failed"));
+    }
+
+    #[test]
+    fn test_rollup_scan_status_only_not_applicable_stays_not_applicable() {
+        // #3144: when every configured scanner declined, nothing was
+        // scanned. Surfacing `completed` would overstate coverage; the
+        // truthful label is `not_applicable`.
+        let statuses = vec![s("not_applicable"), s("not_applicable")];
+        assert_eq!(
+            rollup_scan_status(&statuses).as_deref(),
+            Some("not_applicable")
+        );
+    }
+
+    #[test]
+    fn test_rollup_scan_status_not_applicable_does_not_mask_mixed_terminal() {
+        // Positive control for #3144: a genuinely mixed terminal set (one
+        // green, one red) still rolls up as `partial` when a neutral
+        // `not_applicable` row is also present — the neutral arm must not
+        // accidentally collapse real disagreement.
+        let statuses = vec![s("completed"), s("failed"), s("not_applicable")];
+        assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("partial"));
+    }
+
+    #[test]
+    fn test_rollup_scan_status_not_applicable_loses_to_in_flight() {
+        // #3144: precedence unchanged — in-flight still beats everything,
+        // including the new neutral arm.
+        let statuses = vec![s("not_applicable"), s("running")];
+        assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("running"));
+
+        let statuses = vec![s("not_applicable"), s("pending")];
+        assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("pending"));
+    }
+
+    #[test]
+    fn test_rollup_scan_status_not_applicable_plus_unknown_is_partial() {
+        // #3144: the neutral arm must not extend to unrecognized statuses —
+        // an unknown string alongside `not_applicable` stays pessimistic.
+        let statuses = vec![s("not_applicable"), s("weird-state")];
         assert_eq!(rollup_scan_status(&statuses).as_deref(), Some("partial"));
     }
 

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -583,7 +583,11 @@ pub struct ScanConfigResponse {
     pub scan_enabled: bool,
     pub scan_on_upload: bool,
     pub scan_on_proxy: bool,
+    /// Persisted and returned, but not currently consulted by any enforcement
+    /// gate — blocking is configured via scan policies instead (#3144/#3246).
     pub block_on_policy_violation: bool,
+    /// Persisted and returned, but not currently consulted by any enforcement
+    /// gate (#3243).
     pub severity_threshold: String,
     /// #2954: fail-open (default) / fail-closed action for the inline proxy
     /// scan-on-fetch.

--- a/backend/src/models/security.rs
+++ b/backend/src/models/security.rs
@@ -151,7 +151,13 @@ pub struct ScanConfig {
     pub scan_enabled: bool,
     pub scan_on_upload: bool,
     pub scan_on_proxy: bool,
+    /// Persisted and round-tripped through the API, but consulted by NO gate:
+    /// enforcement is driven by the separate `scan_policies` table
+    /// (`PolicyService::evaluate_artifact`). Wiring this up either direction is
+    /// a policy change (see #3144); disposition tracked in #3246.
     pub block_on_policy_violation: bool,
+    /// Persisted but consulted by no production gate (the inline proxy scan
+    /// gate deliberately blocks on ANY finding) — see #3243 before wiring up.
     pub severity_threshold: String,
     /// #2954: fail-open (default) vs fail-closed action for the inline proxy
     /// scan-on-fetch. `'fail_open'` | `'fail_closed'`.

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -627,13 +627,19 @@ pub async fn check_artifact_download(db: &PgPool, artifact_id: Uuid) -> Result<(
 
 /// The shared download choke point (#2954): enforce quarantine THEN scan policy.
 ///
-/// This folds `PolicyService::evaluate_artifact` — which enforces
-/// `block_unscanned` / `block_on_fail` / `max_severity`
-/// (`block_on_policy_violation`) and previously only ran on the promotion gate —
+/// This folds `PolicyService::evaluate_artifact` — which enforces the
+/// `scan_policies` columns `block_unscanned` / `block_on_fail` / `max_severity`
+/// and previously only ran on the promotion gate —
 /// into the single function every ~30 per-format download handler already calls,
 /// so scan-policy blocking lights up on the raw download path for all formats at
 /// once (it was a false affordance before: a hosted artifact with CVE findings
 /// was downloadable unless a scan happened to auto-quarantine it).
+///
+/// NOT enforced here (or anywhere): `scan_configs.block_on_policy_violation`.
+/// An earlier version of this comment named that toggle as the thing
+/// `max_severity` implements, which was wrong — the toggle lives in a different
+/// table, is never read by any gate, and its disposition (wire up vs remove) is
+/// tracked in #3246 (#3144).
 ///
 /// Ordering is deliberate: the quarantine state is checked FIRST (a quarantined
 /// artifact is a 409 before any policy consideration), then the scan policy. A

--- a/backend/src/services/scan_config_service.rs
+++ b/backend/src/services/scan_config_service.rs
@@ -45,8 +45,11 @@ pub struct UpsertScanConfigRequest {
     pub scan_on_upload: Option<bool>,
     #[serde(default)]
     pub scan_on_proxy: Option<bool>,
+    /// Accepted and persisted, but consulted by no gate — enforcement is the
+    /// `scan_policies` table's job (#3144; disposition tracked in #3246).
     #[serde(default)]
     pub block_on_policy_violation: Option<bool>,
+    /// Accepted and persisted, but consulted by no production gate (#3243).
     #[serde(default)]
     pub severity_threshold: Option<String>,
     /// #2954: `'fail_open'` (default) | `'fail_closed'` for the inline proxy


### PR DESCRIPTION
Fixes #3144

Both halves of the issue were verified against current main (`01ebcb2`) before touching anything. One half is fixed; the other half's *behavioral* fix is deliberately NOT shipped here, following the same direction-analysis discipline as #3243 — details below.

## Half 2 (fixed): `rollup_scan_status` mislabels `not_applicable` as `partial`

**Confirmed.** `rollup_scan_status` (`backend/src/api/handlers/repositories.rs`) matched only `running` / `pending` / `completed` / `failed`; `not_applicable` fell into the `has_unknown` bucket, which blocks both terminal collapses, so the default shape for most formats — completed grype + `not_applicable` OpenSCAP (the #2324 degrade path) — rendered as **`partial`** in the Docker tag listing.

**Gate check (as #3138/#3218 taught us to ask): does any gate read this rollup?** No. The sole production caller is `fetch_docker_tag_rows` → `DockerTagRow.scan_status` → the tag-listing response DTO. `PolicyService::evaluate_artifact` and the quarantine/download gates read `scan_results` directly and already handle `not_applicable` correctly (#3142). This is a status-reporting bug, not a security bug, and fixing it cannot un-block anything.

**Fix:** `not_applicable` is now a neutral arm, mirroring `PolicyService` (#3142) and the #2471 scan-list collapse:

- `completed` + `not_applicable` → `completed` (the reported bug)
- `failed` + `not_applicable` → `failed` (a declined scanner must not soften a hard failure)
- *only* `not_applicable` → `not_applicable` — deliberately **not** `completed`: when every scanner declined, nothing was scanned, and calling that `completed` would overstate coverage
- mixed `completed`+`failed` (+NA) → still `partial`; `running`/`pending` still win; unknown strings still pessimistically block collapse (the neutral arm does not extend to unrecognized statuses)

## Half 1 (confirmed dead; docs corrected, wiring deliberately withheld): `block_on_policy_violation`

**Confirmed.** `scan_configs.block_on_policy_violation` (migration 022, `DEFAULT false`) has model/CRUD/DTO plumbing and **zero enforcement readers**. Every gate that blocks today reads the separate `scan_policies` table (`block_unscanned` / `block_on_fail` / `max_severity`) via `PolicyService::evaluate_artifact`. The `quarantine_service::enforce_download_gate` doc comment claimed `max_severity` *was* `block_on_policy_violation` — false, and exactly the kind of doc that misleads the next fixer.

**Direction analysis — why this PR does not wire it up:**

- Wired as a **precondition** ("only enforce scan policy when the toggle is true"): the column default is `false`, so every repo that never touched the toggle would silently lose the scan-policy blocking it has today — a fail-**open** regression of the #3218/#3138 class.
- Wired as an **additional blocker**: requires a severity criterion, i.e. `scan_configs.severity_threshold`, which #3243 already established has no consumer and was deliberately left unwired (default `'high'` would weaken the any-finding gates). It would also 403 artifacts that download fine today.

Either direction is a policy change, not a patch fix. The two columns were introduced together in 022 and should be decided together: **disposition tracked in #3246** (wire both behind explicit opt-in, or remove both from the API surface).

**What this PR ships for half 1 (the safe half):**
- Corrected the `enforce_download_gate` doc comment and added an explicit "NOT enforced here (or anywhere)" note.
- Honest field docs on `ScanConfig` (model), `UpsertScanConfigRequest`, and `ScanConfigResponse` (public OpenAPI schema) stating the toggle is persisted but consulted by no gate — closing the "no enforcement and no warning" gap the issue names, at the operator-facing surface.

No behavior of any gate changes in this PR.

## Tests + revert-proof

Six new pure `#[cfg(test)]` tests next to the existing #1497 suite (in-file, so they count for the `--lib` coverage gate). Run with `DATABASE_URL` + `AK_TESTS_REQUIRE_DB=1` exported.

**Fixed tree:** 15/15 rollup tests pass.

**Faithful revert** (production code restored byte-identical to merge-base `01ebcb2`, tests kept):

```
$ git diff 01ebcb2 --shortstat   # on the REVERTED tree
 1 file changed, 59 insertions(+)
```

— insertions only, single hunk at `@@ -12478,0 +12479,59 @@ mod tests`, i.e. entirely inside the test module.

**Revert run:** 12 passed, 3 failed — the three that encode the bug, each failing with the bug's exact symptom:

```
test_rollup_scan_status_completed_plus_not_applicable_is_completed
  left: Some("partial")  right: Some("completed")
test_rollup_scan_status_failed_plus_not_applicable_is_failed
  left: Some("partial")  right: Some("failed")
test_rollup_scan_status_only_not_applicable_stays_not_applicable
  left: Some("partial")  right: Some("not_applicable")
```

The other three new tests are positive controls that must pass on both trees: genuinely mixed terminal sets still collapse to `partial` (the neutral arm cannot mask real disagreement), in-flight still beats everything, and unknown statuses remain pessimistic.

Existing guard `test_rollup_scan_status_unknown_status_collapses_to_partial` uses `"weird-state"`, not `not_applicable` — no existing test asserted the bug as a requirement.

`cargo fmt --all` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, touched-module sweep (214 tests incl. DB-backed) green. No migration; no `sqlx::query!` text touched.
