### PR TITLE
ci: stop shared-cargo-registry mutation flake and unmask coverage build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
   test-backend-unit:
     name: 🧪 Backend Unit Tests
     runs-on: ak-ci-runners
-    timeout-minutes: 25
+    timeout-minutes: 40
     needs: [changes, release-bump]
     # Skip on docs-only PRs and version-bump-only release PRs — see check-rust.
     if: ${{ !cancelled() && needs.changes.outputs.code != 'false' && needs.release-bump.outputs.bump_only != 'true' }}
@@ -560,7 +560,7 @@ jobs:
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners
-    timeout-minutes: 35
+    timeout-minutes: 45
     needs: [changes, release-bump]
     # Skip on docs-only PRs and version-bump-only release PRs — see check-rust.
     if: ${{ !cancelled() && needs.changes.outputs.code != 'false' && needs.release-bump.outputs.bump_only != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,10 +293,46 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # PRIVATE PER-JOB CARGO_HOME (#3154). The ARC runner pods set
+      # CARGO_HOME=/cache/cargo-home, a hostPath volume SHARED by up to six
+      # concurrent runner pods on the node — but two things treat that
+      # registry as private, mutable state:
+      #   1. Swatinem/rust-cache: its restore tar-extracts registry files
+      #      (unlink+rewrite) over the live shared copy, and its post-save
+      #      clean DELETES registry/src for non `-sys` crates and prunes
+      #      registry/cache and index caches down to the saving job's own
+      #      package set (see cleanRegistry in the pinned rust-cache src).
+      #   2. cargo itself: whenever those files go missing it re-extracts
+      #      them (rm_rf + rewrite) under a package-cache lock that sibling
+      #      pods' COMPILE phases do not hold.
+      # Any job compiling while another pod restores, saves, or re-extracts
+      # reads half-written or deleted sources. Observed as: aws-lc-sys cc
+      # "unterminated #ifndef" on a truncated vendored header, "could not
+      # execute process ... (os error 2)" (spawn cwd = deleted registry src
+      # dir), and "could not parse/generate dep info ... No such file or
+      # directory" cascades — the #3154 flake family. All failing jobs had
+      # RUSTC_WRAPPER="" (sccache was NOT involved).
+      #
+      # RUNNER_TEMP is on the pod-local emptyDir work volume and the pods
+      # are ephemeral (one job each), so this makes every job's cargo home
+      # private and self-consistent. Warm-path cost is unchanged for jobs
+      # with rust-cache (the tarball already contains registry index+cache
+      # and restores into the private path). Tool binaries are unaffected:
+      # the runner image bakes them into /usr/local/cargo/bin, which stays
+      # on PATH regardless of CARGO_HOME (ak-runner-rust Dockerfile).
+      - name: Isolate CARGO_HOME per job (#3154)
+        run: echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
+
       # Cache the dependency build so only the workspace crate recompiles.
       # ~635 deps are byte-identical run-to-run; cold compile was ~9m.
+      #
+      # prefix-key bumped v0->v1 (#3154): pre-existing tarballs archived the
+      # old shared /cache/cargo-home with absolute paths, so restoring one
+      # under an old key would write into the shared volume again and leave
+      # the private CARGO_HOME cold. A fresh namespace repopulates cleanly.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          prefix-key: v1-rust
           shared-key: clippy
 
       - name: Check formatting
@@ -403,10 +439,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Shield this job from concurrent mutation of the shared registry —
+      # see the #3154 comment on the same step in check-rust. A dep-info
+      # ENOENT instance of that flake hit THIS job on 2026-08-10
+      # (job 93341706470, PR #3237).
+      - name: Isolate CARGO_HOME per job (#3154)
+        run: echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
+
       # Separate cache key from check-rust: same target dir but a different
       # build profile (test vs clippy), so they must not share a cache.
+      # prefix-key: see the #3154 note in check-rust.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          prefix-key: v1-rust
           shared-key: unit
 
       # Catch migration-slot collisions before they reach the e2e/nightly job.
@@ -585,13 +630,25 @@ jobs:
             echo "### Coverage: skipped (no Rust source changes in this PR)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # Shield this job from concurrent mutation of the shared registry —
+      # see the #3154 comment on the same step in check-rust. This job is
+      # the most frequent victim: its instrumented build is the longest in
+      # CI, so its compile phase overlaps other jobs' cache restores/saves
+      # most often (observed 2026-08-07 twice as aws-lc-sys cc failures,
+      # 2026-08-09 twice as dep-info ENOENT, both pods within seconds).
+      - name: Isolate CARGO_HOME per job (#3154)
+        if: steps.detect.outputs.rust_changed == 'true'
+        run: echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
+
       # Distinct cache key: the instrumented coverage build is incompatible
       # with the clippy/unit profiles, and cargo-llvm-cov builds into
       # target/llvm-cov-target, so point rust-cache there or it caches an
       # empty target/ and silently no-ops.
+      # prefix-key: see the #3154 note in check-rust.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.detect.outputs.rust_changed == 'true'
         with:
+          prefix-key: v1-rust
           shared-key: coverage
           workspaces: ". -> target/llvm-cov-target"
 
@@ -604,6 +661,30 @@ jobs:
         run: sqlx migrate run --source backend/migrations
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
+
+      # Build the instrumented test binaries as a step of their own, so a
+      # BUILD failure is visibly distinct from a coverage-gate failure
+      # (#3154's "masquerading" half). Before this split, an aws-lc-sys /
+      # dep-info build flake surfaced as "Code Coverage: fail", which reads
+      # as "your new code is under the 70% threshold" and sends people off
+      # to write tests they do not need. The only tell was the job duration
+      # (~1-2 min vs ~14 min for a real gate run), which is not
+      # discoverable. The ::error:: annotation below shows up directly on
+      # the PR checks page.
+      - name: Build instrumented test binaries
+        if: steps.detect.outputs.rust_changed == 'true'
+        env:
+          SQLX_OFFLINE: true
+          RUSTC_WRAPPER: ""
+        # The explicit `clean --workspace` keeps the implicit-clean
+        # semantics the single `cargo llvm-cov nextest` invocation had.
+        run: |
+          source <(cargo llvm-cov show-env --sh)
+          cargo llvm-cov clean --workspace
+          if ! cargo nextest run --workspace --lib --no-run; then
+            echo "::error title=Coverage BUILD failed — not a coverage-gate failure::cargo could not build the instrumented test binaries, so no coverage was measured; the 70% new-code gate, the 50% floor, and the jscpd duplication gate never ran. A genuine compile error will also fail Check Rust / Backend Unit Tests on this commit; if those are green and this log shows ENOENT / 'dep info' / cc errors in vendored sources, this was the #3154 flake class — rerun the job."
+            exit 1
+          fi
 
       - name: Generate coverage report
         if: steps.detect.outputs.rust_changed == 'true'
@@ -634,13 +715,13 @@ jobs:
         # of cargo-llvm-cov's default one-.profraw-per-test-process: with
         # ~12k test processes the per-process files cost tens of GB of write
         # I/O per run, while the pool online-merges the same counters into at
-        # most 32 files (~92MB) with byte-equal coverage aggregates. The
-        # explicit `clean --workspace` keeps the implicit-clean semantics the
-        # single `cargo llvm-cov nextest` invocation had.
+        # most 32 files (~92MB) with byte-equal coverage aggregates.
+        #
+        # NO `cargo llvm-cov clean` here: it ran in the build step above and
+        # must not run again between build and test execution.
         run: |
           source <(cargo llvm-cov show-env --sh)
           export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE%/*}/%32m.profraw"
-          cargo llvm-cov clean --workspace
           cargo nextest run --workspace --lib --test-threads 8
           cargo llvm-cov report --lcov --output-path lcov.info
 
@@ -1000,6 +1081,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Shield this job from concurrent mutation of the shared registry —
+      # see the #3154 comment on the same step in check-rust. The
+      # "stale/truncated crates.io index" failure documented on the fetch
+      # step below is the same corruption class (a sibling pod rewriting
+      # the shared registry index mid-read). This job carries no
+      # rust-cache, so a private CARGO_HOME means it now downloads the
+      # dependency graph from crates.io each run instead of reading the
+      # shared warm registry; CARGO_NET_RETRY and the fetch retry below
+      # already absorb network hiccups, and correctness beats the ~1-2
+      # minutes of download.
+      - name: Isolate CARGO_HOME per job (#3154)
+        run: echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
 
       # Resolve and download the dependency graph in its own step, ahead of the
       # test steps, with a retry.
@@ -1654,6 +1748,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Shield this job from concurrent mutation of the shared registry —
+      # see the #3154 comment on the same step in check-rust. No rust-cache
+      # here either (cf. the integration job note): the graph is downloaded
+      # per run, which this main-push-only job can afford.
+      - name: Isolate CARGO_HOME per job (#3154)
+        run: echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
 
       - name: Build Windows binary (cross-compile)
         env:


### PR DESCRIPTION
Fixes #3154

## What the flake actually is

The Code Coverage job — and, less often, every other Rust job on `ak-ci-runners` — intermittently dies **1–2.5 minutes into its build** with one of three signatures, on commits that pass identical builds in sibling jobs:

| Signature | Example | Root diagnostic in the log |
|---|---|---|
| `error occurred in cc-rs` building vendored `aws-lc-sys` C | job 92771558547 (run 31148018643, 2026-08-07 04:40), job 92855151814 (run 31175059925, 2026-08-07 11:42) | `aws-lc/include/openssl/bn.h:11: error: unterminated #ifndef` — the header under `/cache/cargo-home/registry/src/...` was **truncated mid-read** |
| `could not execute process 'cargo-llvm-cov ... rustc ...' — No such file or directory` | job 93166712233 (2026-08-09 00:09:20) | spawn failed because the child's **cwd** — the crate's registry src dir (`cranelift-codegen-meta`) — had been **deleted** |
| `could not parse/generate dep info at .../deps/<crate>.d — No such file or directory` | jobs 93166712233 + 93167009499 (two different PRs' coverage jobs, two different pods, failing within 13 s of each other), job 93341706470 (Backend Unit Tests, PR #3237, 2026-08-10 03:19:43) | sources listed in the `.d` (all **registry** crates: hyper, regex-automata, rustls, wasmtime, curve25519-dalek…) had vanished |

**Frequency:** in the last ~7 days of `ci.yml` failure history I can attribute at least 6 failed jobs to this class (2× aws-lc-sys on 2026-08-07, 2× dep-info on 2026-08-09, 1× dep-info unit-tests on 2026-08-10, 1× a 1m35s Check Rust death in the same 2026-08-10 window), out of ~16 Code-Coverage-job failures overall — the rest were genuine (real coverage-gate misses at ~15 min, real compile errors on dependabot bumps, a real test failure). Every instance cleared on rerun.

## Root cause (shared by both variants)

The ARC runner pods set `CARGO_HOME=/cache/cargo-home` on a **hostPath volume shared by up to 6 concurrent runner pods** (`artifact-keeper-arc-runners/argocd/arc-ci-runners-values.yaml`). Two things treat that registry as private, mutable state:

1. **`Swatinem/rust-cache`** — written for GitHub-hosted runners with a private `~/.cargo`:
   - its **restore** tar-extracts registry index caches, `registry/cache/*.crate`, and `-sys` crate sources (unlink + rewrite) **over the live shared copy** at every job start;
   - its **post-save clean** (`cleanRegistry` in the pinned v2.9.1 source) **deletes `registry/src`** for all non-`-sys` crates and prunes `registry/cache` and the index `.cache` down to *the saving job's own package set* — which, on a registry shared with other jobs and other repos, deletes files others still need.
2. **cargo itself** — whenever those files go missing it re-extracts them (`rm_rf` + rewrite) under the package-cache lock. The lock protects extraction against other *extractions*, but sibling pods' **compile phases read registry sources without holding any lock**, so they see files mid-delete or mid-rewrite.

Every observed symptom is a direct read of that mutation: cc reading a half-written vendored header (`unterminated #ifndef`), cargo spawning rustc with a deleted registry dir as cwd (`could not execute process`, ENOENT), and dep-info translation statting deleted registry sources. It also explains why the failure window is always the first ~1–2.5 min of a build (maximum overlap with sibling restores/extraction storms), why reruns always clear it, and why two pods failed within 13 s of each other on 2026-08-09. The integration job's existing "stale/truncated crates.io index" fetch-retry comment (added for run 31176621357) is the same corruption class caught at the index instead of the sources.

**Do the aws-lc-sys and dep-info variants share a root cause? Yes.** Same shared-registry mutation, different read path: `cc` reads the vendored C/headers directly (truncation ⇒ cc-rs error), rustc/cargo read `.rs` sources and spawn cwds (deletion ⇒ dep-info / could-not-execute). The failing invocation is the same `cargo test --no-run --workspace --lib` in both.

**What it is NOT (all log-verified):** not sccache — every failing job ran with `RUSTC_WRAPPER: ""` (the existing bypass), so the "sccache dep-info flake" diagnosis is wrong for these instances; not OOM — no `signal: 9` anywhere, and the failures are ENOENT/truncation, not kills; not disk pressure — ENOSPC never appears; not the monthly registry-cleanup CronJob — it runs 05:00 on the 1st, matching none of the failure times.

## The fix (narrowest that addresses the cause; CI-config-only)

1. **Private per-job `CARGO_HOME`** — a one-line step in each of the 5 Rust jobs (`check-rust`, `test-backend-unit`, `coverage`, `test-backend-integration`, `build-windows-dev`) sets `CARGO_HOME=$RUNNER_TEMP/cargo-home` before rust-cache runs. `RUNNER_TEMP` is on the pod-local emptyDir work volume and ARC pods are ephemeral (one job each), so each job's cargo home is private and self-consistent; nothing can mutate it mid-build. This removes both the *writers* (this repo's rust-cache restores/saves now target private state) and the *exposure* (builds no longer read shared state), so it also shields against mutations from other repos' jobs on the same runners.
   - Warm path unchanged for the three rust-cache jobs: the tarball already contains registry index+cache and now restores into the private path (restore was already how every job start worked).
   - `prefix-key` bumped `v0-rust` → `v1-rust`: existing tarballs archived the old shared `/cache/cargo-home` with absolute paths; restored under an old key they would write into the shared volume again and leave the private home cold. First run per key is a cold build (~9 min for clippy per the existing comment), then warm.
   - Tool binaries are unaffected: the runner image deliberately bakes nextest/llvm-cov/sqlx-cli into `/usr/local/cargo/bin`, which stays on PATH regardless of `CARGO_HOME` (its Dockerfile comment says exactly this).
   - The two uncached jobs (integration, windows) trade the shared warm registry for a per-run `cargo fetch` from crates.io (~1–2 min); their existing `CARGO_NET_RETRY`/fetch-retry absorb network hiccups.

2. **Unmask the failure mode** (the issue's "masquerading" half): the coverage job now builds the instrumented test binaries in their own step (`cargo nextest run --no-run`). If the build fails, a `::error::` annotation titled **"Coverage BUILD failed — not a coverage-gate failure"** appears on the PR checks page, stating that no coverage was measured and the 70% gate / 50% floor / jscpd duplication gate never ran. A genuine compile error still fails the job (and Check Rust alongside it); nothing is retried or swallowed.

## Alternatives evaluated (per the issue's checklist)

- **sccache knobs / per-job sccache dir / cache-size tuning:** moot — sccache is bypassed (`RUSTC_WRAPPER: ""`) in every failing job, and `cc` invocations never went through sccache. The failure lives in the cargo registry, not the compile cache.
- **`CARGO_INCREMENTAL`:** already `0` in the affected jobs; incremental state is in the (pod-local) target dir and is not implicated.
- **cc-rs parallelism / `CARGO_BUILD_JOBS` caps:** would only shrink the race window; the diagnostic is truncation/ENOENT, not resource exhaustion, and single-threaded builds read the same shared files.
- **Not caching `*-sys` crates:** backwards — rust-cache already *keeps* `-sys` sources on clean; it's the restore *rewriting* them and the deletion of everything else that breaks builds. Excluding more crates increases re-extraction churn on shared state.
- **Warm cache key for coverage (issue suggestion 2):** already exists (`shared-key: coverage`, full-match hits observed in the failing jobs' logs) — it did not prevent the flake because the mutation is cross-job, not cold-cache.
- **Narrow signature-matched retry:** rejected while a config fix exists that removes the cause; retry stays the workaround only for unfixed instances (`gh run rerun --failed`).
- **Fixing it in the runner infra instead (per-pod hostPath subdirs):** equivalent effect, but requires an `artifact-keeper-arc-runners` change + redeploy and would still leave workflow-level rust-cache assumptions in play; the workflow-side change is self-contained and reviewable here. A follow-on infra cleanup (retiring the now-mostly-idle shared `cargo-home`) can ride the next runner-image update.

## Proved vs. reasoned

**Proved from logs/config:** the three signatures and their locations under `/cache/cargo-home/registry/src`; the truncated-header diagnostic; the cross-pod simultaneity (13 s apart on 2026-08-09); `RUSTC_WRAPPER=""` in all failing jobs (sccache exonerated); the shared hostPath `CARGO_HOME` (iac values); rust-cache v2.9.1's `cleanRegistry` deleting non-`-sys` `registry/src` and pruning `registry/cache`/index to the saver's package set (read at the pinned commit); tools living in `/usr/local/cargo/bin` (runner Dockerfile); nextest supporting `--no-run`.

**Reasoned but not directly observed:** which specific mutation event (a restore, a save-clean, or a cargo re-extraction) fired at each individual failure instant — the runner host is not reachable from here and GitHub's API does not expose sibling repos'/pods' filesystem activity, so I could not catch a deleter in the act. The mechanism is the only one consistent with all observed evidence, and the fix removes the entire class rather than one deleter. I could not pre-validate on the PR's own CI either: this PR necessarily changes the workflow it needs to exercise, and the flake is a low-probability race — a green run here demonstrates the changed config builds and gates normally (including the new cold-cache path), not the absence of the race. Validation plan: after merge, watch for any recurrence of the three signatures; each pre-merge instance was ≤3 days apart, so two quiet weeks is strong evidence.

**Validated locally:** workflow YAML parses (PyYAML); `actionlint` is not available on this host — flagging that honestly. No Rust code touched, so no build/fmt was needed.
