### PR TITLE
fix(auth): remove stale 'enforcement is NOT active' startup warning (#3185)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -256,26 +256,19 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     let peer_id = init_peer_identity(&db_pool, &config).await?;
     tracing::info!("Peer identity: {} ({})", config.peer_instance_name, peer_id);
 
-    // Warn when permission rules exist but enforcement is not yet active (#794).
-    // This makes the gap visible in server logs so administrators do not
-    // assume their rules are protecting anything.
-    match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM permissions")
-        .fetch_one(&db_pool)
-        .await
-    {
-        Ok(count) if count > 0 => {
-            tracing::warn!(
-                permission_rules = count,
-                "Found {} permission rule(s) in the database, but enforcement is NOT active. \
-                 Permission rules created via /api/v1/permissions are stored but not consulted \
-                 during request authorization. This will be addressed in a future release. \
-                 See https://github.com/artifact-keeper/artifact-keeper/issues/794",
-                count,
-            );
-        }
-        Ok(_) => {}  // no rules, nothing to warn about
-        Err(_) => {} // table may not exist on old schema, ignore
-    }
+    // Note: a startup warning claiming "permission rules are stored but not
+    // consulted during request authorization (#794)" used to live here. That
+    // gap was closed — fine-grained `permissions` rules are now enforced on
+    // both the native-protocol path (`repo_visibility_middleware` in
+    // `api/middleware/auth.rs`, via `PermissionService::check_repository_action`
+    // for writes and `has_any_rules_for_target`/`check_permission` for reads)
+    // and the REST path (`require_repo_action` in `api/handlers/repositories.rs`).
+    // `/api/v1/system/config` reports `enforcement_enabled: true` accordingly.
+    // The warning was left behind after #817/#824/#826/#827/#819/#2603 landed and
+    // was misleading operators (#3185), so it has been removed. The regression
+    // test `permission_service::tests::permission_rule_is_consulted_during_authorization`
+    // pins the enforcement so this message and the behaviour cannot drift apart
+    // again.
 
     // Initialize WASM plugin system (T068)
     let plugins_dir =

--- a/backend/src/services/permission_service.rs
+++ b/backend/src/services/permission_service.rs
@@ -2054,42 +2054,30 @@ mod tests {
             "the just-inserted permissions rule must be observable"
         );
 
-        // Negative: the principal the rule does NOT name is denied. This is the
-        // enforcement the warning claimed did not exist. A rule-less private
-        // repo would deny `other_user` too, so the negative alone is not proof —
-        // hence the positive control below in the SAME fixture.
-        assert!(
-            !service
-                .check_repository_action(other_user, repo_id, "write", false)
-                .await
-                .expect("write check must reach the DB"),
-            "a principal without a matching rule must be denied write (rule IS consulted)"
-        );
-        assert!(
-            !service
-                .check_permission(other_user, "repository", repo_id, "read", false)
-                .await
-                .expect("read check must reach the DB"),
-            "a principal without a matching rule must be denied read once rules exist"
-        );
-
-        // Positive control (mandatory): the granted principal succeeds in the
-        // same fixture, so the negatives above cannot be satisfied by a gate
-        // that simply denies everyone.
-        assert!(
-            service
-                .check_repository_action(granted_user, repo_id, "write", false)
-                .await
-                .expect("write check must reach the DB"),
-            "the granted principal must be allowed write (positive control)"
-        );
-        assert!(
-            service
-                .check_permission(granted_user, "repository", repo_id, "read", false)
-                .await
-                .expect("read check must reach the DB"),
-            "the granted principal must be allowed read (positive control)"
-        );
+        // Collect every verdict BEFORE tearing down, then assert after. A
+        // failing assert must not skip cleanup: this suite runs
+        // process-per-test against a SHARED database, so leaked rows surface
+        // as unrelated failures elsewhere (the #3129 class).
+        let other_write = service
+            .check_repository_action(other_user, repo_id, "write", false)
+            .await
+            .expect("write check must reach the DB");
+        let other_read = service
+            .check_permission(other_user, "repository", repo_id, "read", false)
+            .await
+            .expect("read check must reach the DB");
+        let granted_write = service
+            .check_repository_action(granted_user, repo_id, "write", false)
+            .await
+            .expect("write check must reach the DB");
+        let granted_read = service
+            .check_permission(granted_user, "repository", repo_id, "read", false)
+            .await
+            .expect("read check must reach the DB");
+        let granted_delete = service
+            .check_repository_action(granted_user, repo_id, "delete", false)
+            .await
+            .expect("delete check must reach the DB");
 
         // Scope teardown to this fixture's own rows only (#3129: no
         // cluster-wide deletes on a shared database).
@@ -2106,5 +2094,42 @@ mod tests {
             .bind(repo_id)
             .execute(&pool)
             .await;
+
+        // These two are CONTROLS, not the discriminating assertions — the
+        // comments here previously had it the other way round. `other_user`
+        // has no applicable rule, so it never takes the rule arm: it falls
+        // through to the role-assignment `ELSE` (see the `CASE` around
+        // permission_service.rs:216-224) and is denied for want of a role.
+        // Mutating the rule arm to `WHEN false` leaves BOTH of these green.
+        assert!(
+            !other_write,
+            "a principal with neither a rule nor a role must be denied write"
+        );
+        assert!(
+            !other_read,
+            "a principal with neither a rule nor a role must be denied read"
+        );
+
+        // THESE gate the claim. `granted_user` holds no role assignment, so
+        // the only way it can be allowed is if the `permissions` rule was
+        // actually consulted. Mutating the rule arm to `WHEN false` fails
+        // exactly here.
+        assert!(
+            granted_write,
+            "the granted principal must be allowed write — the rule IS consulted"
+        );
+        assert!(
+            granted_read,
+            "the granted principal must be allowed read — the rule IS consulted"
+        );
+
+        // The rule is AUTHORITATIVE for the principal it names, not merely
+        // additive: an action it does not carry is denied. Without this, a
+        // resolver returning "any applicable rule ⇒ allow" would satisfy
+        // everything above.
+        assert!(
+            !granted_delete,
+            "the granted principal holds read+write only; delete must be denied"
+        );
     }
 }

--- a/backend/src/services/permission_service.rs
+++ b/backend/src/services/permission_service.rs
@@ -2012,4 +2012,99 @@ mod tests {
             tx.rollback().await.expect("rollback migration fixture");
         }
     }
+
+    // -----------------------------------------------------------------------
+    // #3185: enforcement-vs-message drift guard.
+    //
+    // A stale startup warning claimed permission rules are "stored but not
+    // consulted during request authorization" (#794). That claim is false —
+    // enforcement landed across #817/#824/#826/#827/#819/#2603. This DB-backed
+    // test pins the actual behaviour the warning described so the two cannot
+    // drift apart again: a fine-grained `permissions` rule IS consulted, with
+    // deny-by-default for a principal the rule does not name. If enforcement is
+    // ever silently regressed (rules stored but not honoured — i.e. the warning
+    // becomes true again), this test goes red rather than a log line quietly
+    // becoming accurate. Requires a database: with none, it returns PASS early
+    // (~0.04s tell) exactly like the sibling DB tests.
+    // -----------------------------------------------------------------------
+    #[tokio::test]
+    async fn permission_rule_is_consulted_during_authorization() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let service = PermissionService::new(pool.clone());
+
+        // A private repository with a single fine-grained grant.
+        let (repo_id, _key, _dir) = tdh::create_repo(&pool, "local", "generic").await;
+        let (granted_user, _gu) = tdh::create_user(&pool).await; // holds the rule
+        let (other_user, _ou) = tdh::create_user(&pool).await; // no rule, no role
+
+        // Grant `granted_user` read+write on this repo via the `permissions`
+        // table (the exact CRUD surface #794 said was inert).
+        tdh::grant_repo_actions(&pool, repo_id, granted_user, &["read", "write"]).await;
+
+        // The rule is visible to the middleware's "should we enforce?" probe.
+        assert!(
+            service
+                .has_any_rules_for_target("repository", repo_id)
+                .await
+                .expect("rule-existence probe must reach the DB"),
+            "the just-inserted permissions rule must be observable"
+        );
+
+        // Negative: the principal the rule does NOT name is denied. This is the
+        // enforcement the warning claimed did not exist. A rule-less private
+        // repo would deny `other_user` too, so the negative alone is not proof —
+        // hence the positive control below in the SAME fixture.
+        assert!(
+            !service
+                .check_repository_action(other_user, repo_id, "write", false)
+                .await
+                .expect("write check must reach the DB"),
+            "a principal without a matching rule must be denied write (rule IS consulted)"
+        );
+        assert!(
+            !service
+                .check_permission(other_user, "repository", repo_id, "read", false)
+                .await
+                .expect("read check must reach the DB"),
+            "a principal without a matching rule must be denied read once rules exist"
+        );
+
+        // Positive control (mandatory): the granted principal succeeds in the
+        // same fixture, so the negatives above cannot be satisfied by a gate
+        // that simply denies everyone.
+        assert!(
+            service
+                .check_repository_action(granted_user, repo_id, "write", false)
+                .await
+                .expect("write check must reach the DB"),
+            "the granted principal must be allowed write (positive control)"
+        );
+        assert!(
+            service
+                .check_permission(granted_user, "repository", repo_id, "read", false)
+                .await
+                .expect("read check must reach the DB"),
+            "the granted principal must be allowed read (positive control)"
+        );
+
+        // Scope teardown to this fixture's own rows only (#3129: no
+        // cluster-wide deletes on a shared database).
+        let _ = sqlx::query("DELETE FROM permissions WHERE target_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id IN ($1, $2)")
+            .bind(granted_user)
+            .bind(other_user)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+    }
 }


### PR DESCRIPTION
## What this fixes

Every boot with at least one row in `permissions`, the backend logged:

> Found N permission rule(s) in the database, but enforcement is NOT active. Permission rules created via /api/v1/permissions are stored but not consulted during request authorization. This will be addressed in a future release. See #794

That warning is **false**. It was inert log text left in `main.rs` after the enforcement work landed, and it misleads operators about their security posture — the concern the reporter raised.

## Which world we are in: the warning is STALE; enforcement IS active

I established this from the enforcement code, not the warning text or #794's closing comment:

- **Native-protocol / format-handler path** — `repo_visibility_middleware` (`backend/src/api/middleware/auth.rs`) gates writes through `PermissionService::check_repository_action` (deny-by-default when a rule exists) and reads through `has_any_rules_for_target` + `check_permission`.
- **REST path** — `require_repo_action` (`backend/src/api/handlers/repositories.rs`) calls the same `check_repository_action`.
- **`check_repository_action`** (`backend/src/services/permission_service.rs`) runs a real SQL decision over the `permissions` table (direct + group + inherited-project grants), with a `CASE` that is authoritative-and-deny-by-default once any applicable rule exists.
- The runtime posture endpoint `/api/v1/system/config` already reports `permissions.enforcement_enabled: true` (`backend/src/api/handlers/system_config.rs`), directly contradicting the startup warning.

So a permissions rule **is** consulted during request authorization. The reporter's own black-box test (grantee allowed, ungranted account denied) matches this; the warning is the thing that is wrong.

I did not take the mere presence of a gate-shaped call as proof — `check_repository_action` runs an actual grant-resolving query and the middleware routes writes through it deny-by-default.

## What I changed

- Removed the stale warning block in `backend/src/main.rs`, replacing it with a short comment pointing at the enforcement paths and the regression test (so nobody re-adds it).
- Added a DB-backed regression test `permission_service::tests::permission_rule_is_consulted_during_authorization` that pins the enforcement the warning denied, so the message and behaviour cannot drift apart again. If enforcement is ever silently regressed (rules stored but not honoured — the warning becoming true again), this test goes red instead of a log line quietly becoming accurate.

## Scope note

This is a log-message correction backed by an enforcement regression guard. I did **not** find a live authorization gap on the surfaces the warning covers — enforcement is genuinely active on both the native and REST paths. No enforcement code was changed.

Fixes #3185
