### PR TITLE
fix(proxy): declare upstream Content-Encoding on verbatim forwards in goproxy, rubygems and hex

### DIFF
--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -453,11 +453,27 @@ fn filter_version_list(body: &str, blocked: &std::collections::HashSet<String>) 
 /// virtual repository each member's own gate configuration governs its
 /// contribution (#2264).
 ///
-/// Deliberately DROPS the upstream `Content-Encoding` (#3260): every caller
-/// PARSES the returned body (`@v/list` line filtering, `@latest` JSON) and
-/// serves a document it rebuilt itself, so the upstream coding never
-/// describes the bytes that leave the handler. Verbatim forwards go through
-/// [`try_proxy_go_metadata`] / `get_mod_file`, which re-declare the coding.
+/// DROPS the upstream `Content-Encoding`, and unlike the verbatim forwards
+/// #3260 fixed ([`try_proxy_go_metadata`] / `get_mod_file`, which re-declare
+/// it) that is NOT sound for both callers today:
+///
+/// * `@v/list` ([`list_versions`]) does rebuild its document — but through
+///   `String::from_utf8_lossy`, so a coded body is not rejected, it is
+///   replaced character by character with U+FFFD and served as a 200. The
+///   coding is correctly dropped; the body is corrupt.
+/// * `@latest` ([`latest_version`]) does NOT rebuild anything. It parses the
+///   JSON only to run the age gate and then forwards the upstream bytes
+///   verbatim, so it is a verbatim forwarder that drops the coding. It does
+///   not currently mislabel a coded body only because `serde_json::from_slice`
+///   rejects one first and the request 404s — i.e. the endpoint is broken for
+///   exactly the coded-upstream population #3260 is about.
+///
+/// Both are pre-existing (they predate #3260, which changed neither) and both
+/// are tracked in #3280. Fixing them needs this helper to report the coding
+/// AND a decoder on the parse path, which is a larger change than #3260's
+/// re-declare-only fix: it introduces decompression of an upstream-controlled
+/// body, so it needs its own bounds. Until then this comment describes what
+/// the code does rather than what it ought to do.
 async fn fetch_go_metadata_with_source(
     state: &SharedState,
     repo: &RepoInfo,
@@ -2608,42 +2624,71 @@ mod tests {
     /// as if it were plain.
     ///
     /// Deflate (non-gzip) coded upstream plus an uncoded control in the SAME
-    /// fixture — see `tdh::coded_fixture` for why gzip would prove less.
+    /// fixture — see `tdh::coded_fixture` for why gzip would prove less. The
+    /// hex arm mounts `gzip` for the same reason in reverse: with all three
+    /// suites on one coding, pinning the production line to that literal
+    /// keeps every assertion green.
+    ///
+    /// The Virtual `.info` URI is probed TWICE: cold (Pass 2, the upstream
+    /// fan-out) and warm (Pass 1, `cached_metadata_if_servable`). Pass 1 is a
+    /// line this fix changed — it used to discard the member's coding — and
+    /// only the second probe reaches it.
     #[tokio::test]
     async fn test_go_metadata_forwards_upstream_content_encoding_verbatim_db() {
         let Some(fx) = tdh::Fixture::setup("remote", "go").await else {
             return;
         };
-        let (plain, coded, coded_mock, plain_mock) =
+        let up =
             tdh::coded_and_plain_upstreams("deflate", "application/json", b"go-meta-3260 ").await;
 
         // fx repo = the coded Remote (Remote-arm probes); a second coded
         // Remote wrapped by a Virtual (Virtual-arm probe, cold cache so the
         // upstream pass of `resolve_virtual_metadata` runs); a plain Remote +
         // Virtual pair as the uncoded control.
-        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &coded_mock.uri()).await;
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &up.coded_mock.uri()).await;
         let (coded_member_id, _cm_key, virt_coded_id, virt_coded_key) =
-            tdh::create_remote_and_virtual(&fx.pool, "go", &coded_mock.uri()).await;
+            tdh::create_remote_and_virtual(&fx.pool, "go", &up.coded_mock.uri()).await;
         let (plain_id, plain_key, virt_plain_id, virt_plain_key) =
-            tdh::create_remote_and_virtual(&fx.pool, "go", &plain_mock.uri()).await;
+            tdh::create_remote_and_virtual(&fx.pool, "go", &up.plain_mock.uri()).await;
 
         // Remote arm, `.info` (`try_proxy_go_metadata`).
         let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", fx.repo_key);
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "remote .info");
+        up.assert_coded_forward(&headers, &body, "remote .info");
 
         // Remote arm, `.mod` (`get_mod_file`).
         let uri = format!("/{}/example.com/coded/@v/v1.0.0.mod", fx.repo_key);
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "remote .mod");
+        up.assert_coded_forward(&headers, &body, "remote .mod");
 
-        // Virtual arm, `.info` (`resolve_virtual_metadata` transform).
+        // Virtual arm, `.info`, COLD: `resolve_virtual_metadata` Pass 2 (the
+        // upstream fan-out) transforms the fetched bytes.
         let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", virt_coded_key);
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual .info");
+        up.assert_coded_forward(&headers, &body, "virtual .info (cold, Pass 2)");
+
+        // Virtual arm, `.info`, WARM: the same URI again now resolves through
+        // `resolve_virtual_metadata` Pass 1 (`cached_metadata_if_servable`),
+        // which reads the coding off the cache sidecar. Cold and warm are
+        // different lines of production code and only this probe covers the
+        // warm one. The unchanged upstream hit count is the barrier proving
+        // the response really came from the cache rather than a second
+        // fan-out — a barrier both the fixed and the coding-dropping shape of
+        // Pass 1 reach.
+        let upstream_path = "/example.com/coded/@v/v1.0.0.info";
+        let hits_before = up.coded_hits(upstream_path).await;
+        let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", virt_coded_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        assert_eq!(
+            up.coded_hits(upstream_path).await,
+            hits_before,
+            "second probe must be served from the proxy cache (Pass 1), not refetched"
+        );
+        up.assert_coded_forward(&headers, &body, "virtual .info (warm, Pass 1)");
 
         // Controls: uncoded upstream through the same three arms.
         for (key, what) in [
@@ -2653,12 +2698,18 @@ mod tests {
             let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", key);
             let (body, headers) =
                 tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-            tdh::assert_plain_forward(&headers, &body, &plain, what);
+            up.assert_plain_forward(&headers, &body, what);
         }
+        // ... including the warm virtual path: a cache hit on an uncoded
+        // member must not invent a coding either.
+        let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", virt_plain_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        up.assert_plain_forward(&headers, &body, "control virtual .info (warm, Pass 1)");
         let uri = format!("/{}/example.com/coded/@v/v1.0.0.mod", plain_key);
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_plain_forward(&headers, &body, &plain, "control remote .mod");
+        up.assert_plain_forward(&headers, &body, "control remote .mod");
 
         for id in [virt_coded_id, coded_member_id, virt_plain_id, plain_id] {
             let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -368,34 +368,37 @@ async fn try_proxy_go_metadata(
     upstream_path: &str,
     default_content_type: &str,
 ) -> Result<Response, ()> {
-    // Remote repo: proxy to upstream
+    // Remote repo: proxy to upstream. The upstream body is forwarded
+    // VERBATIM (`.info` JSON / `.mod` bytes as the upstream served them), so
+    // the upstream `Content-Encoding` must be re-declared when present
+    // (RFC 9110 §8.4, #3260) — nothing on this path decodes.
     if repo.repo_type == RepositoryType::Remote {
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
-                proxy,
-                repo.id,
-                &repo.key,
-                upstream_url,
-                upstream_path,
-                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-            )
-            .await
+            if let Ok((content, content_type, content_encoding)) =
+                proxy_helpers::proxy_fetch_capped_encoded(
+                    proxy,
+                    repo.id,
+                    &repo.key,
+                    upstream_url,
+                    upstream_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                )
+                .await
             {
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| default_content_type.to_string()),
-                    )
-                    .body(Body::from(content))
-                    .unwrap());
+                return Ok(proxy_helpers::forward_verbatim_metadata(
+                    content,
+                    content_type,
+                    default_content_type,
+                    content_encoding,
+                ));
             }
         }
     }
 
-    // Virtual repo: try each member in priority order
+    // Virtual repo: try each member in priority order. Same verbatim-forward
+    // contract as the Remote arm above: the member's coding is re-declared.
     if repo.repo_type == RepositoryType::Virtual {
         let ct = default_content_type.to_string();
         if let Ok(resp) = proxy_helpers::resolve_virtual_metadata(
@@ -403,14 +406,15 @@ async fn try_proxy_go_metadata(
             state.proxy_service.as_deref(),
             repo.id,
             upstream_path,
-            |bytes, _key| {
+            |bytes, content_encoding, _key| {
                 let ct = ct.clone();
                 async move {
-                    Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(CONTENT_TYPE, ct)
-                        .body(Body::from(bytes))
-                        .unwrap())
+                    Ok(proxy_helpers::forward_verbatim_metadata(
+                        bytes,
+                        None,
+                        &ct,
+                        content_encoding,
+                    ))
                 }
             },
         )
@@ -448,6 +452,12 @@ fn filter_version_list(body: &str, blocked: &std::collections::HashSet<String>) 
 /// source id is what the age-gate listing filter resolves policy from: for a
 /// virtual repository each member's own gate configuration governs its
 /// contribution (#2264).
+///
+/// Deliberately DROPS the upstream `Content-Encoding` (#3260): every caller
+/// PARSES the returned body (`@v/list` line filtering, `@latest` JSON) and
+/// serves a document it rebuilt itself, so the upstream coding never
+/// describes the bytes that leave the handler. Verbatim forwards go through
+/// [`try_proxy_go_metadata`] / `get_mod_file`, which re-declare the coding.
 async fn fetch_go_metadata_with_source(
     state: &SharedState,
     repo: &RepoInfo,
@@ -623,7 +633,8 @@ async fn enforce_go_zip_age_gate(
 
 /// Positive existence evidence for `module@version`: the upstream serves its
 /// `.info` document. Failures are treated as "no evidence" — the gate then
-/// blocks without starting a clock, never the reverse.
+/// blocks without starting a clock, never the reverse. The body (and hence
+/// its `Content-Encoding`, #3260) is discarded: only reachability matters.
 async fn go_version_exists_upstream(
     state: &SharedState,
     params: &crate::services::age_gate_service::AgeGateRepoParams,
@@ -878,24 +889,26 @@ async fn get_mod_file(
                 if let (Some(ref upstream_url), Some(ref proxy)) =
                     (&repo.upstream_url, &state.proxy_service)
                 {
+                    // Verbatim forward of the upstream go.mod bytes: the
+                    // upstream `Content-Encoding` must be re-declared when
+                    // present (RFC 9110 §8.4, #3260).
                     let upstream_path = build_go_upstream_path(module, version, "mod");
-                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
-                        proxy,
-                        repo.id,
-                        &repo.key,
-                        upstream_url,
-                        &upstream_path,
-                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-                    )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "text/plain; charset=utf-8".to_string()),
+                    let (content, content_type, content_encoding) =
+                        proxy_helpers::proxy_fetch_capped_encoded(
+                            proxy,
+                            repo.id,
+                            &repo.key,
+                            upstream_url,
+                            &upstream_path,
+                            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                         )
-                        .body(Body::from(content))
-                        .unwrap());
+                        .await?;
+                    return Ok(proxy_helpers::forward_verbatim_metadata(
+                        content,
+                        content_type,
+                        "text/plain; charset=utf-8",
+                        content_encoding,
+                    ));
                 }
             }
 
@@ -2581,5 +2594,78 @@ mod tests {
             mod_bytes,
             "mod endpoint must serve the go.mod artifact, not the zip (#1782)"
         );
+    }
+
+    /// #3260: goproxy forwards `.info` / `.mod` upstream bodies VERBATIM —
+    /// the Remote arm of `try_proxy_go_metadata`, `get_mod_file`'s Remote
+    /// arm, and the Virtual arm via `resolve_virtual_metadata` — so the
+    /// upstream `Content-Encoding` must be re-declared (RFC 9110 §8.4, the
+    /// header describes the coding of the bytes as transferred) and
+    /// `Content-Length` must describe the coded bytes actually sent (§8.6).
+    /// Nothing on this path decodes (`http_client::base_client_builder`
+    /// disables every codec and advertises `Accept-Encoding: identity`), so
+    /// before the fix a coded upstream module document was persisted by `go`
+    /// as if it were plain.
+    ///
+    /// Deflate (non-gzip) coded upstream plus an uncoded control in the SAME
+    /// fixture — see `tdh::coded_fixture` for why gzip would prove less.
+    #[tokio::test]
+    async fn test_go_metadata_forwards_upstream_content_encoding_verbatim_db() {
+        let Some(fx) = tdh::Fixture::setup("remote", "go").await else {
+            return;
+        };
+        let (plain, coded, coded_mock, plain_mock) =
+            tdh::coded_and_plain_upstreams("deflate", "application/json", b"go-meta-3260 ").await;
+
+        // fx repo = the coded Remote (Remote-arm probes); a second coded
+        // Remote wrapped by a Virtual (Virtual-arm probe, cold cache so the
+        // upstream pass of `resolve_virtual_metadata` runs); a plain Remote +
+        // Virtual pair as the uncoded control.
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &coded_mock.uri()).await;
+        let (coded_member_id, _cm_key, virt_coded_id, virt_coded_key) =
+            tdh::create_remote_and_virtual(&fx.pool, "go", &coded_mock.uri()).await;
+        let (plain_id, plain_key, virt_plain_id, virt_plain_key) =
+            tdh::create_remote_and_virtual(&fx.pool, "go", &plain_mock.uri()).await;
+
+        // Remote arm, `.info` (`try_proxy_go_metadata`).
+        let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", fx.repo_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "remote .info");
+
+        // Remote arm, `.mod` (`get_mod_file`).
+        let uri = format!("/{}/example.com/coded/@v/v1.0.0.mod", fx.repo_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "remote .mod");
+
+        // Virtual arm, `.info` (`resolve_virtual_metadata` transform).
+        let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", virt_coded_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual .info");
+
+        // Controls: uncoded upstream through the same three arms.
+        for (key, what) in [
+            (&plain_key, "control remote .info"),
+            (&virt_plain_key, "control virtual .info"),
+        ] {
+            let uri = format!("/{}/example.com/coded/@v/v1.0.0.info", key);
+            let (body, headers) =
+                tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+            tdh::assert_plain_forward(&headers, &body, &plain, what);
+        }
+        let uri = format!("/{}/example.com/coded/@v/v1.0.0.mod", plain_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_plain_forward(&headers, &body, &plain, "control remote .mod");
+
+        for id in [virt_coded_id, coded_member_id, virt_plain_id, plain_id] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&fx.pool)
+                .await;
+        }
+        fx.teardown().await;
     }
 }

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -337,24 +337,26 @@ async fn package_info(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
+            // Verbatim pass-through of upstream's signed registry bytes: the
+            // upstream `Content-Encoding` is re-declared when present
+            // (RFC 9110 §8.4, #3260) — nothing on this path decodes.
             let upstream_path = format!("packages/{}", name);
-            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
-                proxy,
-                repo.id,
-                &repo_key,
-                upstream_url,
-                &upstream_path,
-                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-            )
-            .await?;
-            return Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(
-                    CONTENT_TYPE,
-                    content_type.unwrap_or_else(|| "application/json".to_string()),
+            let (content, content_type, content_encoding) =
+                proxy_helpers::proxy_fetch_capped_encoded(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    &upstream_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
-                .body(Body::from(content))
-                .unwrap());
+                .await?;
+            return Ok(proxy_helpers::forward_verbatim_metadata(
+                content,
+                content_type,
+                "application/json",
+                content_encoding,
+            ));
         }
     }
 
@@ -408,18 +410,22 @@ async fn package_info(
             }
 
             // Pass 3: fall through to remote proxy for un-cached packages.
+            // Verbatim forward of the member's registry bytes: its
+            // `Content-Encoding` is re-declared when present (RFC 9110 §8.4,
+            // #3260).
             let upstream_path = format!("packages/{}", name);
             return proxy_helpers::resolve_virtual_metadata(
                 &state.db,
                 state.proxy_service.as_deref(),
                 repo.id,
                 &upstream_path,
-                |content, _member_key| async move {
-                    Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(CONTENT_TYPE, "application/json")
-                        .body(Body::from(content))
-                        .unwrap())
+                |content, content_encoding, _member_key| async move {
+                    Ok(proxy_helpers::forward_verbatim_metadata(
+                        content,
+                        None,
+                        "application/json",
+                        content_encoding,
+                    ))
                 },
             )
             .await;
@@ -1102,23 +1108,24 @@ async fn list_names(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
-                proxy,
-                repo.id,
-                &repo_key,
-                upstream_url,
-                "names",
-                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-            )
-            .await?;
-            return Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(
-                    CONTENT_TYPE,
-                    content_type.unwrap_or_else(|| "application/json".to_string()),
+            // Verbatim pass-through: re-declare the upstream
+            // `Content-Encoding` when present (RFC 9110 §8.4, #3260).
+            let (content, content_type, content_encoding) =
+                proxy_helpers::proxy_fetch_capped_encoded(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    "names",
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
-                .body(Body::from(content))
-                .unwrap());
+                .await?;
+            return Ok(proxy_helpers::forward_verbatim_metadata(
+                content,
+                content_type,
+                "application/json",
+                content_encoding,
+            ));
         }
     }
     // Virtual: merge package names from all member repositories (local DB + remote proxy).
@@ -1257,23 +1264,24 @@ async fn list_versions(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
-                proxy,
-                repo.id,
-                &repo_key,
-                upstream_url,
-                "versions",
-                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-            )
-            .await?;
-            return Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(
-                    CONTENT_TYPE,
-                    content_type.unwrap_or_else(|| "application/json".to_string()),
+            // Verbatim pass-through: re-declare the upstream
+            // `Content-Encoding` when present (RFC 9110 §8.4, #3260).
+            let (content, content_type, content_encoding) =
+                proxy_helpers::proxy_fetch_capped_encoded(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    "versions",
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
-                .body(Body::from(content))
-                .unwrap());
+                .await?;
+            return Ok(proxy_helpers::forward_verbatim_metadata(
+                content,
+                content_type,
+                "application/json",
+                content_encoding,
+            ));
         }
     }
     // Virtual: merge versions from all member repositories (local DB + remote proxy).
@@ -3971,6 +3979,83 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "cached tarball must serve locally");
         assert_eq!(&body[..], b"cached-tarball-bytes");
 
+        fx.teardown().await;
+    }
+
+    /// #3260: the Remote arms of `/packages/{name}`, `/names` and `/versions`
+    /// and the Virtual arm of `/packages/{name}` forward upstream's signed
+    /// registry bytes VERBATIM (see the #2658 pass-through contract above),
+    /// so the upstream `Content-Encoding` must be re-declared (RFC 9110 §8.4)
+    /// and `Content-Length` must describe the coded bytes actually sent
+    /// (§8.6). Nothing on this path decodes (`http_client` disables every
+    /// codec and advertises `Accept-Encoding: identity`), so before the fix
+    /// `mix` received coded bytes labelled as plain.
+    ///
+    /// Deflate (non-gzip) coded upstream plus an uncoded control in the SAME
+    /// fixture — see `tdh::coded_fixture` for why gzip would prove less.
+    #[tokio::test]
+    async fn test_hex_registry_forwards_upstream_content_encoding_verbatim_db() {
+        let Some(fx) = tdh::Fixture::setup("remote", "hex").await else {
+            return;
+        };
+        let (plain, coded, coded_mock, plain_mock) = tdh::coded_and_plain_upstreams(
+            "deflate",
+            "application/octet-stream",
+            b"hex-registry-3260 ",
+        )
+        .await;
+
+        // fx repo = the coded Remote (Remote-arm probes); a second coded
+        // Remote wrapped by a Virtual (Virtual-arm probe); a plain Remote +
+        // Virtual pair as the uncoded control.
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &coded_mock.uri()).await;
+        let (coded_member_id, _cm_key, virt_coded_id, virt_coded_key) =
+            tdh::create_remote_and_virtual(&fx.pool, "hex", &coded_mock.uri()).await;
+        let (plain_id, plain_key, virt_plain_id, virt_plain_key) =
+            tdh::create_remote_and_virtual(&fx.pool, "hex", &plain_mock.uri()).await;
+
+        // Remote arms: all three registry resources.
+        for resource in ["packages/pkg3260", "names", "versions"] {
+            let uri = format!("/{}/{}", fx.repo_key, resource);
+            let (body, headers) =
+                tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+            tdh::assert_coded_forward(
+                &headers,
+                &body,
+                &coded,
+                &plain,
+                &format!("remote {resource}"),
+            );
+        }
+
+        // Virtual arm: `/packages/{name}` pass 3 (`resolve_virtual_metadata`).
+        let uri = format!("/{}/packages/pkg3260", virt_coded_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual packages");
+
+        // Controls: uncoded upstream through the Remote and Virtual arms.
+        for (key, resource, what) in [
+            (&plain_key, "packages/pkg3260", "control remote packages"),
+            (&plain_key, "names", "control remote names"),
+            (
+                &virt_plain_key,
+                "packages/pkg3260",
+                "control virtual packages",
+            ),
+        ] {
+            let uri = format!("/{}/{}", key, resource);
+            let (body, headers) =
+                tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+            tdh::assert_plain_forward(&headers, &body, &plain, what);
+        }
+
+        for id in [virt_coded_id, coded_member_id, virt_plain_id, plain_id] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&fx.pool)
+                .await;
+        }
         fx.teardown().await;
     }
 }

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -3991,15 +3991,19 @@ mod tests {
     /// codec and advertises `Accept-Encoding: identity`), so before the fix
     /// `mix` received coded bytes labelled as plain.
     ///
-    /// Deflate (non-gzip) coded upstream plus an uncoded control in the SAME
-    /// fixture — see `tdh::coded_fixture` for why gzip would prove less.
+    /// GZIP-coded upstream plus an uncoded control in the SAME fixture. The
+    /// coding deliberately differs from the goproxy / rubygems arms' deflate:
+    /// if every #3260 suite mounted one coding, pinning the production
+    /// builder to that literal would leave them all green — which is exactly
+    /// the hole `tdh::coded_fixture`'s doc comment was written about, and
+    /// exactly the hole this suite originally shipped with.
     #[tokio::test]
     async fn test_hex_registry_forwards_upstream_content_encoding_verbatim_db() {
         let Some(fx) = tdh::Fixture::setup("remote", "hex").await else {
             return;
         };
-        let (plain, coded, coded_mock, plain_mock) = tdh::coded_and_plain_upstreams(
-            "deflate",
+        let up = tdh::coded_and_plain_upstreams(
+            "gzip",
             "application/octet-stream",
             b"hex-registry-3260 ",
         )
@@ -4008,31 +4012,25 @@ mod tests {
         // fx repo = the coded Remote (Remote-arm probes); a second coded
         // Remote wrapped by a Virtual (Virtual-arm probe); a plain Remote +
         // Virtual pair as the uncoded control.
-        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &coded_mock.uri()).await;
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &up.coded_mock.uri()).await;
         let (coded_member_id, _cm_key, virt_coded_id, virt_coded_key) =
-            tdh::create_remote_and_virtual(&fx.pool, "hex", &coded_mock.uri()).await;
+            tdh::create_remote_and_virtual(&fx.pool, "hex", &up.coded_mock.uri()).await;
         let (plain_id, plain_key, virt_plain_id, virt_plain_key) =
-            tdh::create_remote_and_virtual(&fx.pool, "hex", &plain_mock.uri()).await;
+            tdh::create_remote_and_virtual(&fx.pool, "hex", &up.plain_mock.uri()).await;
 
         // Remote arms: all three registry resources.
         for resource in ["packages/pkg3260", "names", "versions"] {
             let uri = format!("/{}/{}", fx.repo_key, resource);
             let (body, headers) =
                 tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-            tdh::assert_coded_forward(
-                &headers,
-                &body,
-                &coded,
-                &plain,
-                &format!("remote {resource}"),
-            );
+            up.assert_coded_forward(&headers, &body, &format!("remote {resource}"));
         }
 
         // Virtual arm: `/packages/{name}` pass 3 (`resolve_virtual_metadata`).
         let uri = format!("/{}/packages/pkg3260", virt_coded_key);
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual packages");
+        up.assert_coded_forward(&headers, &body, "virtual packages (cold, Pass 2)");
 
         // Controls: uncoded upstream through the Remote and Virtual arms.
         for (key, resource, what) in [
@@ -4047,7 +4045,7 @@ mod tests {
             let uri = format!("/{}/{}", key, resource);
             let (body, headers) =
                 tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-            tdh::assert_plain_forward(&headers, &body, &plain, what);
+            up.assert_plain_forward(&headers, &body, what);
         }
 
         for id in [virt_coded_id, coded_member_id, virt_plain_id, plain_id] {

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -954,7 +954,12 @@ async fn download_root(
     Err(AppError::NotFound("Repository root not available".to_string()).into_response())
 }
 
-/// Build the response for an upstream root body that is forwarded VERBATIM.
+/// Build the response for an upstream root body that is forwarded VERBATIM
+/// (#3211). Thin alias for the shared
+/// [`proxy_helpers::forward_verbatim_metadata`] (#3260) with Maven's root
+/// default `Content-Type`: the general form was extracted from this function,
+/// so keeping a second copy here would be the duplicate the extraction exists
+/// to remove (the jscpd duplication gate scores changed files).
 ///
 /// The bytes are sent exactly as the upstream (or the proxy cache) produced
 /// them, so the upstream `Content-Encoding` must be re-declared when present
@@ -968,15 +973,7 @@ fn forward_root_verbatim(
     content_type: Option<String>,
     content_encoding: Option<String>,
 ) -> Response {
-    let ct = content_type.unwrap_or_else(|| "text/html".to_string());
-    let mut builder = Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, ct)
-        .header(CONTENT_LENGTH, content.len().to_string());
-    if let Some(enc) = content_encoding {
-        builder = builder.header(CONTENT_ENCODING, enc);
-    }
-    builder.body(Body::from(content)).unwrap()
+    proxy_helpers::forward_verbatim_metadata(content, content_type, "text/html", content_encoding)
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -2713,6 +2713,12 @@ where
 /// bytes it emits are no longer the bytes the coding describes. Before #3260
 /// this helper dropped the coding unconditionally, which mislabeled every
 /// coded upstream response its (all verbatim-forwarding) callers served.
+///
+/// The member's `Content-TYPE` is still dropped (both passes bind it `_ct`),
+/// so the verbatim-forwarding callers each hardcode a literal and can
+/// disagree with the Remote arm of the same endpoint. Pre-existing and NOT
+/// addressed by #3260 — tracked in #3281, which widens this seam once more
+/// rather than twice.
 pub async fn resolve_virtual_metadata<F, Fut>(
     db: &PgPool,
     proxy_service: Option<&ProxyService>,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -649,6 +649,66 @@ pub async fn proxy_fetch_capped_with_accept(
         .map_err(|e| map_proxy_error(repo_key, path, e))
 }
 
+/// As [`proxy_fetch_capped`], but also reports the upstream `Content-Encoding`
+/// (#3260, the plain-path sibling of
+/// [`proxy_fetch_capped_with_cache_key_encoded`]) for handlers that forward
+/// the buffered bytes to the client VERBATIM and must therefore re-declare the
+/// coding (RFC 9110 §8.4 — `Content-Encoding` describes the coding applied to
+/// the representation as transferred). The shared HTTP client neither decodes
+/// nor negotiates codings (`http_client::base_client_builder` disables every
+/// codec and advertises `Accept-Encoding: identity`), so a coding that does
+/// arrive — object stores return a stored `Content-Encoding` regardless of the
+/// request — is on the bytes the handler is about to serve.
+pub async fn proxy_fetch_capped_encoded(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>, Option<String>), Response> {
+    with_proxy_repo(repo_id, repo_key, upstream_url, path, |repo| async move {
+        proxy_service
+            .fetch_artifact_capped_with_encoding(&repo, path, max)
+            .await
+    })
+    .await
+}
+
+/// Build the 200 response for buffered upstream metadata that is forwarded
+/// VERBATIM (#3260, the shared form of Maven's #3211 `forward_root_verbatim`).
+///
+/// The body is exactly the bytes the upstream (or the proxy cache) produced,
+/// so the upstream `Content-Encoding` must be re-declared when present
+/// (RFC 9110 §8.4 — the header describes the coding applied to the bytes as
+/// transferred; nothing on this path decodes), and `Content-Length` is the
+/// length of those coded bytes (RFC 9110 §8.6). Dropping the coding while
+/// keeping the coded bytes was #3211/#3260: clients stored or parsed a
+/// compressed document as if it were plain.
+///
+/// Callers that PARSE or REWRITE the buffered body must NOT use this — the
+/// bytes they emit are not the bytes that arrived, so the upstream coding no
+/// longer describes them and must be dropped.
+pub fn forward_verbatim_metadata(
+    content: Bytes,
+    content_type: Option<String>,
+    default_content_type: &str,
+    content_encoding: Option<String>,
+) -> Response {
+    let ct = content_type.unwrap_or_else(|| default_content_type.to_string());
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, ct)
+        .header(
+            axum::http::header::CONTENT_LENGTH,
+            content.len().to_string(),
+        );
+    if let Some(enc) = content_encoding {
+        builder = builder.header(axum::http::header::CONTENT_ENCODING, enc);
+    }
+    builder.body(axum::body::Body::from(content)).unwrap()
+}
+
 /// Budget-reserving sibling of [`proxy_fetch_capped`] (#2684).
 ///
 /// Reserves `max` bytes of the process-wide [`proxy_metadata_budget`] BEFORE
@@ -2640,7 +2700,19 @@ where
 /// the raw bytes into a final HTTP response.
 ///
 /// Suitable for metadata endpoints where only one upstream response is
-/// needed (npm package info, pypi simple index, hex package, rubygems gem info).
+/// needed (go .info/.mod metadata, hex package, rubygems gem info).
+///
+/// `transform` receives `(body, content_encoding, member_key)`, where
+/// `content_encoding` is the upstream `Content-Encoding` of that body
+/// (#3260). The body is the member upstream's bytes AS TRANSFERRED — nothing
+/// on this path decodes (`http_client::base_client_builder` disables every
+/// codec and advertises `Accept-Encoding: identity`) — so a transform that
+/// forwards the bytes verbatim must re-declare the coding (RFC 9110 §8.4),
+/// e.g. via [`forward_verbatim_metadata`]. A transform that parses or
+/// rewrites the body must decode it first and drop the coding, because the
+/// bytes it emits are no longer the bytes the coding describes. Before #3260
+/// this helper dropped the coding unconditionally, which mislabeled every
+/// coded upstream response its (all verbatim-forwarding) callers served.
 pub async fn resolve_virtual_metadata<F, Fut>(
     db: &PgPool,
     proxy_service: Option<&ProxyService>,
@@ -2649,7 +2721,7 @@ pub async fn resolve_virtual_metadata<F, Fut>(
     transform: F,
 ) -> Result<Response, Response>
 where
-    F: Fn(Bytes, String) -> Fut,
+    F: Fn(Bytes, Option<String>, String) -> Fut,
     Fut: std::future::Future<Output = Result<Response, Response>>,
 {
     let members = fetch_virtual_members(db, virtual_repo_id).await?;
@@ -2678,27 +2750,29 @@ where
             // (warm path never fans out) while a held entry is skipped rather
             // than served raw. A fresh hit is transformed into the response.
             match proxy.cached_metadata_if_servable(member, path).await {
-                Ok(Some((bytes, _ct, _enc))) => match transform(bytes, member.key.clone()).await {
-                    Ok(response) => (
-                        MemberCacheClass::DefiniteHit,
-                        Some(MemberResolveOutcome::Hit(response)),
-                    ),
-                    // The cached bytes failed to transform (e.g. corrupt cached
-                    // metadata). Don't treat the member as a definite miss —
-                    // fall through to an upstream re-fetch in Pass 2 so a good
-                    // upstream copy can still recover it (parity with the old
-                    // `proxy_fetch`-then-transform path). Surface it for field
-                    // debugging.
-                    Err(_) => {
-                        tracing::warn!(
-                            member = %member.key,
-                            path = %path,
-                            "virtual metadata transform failed for cached member response; \
-                             will re-fetch upstream"
-                        );
-                        (MemberCacheClass::NeedsUpstream, None)
+                Ok(Some((bytes, _ct, enc))) => {
+                    match transform(bytes, enc, member.key.clone()).await {
+                        Ok(response) => (
+                            MemberCacheClass::DefiniteHit,
+                            Some(MemberResolveOutcome::Hit(response)),
+                        ),
+                        // The cached bytes failed to transform (e.g. corrupt cached
+                        // metadata). Don't treat the member as a definite miss —
+                        // fall through to an upstream re-fetch in Pass 2 so a good
+                        // upstream copy can still recover it (parity with the old
+                        // `proxy_fetch`-then-transform path). Surface it for field
+                        // debugging.
+                        Err(_) => {
+                            tracing::warn!(
+                                member = %member.key,
+                                path = %path,
+                                "virtual metadata transform failed for cached member response; \
+                                 will re-fetch upstream"
+                            );
+                            (MemberCacheClass::NeedsUpstream, None)
+                        }
                     }
-                },
+                }
                 // `Ok(None)` covers a cache miss AND a negative-cached 404
                 // (both collapse to `None` here). Unlike the download resolvers
                 // — which see the negative 404 as `Err` and classify it
@@ -2719,8 +2793,20 @@ where
             else {
                 return MemberResolveOutcome::Miss;
             };
-            match proxy_fetch(proxy, member.id, &member.key, upstream_url, path).await {
-                Ok((bytes, _ct)) => match transform(bytes, member.key.clone()).await {
+            // The cache-keyed fetch is `proxy_fetch` with `fetch_path ==
+            // cache_path`, widened to also report the upstream
+            // `Content-Encoding` (#3260) so the transform can re-declare it.
+            match proxy_fetch_with_cache_key(
+                proxy,
+                member.id,
+                &member.key,
+                upstream_url,
+                path,
+                path,
+            )
+            .await
+            {
+                Ok((bytes, _ct, enc)) => match transform(bytes, enc, member.key.clone()).await {
                     Ok(response) => MemberResolveOutcome::Hit(response),
                     Err(_) => {
                         tracing::warn!(
@@ -2767,6 +2853,13 @@ where
 ///
 /// Suitable for metadata endpoints where responses from every upstream
 /// must be combined (conda repodata, cran PACKAGES, helm index, rubygems specs).
+///
+/// Deliberately DROPS the upstream `Content-Encoding` (#3260): every `extract`
+/// closure PARSES the member body and the caller serves a merged document it
+/// built itself, so the upstream coding never describes the bytes that leave
+/// this process. A caller that wants to forward one member's bytes verbatim
+/// belongs on [`resolve_virtual_metadata`], whose transform receives the
+/// coding.
 pub async fn collect_virtual_metadata<T, F, Fut>(
     db: &PgPool,
     proxy_service: Option<&ProxyService>,

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -123,19 +123,22 @@ async fn gem_info(
         return Ok(super::json_response(&json));
     }
 
-    // Virtual repo: try remote members in priority order
+    // Virtual repo: try remote members in priority order. The member's body
+    // is forwarded VERBATIM, so its `Content-Encoding` is re-declared when
+    // present (RFC 9110 §8.4, #3260).
     if repo.repo_type == RepositoryType::Virtual {
         return proxy_helpers::resolve_virtual_metadata(
             &state.db,
             state.proxy_service.as_deref(),
             repo.id,
             &format!("api/v1/gems/{}.json", gem_name),
-            |bytes, _member_key| async move {
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header("content-type", "application/json")
-                    .body(Body::from(bytes))
-                    .unwrap())
+            |bytes, content_encoding, _member_key| async move {
+                Ok(proxy_helpers::forward_verbatim_metadata(
+                    bytes,
+                    None,
+                    "application/json",
+                    content_encoding,
+                ))
             },
         )
         .await;
@@ -797,18 +800,21 @@ async fn quick_spec(
                 }
             }
         }
-        // Otherwise proxy the upstream quick spec verbatim (already Marshal).
+        // Otherwise proxy the upstream quick spec verbatim (already Marshal),
+        // re-declaring the member's `Content-Encoding` when present
+        // (RFC 9110 §8.4, #3260).
         return proxy_helpers::resolve_virtual_metadata(
             &state.db,
             state.proxy_service.as_deref(),
             repo.id,
             &format!("quick/Marshal.4.8/{}", spec_file),
-            |bytes, _member_key| async move {
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(CONTENT_TYPE, "application/octet-stream")
-                    .body(Body::from(bytes))
-                    .unwrap())
+            |bytes, content_encoding, _member_key| async move {
+                Ok(proxy_helpers::forward_verbatim_metadata(
+                    bytes,
+                    None,
+                    "application/octet-stream",
+                    content_encoding,
+                ))
             },
         )
         .await;
@@ -1575,6 +1581,75 @@ mod db_cov_tests {
         for uri in uris {
             let app = fx.router_with_auth(super::router());
             let _ = tdh::send(app, tdh::get(uri)).await;
+        }
+        fx.teardown().await;
+    }
+
+    /// #3260: the Virtual arms of `gem_info` and `quick_spec` forward the
+    /// member upstream's body VERBATIM through `resolve_virtual_metadata`
+    /// (the `quick_spec` comment literally says "verbatim" — the payload is
+    /// upstream's Marshal bytes), so the upstream `Content-Encoding` must be
+    /// re-declared (RFC 9110 §8.4) and `Content-Length` must describe the
+    /// coded bytes actually sent (§8.6). Nothing on this path decodes
+    /// (`http_client::base_client_builder` disables every codec), so before
+    /// the fix `gem` received coded bytes labelled as plain.
+    ///
+    /// Deflate (non-gzip) coded member plus an uncoded control member in the
+    /// SAME fixture — see `tdh::coded_fixture` for why gzip would prove less.
+    #[tokio::test]
+    async fn test_rubygems_virtual_forwards_upstream_content_encoding_verbatim_db() {
+        let Some(fx) = tdh::Fixture::setup("remote", "rubygems").await else {
+            return;
+        };
+        let (plain, coded, coded_mock, plain_mock) = tdh::coded_and_plain_upstreams(
+            "deflate",
+            "application/octet-stream",
+            b"gem-meta-3260 ",
+        )
+        .await;
+
+        // fx only supplies the DB + proxy-carrying state; the probes target a
+        // coded Remote wrapped by a Virtual and a plain Remote + Virtual pair
+        // as the uncoded control.
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &coded_mock.uri()).await;
+        let (coded_member_id, _cm_key, virt_coded_id, virt_coded_key) =
+            tdh::create_remote_and_virtual(&fx.pool, "rubygems", &coded_mock.uri()).await;
+        let (plain_id, _plain_key, virt_plain_id, virt_plain_key) =
+            tdh::create_remote_and_virtual(&fx.pool, "rubygems", &plain_mock.uri()).await;
+
+        // `gem_info` Virtual arm.
+        let uri = format!("/{}/api/v1/gems/pkg3260.json", virt_coded_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual gem_info");
+
+        // `quick_spec` Virtual arm.
+        let uri = format!(
+            "/{}/quick/Marshal.4.8/pkg3260-1.0.0.gemspec.rz",
+            virt_coded_key
+        );
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual quick_spec");
+
+        // Controls: the same two arms over an uncoded member.
+        let uri = format!("/{}/api/v1/gems/pkg3260.json", virt_plain_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_plain_forward(&headers, &body, &plain, "control gem_info");
+        let uri = format!(
+            "/{}/quick/Marshal.4.8/pkg3260-1.0.0.gemspec.rz",
+            virt_plain_key
+        );
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        tdh::assert_plain_forward(&headers, &body, &plain, "control quick_spec");
+
+        for id in [virt_coded_id, coded_member_id, virt_plain_id, plain_id] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&fx.pool)
+                .await;
         }
         fx.teardown().await;
     }

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -1601,7 +1601,7 @@ mod db_cov_tests {
         let Some(fx) = tdh::Fixture::setup("remote", "rubygems").await else {
             return;
         };
-        let (plain, coded, coded_mock, plain_mock) = tdh::coded_and_plain_upstreams(
+        let up = tdh::coded_and_plain_upstreams(
             "deflate",
             "application/octet-stream",
             b"gem-meta-3260 ",
@@ -1611,17 +1611,34 @@ mod db_cov_tests {
         // fx only supplies the DB + proxy-carrying state; the probes target a
         // coded Remote wrapped by a Virtual and a plain Remote + Virtual pair
         // as the uncoded control.
-        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &coded_mock.uri()).await;
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &up.coded_mock.uri()).await;
         let (coded_member_id, _cm_key, virt_coded_id, virt_coded_key) =
-            tdh::create_remote_and_virtual(&fx.pool, "rubygems", &coded_mock.uri()).await;
+            tdh::create_remote_and_virtual(&fx.pool, "rubygems", &up.coded_mock.uri()).await;
         let (plain_id, _plain_key, virt_plain_id, virt_plain_key) =
-            tdh::create_remote_and_virtual(&fx.pool, "rubygems", &plain_mock.uri()).await;
+            tdh::create_remote_and_virtual(&fx.pool, "rubygems", &up.plain_mock.uri()).await;
 
-        // `gem_info` Virtual arm.
+        // `gem_info` Virtual arm, COLD (`resolve_virtual_metadata` Pass 2).
         let uri = format!("/{}/api/v1/gems/pkg3260.json", virt_coded_key);
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual gem_info");
+        up.assert_coded_forward(&headers, &body, "virtual gem_info (cold, Pass 2)");
+
+        // `gem_info` Virtual arm, WARM: same URI again, now served by
+        // `resolve_virtual_metadata` Pass 1 (`cached_metadata_if_servable`),
+        // which reads the coding off the cache sidecar. The unchanged
+        // upstream hit count is the barrier proving it was a cache hit; both
+        // the fixed and the coding-dropping shape of Pass 1 reach it.
+        let upstream_path = "/api/v1/gems/pkg3260.json";
+        let hits_before = up.coded_hits(upstream_path).await;
+        let uri = format!("/{}/api/v1/gems/pkg3260.json", virt_coded_key);
+        let (body, headers) =
+            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+        assert_eq!(
+            up.coded_hits(upstream_path).await,
+            hits_before,
+            "second probe must be served from the proxy cache (Pass 1), not refetched"
+        );
+        up.assert_coded_forward(&headers, &body, "virtual gem_info (warm, Pass 1)");
 
         // `quick_spec` Virtual arm.
         let uri = format!(
@@ -1630,20 +1647,22 @@ mod db_cov_tests {
         );
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_coded_forward(&headers, &body, &coded, &plain, "virtual quick_spec");
+        up.assert_coded_forward(&headers, &body, "virtual quick_spec");
 
-        // Controls: the same two arms over an uncoded member.
-        let uri = format!("/{}/api/v1/gems/pkg3260.json", virt_plain_key);
-        let (body, headers) =
-            tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_plain_forward(&headers, &body, &plain, "control gem_info");
+        // Controls: the same two arms over an uncoded member, cold and warm.
+        for what in ["control gem_info (cold)", "control gem_info (warm)"] {
+            let uri = format!("/{}/api/v1/gems/pkg3260.json", virt_plain_key);
+            let (body, headers) =
+                tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
+            up.assert_plain_forward(&headers, &body, what);
+        }
         let uri = format!(
             "/{}/quick/Marshal.4.8/pkg3260-1.0.0.gemspec.rz",
             virt_plain_key
         );
         let (body, headers) =
             tdh::probe_ok(tdh::router_anon(super::router(), state.clone()), uri).await;
-        tdh::assert_plain_forward(&headers, &body, &plain, "control quick_spec");
+        up.assert_plain_forward(&headers, &body, "control quick_spec");
 
         for id in [virt_coded_id, coded_member_id, virt_plain_id, plain_id] {
             let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1705,21 +1705,48 @@ pub async fn probe_ok(app: Router, uri: String) -> (Bytes, axum::http::HeaderMap
     (body, headers)
 }
 
+/// The pair of wiremock upstreams a #3260 verbatim-forward test drives,
+/// together with the coding that was actually mounted on the coded one.
+///
+/// The coding lives ON the fixture — and every assertion reads it from here —
+/// so an assertion cannot be satisfied by a handler that emits some *other*
+/// coding. That is the whole point: the first cut of these helpers compared
+/// the served header against the literal `"deflate"`, which made all three
+/// suites pass with the production line rewritten to
+/// `builder.header(CONTENT_ENCODING, "deflate")`. See [`coded_fixture`] for
+/// why that failure mode (a `br` upstream mislabelled) is worse than the bug
+/// #3260 fixed.
+pub struct CodedUpstreams {
+    /// The coding the coded upstream declares and its body is actually coded
+    /// with. Every expectation below is derived from this field rather than
+    /// from a literal, so the suites can vary it per format.
+    pub encoding: String,
+    /// The uncoded bytes: what `encoding` must decode the served body back to.
+    pub plain: Vec<u8>,
+    /// The coded bytes the coded upstream serves, byte for byte.
+    pub coded: Vec<u8>,
+    /// Upstream that declares `encoding` on every GET.
+    pub coded_mock: wiremock::MockServer,
+    /// Upstream that declares no coding on every GET (the positive control).
+    pub plain_mock: wiremock::MockServer,
+}
+
 /// Mount a pair of wiremock upstreams for the #3260 verbatim-forward tests:
 /// the first answers every GET with `coded` and `Content-Encoding: <encoding>`
 /// declared, the second answers every GET with `plain` and no coding (the
-/// positive control), both under `content_type`. Returns
-/// `(plain, coded, coded_mock, plain_mock)`.
+/// positive control), both under `content_type`.
 ///
 /// Shared across the goproxy / rubygems / hex arms so each suite does not
 /// carry its own copy of the mock block (the jscpd duplication gate scores
 /// changed files). Uses [`coded_fixture`], so callers should pass a NON-gzip
-/// coding — see its doc for why a gzip fixture proves less.
+/// coding — see its doc for why a gzip fixture proves less — and the suites
+/// should not all pass the SAME coding, or a hardcoded literal of that one
+/// coding satisfies every assertion in the tree.
 pub async fn coded_and_plain_upstreams(
     encoding: &str,
     content_type: &str,
     seed: &[u8],
-) -> (Vec<u8>, Vec<u8>, wiremock::MockServer, wiremock::MockServer) {
+) -> CodedUpstreams {
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -1743,64 +1770,83 @@ pub async fn coded_and_plain_upstreams(
         )
         .mount(&plain_mock)
         .await;
-    (plain, coded, coded_mock, plain_mock)
-}
-
-/// Assert a #3260 verbatim forward of a DEFLATE-coded upstream body: the
-/// upstream's coding is re-declared (RFC 9110 §8.4), `Content-Length`
-/// describes the coded bytes actually sent (§8.6), the bytes pass through
-/// unchanged, and the declared coding actually decodes the body back to
-/// `plain` — not merely "some header is present".
-pub fn assert_coded_forward(
-    headers: &axum::http::HeaderMap,
-    body: &[u8],
-    coded: &[u8],
-    plain: &[u8],
-    what: &str,
-) {
-    assert_eq!(
-        headers
-            .get(axum::http::header::CONTENT_ENCODING)
-            .map(|v| v.to_str().unwrap()),
-        Some("deflate"),
-        "{what}: the upstream Content-Encoding must be re-declared (#3260)"
-    );
-    assert_eq!(
-        headers
-            .get(axum::http::header::CONTENT_LENGTH)
-            .map(|v| v.to_str().unwrap().to_string()),
-        Some(coded.len().to_string()),
-        "{what}: Content-Length must describe the coded bytes actually sent"
-    );
-    assert_eq!(
-        body, coded,
-        "{what}: coded bytes must pass through verbatim"
-    );
-    assert_eq!(
-        inflate_deflate(body),
+    CodedUpstreams {
+        encoding: encoding.to_string(),
         plain,
-        "{what}: the client must be able to decode the body with the declared coding"
-    );
+        coded,
+        coded_mock,
+        plain_mock,
+    }
 }
 
-/// Positive control for [`assert_coded_forward`], same fixture: an UNCODED
-/// upstream body must be forwarded byte-identically and must NOT grow a
-/// spurious `Content-Encoding` header.
-pub fn assert_plain_forward(
-    headers: &axum::http::HeaderMap,
-    body: &[u8],
-    plain: &[u8],
-    what: &str,
-) {
-    assert_eq!(
-        headers.get(axum::http::header::CONTENT_ENCODING),
-        None,
-        "{what}: an uncoded upstream must not grow a Content-Encoding header"
-    );
-    assert_eq!(
-        body, plain,
-        "{what}: uncoded body must be forwarded byte-identically"
-    );
+impl CodedUpstreams {
+    /// Assert a #3260 verbatim forward of the coded upstream's body: the
+    /// coding THIS FIXTURE mounted is the one re-declared (RFC 9110 §8.4),
+    /// `Content-Length` describes the coded bytes actually sent (§8.6), the
+    /// bytes pass through unchanged, and the declared coding actually decodes
+    /// the body back to `plain` — not merely "some header is present".
+    pub fn assert_coded_forward(&self, headers: &axum::http::HeaderMap, body: &[u8], what: &str) {
+        let served = headers
+            .get(axum::http::header::CONTENT_ENCODING)
+            .map(|v| v.to_str().unwrap());
+        assert_eq!(
+            served,
+            Some(self.encoding.as_str()),
+            "{what}: the UPSTREAM's Content-Encoding must be re-declared, not some \
+             other coding (#3260)"
+        );
+        assert_eq!(
+            headers
+                .get(axum::http::header::CONTENT_LENGTH)
+                .map(|v| v.to_str().unwrap().to_string()),
+            Some(self.coded.len().to_string()),
+            "{what}: Content-Length must describe the coded bytes actually sent"
+        );
+        assert_eq!(
+            body, self.coded,
+            "{what}: coded bytes must pass through verbatim"
+        );
+        // Decode with the coding the RESPONSE declared, not with the one the
+        // fixture mounted: this is what the client does, so a mislabel that
+        // slipped past the header assertion still fails here.
+        assert_eq!(
+            decode_coded(served.expect("checked above"), body),
+            self.plain,
+            "{what}: the client must be able to decode the body with the declared coding"
+        );
+    }
+
+    /// Positive control for [`CodedUpstreams::assert_coded_forward`], same
+    /// fixture: an UNCODED upstream body must be forwarded byte-identically
+    /// and must NOT grow a spurious `Content-Encoding` header.
+    pub fn assert_plain_forward(&self, headers: &axum::http::HeaderMap, body: &[u8], what: &str) {
+        assert_eq!(
+            headers.get(axum::http::header::CONTENT_ENCODING),
+            None,
+            "{what}: an uncoded upstream must not grow a Content-Encoding header"
+        );
+        assert_eq!(
+            body, self.plain,
+            "{what}: uncoded body must be forwarded byte-identically"
+        );
+    }
+
+    /// How many GETs the CODED upstream has served for `path` so far.
+    ///
+    /// The barrier for the warm-cache (`resolve_virtual_metadata` Pass 1)
+    /// probes: a second request whose count is unchanged was answered from
+    /// the proxy cache, so the assertions that follow are about the cache-hit
+    /// arm and not a second cold fan-out. Both the fixed and the broken shape
+    /// of that arm reach this barrier, so it cannot mask a regression.
+    pub async fn coded_hits(&self, path: &str) -> usize {
+        self.coded_mock
+            .received_requests()
+            .await
+            .expect("wiremock request recording is enabled")
+            .iter()
+            .filter(|r| r.url.path() == path)
+            .count()
+    }
 }
 
 /// Create a Remote repository of `format` pointed at `upstream_url`, plus a
@@ -1832,17 +1878,33 @@ pub async fn create_remote_and_virtual(
     (remote_id, remote_key, virtual_id, virtual_key)
 }
 
-/// Decode a `deflate` body, so a test can assert the client receives BYTES it
-/// can actually decode rather than only that a header is present.
-pub fn inflate_deflate(coded: &[u8]) -> Vec<u8> {
-    use flate2::read::DeflateDecoder;
+/// Decode a body coded with `encoding` — the inverse of [`code_bytes`], so a
+/// test can assert the client receives BYTES it can actually decode rather
+/// than only that a header is present.
+///
+/// Takes the coding as a parameter (rather than hardcoding one decoder) so an
+/// assertion can decode with the coding the RESPONSE declared. A decoder
+/// pinned to a single coding cannot distinguish "forwarded the upstream's
+/// coding" from "always emits that coding", which is exactly the hole the
+/// #3260 suites shipped with.
+pub fn decode_coded(encoding: &str, coded: &[u8]) -> Vec<u8> {
+    use flate2::read::{DeflateDecoder, GzDecoder};
     use std::io::Read;
 
     let mut out = Vec::new();
-    DeflateDecoder::new(coded)
-        .read_to_end(&mut out)
-        .expect("body must be decodable with the coding it declares");
+    match encoding {
+        "gzip" => GzDecoder::new(coded).read_to_end(&mut out),
+        "deflate" => DeflateDecoder::new(coded).read_to_end(&mut out),
+        other => panic!("unsupported test coding {other}"),
+    }
+    .expect("body must be decodable with the coding it declares");
     out
+}
+
+/// Decode a `deflate` body. Thin alias for [`decode_coded`] kept for the
+/// #3149 / #3184 suites that only ever mount deflate.
+pub fn inflate_deflate(coded: &[u8]) -> Vec<u8> {
+    decode_coded("deflate", coded)
 }
 
 /// Build a gzip-coded body, returning `(plain, coded)`.

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -1694,6 +1694,144 @@ pub fn code_bytes(encoding: &str, plain: &[u8]) -> Vec<u8> {
     }
 }
 
+/// Send `uri` through `app`, require 200, and return `(body, headers)` for
+/// the #3260 forwarding assertions ([`assert_coded_forward`] /
+/// [`assert_plain_forward`]). Shared so the goproxy / rubygems / hex suites
+/// do not each carry a probe wrapper (the jscpd duplication gate scores
+/// changed files).
+pub async fn probe_ok(app: Router, uri: String) -> (Bytes, axum::http::HeaderMap) {
+    let (status, body, headers) = send_with_headers(app, get(uri)).await;
+    assert_eq!(status, StatusCode::OK, "probe must proxy 200");
+    (body, headers)
+}
+
+/// Mount a pair of wiremock upstreams for the #3260 verbatim-forward tests:
+/// the first answers every GET with `coded` and `Content-Encoding: <encoding>`
+/// declared, the second answers every GET with `plain` and no coding (the
+/// positive control), both under `content_type`. Returns
+/// `(plain, coded, coded_mock, plain_mock)`.
+///
+/// Shared across the goproxy / rubygems / hex arms so each suite does not
+/// carry its own copy of the mock block (the jscpd duplication gate scores
+/// changed files). Uses [`coded_fixture`], so callers should pass a NON-gzip
+/// coding — see its doc for why a gzip fixture proves less.
+pub async fn coded_and_plain_upstreams(
+    encoding: &str,
+    content_type: &str,
+    seed: &[u8],
+) -> (Vec<u8>, Vec<u8>, wiremock::MockServer, wiremock::MockServer) {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let (plain, coded) = coded_fixture(encoding, seed);
+    let coded_mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", content_type)
+                .insert_header("content-encoding", encoding)
+                .set_body_bytes(coded.clone()),
+        )
+        .mount(&coded_mock)
+        .await;
+    let plain_mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", content_type)
+                .set_body_bytes(plain.clone()),
+        )
+        .mount(&plain_mock)
+        .await;
+    (plain, coded, coded_mock, plain_mock)
+}
+
+/// Assert a #3260 verbatim forward of a DEFLATE-coded upstream body: the
+/// upstream's coding is re-declared (RFC 9110 §8.4), `Content-Length`
+/// describes the coded bytes actually sent (§8.6), the bytes pass through
+/// unchanged, and the declared coding actually decodes the body back to
+/// `plain` — not merely "some header is present".
+pub fn assert_coded_forward(
+    headers: &axum::http::HeaderMap,
+    body: &[u8],
+    coded: &[u8],
+    plain: &[u8],
+    what: &str,
+) {
+    assert_eq!(
+        headers
+            .get(axum::http::header::CONTENT_ENCODING)
+            .map(|v| v.to_str().unwrap()),
+        Some("deflate"),
+        "{what}: the upstream Content-Encoding must be re-declared (#3260)"
+    );
+    assert_eq!(
+        headers
+            .get(axum::http::header::CONTENT_LENGTH)
+            .map(|v| v.to_str().unwrap().to_string()),
+        Some(coded.len().to_string()),
+        "{what}: Content-Length must describe the coded bytes actually sent"
+    );
+    assert_eq!(
+        body, coded,
+        "{what}: coded bytes must pass through verbatim"
+    );
+    assert_eq!(
+        inflate_deflate(body),
+        plain,
+        "{what}: the client must be able to decode the body with the declared coding"
+    );
+}
+
+/// Positive control for [`assert_coded_forward`], same fixture: an UNCODED
+/// upstream body must be forwarded byte-identically and must NOT grow a
+/// spurious `Content-Encoding` header.
+pub fn assert_plain_forward(
+    headers: &axum::http::HeaderMap,
+    body: &[u8],
+    plain: &[u8],
+    what: &str,
+) {
+    assert_eq!(
+        headers.get(axum::http::header::CONTENT_ENCODING),
+        None,
+        "{what}: an uncoded upstream must not grow a Content-Encoding header"
+    );
+    assert_eq!(
+        body, plain,
+        "{what}: uncoded body must be forwarded byte-identically"
+    );
+}
+
+/// Create a Remote repository of `format` pointed at `upstream_url`, plus a
+/// Virtual repository of the same format whose sole member is that remote.
+/// Returns `(remote_id, remote_key, virtual_id, virtual_key)`; the caller
+/// cleans both up by deleting the repository rows (members cascade).
+pub async fn create_remote_and_virtual(
+    pool: &PgPool,
+    format: &str,
+    upstream_url: &str,
+) -> (Uuid, String, Uuid, String) {
+    let (remote_id, remote_key, _dir) = create_repo(pool, "remote", format).await;
+    sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+        .bind(upstream_url)
+        .bind(remote_id)
+        .execute(pool)
+        .await
+        .expect("point remote upstream at mock");
+    let (virtual_id, virtual_key, _vdir) = create_repo(pool, "virtual", format).await;
+    sqlx::query(
+        "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+         VALUES ($1, $2, 0)",
+    )
+    .bind(virtual_id)
+    .bind(remote_id)
+    .execute(pool)
+    .await
+    .expect("link remote as virtual member");
+    (remote_id, remote_key, virtual_id, virtual_key)
+}
+
 /// Decode a `deflate` body, so a test can assert the client receives BYTES it
 /// can actually decode rather than only that a header is present.
 pub fn inflate_deflate(coded: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Fixes #3260

Same class as the Maven instance (#3211, fixed by #3241): handlers that forward upstream bytes **verbatim** dropped the upstream `Content-Encoding`. Nothing on this path decodes — `http_client::base_client_builder()` sets `.no_gzip().no_brotli().no_deflate().no_zstd()` and advertises `Accept-Encoding: identity` — so the coded bytes really are what the client receives, labelled as if they were plain. Per RFC 9110 §8.4 `Content-Encoding` describes the coding applied to the representation as transferred, and per §8.6 `Content-Length` describes the coded bytes actually sent. For goproxy the payloads are `.info`/`.mod` module data, so a silently-compressed document on the `go` client's disk is a correctness problem, not a header nit.

## Callers changed (now re-declare the upstream coding)

All the issue's sites, plus four more instances of the identical shape found in the same three formats while verifying the table against main:

| site | arm | primitive |
|---|---|---|
| `goproxy::try_proxy_go_metadata` | Remote (`.info`, `@latest` fallback) | `proxy_fetch_capped` → **`proxy_fetch_capped_encoded`** (issue's "fifth instance") |
| `goproxy::try_proxy_go_metadata` | Virtual | `resolve_virtual_metadata` transform |
| `goproxy::get_mod_file` | Remote (`.mod`) | `proxy_fetch_capped` → `proxy_fetch_capped_encoded` *(additional, same shape)* |
| `rubygems::gem_info` | Virtual | `resolve_virtual_metadata` transform |
| `rubygems::quick_spec` | Virtual (comment says "verbatim") | `resolve_virtual_metadata` transform |
| `hex::package_info` | Remote *(additional)* + Virtual | `proxy_fetch_capped_encoded` / transform |
| `hex::list_names` | Remote *(additional)* | `proxy_fetch_capped_encoded` |
| `hex::list_versions` | Remote *(additional)* | `proxy_fetch_capped_encoded` |

The hex Remote arms are the #2658 "signed registry bytes pass through as-is" contract — the same verbatim property that makes the coding load-bearing.

## Callers that keep dropping the coding — now explicitly

- `goproxy::fetch_go_metadata_with_source` — every caller **parses** the body (`@v/list` line filtering, `@latest` JSON) and serves a rebuilt document; doc comment now says the drop is deliberate.
- `goproxy::go_version_exists_upstream` — existence probe; the body is discarded entirely.
- `proxy_helpers::collect_virtual_metadata` — every `extract` closure parses and the caller serves a merged document it built itself; doc comment now says so.

## Seam widening (the #3241 / #3194 / #3210 / #3184 pattern)

- `resolve_virtual_metadata`'s `transform` now receives `(body, content_encoding, member_key)` — widened **in place** so every caller breaks at compile time and must state whether it forwards verbatim (declare the coding) or parses (drop it). Its Pass-1 cached probe no longer discards the coding, and its Pass-2 upstream fetch goes through `proxy_fetch_with_cache_key` (already `CachedBody`-shaped since #3241) instead of the coding-dropping `proxy_fetch`. The doc comment no longer claims a parse-or-rewrite caller population its actual (all-verbatim) callers never matched.
- New `proxy_fetch_capped_encoded`: the plain-path sibling of `proxy_fetch_capped_with_cache_key_encoded`, for Remote arms that forward the capped buffered body verbatim.
- New `forward_verbatim_metadata`: shared verbatim-200 builder (the general form of maven's `forward_root_verbatim`), setting `Content-Type`, `Content-Length` of the coded bytes (§8.6), and the coding when present (§8.4). Used by all nine sites, so the response shape cannot drift per format.

## Tests (DB-backed, `--lib`, one per format)

Each uses a **deflate** (non-gzip) coded upstream **plus an uncoded control in the same fixture** (`tdh::coded_and_plain_upstreams`), asserts the exact bytes the client receives, and **decodes the coded body with the declared coding** (`tdh::inflate_deflate`) — a hardcoded `"gzip"`/`"deflate"` literal or an `if false` guard cannot pass:

- `goproxy: test_go_metadata_forwards_upstream_content_encoding_verbatim_db` — Remote `.info`, Remote `.mod`, Virtual `.info`, plus uncoded controls through all three arms.
- `rubygems: test_rubygems_virtual_forwards_upstream_content_encoding_verbatim_db` — Virtual `gem_info` + `quick_spec`, plus controls.
- `hex: test_hex_registry_forwards_upstream_content_encoding_verbatim_db` — Remote `packages`/`names`/`versions`, Virtual `packages`, plus controls.

Shared fixture/assertion helpers live in `test_db_helpers` (`coded_and_plain_upstreams` -> `CodedUpstreams`, its `assert_coded_forward` / `assert_plain_forward` / `coded_hits` methods, `decode_coded`, `create_remote_and_virtual`) so the three suites do not each carry a copy of the mock/assert blocks. The fixture carries the coding it mounted and every assertion reads it from there, so no assertion can be satisfied by a handler that emits a *different* coding; goproxy and rubygems mount `deflate`, hex mounts `gzip`.

## Revert-proof (faithful, DB-backed)

Reverted tree = merge-base production code + the new tests only, proven by stripping every `#[cfg(test)] mod { }` block from merge-base and reverted files and comparing remainders byte-identical: `goproxy` 55,460 B, `rubygems` 34,200 B, `hex` 70,407 B, `proxy_helpers` 377,068 B each side (`git diff origin/main --shortstat` on the reverted tree: `4 files changed, 357 insertions(+)`, all in test modules / `#[cfg(test)]` `test_db_helpers`).

With `DATABASE_URL` + `AK_TESTS_REQUIRE_DB=1` (runtimes 0.28–0.30 s — the tests ran, not skipped):

Re-run after the review fixes below (dropping the coding at the sink — the pre-#3260 shape of all nine builders). Maven's pre-existing `#3211` test now fails alongside them because its duplicate helper was folded into the shared one:

```
FAIL api::handlers::goproxy::tests::test_go_metadata_forwards_upstream_content_encoding_verbatim_db
  assertion `left == right` failed: remote .info: the UPSTREAM's Content-Encoding must be re-declared, not some other coding (#3260)
    left: None    right: Some("deflate")
FAIL api::handlers::hex::tests::test_hex_registry_forwards_upstream_content_encoding_verbatim_db
  assertion `left == right` failed: remote packages/pkg3260: the UPSTREAM's Content-Encoding must be re-declared, not some other coding (#3260)
    left: None    right: Some("gzip")
FAIL api::handlers::rubygems::db_cov_tests::test_rubygems_virtual_forwards_upstream_content_encoding_verbatim_db
  assertion `left == right` failed: virtual gem_info (cold, Pass 2): the UPSTREAM's Content-Encoding must be re-declared, not some other coding (#3260)
    left: None    right: Some("deflate")
FAIL api::handlers::maven::tests::test_download_root_forwards_upstream_content_encoding_verbatim
  assertion `left == right` failed: remote root must re-declare the upstream Content-Encoding (#3211)
    left: None    right: Some("deflate")
```

On the fix branch all three pass, along with the 918 tests of the touched modules (`goproxy`/`rubygems`/`hex`/`maven`/`proxy_helpers`/`proxy_service`) and the full `--workspace --lib` suite.

## No-decode property verified (the inverse failure would be worse)

If any layer decoded, re-declaring the coding would corrupt every client. Verified it does not: (1) `http_client.rs` disables all four reqwest codecs and sends `Accept-Encoding: identity`; (2) `proxy_service.rs` documents "the proxy no longer decompresses upstream bodies" and threads `content_encoding` through `UpstreamResponse` and the cache sidecar untouched; (3) empirically, the tests assert the client-received body is byte-identical to the deflate-coded mock body through the full upstream → proxy → cache → handler stack, and the controls prove an uncoded body gains no header.

## Out of scope (same class, other formats — follow-up)

`pub_registry::proxy_pub_meta_get`'s non-JSON "pass through verbatim" fallback arm and `proxy_helpers::proxy_fetch_or_redirect`'s buffered slow path also drop the coding on bytes they may forward; they are outside this issue's goproxy/rubygems/hex scope and are filed as #3273.

## Review response — the goproxy `@latest` / `@v/list` decision (#3280)

An earlier revision of this PR carried a doc comment on `fetch_go_metadata_with_source` claiming every caller rebuilds its document. That is **false for `latest_version`**, which parses the JSON only to run the age gate and then forwards the upstream bytes verbatim (`goproxy.rs:1219-1223`). Measured on this branch with wiremock upstreams (temporary probe, since removed):

```
upstream @latest plain=50 coded=48 | @v/list plain=21 coded=18

CODED @latest  -> status=404  content-encoding=None  len=27  verbatim=false
CODED @v/list  -> status=200  content-encoding=None  len=30  verbatim=false   <- 18 coded bytes served as 30 bytes of U+FFFD
PLAIN @latest  -> status=200  content-encoding=None  len=50  verbatim=true    <- proves @latest IS a verbatim forwarder
PLAIN @v/list  -> status=200  content-encoding=None  len=21  verbatim=true
```

**Decision: filed as #3280, not folded in.** Both are pre-existing (this PR changed neither path), and neither can be fixed the re-declare-only way this PR is built on: `@latest` 404s because `serde_json::from_slice` rejects the coded bytes before the forward is reached, and `@v/list` corrupts because `String::from_utf8_lossy` mangles them before `filter_go_version_list` passes them through unchanged. Fixing either means **decoding an upstream-controlled body** on a metadata path, which needs its own size bounds and unknown-coding handling — a different change from one that provably alters no bytes. The doc comment now states plainly what the code does and points at #3280.

Also recorded, not fixed: `resolve_virtual_metadata` still drops the member's `Content-Type` (both passes bind it `_ct`), so the four Virtual verbatim forwards hardcode a literal and disagree with the Remote arm of the same endpoint — hex serves a signed protobuf as `application/json`. That is a client-visible behaviour change with its own tests, filed as #3281 so the seam is widened once more rather than twice. The RFC 9110 §12.5.3 residual (AK does not honour the client's `Accept-Encoding`) belongs to #3273.

