### PR TITLE
fix(oci): emit the spec error envelope on scope-denial and curation-block /v2 paths

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -455,14 +455,20 @@ fn oci_scopes_grant(scopes: &Option<Vec<String>>, required: &str) -> bool {
 
 /// Build a 403 Forbidden response when an API-token scope check fails on
 /// an OCI write/delete path. See GHSA-vvc3-h39c-mrq5.
+///
+/// Uses the OCI error envelope (#3110): the distribution-spec "Error Codes"
+/// section requires any JSON body on a 4XX to be
+/// `{"errors":[{"code","message","detail"}]}`, and a bare-string body is
+/// opaque to conforming clients (docker/podman surface `errors[0].message`).
+/// `DENIED` is the registered code (code-12, "requested access to the
+/// resource is denied"). The legacy message text is preserved verbatim
+/// inside the envelope so operators/scripts that match on it keep working.
 fn oci_forbidden_scope(required: &str) -> Response {
-    Response::builder()
-        .status(StatusCode::FORBIDDEN)
-        .body(Body::from(format!(
-            "Token does not have required scope: {}",
-            required
-        )))
-        .unwrap()
+    oci_error(
+        StatusCode::FORBIDDEN,
+        "DENIED",
+        &format!("Token does not have required scope: {}", required),
+    )
 }
 
 /// Build a 403 Forbidden response when a caller is authenticated but lacks
@@ -7404,7 +7410,9 @@ async fn handle_head_manifest(
     )
     .await
     {
-        return resp;
+        // #3110: re-shape the shared gate's REST-style body into the OCI
+        // error envelope this surface is contractually required to emit.
+        return oci_curation_deny_response(resp.status(), &repo.image);
     }
 
     // Reference can be a tag or a digest. Resolve locally first: a surviving
@@ -7880,6 +7888,25 @@ fn oci_manifest_synthetic_artifact(
     }
 }
 
+/// Map the shared curation gate's deny response onto the OCI error envelope
+/// (#3110). `proxy_helpers::enforce_curation_lookup` builds a REST-shaped
+/// `{"error":"curation_blocked",...}` body shared by every proxy format; on
+/// the `/v2` surface that shape violates the distribution-spec "Error Codes"
+/// MUST (a 4XX JSON body must be `{"errors":[...]}`) and docker clients
+/// cannot render it. Status is preserved; the `curation_blocked` marker is
+/// kept inside the message so existing oracles/scripts that grep for it
+/// still match. Sibling of [`oci_scan_deny_response`].
+fn oci_curation_deny_response(status: StatusCode, image: &str) -> Response {
+    oci_error(
+        status,
+        "DENIED",
+        &format!(
+            "curation_blocked: pull of {} is blocked by this repository's curation policy",
+            image
+        ),
+    )
+}
+
 /// Map the shared gate's deny response onto the OCI error body shape docker
 /// clients surface. Status is preserved: 403 = cached/inline vulnerable
 /// verdict, 423 = inconclusive under fail-closed (scan pending/failed —
@@ -8269,7 +8296,9 @@ async fn handle_get_manifest(
     )
     .await
     {
-        return resp;
+        // #3110: re-shape the shared gate's REST-style body into the OCI
+        // error envelope this surface is contractually required to emit.
+        return oci_curation_deny_response(resp.status(), &repo.image);
     }
 
     // Resolve locally first: a surviving tag row, or — for a digest this hosted
@@ -10792,16 +10821,54 @@ mod tests {
 
     #[tokio::test]
     async fn test_oci_forbidden_scope_status_and_body() {
-        // The body string is part of the contract; clients (and clients of
-        // clients) parse it to know whether they hit an auth wall.
+        // #3110: on the /v2 surface the error body is contractually the OCI
+        // error envelope (distribution-spec "Error Codes": a 4XX JSON body
+        // MUST be `{"errors":[{"code","message","detail"}]}` with a
+        // registered code). Assert the PARSED structure, not a substring —
+        // a substring match would pass on the pre-#3110 bare-string body.
         let resp = oci_forbidden_scope("write");
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json"),
+            "OCI error responses must be application/json"
+        );
         let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
-        let s = String::from_utf8_lossy(&body);
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).expect("OCI error body must be valid JSON");
+        assert_eq!(
+            parsed["errors"][0]["code"].as_str(),
+            Some("DENIED"),
+            "scope denial must use the registered DENIED code (code-12): {parsed}"
+        );
+        // The legacy message text is preserved verbatim inside the envelope
+        // (test-ghsa-vvc3-scope-checks.sh greps the raw body for it).
         assert!(
-            s.contains("Token does not have required scope: write"),
-            "unexpected body: {}",
-            s
+            parsed["errors"][0]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Token does not have required scope: write"),
+            "unexpected message: {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oci_curation_deny_response_is_oci_error_envelope() {
+        // #3110: the shared curation gate's `{"error":"curation_blocked"}`
+        // REST shape must never reach the /v2 wire; the OCI mapping keeps the
+        // status and re-shapes the body into the spec envelope.
+        let resp = oci_curation_deny_response(StatusCode::FORBIDDEN, "someimage");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).expect("OCI error body must be valid JSON");
+        assert_eq!(parsed["errors"][0]["code"].as_str(), Some("DENIED"));
+        let message = parsed["errors"][0]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("curation_blocked") && message.contains("someimage"),
+            "message must keep the curation_blocked marker and name the image: {parsed}"
         );
     }
 
@@ -29454,5 +29521,237 @@ mod oci_read_authz_tests {
             String::from_utf8_lossy(&granted_private_body).contains(MANIFEST_MARKER),
             "the granted principal's 200 must carry the private manifest bytes"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OCI error-envelope conformance through the router (#3110).
+//
+// The distribution-spec "Error Codes" section pins the error body contract:
+// a 4XX response body that is JSON MUST be
+// `{"errors":[{"code","message","detail"}]}` with `code` drawn from the
+// registered set. Two /v2 deny paths violated it: the GHSA-vvc3 API-token
+// scope gate returned a bare-string 403, and the shared curation gate
+// returned the REST-shaped `{"error":"curation_blocked",...}` body. These
+// tests drive both through the real router and assert the PARSED envelope
+// (never a substring, which the malformed shapes would also satisfy), each
+// with a positive control in the same fixture so an over-blocking gate
+// cannot satisfy the deny assertion by failing everything.
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
+#[cfg(test)]
+mod oci_error_envelope_db_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use crate::services::auth_service::AuthService;
+    use axum::http::Request;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    const IMAGE_MANIFEST: &[u8] = br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:3110311031103110311031103110311031103110311031103110311031103110","size":4},"layers":[]}"#;
+
+    async fn send(app: Router, request: Request<Body>) -> (StatusCode, serde_json::Value, Bytes) {
+        let resp = app.oneshot(request).await.expect("oneshot");
+        let status = resp.status();
+        let body = to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .expect("response body");
+        let parsed = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+        (status, parsed, body)
+    }
+
+    fn assert_oci_envelope(parsed: &serde_json::Value, raw: &Bytes, expected_code: &str) {
+        let code = parsed["errors"][0]["code"].as_str();
+        assert_eq!(
+            code,
+            Some(expected_code),
+            "body must be the OCI error envelope with code {expected_code}; got: {}",
+            String::from_utf8_lossy(raw)
+        );
+    }
+
+    /// GHSA-vvc3 scope gate: a read-scoped API token on `docker push`'s
+    /// manifest PUT must be refused with the OCI envelope (403 DENIED), and
+    /// a wildcard-scoped token on the byte-identical request must succeed.
+    #[tokio::test]
+    async fn scope_denied_manifest_put_returns_oci_error_envelope() {
+        let Some(fx) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+        tdh::grant_repo_actions(&fx.pool, fx.repo_id, fx.user_id, &["read", "write"]).await;
+        let auth_service = AuthService::new(fx.state.db.clone(), Arc::new(fx.state.config.clone()));
+        let (read_token, _) = auth_service
+            .generate_api_token(
+                fx.user_id,
+                "envelope-read",
+                vec!["read:artifacts".to_string()],
+                None,
+            )
+            .await
+            .expect("generate read-scoped API token");
+        let (full_token, _) = auth_service
+            .generate_api_token(fx.user_id, "envelope-full", vec!["*".to_string()], None)
+            .await
+            .expect("generate wildcard API token");
+
+        let uri = format!("/{}/image/manifests/v3110", fx.repo_key);
+        let put = |token: String, uri: String| {
+            Request::builder()
+                .method(Method::PUT)
+                .uri(uri)
+                .header(
+                    AUTHORIZATION,
+                    format!(
+                        "Basic {}",
+                        base64::engine::general_purpose::STANDARD
+                            .encode(format!("{}:{}", fx.username, token))
+                    ),
+                )
+                .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+                .body(Body::from(IMAGE_MANIFEST))
+                .expect("build request")
+        };
+
+        let (denied_status, denied_json, denied_raw) = send(
+            router().with_state(fx.state.clone()),
+            put(read_token, uri.clone()),
+        )
+        .await;
+
+        let (allowed_status, _allowed_json, allowed_raw) = send(
+            router().with_state(fx.state.clone()),
+            put(full_token, uri.clone()),
+        )
+        .await;
+
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(fx.user_id)
+            .execute(&fx.pool)
+            .await;
+        for table in ["oci_manifest_refs", "manifest_blob_refs", "oci_tags"] {
+            let _ = sqlx::query(&format!("DELETE FROM {} WHERE repository_id = $1", table))
+                .bind(fx.repo_id)
+                .execute(&fx.pool)
+                .await;
+        }
+        fx.teardown().await;
+
+        assert_eq!(
+            denied_status,
+            StatusCode::FORBIDDEN,
+            "read-scoped token must be refused on manifest PUT: {}",
+            String::from_utf8_lossy(&denied_raw)
+        );
+        assert_oci_envelope(&denied_json, &denied_raw, "DENIED");
+        assert!(
+            denied_json["errors"][0]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Token does not have required scope"),
+            "envelope message must carry the scope-denial text: {denied_json}"
+        );
+        // Positive control, same fixture, byte-identical request: the gate
+        // must open for a token that HAS the scope — otherwise the deny
+        // assertion above would also be satisfied by a gate that rejects
+        // everything.
+        assert_eq!(
+            allowed_status,
+            StatusCode::CREATED,
+            "wildcard-scoped token must complete the same PUT: {}",
+            String::from_utf8_lossy(&allowed_raw)
+        );
+    }
+
+    /// Curation block on a proxy pull: the manifest GET for a blocked image
+    /// must return the OCI envelope (403 DENIED, message carrying the
+    /// `curation_blocked` marker), while a non-blocked image on the same
+    /// repository falls through the gate (and its miss is itself the
+    /// spec-shaped 404 MANIFEST_UNKNOWN envelope).
+    #[tokio::test]
+    async fn curation_blocked_manifest_get_returns_oci_error_envelope() {
+        let Some(fx) = tdh::Fixture::setup("remote", "docker").await else {
+            return;
+        };
+        sqlx::query(
+            "UPDATE repositories SET curation_enabled = true, curation_default_action = 'allow' \
+             WHERE id = $1",
+        )
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("enable curation on fixture repo");
+        sqlx::query(
+            "INSERT INTO curation_rules \
+                 (staging_repo_id, package_pattern, version_constraint, architecture, \
+                  action, priority, reason, enabled, created_by) \
+             VALUES ($1, 'blockedimg*', '*', '*', 'block', 10, 'blocked by test rule', true, $2)",
+        )
+        .bind(fx.repo_id)
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert curation block rule");
+
+        let auth_service = AuthService::new(fx.state.db.clone(), Arc::new(fx.state.config.clone()));
+        let (api_token, _) = auth_service
+            .generate_api_token(fx.user_id, "envelope-curation", vec!["*".to_string()], None)
+            .await
+            .expect("generate API token");
+        let basic = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD
+                .encode(format!("{}:{}", fx.username, api_token))
+        );
+        let get = |image: &str| {
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/{}/{}/manifests/latest", fx.repo_key, image))
+                .header(AUTHORIZATION, basic.clone())
+                .body(Body::empty())
+                .expect("build request")
+        };
+
+        let (blocked_status, blocked_json, blocked_raw) =
+            send(router().with_state(fx.state.clone()), get("blockedimg")).await;
+        let (allowed_status, allowed_json, allowed_raw) =
+            send(router().with_state(fx.state.clone()), get("goodimg")).await;
+
+        let _ = sqlx::query("DELETE FROM curation_rules WHERE staging_repo_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(fx.user_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "curation-blocked image pull must be 403: {}",
+            String::from_utf8_lossy(&blocked_raw)
+        );
+        assert_oci_envelope(&blocked_json, &blocked_raw, "DENIED");
+        assert!(
+            blocked_json["errors"][0]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("curation_blocked"),
+            "envelope message must keep the curation_blocked marker: {blocked_json}"
+        );
+        // Positive control, same fixture: the non-matching image must NOT be
+        // caught by the gate. Its upstream miss (no reachable upstream in
+        // this fixture) is the spec-shaped MANIFEST_UNKNOWN 404 — which also
+        // pins the 404 arm's envelope.
+        assert_eq!(
+            allowed_status,
+            StatusCode::NOT_FOUND,
+            "non-blocked image must pass the curation gate: {}",
+            String::from_utf8_lossy(&allowed_raw)
+        );
+        assert_oci_envelope(&allowed_json, &allowed_raw, "MANIFEST_UNKNOWN");
     }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -14,6 +14,7 @@ use std::sync::{
 use std::time::Duration;
 
 use axum::body::{to_bytes, Body, HttpBody};
+use axum::extract::rejection::{BytesRejection, QueryRejection};
 use axum::extract::{DefaultBodyLimit, Query, State};
 use axum::http::header::{AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 use axum::http::{HeaderMap, Method, StatusCode};
@@ -58,11 +59,27 @@ struct OciErrorEntry {
 }
 
 fn oci_error(status: StatusCode, code: &str, message: &str) -> Response {
+    oci_error_detail(status, code, message, None)
+}
+
+/// [`oci_error`] with the spec's OPTIONAL `detail` member populated.
+///
+/// distribution-spec `spec.md` "Error Codes": *"The `detail` field is
+/// OPTIONAL and MAY contain arbitrary JSON data providing information the
+/// client can use to resolve the issue."* It is serialized only when
+/// present (`skip_serializing_if`), so a `None` body is byte-identical to
+/// what [`oci_error`] emitted before this helper existed.
+fn oci_error_detail(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    detail: Option<serde_json::Value>,
+) -> Response {
     let body = OciErrorResponse {
         errors: vec![OciErrorEntry {
             code: code.to_string(),
             message: message.to_string(),
-            detail: None,
+            detail,
         }],
     };
     let json = serde_json::to_string(&body).unwrap_or_default();
@@ -4134,9 +4151,35 @@ async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response
 async fn token(
     State(state): State<SharedState>,
     headers: HeaderMap,
-    Query(query): Query<TokenQuery>,
-    body: Bytes,
+    query: Result<Query<TokenQuery>, QueryRejection>,
+    body: Result<Bytes, BytesRejection>,
 ) -> Response {
+    // #3110: these two extractors are the only FALLIBLE ones on the /v2
+    // surface, and axum renders its own rejections as `text/plain` — a
+    // repeated `?service=` yields "400 Failed to deserialize query string:
+    // duplicate field `service`" (the same serde_urlencoded mechanism
+    // documented on `TokenQuery::scope` above), and a request body over
+    // TOKEN_REQUEST_BODY_LIMIT_BYTES yields a plaintext 413. Neither is a
+    // spec VIOLATION — distribution-spec "Error Codes" says a 4XX "MAY
+    // return a body in any format" — but they are the last bare-string 4XX
+    // bodies a docker client can meet on this router, so they are re-shaped
+    // into the envelope here. The rejection's own status and text are
+    // preserved; `UNSUPPORTED` (code-14, "The operation is unsupported.") is
+    // the closest registered code, as the spec's closed table has no
+    // malformed-request entry.
+    let Query(query) = match query {
+        Ok(q) => q,
+        Err(rejection) => {
+            return oci_error(rejection.status(), "UNSUPPORTED", &rejection.body_text());
+        }
+    };
+    let body = match body {
+        Ok(b) => b,
+        Err(rejection) => {
+            return oci_error(rejection.status(), "UNSUPPORTED", &rejection.body_text());
+        }
+    };
+
     // Per the OCI Distribution token spec, clients must request a token
     // scoped to the same `service` the server advertises. Reject mismatches
     // with 400 DENIED. Allow a missing `service` so curl-style and older
@@ -7400,7 +7443,7 @@ async fn handle_head_manifest(
     // Curation enforcement (#2930): mirror the GET-manifest gate so a HEAD probe
     // (which many clients issue before the GET) is blocked identically. No-op
     // for hosted repos / curation off.
-    if let Err(resp) = proxy_helpers::enforce_curation_lookup(
+    if let Err(block) = proxy_helpers::evaluate_curation_lookup(
         &state.db,
         repo.id,
         &repo.key,
@@ -7410,9 +7453,10 @@ async fn handle_head_manifest(
     )
     .await
     {
-        // #3110: re-shape the shared gate's REST-style body into the OCI
-        // error envelope this surface is contractually required to emit.
-        return oci_curation_deny_response(resp.status(), &repo.image);
+        // #3110: this surface is contractually required to emit the OCI error
+        // envelope, so it renders the verdict itself rather than forwarding the
+        // shared gate's REST-shaped body — carrying the rule reason through.
+        return oci_curation_deny_response(&block);
     }
 
     // Reference can be a tag or a digest. Resolve locally first: a surviving
@@ -7888,22 +7932,39 @@ fn oci_manifest_synthetic_artifact(
     }
 }
 
-/// Map the shared curation gate's deny response onto the OCI error envelope
-/// (#3110). `proxy_helpers::enforce_curation_lookup` builds a REST-shaped
-/// `{"error":"curation_blocked",...}` body shared by every proxy format; on
-/// the `/v2` surface that shape violates the distribution-spec "Error Codes"
-/// MUST (a 4XX JSON body must be `{"errors":[...]}`) and docker clients
-/// cannot render it. Status is preserved; the `curation_blocked` marker is
-/// kept inside the message so existing oracles/scripts that grep for it
-/// still match. Sibling of [`oci_scan_deny_response`].
-fn oci_curation_deny_response(status: StatusCode, image: &str) -> Response {
-    oci_error(
-        status,
+/// Render a curation `block` verdict as the OCI error envelope (#3110).
+///
+/// `proxy_helpers`' shared curation seam renders a REST-shaped
+/// `{"error":"curation_blocked","package":…,"reason":…}` body for every proxy
+/// format; on the `/v2` surface that shape violates the distribution-spec
+/// "Error Codes" MUST (a 4XX JSON body must be `{"errors":[...]}`) and docker
+/// clients cannot render it. This is the OCI seam's own rendering of the same
+/// verdict, built from the structured [`proxy_helpers::CurationBlock`] so no
+/// information is lost in the translation:
+///
+/// * `code` is the registered `DENIED` (code-12).
+/// * `message` keeps the `curation_blocked` marker (existing operator scripts
+///   grep for it) and names both the image and the rule reason, because
+///   `errors[0].message` is what `docker pull` prints to the operator.
+/// * `detail` carries the package and reason as structured JSON, which is
+///   what `spec.md` provides that member for — parity with the `reason` every
+///   non-OCI format already reports.
+///
+/// The status is fixed at 403: the shared seam's only block verdict is
+/// `curation_blocked_response`, which is unconditionally `FORBIDDEN`.
+/// Sibling of [`oci_scan_deny_response`].
+fn oci_curation_deny_response(block: &proxy_helpers::CurationBlock) -> Response {
+    oci_error_detail(
+        StatusCode::FORBIDDEN,
         "DENIED",
         &format!(
-            "curation_blocked: pull of {} is blocked by this repository's curation policy",
-            image
+            "curation_blocked: pull of {} is blocked by this repository's curation policy: {}",
+            block.package, block.reason
         ),
+        Some(serde_json::json!({
+            "package": block.package,
+            "reason": block.reason,
+        })),
     )
 }
 
@@ -8286,7 +8347,7 @@ async fn handle_get_manifest(
     // per-blob check. The image name is the curation identity; the reference
     // (tag or digest) is not passed as a version. No-op for hosted repos /
     // curation off.
-    if let Err(resp) = proxy_helpers::enforce_curation_lookup(
+    if let Err(block) = proxy_helpers::evaluate_curation_lookup(
         &state.db,
         repo.id,
         &repo.key,
@@ -8296,9 +8357,10 @@ async fn handle_get_manifest(
     )
     .await
     {
-        // #3110: re-shape the shared gate's REST-style body into the OCI
-        // error envelope this surface is contractually required to emit.
-        return oci_curation_deny_response(resp.status(), &repo.image);
+        // #3110: this surface is contractually required to emit the OCI error
+        // envelope, so it renders the verdict itself rather than forwarding the
+        // shared gate's REST-shaped body — carrying the rule reason through.
+        return oci_curation_deny_response(&block);
     }
 
     // Resolve locally first: a surviving tag row, or — for a digest this hosted
@@ -10857,9 +10919,13 @@ mod tests {
     #[tokio::test]
     async fn test_oci_curation_deny_response_is_oci_error_envelope() {
         // #3110: the shared curation gate's `{"error":"curation_blocked"}`
-        // REST shape must never reach the /v2 wire; the OCI mapping keeps the
-        // status and re-shapes the body into the spec envelope.
-        let resp = oci_curation_deny_response(StatusCode::FORBIDDEN, "someimage");
+        // REST shape must never reach the /v2 wire; the OCI seam renders the
+        // same verdict as the spec envelope, keeping the 403 and — per the
+        // review of this PR — the rule `reason` that the first cut dropped.
+        let resp = oci_curation_deny_response(&proxy_helpers::CurationBlock {
+            package: "someimage".to_string(),
+            reason: "blocked by test rule".to_string(),
+        });
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
         let parsed: serde_json::Value =
@@ -10869,6 +10935,43 @@ mod tests {
         assert!(
             message.contains("curation_blocked") && message.contains("someimage"),
             "message must keep the curation_blocked marker and name the image: {parsed}"
+        );
+        // The rule reason must be reachable both to a human reading the
+        // docker CLI output (`errors[0].message`) and to a machine reading
+        // the spec's structured `detail` member. Parsed field lookups, not
+        // substring matches on the body: the REST shape carries `reason` at
+        // the top level and would satisfy a whole-body substring test.
+        assert!(
+            message.contains("blocked by test rule"),
+            "message must name the rule that fired (docker prints message): {parsed}"
+        );
+        assert_eq!(
+            parsed["errors"][0]["detail"]["reason"].as_str(),
+            Some("blocked by test rule"),
+            "detail must carry the curation rule reason: {parsed}"
+        );
+        assert_eq!(
+            parsed["errors"][0]["detail"]["package"].as_str(),
+            Some("someimage"),
+            "detail must carry the blocked package: {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oci_error_omits_detail_when_absent() {
+        // Positive control for the `detail` plumbing: `oci_error` must remain
+        // byte-identical to its pre-#3110 output, i.e. no `detail` key at all
+        // (`skip_serializing_if`), so adding the member to the curation body
+        // cannot have changed every other error on the surface.
+        let resp = oci_error(
+            StatusCode::NOT_FOUND,
+            "MANIFEST_UNKNOWN",
+            "manifest not found",
+        );
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            r#"{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest not found"}]}"#
         );
     }
 
@@ -29572,6 +29675,68 @@ mod oci_error_envelope_db_tests {
         );
     }
 
+    /// `/v2/token` is the only route on this router with FALLIBLE extractors
+    /// (`Query<TokenQuery>` + `Bytes`), so it was the one place a docker
+    /// client could still be handed a bare `text/plain` 4XX: a repeated
+    /// `?service=` makes serde_urlencoded reject with "duplicate field
+    /// `service`". The rejection must now be the spec envelope, with the
+    /// status and axum's own explanatory text preserved — and the
+    /// single-`service` request in the same fixture must still mint a token,
+    /// so the assertion cannot be satisfied by a route that rejects
+    /// everything.
+    #[tokio::test]
+    async fn token_query_rejection_returns_oci_error_envelope() {
+        let Some(fx) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+        let get = |uri: &str| {
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("build request")
+        };
+        let (rejected_status, rejected_json, rejected_raw) = send(
+            router().with_state(fx.state.clone()),
+            get("/token?service=a&service=b"),
+        )
+        .await;
+        let (ok_status, ok_json, ok_raw) = send(
+            router().with_state(fx.state.clone()),
+            get("/token?service=artifact-keeper"),
+        )
+        .await;
+        fx.teardown().await;
+
+        assert_eq!(
+            rejected_status,
+            StatusCode::BAD_REQUEST,
+            "a duplicate query field must stay a 400: {}",
+            String::from_utf8_lossy(&rejected_raw)
+        );
+        assert_oci_envelope(&rejected_json, &rejected_raw, "UNSUPPORTED");
+        assert!(
+            rejected_json["errors"][0]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("duplicate field"),
+            "axum's own rejection text must survive into the envelope: {}",
+            String::from_utf8_lossy(&rejected_raw)
+        );
+        // Positive control, same fixture: the well-formed request still works.
+        assert_eq!(
+            ok_status,
+            StatusCode::OK,
+            "single-service token request must still succeed: {}",
+            String::from_utf8_lossy(&ok_raw)
+        );
+        assert!(
+            ok_json["token"].as_str().is_some_and(|t| !t.is_empty()),
+            "token response must carry a token: {}",
+            String::from_utf8_lossy(&ok_raw)
+        );
+    }
+
     /// GHSA-vvc3 scope gate: a read-scoped API token on `docker push`'s
     /// manifest PUT must be refused with the OCI envelope (403 DENIED), and
     /// a wildcard-scoped token on the byte-identical request must succeed.
@@ -29741,6 +29906,23 @@ mod oci_error_envelope_db_tests {
                 .unwrap_or_default()
                 .contains("curation_blocked"),
             "envelope message must keep the curation_blocked marker: {blocked_json}"
+        );
+        // The rule's `reason` must survive the REST -> OCI translation, end to
+        // end through the real gate (the rule row above sets it to 'blocked by
+        // test rule'). Parsed field lookups: the pre-#3110 REST body carried
+        // `reason` at the TOP level, so a whole-body substring check for the
+        // text would pass on the shape this PR removes.
+        assert_eq!(
+            blocked_json["errors"][0]["detail"]["reason"].as_str(),
+            Some("blocked by test rule"),
+            "detail.reason must name the curation rule that fired: {}",
+            String::from_utf8_lossy(&blocked_raw)
+        );
+        assert_eq!(
+            blocked_json["errors"][0]["detail"]["package"].as_str(),
+            Some("blockedimg"),
+            "detail.package must name the blocked image: {}",
+            String::from_utf8_lossy(&blocked_raw)
         );
         // Positive control, same fixture: the non-matching image must NOT be
         // caught by the gate. Its upstream miss (no reachable upstream in

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -5488,6 +5488,34 @@ pub fn age_gate_blocked_response(
         .into_response()
 }
 
+/// The structured facts behind a curation `block` verdict (#3110).
+///
+/// The enforcement seam used to hand callers an already-rendered `Response`,
+/// which made the rule's `reason` unreachable to any caller that needs to
+/// serve a different body shape. The OCI `/v2` surface is exactly that case:
+/// it must emit the distribution-spec error envelope, and the spec provides
+/// `detail` ("OPTIONAL and MAY contain arbitrary JSON data providing
+/// information the client can use to resolve the issue", `spec.md` "Error
+/// Codes") for precisely this payload. Every non-OCI format renders this
+/// through [`CurationBlock::into_rest_response`], so their wire body is
+/// byte-identical to before.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurationBlock {
+    /// The package identity the rule matched (npm name, OCI image,
+    /// `groupId:artifactId`, crate name, nuget id, …).
+    pub package: String,
+    /// Human-readable statement of which rule fired, from
+    /// `CurationService::evaluate_pep503_package`.
+    pub reason: String,
+}
+
+impl CurationBlock {
+    /// The shared REST-shaped 403 body every non-OCI proxy format serves.
+    pub fn into_rest_response(&self) -> Response {
+        curation_blocked_response(&self.package, &self.reason)
+    }
+}
+
 /// 403 response for a curation-rule block on a proxy request.
 pub fn curation_blocked_response(package: &str, reason: &str) -> Response {
     let body = serde_json::json!({
@@ -5558,6 +5586,22 @@ pub async fn enforce_curation<'a>(
     package: &str,
     version: Option<&str>,
 ) -> Result<(), Response> {
+    evaluate_curation(db, target, package, version)
+        .await
+        .map_err(|block| block.into_rest_response())
+}
+
+/// [`enforce_curation`] without the rendering step: yields the structured
+/// [`CurationBlock`] so a caller whose surface has its own error contract
+/// (the OCI `/v2` envelope, #3110) can carry the package and the rule
+/// `reason` into that shape instead of losing them inside an opaque
+/// `Response`.
+pub async fn evaluate_curation<'a>(
+    db: &PgPool,
+    target: impl Into<CurationTarget<'a>>,
+    package: &str,
+    version: Option<&str>,
+) -> Result<(), CurationBlock> {
     let target = target.into();
     if !target.curation_enabled || !matches!(target.repo_type, "remote" | "virtual") {
         return Ok(());
@@ -5578,7 +5622,10 @@ pub async fn enforce_curation<'a>(
         .ok();
     if let Some(eval) = eval {
         if eval.action == "block" {
-            return Err(curation_blocked_response(package, &eval.reason));
+            return Err(CurationBlock {
+                package: package.to_string(),
+                reason: eval.reason,
+            });
         }
     }
     Ok(())
@@ -5603,6 +5650,22 @@ pub async fn enforce_curation_lookup(
     package: &str,
     version: Option<&str>,
 ) -> Result<(), Response> {
+    evaluate_curation_lookup(db, repo_id, repo_key, repo_type, package, version)
+        .await
+        .map_err(|block| block.into_rest_response())
+}
+
+/// [`enforce_curation_lookup`] without the rendering step — see
+/// [`evaluate_curation`]. The OCI `/v2` manifest GET/HEAD seams call this so
+/// the rule `reason` survives into the spec envelope's `detail` (#3110).
+pub async fn evaluate_curation_lookup(
+    db: &PgPool,
+    repo_id: Uuid,
+    repo_key: &str,
+    repo_type: &str,
+    package: &str,
+    version: Option<&str>,
+) -> Result<(), CurationBlock> {
     if !matches!(repo_type, "remote" | "virtual") {
         return Ok(());
     }
@@ -5641,7 +5704,7 @@ pub async fn enforce_curation_lookup(
         curation_enabled,
         default_action: &default_action,
     };
-    enforce_curation(db, target, package, version).await
+    evaluate_curation(db, target, package, version).await
 }
 
 /// On-demand curation INGESTION for pypi/npm (#2955 Stage 2).
@@ -6225,6 +6288,28 @@ pub(crate) async fn gate_proxy_scan_serve(
 mod tests {
     use super::*;
     use axum::http::StatusCode;
+
+    // ── Curation block rendering (#2930 body, #3110 structured verdict) ──
+    //
+    // Splitting the curation seam into `evaluate_*` (structured
+    // [`CurationBlock`]) + `enforce_*` (rendered `Response`) so the OCI `/v2`
+    // surface can build its own spec envelope must NOT move the shared REST
+    // body every other proxy format serves. `curation-multiformat-enforce`'s
+    // npm arm reads `.error` out of exactly these bytes.
+    #[tokio::test]
+    async fn curation_block_rest_body_is_unchanged() {
+        let block = CurationBlock {
+            package: "left-pad".to_string(),
+            reason: "#2930 tier block".to_string(),
+        };
+        let resp = block.into_rest_response();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            r##"{"error":"curation_blocked","package":"left-pad","reason":"#2930 tier block"}"##
+        );
+    }
 
     // ── Stricter-of-two virtual scan policy (#3023) ──────────────────
     //


### PR DESCRIPTION
Fixes #3110

Companion (**merge this second** — see [Merge order](#merge-order)): artifact-keeper/artifact-keeper-test#337.

> **Rebased onto `8b9e0ff`.** The original merge-base was `1115203`; #3268, #3272, #3277 and #3278 landed underneath. Conflict resolution and the post-rebase re-audit are described in [Rebase](#rebase) at the end.

## What the issue claimed, and what verification showed

#3110 makes two claims. Both were verified against a live build of current main (`1115203`) by running the pinned upstream conformance suite (`opencontainers/distribution-spec` v1.1.0, the same suite and pin the corpus oracle `deploy-test/harness/tiers/oci-conformance/oracle.sh` adopts) against a freshly migrated stack:

1. **"The conformance test 'Pull / Error codes / 400 response body should contain OCI-conforming JSON message' fails."** — **Not reproducible at current main.** The suite run finished 59 passed / 6 failed, and this test **passes**: `GET /v2/<name>/manifests/sha256:totallywrong` returns `404 {"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest not found"}]}`, which the test accepts (its envelope assertions sit inside an `if StatusCode == 400`, and a 404 satisfies the `SatisfyAny(400, 404)` check unconditionally — `conformance/01_pull_test.go:250-268`). The 6 real failures are unrelated functionality gaps, not body-shape bugs: 5 are the Referrers API (already tracked as #3108), 1 is the upload-status GET (#3275).

2. **"Chunked-range errors return 416 where the spec pins SIZE_INVALID/400."** — **Refuted by the spec text.** distribution-spec v1.1.0 `spec.md` (Pushing a blob in chunks): *"If a chunk is uploaded out of order, the registry MUST respond with a `416 Requested Range Not Satisfiable` code."* The endpoints table pins end-5 (`PATCH .../blobs/uploads/<reference>`) failure codes as `404`/`416`, and the conformance suite itself asserts 416 ("Out-of-order blob upload should return 416", "Retry previous blob chunk should return 416" — both **pass** against main, and both of AK's 416 arms already carry the `BLOB_UPLOAD_INVALID` envelope). `SIZE_INVALID` (code-10) belongs to length-mismatch cases such as end-6, not to out-of-order chunks. **No status codes are changed by this PR.**

## What was actually wrong (full enumeration of /v2 error paths)

Auditing every error return on the `/v2` surface at current main (`oci_error` call sites, raw `Response::builder` sites, shared-gate returns, extractors, middleware):

**Conforming already** (no change): all `catch_all` dispatch errors, `resolve_repo*` (NAME_UNKNOWN/INTERNAL_ERROR incl. 503 shed), digest validation (DIGEST_INVALID), manifest classification (MANIFEST_INVALID), pagination (400 `PAGINATION_NUMBER_INVALID` — see the note below), all five 416 range arms (BLOB_UPLOAD_INVALID), 401 challenge (UNAUTHORIZED + WWW-Authenticate), quarantine block (DENIED), scan gates (`oci_scan_deny_response`: DENIED 403/423), blob scan re-block (DENIED), token endpoint errors (DENIED), 405 fallback (UNSUPPORTED). There are zero `.into_response()` calls in the file's production code, and every `if let Err(resp) = <gate>` helper returns an envelope.

**Non-conforming — fixed here:**

- `oci_forbidden_scope` (GHSA-vvc3 API-token scope gate; 6 call sites: monolithic blob POST, upload PATCH, upload PUT, blob DELETE via upload-session, manifest PUT, manifest DELETE) returned a **bare-string 403** `Token does not have required scope: ...`. Now `{"errors":[{"code":"DENIED","message":"Token does not have required scope: ..."}]}` — status unchanged, legacy text preserved verbatim inside the envelope (`test-ghsa-vvc3-scope-checks.sh:317` greps the raw body and still matches).
- The shared curation gate (called from manifest GET and HEAD) leaked the REST-shaped **`{"error":"curation_blocked","package":…,"reason":…}`** 403 body onto the OCI wire. Per the spec's Error Codes section, *"If the response body is in JSON format, it MUST have the following format"* (`{"errors":[...]}`) — a differently-shaped JSON object is a MUST violation. The OCI seam now renders the verdict itself via `oci_curation_deny_response` (sibling of `oci_scan_deny_response`): code `DENIED`, the `curation_blocked` marker kept in the message, **and the rule's `reason` carried through** (see below).
- `/v2/token`'s two **fallible** extractors. `Query<TokenQuery>` + `Bytes` produce axum's own `text/plain` rejections: `?service=a&service=b` yields `400 Failed to deserialize query string: duplicate field \`service\`` (the serde_urlencoded mechanism the module comment at `oci_v2.rs:3741-3753` already documents for `scope`), and a body over `TOKEN_REQUEST_BODY_LIMIT_BYTES` yields a plaintext 413. Both are now re-shaped into the envelope with the rejection's own status and text preserved.

## Changes since the independent review ([comment](https://github.com/artifact-keeper/artifact-keeper/pull/3274#issuecomment-5245426938))

The review confirmed claims 1, 2, 3 and 5, reproduced the revert-proof independently, and confirmed the handler-surface enumeration is complete. It found one blocking defect, one observability regression, and two inaccurate statements in this description. All four are addressed:

### 1. The DTF `curation-multiformat-enforce` oracle does **not** still match — fixed in the companion PR

This description previously claimed the `curation_blocked` marker in the message kept that oracle matching. **That was wrong.** The oracle is a JSON field lookup, not a grep (`oracle.sh:142-143`): `jq -r '.error // empty'` yields `''` against the new body, so the docker arm of a **blocking** gate would have gone red on the first release carrying this PR.

Fixed in **artifact-keeper/artifact-keeper-test#337**, validated red→green locally before opening against bodies captured from this backend (not hand-written). The oracle now selects the expected shape from the deployed backend version — envelope **required** at ≥ 1.7.2, either shape accepted below it, since that oracle runs at `@main` against 1.7.x cuts that predate this fix — and asserts it with `jq` field lookups (`errors[0].code`, `errors[0].message`, `errors[0].detail.reason`), never a substring match on the raw body.

The other consumer, `test-ghsa-vvc3-scope-checks.sh`, greps the raw body and survives; independently re-verified. `curation_blocked` has no other consumer in either repo.

### 2. The curation rule `reason` was being discarded — fixed here

At `301f3d4` the OCI body dropped `reason` and hardcoded `detail: None`, so an operator debugging a blocked `docker pull` got "blocked by this repository's curation policy" while every other proxy format still reported which rule fired. The reason was unreachable only because the shared seam handed callers an already-rendered `Response`.

Split at the seam: `proxy_helpers::evaluate_curation{,_lookup}` now return a structured `CurationBlock { package, reason }`, and `enforce_curation{,_lookup}` are thin wrappers that render it through `CurationBlock::into_rest_response`. Every non-OCI format's wire body is byte-identical (pinned by a new test). The OCI seam builds its own envelope from the structured verdict:

```json
{"errors":[{"code":"DENIED",
            "message":"curation_blocked: pull of library/hello-world is blocked by this repository's curation policy: #2930 tier block",
            "detail":{"package":"library/hello-world","reason":"#2930 tier block"}}]}
```

`spec.md` "Error Codes": *"The `detail` field is OPTIONAL and MAY contain arbitrary JSON data providing information the client can use to resolve the issue."* The reason is in **both** `message` (what `docker pull` prints) and `detail` (what a machine reads). `oci_error` gained an `oci_error_detail` sibling and is otherwise byte-identical — `detail` is `skip_serializing_if = "Option::is_none"`, pinned by `test_oci_error_omits_detail_when_absent`.

### 3. "Extractors in the `/v2` router are `Infallible`" — that claim was **false**, and the underlying gap is now fixed

Confirmed against the running router, not just by reading: `GET /v2/token?service=a&service=b` returned `400 text/plain` *"Failed to deserialize query string: duplicate field `service`"*, while `?service=artifact-keeper` returned `200` with a token. `Query<TokenQuery>` and `Bytes` are both fallible; only `catch_all` / `handle_catalog`'s `Query<HashMap<String,String>>` is effectively infallible. The sentence has been removed from the enumeration above.

Neither rejection was a spec *violation* — `spec.md`: a 4XX *"MAY return a body in any format"* — but they were the last bare-string 4XX bodies a docker client could meet on this router, which is the same ergonomics argument the rest of this PR makes, so they are re-shaped rather than merely documented. Status and axum's explanatory text are preserved; `UNSUPPORTED` (code-14, *"The operation is unsupported."*) is the closest registered code, as the closed table has no malformed-request entry.

### 4. `PAGINATION_NUMBER_INVALID` — "cosmetic" was the wrong justification

`spec.md` "Error Codes" reads *"The `code` field MUST be one of the following:"* over a closed 14-row table, and `PAGINATION_NUMBER_INVALID` is not in it, so calling the mismatch cosmetic was not defensible. The real reason to leave it is the reference implementation, which is what clients are written against: `distribution/distribution` registers exactly this code, string and status —

```go
// registry/api/errcode/register.go:219-226 (main); same in registry/api/v2/errors.go:137-144 on release/2.8
ErrorCodePaginationNumberInvalid = register(errGroup, ErrorDescriptor{
    Value:          "PAGINATION_NUMBER_INVALID",
    Message:        "invalid number of results requested",
    ...
    HTTPStatusCode: http.StatusBadRequest,
})
```

AK's body is already the conforming envelope; only the code is an upstream-compatible extension. Changing it would move away from the behaviour Docker Hub-oriented clients see. Left as-is, on that ground.

## Known residuals (deliberately not in this diff)

- **`setup_guard` / `demo_guard` emit REST-shaped JSON 4XX on `/v2`.** `routes.rs:146` nests `/v2` inside the global layer stack, so a request can be refused before reaching any handler. `setup_guard` (`middleware/setup.rs:32-79`) has no `/v2` entry in its allowlist and 403s the `docker login` probe with `{"error":"SETUP_REQUIRED",…}` while setup is pending; `demo_guard` (`middleware/demo.rs:71-77`) does the same on write verbs in demo mode. Both are narrow states and both are middleware, not handler surface — filed as **#3284** rather than grown into this PR. (`guest_access_guard` is already correctly allowlisted for `/v2`.)
- Referrers API 404s (#3108); upload-status GET 405 (#3275).
- The shared REST bodies of `curation_blocked_response` / `scan_blocked_response` for non-OCI formats — their consumers expect that shape, and this PR now pins it with a test.

## Spec grounding

OCI Distribution Specification (opencontainers/distribution-spec, `spec.md` § "Error Codes"): *"A `4XX` response code from the registry MAY return a body in any format. If the response body is in JSON format, it MUST have the following format: `{"errors":[{"code":..., "message":..., "detail":...}]}`. The `code` field MUST be a unique identifier, containing only uppercase alphabetic characters and underscores"* — with `DENIED` registered as code-12 ("requested access to the resource is denied") and `UNSUPPORTED` as code-14.

## Tests (7 new/rewritten, all `--lib` so the coverage gate sees them)

- `tests::test_oci_forbidden_scope_status_and_body` — rewritten: previously asserted the bare-string body *as the contract*; now asserts the **parsed** envelope (`errors[0].code == "DENIED"`, content-type, legacy message preserved).
- `tests::test_oci_curation_deny_response_is_oci_error_envelope` — envelope + 403 + `curation_blocked` marker + `detail.reason` / `detail.package`, all parsed.
- `tests::test_oci_error_omits_detail_when_absent` — positive control on the `detail` plumbing: `oci_error`'s output is byte-for-byte what it was.
- `proxy_helpers::tests::curation_block_rest_body_is_unchanged` — the shared REST body every other format serves is byte-identical after the seam split. This is what stops the `evaluate`/`enforce` refactor from silently moving npm's wire shape (which the DTF tier's npm arm reads).
- `oci_error_envelope_db_tests::scope_denied_manifest_put_returns_oci_error_envelope` (DB, real router): read-scoped API token PUT manifest → 403 envelope DENIED; **positive control in the same fixture**: wildcard-scoped token, byte-identical request → 201 CREATED.
- `oci_error_envelope_db_tests::curation_blocked_manifest_get_returns_oci_error_envelope` (DB, real router): curation-blocked image GET → 403 envelope DENIED with marker **and `detail.reason == "blocked by test rule"`** from the actual rule row; **positive control**: non-matching image on the same repo passes the gate and its miss is the spec-shaped `404 MANIFEST_UNKNOWN` envelope.
- `oci_error_envelope_db_tests::token_query_rejection_returns_oci_error_envelope` (DB, real router): `?service=a&service=b` → 400 envelope `UNSUPPORTED` carrying axum's own text; **positive control**: `?service=artifact-keeper` still mints a token, so the assertion cannot be satisfied by a route that rejects everything.

Every assertion goes through `serde_json::from_slice` and indexes `errors[0]…`; none is a substring match on the raw body. That matters concretely: the REST body this PR removes contains the literal `curation_blocked` **and** the reason at the top level, so a whole-body `contains` check would pass on the shape being removed.

## Revert-proof (run with `DATABASE_URL` **and** `AK_TESTS_REQUIRE_DB=1`)

Three independent reverts to the pre-fix shape in one tree — the curation body back to `301f3d4` (reason discarded, no `detail`), `/v2/token` back to `Query(query): Query<TokenQuery>, body: Bytes`, and the shared REST body's `"error"` key moved. Exactly the four guards that cover them fail, with real DB timings; the three that cover the untouched scope gate keep passing:

```
FAIL [ 0.013s] proxy_helpers::tests::curation_block_rest_body_is_unchanged
  left:  "{\"curation_error\":\"curation_blocked\",\"package\":\"left-pad\",…}"
  right: "{\"error\":\"curation_blocked\",\"package\":\"left-pad\",…}"

FAIL [ 0.018s] oci_v2::tests::test_oci_curation_deny_response_is_oci_error_envelope
  message must name the rule that fired (docker prints message):
  {"errors":[{"code":"DENIED","message":"curation_blocked: pull of someimage is blocked by this repository's curation policy"}]}

FAIL [ 0.280s] oci_error_envelope_db_tests::token_query_rejection_returns_oci_error_envelope
  body must be the OCI error envelope with code UNSUPPORTED;
  got: Failed to deserialize query string: duplicate field `service`

FAIL [ 3.883s] oci_error_envelope_db_tests::curation_blocked_manifest_get_returns_oci_error_envelope
  detail.reason must name the curation rule that fired:
  {"errors":[{"code":"DENIED","message":"curation_blocked: pull of blockedimg is blocked by this repository's curation policy"}]}
  left: None   right: Some("blocked by test rule")

PASS [ 4.842s] oci_error_envelope_db_tests::scope_denied_manifest_put_returns_oci_error_envelope
PASS [ 0.030s] oci_v2::tests::test_oci_forbidden_scope_status_and_body
PASS [ 0.030s] oci_v2::tests::test_oci_error_omits_detail_when_absent
```

**3.8s and 4.9s, not 0.04s** — the DB guards executed against a real database in both directions. Fixed tree: 7/7 pass. Both directions re-run **after** the rebase, on the rebased tree.

Full `oci_v2` + `proxy_helpers` battery on the rebased fixed tree: **795/795** (up from 788 — #3268 added a module). Whole backend `--lib` suite on the rebased tree: **15104/15104 passed, 0 failed** — run because the `evaluate`/`enforce` seam split touches a helper with 9 callers across the format handlers, so the blast radius is wider than the two files in the diff. `cargo fmt --all --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean. No `sqlx::query!` macro text touched (runtime queries only), no migrations.

## Merge order

The DTF release gate is invoked **only** on a `v*` tag push (`release.yml` → `artifact-keeper-test/.github/workflows/release-gate.yml@main`) and by `release-gate-rehearsal.yml`. There is no PR-level DTF gate, so no merge into `main` turns it red by itself — but the order still matters for the next tag:

1. **artifact-keeper/artifact-keeper-test#337 first.** It is green against every backend that exists today (1.7.1 and older take its below-floor branch and pass on the REST body), so it is a no-op until a backend carrying this PR is deployed.
2. **Then this PR.**
3. Both before the next `v*` tag. The reverse order leaves a window in which a release cut runs the old `.error` lookup against the new envelope and fails a blocking gate.

If this PR slips out of milestone 1.7.2, `CURATION_OCI_ENVELOPE_MIN_VERSION` in #337 must move with it.

## Rebase

Rebased from merge-base `1115203` onto `8b9e0ff`. What landed underneath and what it cost:

- **#3268** (`f75f010`) — `require_oci_repo_read_access` on GET/HEAD blob, GET/HEAD manifest and `GET tags/list`; `authorize_virtual_members` on the OCI read path; `enforce_scan_pull_scope` / `enforce_token_repo_scope` moved to run first.
- **#3272** (`118a8b0`) — `resolve_virtual_metadata`'s transform signature is now `(body, content_encoding, member_key)`, plus `forward_verbatim_metadata`.

**Conflicts: two, both in `oci_v2.rs`, both "we each appended a new test module at EOF"** — #3268's `oci_read_authz_tests` against this PR's `oci_error_envelope_db_tests`. Resolved by keeping both, each with its own header comment and attributes. `proxy_helpers.rs` merged without conflict (#3272's change is ~2,800 lines away from the curation seam).

**Verified rather than assumed**, because a clean auto-merge is not evidence:

- Every deleted line in `git diff 8b9e0ff` across both files was audited one by one. **All 21 are this PR's own** (the bare-string `oci_forbidden_scope` body, the two `return resp;` arms, the old `Query`/`Bytes` extractor params, the old `detail: None`, the two `enforce_curation_lookup` call heads, the pre-rewrite test asserts, and the two seam-internal lines). Nothing from #3268 or #3272 was dropped or rewritten.
- Gate ORDERING preserved: `enforce_scan_pull_scope` → `enforce_token_repo_scope` → `require_oci_repo_read_access` → the curation seam, in both `handle_get_manifest` and `handle_head_manifest`. The curation gate stays last, where it was.
- The negative-cache constraint in `authorized_virtual_members` is byte-identical: `VirtualResolveKey` carries no principal term, so the cache is still consulted and populated only when `members.len() == total`. This PR never enters that region — confirmed by the deletion audit above, not by inspection alone.
- **The `/v2` enumeration was re-run against the new code.** #3268's error returns are `oci_denied_repo_access()` (403 DENIED), `oci_error(404, "NAME_UNKNOWN", …)` and `oci_authorization_unavailable()` (503 DENIED) — all already the envelope, so nothing new to fix and the "conforming already" list above holds. A denied virtual member is dropped from the walk, so it surfaces as the existing `MANIFEST_UNKNOWN` 404 envelope.
- `cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, the 795-test battery and the full revert-proof were all re-run **after** the rebase, on the rebased tree, with `DATABASE_URL` + `AK_TESTS_REQUIRE_DB=1`. The numbers quoted above are the post-rebase ones.

The DTF companion (#337) is unaffected: it changes only `artifact-keeper-test`, and the wire body it asserts is unchanged by the rebase.
