### PR TITLE
fix(analytics): guard + document the daily storage snapshot's ledger accounting (#3249)

### DIFF
--- a/backend/src/services/analytics_service.rs
+++ b/backend/src/services/analytics_service.rs
@@ -21,7 +21,22 @@ pub struct AnalyticsService {
 pub struct StorageSnapshot {
     pub snapshot_date: NaiveDate,
     pub total_repositories: i64,
+    /// Rows in `artifacts` (for OCI repositories that is manifests only —
+    /// layer/config blobs are content-addressed objects, not artifacts), the
+    /// same deliberate decision as the dashboard's
+    /// `SystemStats::total_artifacts` (#3134). Unlike the byte total, this
+    /// count still includes legacy backfilled `proxy-cache/%` rows.
     pub total_artifacts: i64,
+    /// All stored bytes at snapshot time, summed from
+    /// `repository_usage_ledger` (`hosted_bytes + proxy_bytes + oci_bytes`) —
+    /// the same source as the dashboard `total_storage_bytes` and quota
+    /// admission (#3134/#3249), so the analytics series is consistent with
+    /// both by construction. Includes OCI layer/config blob bytes
+    /// (`oci_blobs`) and proxy-cached bytes (`proxy_cache_artifacts`);
+    /// excludes legacy backfilled `proxy-cache/%` `artifacts` rows (their
+    /// bytes are represented by the proxy-cache catalog instead). This is the
+    /// LOGICAL figure: a blob cross-repo-mounted into N repositories counts
+    /// once per repository, matching the per-repo storage column and quota.
     pub total_storage_bytes: i64,
     pub total_downloads: i64,
     pub total_users: i64,
@@ -75,6 +90,18 @@ pub struct StaleArtifact {
 }
 
 /// Growth summary for a time range.
+///
+/// Computed from `storage_metrics` daily snapshots. **Accounting-basis note
+/// (#3249):** snapshots taken before the #3134/#3249 fix summed
+/// `artifacts.size_bytes` only, missing OCI layer/config blob bytes
+/// (`oci_blobs`) and proxy-cached bytes (`proxy_cache_artifacts`) while
+/// counting legacy backfilled `proxy-cache/%` rows. Those historical rows are
+/// deliberately left as recorded — the source tables hold no history, so past
+/// values cannot be recomputed, only fabricated. A growth series that spans
+/// the fix date therefore shows a one-day upward step in
+/// `storage_bytes_start/end` / `storage_growth_bytes` /
+/// `storage_growth_percent` when the corrected accounting first lands; it is
+/// a measurement correction, not real growth.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct GrowthSummary {
     pub period_start: NaiveDate,
@@ -120,7 +147,7 @@ impl AnalyticsService {
                 CURRENT_DATE,
                 (SELECT COUNT(*) FROM repositories),
                 (SELECT COUNT(*) FROM artifacts WHERE is_deleted = false),
-                -- #3134: same source as `GET /api/v1/admin/stats`
+                -- #3134/#3249: same source as `GET /api/v1/admin/stats`
                 -- (`repository_usage_ledger`, trigger-maintained), so the
                 -- snapshot trend does not diverge from the dashboard total
                 -- by OCI blob and proxy-cached bytes.
@@ -862,6 +889,227 @@ mod tests {
         assert!(
             today_proxy >= 1,
             "downloads/trend must include today's proxy serve in proxy_download_count (#2704), got {today_proxy}"
+        );
+    }
+
+    /// DB-backed regression for #3249: the daily `storage_metrics` snapshot's
+    /// `total_storage_bytes` must include OCI layer/config blob bytes
+    /// (`oci_blobs` — only manifests land in `artifacts`) and proxy-cached
+    /// bytes (`proxy_cache_artifacts`), and must NOT count legacy backfilled
+    /// `proxy-cache/%` `artifacts` rows. Same accounting (and same fixture
+    /// semantics) as the #3134 dashboard test
+    /// (`admin::tests::test_system_stats_total_storage_includes_oci_blob_bytes`):
+    ///  - LOGICAL counting: a blob digest cross-repo-mounted into two
+    ///    repositories counts once per repository, and extra
+    ///    `manifest_blob_refs` rows for the same blob do NOT multiply it;
+    ///  - positive control: a non-OCI repository's hosted bytes are still
+    ///    counted unchanged.
+    ///
+    /// Test-strategy note (why #3249 was scoped out of #3134's PR): the
+    /// snapshot upsert is keyed cluster-wide on `CURRENT_DATE`, so the
+    /// written row can never be fixture-scoped — any global-value assertion
+    /// races every concurrently running test (the #3129 flake class). This
+    /// test therefore never asserts the stored row's absolute value. It calls
+    /// `capture_daily_snapshot()` itself before and after seeding and asserts
+    /// the DELTA between the two RETURNING payloads, with the two defenses
+    /// the #3134 test proved out under a full parallel suite run:
+    ///  - fixture sizes are TERABYTE-scale integers (no real storage is
+    ///    written), so every wrong composition (blob bytes missing, legacy
+    ///    row double count, per-reference multiplication, physical-once
+    ///    dedup) lands >= 23 TB outside the window while concurrent tests
+    ///    move KBs-to-GBs;
+    ///  - the check tolerates +/- `SLACK` (10 GB) of unrelated churn inside
+    ///    the observation window and retries a few times.
+    /// The repeated upserts themselves are safe: each overwrites today's row
+    /// with a fresh cluster-wide aggregate, which is exactly what the daily
+    /// scheduler does, and no other test asserts `storage_metrics` contents.
+    #[tokio::test]
+    async fn test_capture_daily_snapshot_includes_oci_blob_and_proxy_cache_bytes() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::repository_service::RepositoryService;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let service = AnalyticsService::new(pool.clone());
+        let repo_service = RepositoryService::new(pool.clone());
+
+        // Distinctive prime multiples of 1 TB so the expected delta cannot be
+        // assembled by accident from a different combination of components.
+        const TB: i64 = 1_000_000_000_000;
+        const MANIFEST: i64 = 11 * TB; // artifacts row in the docker repo
+        const BLOB_SHARED: i64 = 23 * TB; // digest mounted in BOTH docker repos
+        const BLOB_SOLO: i64 = 37 * TB; // blob only in the first docker repo
+        const HOSTED_PLAIN: i64 = 41 * TB; // artifacts row in the generic repo (positive control)
+        const LEGACY: i64 = 53 * TB; // legacy `proxy-cache/%` artifacts row (must be excluded)
+        const CACHED: i64 = 61 * TB; // proxy_cache_artifacts catalog row
+        const SLACK: i64 = 10_000_000_000; // unrelated concurrent churn budget
+
+        // Once per repo: BLOB_SHARED twice (two repos), refs don't multiply,
+        // legacy row excluded.
+        const EXPECTED_TOTAL_DELTA: i64 =
+            MANIFEST + 2 * BLOB_SHARED + BLOB_SOLO + HOSTED_PLAIN + CACHED;
+
+        let (oci_a, _, _) = tdh::create_repo(&pool, "local", "docker").await;
+        let (oci_b, _, _) = tdh::create_repo(&pool, "local", "docker").await;
+        let (plain, _, _) = tdh::create_repo(&pool, "local", "generic").await;
+        let (remote, _, _) = tdh::create_repo(&pool, "remote", "pypi").await;
+        let repo_ids = [oci_a, oci_b, plain, remote];
+
+        let mut matched = false;
+        for _attempt in 0..5 {
+            let before = service
+                .capture_daily_snapshot()
+                .await
+                .expect("capture baseline snapshot");
+
+            let digest_shared = format!("sha256:{:0>64}", Uuid::new_v4().simple());
+            let digest_solo = format!("sha256:{:0>64}", Uuid::new_v4().simple());
+
+            for (repo, name, size, storage_key) in [
+                (
+                    oci_a,
+                    "manifest",
+                    MANIFEST,
+                    format!("oci/{oci_a}/manifests/m"),
+                ),
+                (
+                    plain,
+                    "plain",
+                    HOSTED_PLAIN,
+                    format!("generic/{plain}/plain.bin"),
+                ),
+                (
+                    remote,
+                    "legacy",
+                    LEGACY,
+                    format!("proxy-cache/{remote}/legacy.whl"),
+                ),
+            ] {
+                sqlx::query(
+                    "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, \
+                     checksum_sha256, content_type, storage_key) \
+                     VALUES ($1, $2, $3, '1.0.0', $4, $5, 'application/octet-stream', $6)",
+                )
+                .bind(repo)
+                .bind(format!("snapshot-3249/{name}/{}", Uuid::new_v4()))
+                .bind(name)
+                .bind(size)
+                .bind(format!("{:0>64}", "3249"))
+                .bind(storage_key)
+                .execute(&pool)
+                .await
+                .expect("seed artifacts row");
+            }
+
+            for (repo, digest, size) in [
+                (oci_a, &digest_shared, BLOB_SHARED),
+                (oci_b, &digest_shared, BLOB_SHARED),
+                (oci_a, &digest_solo, BLOB_SOLO),
+            ] {
+                sqlx::query(
+                    "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) \
+                     VALUES ($1, $2, $3, $4)",
+                )
+                .bind(repo)
+                .bind(digest)
+                .bind(size)
+                .bind(format!("oci-blobs/{digest}"))
+                .execute(&pool)
+                .await
+                .expect("seed oci_blobs row");
+            }
+
+            // Two manifests referencing the shared blob in the same repo:
+            // per-REFERENCE counting would inflate the figure; per-repo-row
+            // counting (the ledger's) must not.
+            for i in 0..2 {
+                sqlx::query(
+                    "INSERT INTO manifest_blob_refs \
+                     (manifest_digest, blob_digest, repository_id, kind) \
+                     VALUES ($1, $2, $3, 'layer')",
+                )
+                .bind(format!("sha256:{:0>63}{i}", Uuid::new_v4().simple()))
+                .bind(&digest_shared)
+                .bind(oci_a)
+                .execute(&pool)
+                .await
+                .expect("seed manifest_blob_refs row");
+            }
+
+            sqlx::query(
+                "INSERT INTO proxy_cache_artifacts \
+                 (repository_id, path, storage_key, metadata_key, size_bytes) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(remote)
+            .bind("snapshot-3249/legacy.whl")
+            .bind(format!(
+                "proxy-cache/{remote}/snapshot-3249/legacy.whl/__content__"
+            ))
+            .bind(format!(
+                "proxy-cache/{remote}/snapshot-3249/legacy.whl/__cache_meta__.json"
+            ))
+            .bind(CACHED)
+            .execute(&pool)
+            .await
+            .expect("seed proxy cache row");
+
+            // The migration-182 triggers charge the ledger inline; reconcile
+            // anyway so the assertion binds to the documented authoritative
+            // per-repo sums rather than to trigger bookkeeping.
+            for repo in repo_ids {
+                repo_service
+                    .reconcile_usage_ledger(repo)
+                    .await
+                    .expect("reconcile usage ledger");
+            }
+
+            let after = service
+                .capture_daily_snapshot()
+                .await
+                .expect("capture post-seed snapshot");
+
+            // Remove this attempt's rows before deciding, so a retry re-seeds
+            // from a clean slate.
+            for table in ["manifest_blob_refs", "oci_blobs", "proxy_cache_artifacts"] {
+                let sql = format!("DELETE FROM {table} WHERE repository_id = ANY($1)");
+                sqlx::query(&sql)
+                    .bind(&repo_ids[..])
+                    .execute(&pool)
+                    .await
+                    .expect("cleanup seeded rows");
+            }
+            sqlx::query("DELETE FROM artifacts WHERE repository_id = ANY($1)")
+                .bind(&repo_ids[..])
+                .execute(&pool)
+                .await
+                .expect("cleanup seeded artifacts");
+
+            let total_delta = after.total_storage_bytes - before.total_storage_bytes;
+            if (total_delta - EXPECTED_TOTAL_DELTA).abs() <= SLACK {
+                matched = true;
+                break;
+            }
+            eprintln!(
+                "attempt saw snapshot total_storage_bytes delta {total_delta} \
+                 (expected {EXPECTED_TOTAL_DELTA}); retrying"
+            );
+        }
+        // Clean up the fixture repositories BEFORE asserting, so a failing
+        // run does not leak them into the shared test database.
+        sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+            .bind(&repo_ids[..])
+            .execute(&pool)
+            .await
+            .expect("cleanup repos");
+
+        assert!(
+            matched,
+            "capture_daily_snapshot never reflected the seeded storage: expected \
+             total_storage_bytes +{EXPECTED_TOTAL_DELTA} +/- {SLACK} (manifest {MANIFEST} + \
+             shared blob {BLOB_SHARED} once per mounted repo + solo blob {BLOB_SOLO} + hosted \
+             {HOSTED_PLAIN} + cached {CACHED}, legacy proxy-cache/% row {LEGACY} excluded)"
         );
     }
 }


### PR DESCRIPTION
Fixes #3249

## State of the issue when this PR was opened

#3249 was filed as "scoped out of #3134's PR" — but the query change itself actually shipped with #3251: `capture_daily_snapshot` on current main already sums `repository_usage_ledger` (`hosted_bytes + proxy_bytes + oci_bytes`) instead of the raw `SUM(artifacts.size_bytes)`, and #3251's CHANGELOG entry documents the snapshot behavior change. What was genuinely still missing — and what this PR delivers — is everything the scope-out was about:

1. **The regression test.** The snapshot's ledger accounting had no guard; a revert of #3251's analytics hunk would have gone green. The cluster-wide `CURRENT_DATE` upsert was the stated reason no test existed.
2. **The `GrowthSummary` doc comment** the issue asks for (the one-day accounting step in historical series), plus doc comments on `StorageSnapshot::total_storage_bytes` and `::total_artifacts` stating the accounting basis.

No production query text changes beyond adding `#3249` to the existing `#3134` SQL comment. No migration; no `sqlx::query!` macros touched (the snapshot uses runtime `query_as`), so `.sqlx` is unchanged.

## Accounting basis: logical bytes, matching #3251

The snapshot inherits #3251's **LOGICAL** counting decision, stated here explicitly for the analytics series: a blob cross-repo-mounted into N repositories counts once per repository (`oci_blobs` is `UNIQUE(repository_id, digest)`), extra manifest references within one repository do not multiply the figure, legacy backfilled `proxy-cache/%` `artifacts` rows are excluded (their bytes are represented by the `proxy_cache_artifacts` catalog). This keeps the daily series consistent with the dashboard `total_storage_bytes`, the per-repository storage column, and quota admission by construction — one accounting implementation (the ledger, trigger-maintained by migration 182, trued up every 30 min by `reconcile_all_usage_ledgers`), not a second aggregate that can diverge (the #3077/#3179 two-normalizers failure class).

`total_artifacts` in the snapshot deliberately still counts `artifacts` rows only (for OCI, manifests — blobs are content-addressed objects, not artifacts), the same decision #3251 made and documented for `SystemStats::total_artifacts`; now documented on `StorageSnapshot` too.

## The test-strategy problem (why this was scoped out) and how it is solved

The snapshot upsert is keyed cluster-wide on `CURRENT_DATE`, so the written `storage_metrics` row can never be fixture-scoped: any assertion on its absolute value races every concurrently running test in the shared database (the #3129 flake class, fixed in #3242 for the OCI footprint test).

`test_capture_daily_snapshot_includes_oci_blob_and_proxy_cache_bytes` (in-file `#[cfg(test)]`, so it counts for the `--lib` coverage gate) therefore **never reads the stored row**. It calls `capture_daily_snapshot()` itself before and after seeding and asserts the **delta between the two RETURNING payloads**, with the two defenses the #3251 dashboard test proved out under a full parallel suite run:

- fixture sizes are terabyte-scale prime multiples (no real storage written), so every wrong composition — blob bytes missing (−83 TB), legacy row double-counted (+53 TB), per-reference multiplication (+23 TB), physical-once dedup (−23 TB), cached bytes missing (−61 TB) — lands ≥ 23 TB outside the window while concurrent tests move KBs–GBs;
- a ±10 GB slack window plus a retry loop absorbs unrelated concurrent churn inside the observation window.

The repeated upserts are what the daily scheduler does anyway (overwrite today's row with a fresh cluster-wide aggregate), and no other test asserts `storage_metrics` contents.

**What the test still proves:** that the value `capture_daily_snapshot` computes and persists follows ledger accounting — OCI blob bytes counted once per mounted repository, proxy-cache catalog bytes counted, hosted bytes counted (positive control: a non-OCI generic repo's artifact, unchanged either way), manifest references not multiplied, legacy `proxy-cache/%` rows excluded. **What it deliberately does not prove:** anything about the absolute stored value of a given date's row (unknowable in a shared cluster-wide keyspace), and the snapshot's count columns (`total_artifacts` etc.), which cannot be TB-scaled away from count churn.

Fixture semantics are identical to `admin::tests::test_system_stats_total_storage_includes_oci_blob_bytes`, so the dashboard and the snapshot are guarded against the same mutations and cannot silently diverge from each other.

## Backfill recommendation: none — documented instead

Historical `storage_metrics` rows written before the fix keep the old under-reported basis. **Recommendation: do not backfill.** The ledger and its source tables hold no history — there is no data from which a past date's OCI/proxy bytes can be recomputed; any "backfill" would overwrite real observations with fabricated values (e.g. today's ledger totals stamped onto past dates) and silently destroy the record of what was actually measured. The one-day upward step a growth series shows when the corrected accounting first lands is a measurement correction, not real growth — now documented on `GrowthSummary` exactly as the issue suggested. If a maintainer ever wants the step marked explicitly, a `storage_metrics.accounting_basis` column would be the honest shape, but that seems disproportionate for an admin-facing trend chart.

## Revert-proof

Production reverted faithfully to the pre-#3251 shape (the exact line from `83b9bc0`, the commit preceding #3251's analytics hunk): the ledger subquery + comment block replaced with

```sql
(SELECT COALESCE(SUM(size_bytes), 0) FROM artifacts WHERE is_deleted = false),
```

Result against a live migrated database (`AK_TESTS_REQUIRE_DB=1`; 0.6 s — a real run, not a skip):

```
FAIL services::analytics_service::tests::test_capture_daily_snapshot_includes_oci_blob_and_proxy_cache_bytes
attempt saw snapshot total_storage_bytes delta 105000000000000 (expected 196000000000000)
```

105 TB is exactly the artifacts-only sum (manifest 11 + hosted 41 + legacy 53): all 83 TB of OCI blob bytes and 61 TB of proxy-cache bytes absent, legacy row wrongly counted — the same diagnostic signature as #3251's revert-proof on the dashboard. With the fix restored the test passes (196 TB delta, 0.43 s).

**Faithfulness, proven on the reverted tree:** `git diff 1115203 --shortstat` = `1 file changed, 249 insertions(+), 6 deletions(-)`; since this PR adds doc comments (legitimate production-file lines), the stronger property was checked directly: stripping the `#[cfg(test)] mod tests` block from both the reverted file and `83b9bc0`'s file, the remainders differ **only** in 27 added `///` doc-comment lines — zero non-doc-comment differences. The executable production code on the reverted tree is byte-identical to the true pre-fix code, so the red can only come from the accounting claim under test.

## Checks

- `cargo nextest run --lib -E 'test(analytics_service)'` — 19/19 pass against the live DB (`AK_TESTS_REQUIRE_DB=1`)
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean
- No migration (ledger still ends at 195); no `.sqlx` changes (runtime `query_as` only)
