### PR TITLE
fix(tests): scope admin empty-set COALESCE aggregates to a fixture UUID (#3277)

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -1872,11 +1872,21 @@ mod tests {
     }
 
     /// DB-backed (skips without `DATABASE_URL`): the proxy-cache aggregate
-    /// must COALESCE `SUM(size_bytes)` to 0 — not NULL — over an empty table,
+    /// must COALESCE `SUM(size_bytes)` to 0 — not NULL — over an empty set,
     /// since the handler decodes the column as a non-nullable BIGINT
-    /// (`"size!"`). The shared test database can hold rows from concurrent
-    /// tests, so the empty-table shape is forced inside a transaction: the
-    /// DELETE is rolled back and never observed by other tests.
+    /// (`"size!"`). Without the COALESCE, `SUM` yields SQL NULL and the
+    /// `(i64, i64)` decode below is a hard error, so this test fails.
+    ///
+    /// #3277: the empty set is a SCOPED subset, not the whole table. The
+    /// suite runs process-per-test against a SHARED database, and the
+    /// previous shape (DELETE everything + cluster-wide aggregate inside a
+    /// rolled-back transaction) raced concurrent tests: READ COMMITTED lets
+    /// the SELECT see rows other tests commit after the DELETE. Filtering on
+    /// a freshly generated `repository_id` gives a subset the FK to
+    /// `repositories` guarantees is empty — `SUM` over zero rows is NULL
+    /// either way, so the COALESCE contract is exercised identically with no
+    /// global assumption. Same approach as #3242 for the storage-GC
+    /// footprint test.
     #[tokio::test]
     async fn test_proxy_cache_stats_query_empty_table_coalesces_to_zero_db() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -1885,24 +1895,22 @@ mod tests {
             return;
         };
 
-        let mut tx = pool.begin().await.expect("begin transaction");
-        sqlx::query("DELETE FROM proxy_cache_artifacts")
-            .execute(&mut *tx)
-            .await
-            .expect("clear proxy cache rows inside transaction");
+        // Never inserted into `repositories`, so the FK guarantees no
+        // `proxy_cache_artifacts` row can carry it: a deterministically
+        // empty subset regardless of concurrent suite activity.
+        let unused_repo_id = Uuid::new_v4();
+
         let (count, size): (i64, i64) = sqlx::query_as(
-            "SELECT COUNT(*), COALESCE(SUM(size_bytes), 0)::BIGINT FROM proxy_cache_artifacts",
+            "SELECT COUNT(*), COALESCE(SUM(size_bytes), 0)::BIGINT \
+             FROM proxy_cache_artifacts WHERE repository_id = $1",
         )
-        .fetch_one(&mut *tx)
+        .bind(unused_repo_id)
+        .fetch_one(&pool)
         .await
-        .expect("aggregate over empty proxy cache table");
-        tx.rollback().await.expect("rollback");
+        .expect("aggregate over empty proxy cache subset");
 
         assert_eq!(count, 0);
-        assert_eq!(
-            size, 0,
-            "COALESCE must map SUM's NULL to 0 on an empty table"
-        );
+        assert_eq!(size, 0, "COALESCE must map SUM's NULL to 0 on an empty set");
     }
 
     /// DB-backed regression for #3134: the dashboard `total_storage_bytes`
@@ -2127,10 +2135,15 @@ mod tests {
 
     /// DB-backed (skips without `DATABASE_URL`): the #3134 ledger aggregate
     /// must COALESCE `SUM(...)` to 0 — not NULL — over an empty
-    /// `repository_usage_ledger` (a fresh install's dashboard), since the
-    /// handler decodes both columns as non-nullable BIGINT (`"total!"`,
-    /// `"proxy!"`). Same shape-forcing pattern as the proxy-cache test above:
-    /// the DELETE happens inside a rolled-back transaction.
+    /// `repository_usage_ledger` set (a fresh install's dashboard), since
+    /// the handler decodes both columns as non-nullable BIGINT (`"total!"`,
+    /// `"proxy!"`). Without the COALESCE, `SUM` yields SQL NULL and the
+    /// `(i64, i64)` decode is a hard error, so this test fails.
+    ///
+    /// #3277: same scoped-empty-subset shape as the proxy-cache test above —
+    /// the previous DELETE-then-aggregate-in-a-rolled-back-transaction raced
+    /// concurrent tests under READ COMMITTED (this table is written by the
+    /// migration-182 triggers on every artifact insert suite-wide).
     #[tokio::test]
     async fn test_ledger_totals_query_empty_table_coalesces_to_zero_db() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -2139,20 +2152,19 @@ mod tests {
             return;
         };
 
-        let mut tx = pool.begin().await.expect("begin transaction");
-        sqlx::query("DELETE FROM repository_usage_ledger")
-            .execute(&mut *tx)
-            .await
-            .expect("clear ledger rows inside transaction");
+        // Never inserted into `repositories`; the ledger PK/FK guarantees an
+        // empty subset for it.
+        let unused_repo_id = Uuid::new_v4();
+
         let (total, proxy): (i64, i64) = sqlx::query_as(
             "SELECT COALESCE(SUM(hosted_bytes + proxy_bytes + oci_bytes), 0)::BIGINT, \
                     COALESCE(SUM(proxy_bytes), 0)::BIGINT \
-             FROM repository_usage_ledger",
+             FROM repository_usage_ledger WHERE repository_id = $1",
         )
-        .fetch_one(&mut *tx)
+        .bind(unused_repo_id)
+        .fetch_one(&pool)
         .await
-        .expect("aggregate over empty ledger");
-        tx.rollback().await.expect("rollback");
+        .expect("aggregate over empty ledger subset");
 
         assert_eq!(total, 0, "COALESCE must map SUM's NULL to 0");
         assert_eq!(proxy, 0, "COALESCE must map SUM's NULL to 0");


### PR DESCRIPTION
Fixes #3277

## What

Test-only change. Rewrites the two empty-set `COALESCE(SUM(...), 0)` regression tests in `api::handlers::admin::tests` so they no longer assert a cluster-wide empty table:

- `test_proxy_cache_stats_query_empty_table_coalesces_to_zero_db` (the #3277 flake, added by #3088)
- `test_ledger_totals_query_empty_table_coalesces_to_zero_db` — the one sibling in the module with the identical `DELETE`-then-global-aggregate shape (also written to by the migration-182 triggers on every artifact insert suite-wide, so it carries the same race)

## Why the old shape raced

The `DELETE FROM <table>` + aggregate inside a rolled-back transaction looks isolated but is not: Postgres defaults to READ COMMITTED, so each statement takes a fresh snapshot. Any row a concurrent test **commits** between the `DELETE` and the `SELECT` is visible to the `SELECT`, and the suite runs process-per-test against a shared database. This took down `Backend Unit Tests` on #3274, which does not touch this code.

## The fix (issue's option 1, per the #3242 precedent)

Scope the aggregate to a subset this test controls: filter on `repository_id = $1` bound to a freshly generated UUID that is never inserted into `repositories`. The FK guarantees that subset is empty for the lifetime of the test regardless of concurrent activity — nothing is seeded, nothing is deleted, no transaction is needed, and no global assumption remains.

The pinned property is unchanged: `SUM` over zero rows yields SQL `NULL` whether the set is emptied by a filter or by an empty table, so `COALESCE(SUM(...), 0)` is exercised identically. Without the `COALESCE`, the `(i64, i64)` decode is a hard error and the test fails — verified by mutation (below).

The advisory-lock serialization pattern (option 2) was not needed: the property never required a globally empty table, only an empty *set*.

## Evidence (dedicated Postgres 16, all migrations applied, `DATABASE_URL` + `AK_TESTS_REQUIRE_DB=1` exported; test runtimes 0.15–0.2 s, i.e. really running, not the ~0.04 s DB-skip signature)

Concurrent load: a committed-insert loop (~175 commits/sec) inserting fresh `repositories` + `repository_usage_ledger` + `proxy_cache_artifacts` rows, always-fresh identities so nothing blocks on the test transaction's row locks.

| Version | Runs under load | Passed | Failed |
|---|---|---|---|
| OLD (both tests, pre-PR shape) | 15 | 0 | **15** (proxy-cache test failed 15/15, ledger test 13/15) |
| NEW (this PR) | 30 | **30** | 0 |

Mutation control — the new tests can still fail on the property they pin: stripping `COALESCE` from each test's SQL (leaving bare `SUM(...)::BIGINT`) makes both tests FAIL with a NULL-decode error, then pass again restored.

Full `api::handlers::admin::tests` module against the DB: 47/47 pass.

## Gates

- Diff is entirely inside `#[cfg(test)] mod tests` (every hunk ≥ line 1875; module starts at 1482) — production code untouched
- `cargo fmt --all` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean

## Sibling audit

Checked every DB-backed aggregate test in the module. The two delta-based stats tests (`test_get_system_stats_reports_proxy_cache_totals_db`, `test_system_stats_total_storage_includes_oci_blob_bytes`) already assert fixture-scoped before/after deltas with bounded retries and need no change. No other test in the module asserts a global `COUNT(*)`/`SUM(...)` without a fixture-scoped predicate.
