### PR TITLE
fix(npm): cache remote scoped packuments under the decoded @scope/name (#3297)

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2225,13 +2225,20 @@ async fn get_package_metadata(
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let encoded_name = encode_package_name_for_upstream(package_name);
+                // Fetch/cache split (#3297): the `%2F`-encoded name is what
+                // upstream registries require in the URL, but the local proxy
+                // cache key (persisted into the `proxy_cache_artifacts`
+                // catalog and shown in the web UI) must use the canonical
+                // decoded `@scope/name`.
                 let (content, content_type, _budget_permit) =
-                    proxy_helpers::proxy_fetch_capped_budgeted(
+                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
                         proxy,
                         repo.id,
                         repo_key,
                         upstream_url,
                         &encoded_name,
+                        package_name,
+                        None,
                         proxy_helpers::LARGE_METADATA_MAX_BYTES,
                     )
                     .await?;
@@ -2315,12 +2322,16 @@ async fn get_package_metadata(
             };
 
             let encoded_name = encode_package_name_for_upstream(package_name);
-            let result = proxy_helpers::proxy_fetch_capped_budgeted(
+            // Fetch/cache split (#3297): encoded name upstream, decoded
+            // `@scope/name` as the member's local cache key.
+            let result = proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
                 proxy,
                 member.id,
                 &member.key,
                 upstream_url,
                 &encoded_name,
+                package_name,
+                None,
                 proxy_helpers::LARGE_METADATA_MAX_BYTES,
             )
             .await;
@@ -2495,15 +2506,20 @@ async fn fetch_remote_packument(
         .as_ref()
         .ok_or_else(|| AppError::NotFound("Package not found".to_string()).into_response())?;
     let encoded_name = encode_package_name_for_upstream(package_name);
-    let (content, _ct, _budget_permit) = proxy_helpers::proxy_fetch_capped_budgeted(
-        proxy,
-        repo.id,
-        repo_key,
-        upstream_url,
-        &encoded_name,
-        proxy_helpers::LARGE_METADATA_MAX_BYTES,
-    )
-    .await?;
+    // Fetch/cache split (#3297): encoded name upstream, decoded `@scope/name`
+    // as the local cache key.
+    let (content, _ct, _budget_permit) =
+        proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
+            proxy,
+            repo.id,
+            repo_key,
+            upstream_url,
+            &encoded_name,
+            package_name,
+            None,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        )
+        .await?;
     let mut json: serde_json::Value = serde_json::from_slice(&content).map_err(|e| {
         AppError::Internal(format!("Invalid JSON from upstream: {}", e)).into_response()
     })?;
@@ -2586,12 +2602,16 @@ async fn fetch_virtual_packument(
         };
 
         let encoded_name = encode_package_name_for_upstream(package_name);
-        let result = proxy_helpers::proxy_fetch_capped_budgeted(
+        // Fetch/cache split (#3297): encoded name upstream, decoded
+        // `@scope/name` as the member's local cache key.
+        let result = proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
             proxy,
             member.id,
             &member.key,
             upstream_url,
             &encoded_name,
+            package_name,
+            None,
             proxy_helpers::LARGE_METADATA_MAX_BYTES,
         )
         .await;
@@ -2736,15 +2756,23 @@ async fn npm_publish_time_for_version(
         // Capped like every other buffered packument read (#2181): this runs
         // on the tarball download path, where an unbounded upstream metadata
         // body must not be able to balloon memory.
-        if let Ok((content, _, _budget_permit)) = proxy_helpers::proxy_fetch_capped_budgeted(
-            proxy,
-            repo.id,
-            &repo.key,
-            upstream_url,
-            &encoded_name,
-            proxy_helpers::LARGE_METADATA_MAX_BYTES,
-        )
-        .await
+        //
+        // Fetch/cache split (#3297): same decoded cache key as the metadata
+        // handlers, so the packument this age-gate probe caches is the SAME
+        // entry `get_package_metadata` reads and refreshes — leaving this
+        // site on the encoded key would double-cache every scoped packument.
+        if let Ok((content, _, _budget_permit)) =
+            proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
+                proxy,
+                repo.id,
+                &repo.key,
+                upstream_url,
+                &encoded_name,
+                package_name,
+                None,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await
         {
             if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&content) {
                 let times = UpstreamMetadataCache::parse_npm_publish_times(&json);
@@ -7544,6 +7572,192 @@ mod tests {
         assert_eq!(&body_bytes[..], tarball_bytes.as_ref());
 
         cleanup().await;
+    }
+
+    /// #3297: a Remote npm proxy must request a scoped packument from
+    /// upstream with the scope separator percent-encoded (`@scope%2Fpkg` —
+    /// private registries require that form) while keying the LOCAL proxy
+    /// cache — and therefore the `proxy_cache_artifacts` catalog row that the
+    /// web UI's Artifacts tab lists — under the canonical decoded
+    /// `@scope/pkg`. Before the fix the handlers passed the encoded upstream
+    /// form as the single `path` of `proxy_fetch_capped_budgeted`, which
+    /// reuses it as the cache key, so the catalog listed `@scope%2Fpkg`
+    /// verbatim.
+    ///
+    /// Positive controls in the same fixture:
+    /// * the upstream mock matches ONLY the encoded literal path, so the
+    ///   fetch/cache split cannot have decoded the UPSTREAM request;
+    /// * an unscoped package still resolves and catalogs under its plain
+    ///   name (separator-free names cannot diverge, per the #3179 lesson,
+    ///   so they must be unaffected);
+    /// * a second scoped request is answered from the cache written under
+    ///   the decoded key — wiremock's `expect(1)` fails the test if the
+    ///   re-read misses its own write and refetches upstream.
+    ///
+    /// Skips when no test database is configured.
+    #[tokio::test]
+    async fn test_remote_scoped_packument_cached_under_decoded_name() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+
+        let mock_server = MockServer::start().await;
+        let scoped_packument = serde_json::json!({
+            "name": "@e2escope/scopedpkg",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": {
+                "1.0.0": {
+                    "name": "@e2escope/scopedpkg",
+                    "version": "1.0.0",
+                    "dist": {
+                        "tarball": format!(
+                            "{}/@e2escope/scopedpkg/-/scopedpkg-1.0.0.tgz",
+                            mock_server.uri()
+                        )
+                    }
+                }
+            }
+        });
+        // Metadata requests must reach upstream with the literal `%2F`
+        // (unlike tarballs, B7): match ONLY the encoded path, so a decoded
+        // upstream request 404s and fails the test. `expect(1)` proves the
+        // second request below was a cache hit under the decoded key.
+        Mock::given(method("GET"))
+            .and(path("/@e2escope%2Fscopedpkg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_json(&scoped_packument),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let plain_packument = serde_json::json!({
+            "name": "plainpkg",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": {
+                "1.0.0": {
+                    "name": "plainpkg",
+                    "version": "1.0.0",
+                    "dist": {
+                        "tarball": format!(
+                            "{}/plainpkg/-/plainpkg-1.0.0.tgz",
+                            mock_server.uri()
+                        )
+                    }
+                }
+            }
+        });
+        Mock::given(method("GET"))
+            .and(path("/plainpkg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_json(&plain_packument),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock_server.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+
+        // The router percent-decodes `%2F` on the way in, so the handler
+        // receives the canonical decoded name.
+        let scoped_first = super::get_package_metadata(
+            &state,
+            &fx.repo_key,
+            "@e2escope/scopedpkg",
+            "http://localhost",
+            false,
+        )
+        .await;
+        let scoped_second = super::get_package_metadata(
+            &state,
+            &fx.repo_key,
+            "@e2escope/scopedpkg",
+            "http://localhost",
+            false,
+        )
+        .await;
+        let plain = super::get_package_metadata(
+            &state,
+            &fx.repo_key,
+            "plainpkg",
+            "http://localhost",
+            false,
+        )
+        .await;
+
+        // What the Artifacts tab lists: the catalog rows' `path`.
+        let catalog_paths: Vec<String> = sqlx::query_scalar(
+            "SELECT path FROM proxy_cache_artifacts WHERE repository_id = $1 ORDER BY path",
+        )
+        .bind(fx.repo_id)
+        .fetch_all(&fx.pool)
+        .await
+        .expect("read proxy_cache_artifacts catalog");
+
+        // Tear down before asserting so a failure never leaks DB/storage state.
+        fx.teardown().await;
+
+        let scoped_resp = scoped_first.unwrap_or_else(|r| {
+            panic!("scoped packument fetch must succeed; got HTTP {}", r.status())
+        });
+        assert_eq!(scoped_resp.status(), StatusCode::OK);
+        let scoped_body = axum::body::to_bytes(scoped_resp.into_body(), 1024 * 1024)
+            .await
+            .expect("read scoped packument body");
+        let scoped_json: serde_json::Value =
+            serde_json::from_slice(&scoped_body).expect("parse scoped packument");
+        assert_eq!(scoped_json["name"], "@e2escope/scopedpkg");
+
+        let second_resp = scoped_second.unwrap_or_else(|r| {
+            panic!(
+                "second scoped fetch must be served from cache; got HTTP {}",
+                r.status()
+            )
+        });
+        assert_eq!(second_resp.status(), StatusCode::OK);
+
+        let plain_resp = plain.unwrap_or_else(|r| {
+            panic!("unscoped packument fetch must succeed; got HTTP {}", r.status())
+        });
+        assert_eq!(plain_resp.status(), StatusCode::OK);
+
+        // The catalog must list the canonical decoded names — no `%2F`.
+        assert!(
+            catalog_paths.iter().any(|p| p == "@e2escope/scopedpkg"),
+            "scoped packument must be catalogued under its decoded name; rows: {catalog_paths:?}"
+        );
+        assert!(
+            catalog_paths.iter().any(|p| p == "plainpkg"),
+            "unscoped packument must still be catalogued under its plain name; rows: {catalog_paths:?}"
+        );
+        assert!(
+            !catalog_paths
+                .iter()
+                .any(|p| p.contains("%2F") || p.contains("%2f")),
+            "no catalog row may keep the percent-encoded scope separator (#3297); rows: {catalog_paths:?}"
+        );
+
+        // Drop the mock server last: `expect(1)` on each mock verifies the
+        // second scoped request never produced a second upstream round-trip.
+        drop(mock_server);
     }
 
     // #2192 / #1608 Phase 4c: an npm tarball larger than the old buffered cap

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -7716,7 +7716,10 @@ mod tests {
         fx.teardown().await;
 
         let scoped_resp = scoped_first.unwrap_or_else(|r| {
-            panic!("scoped packument fetch must succeed; got HTTP {}", r.status())
+            panic!(
+                "scoped packument fetch must succeed; got HTTP {}",
+                r.status()
+            )
         });
         assert_eq!(scoped_resp.status(), StatusCode::OK);
         let scoped_body = axum::body::to_bytes(scoped_resp.into_body(), 1024 * 1024)
@@ -7735,7 +7738,10 @@ mod tests {
         assert_eq!(second_resp.status(), StatusCode::OK);
 
         let plain_resp = plain.unwrap_or_else(|r| {
-            panic!("unscoped packument fetch must succeed; got HTTP {}", r.status())
+            panic!(
+                "unscoped packument fetch must succeed; got HTTP {}",
+                r.status()
+            )
         });
         assert_eq!(plain_resp.status(), StatusCode::OK);
 


### PR DESCRIPTION
Closes #3297

## Problem

For Remote (proxy) npm repositories, scoped packages (`@scope/name`) were catalogued — and listed in the web UI's Artifacts tab — under their upstream-encoded form (`@scope%2Fname`). The npm-protocol responses served to clients were correct; the leak was confined to the local proxy-cache key and the `proxy_cache_artifacts` catalog row derived from it.

## Root cause

The npm packument fetch sites build the `%2F`-encoded name for the upstream URL (private registries such as Nexus/Verdaccio/GitHub Packages require the encoded scope separator) and passed it as the single `path` argument of `proxy_helpers::proxy_fetch_capped_budgeted`, which reuses that one string as both the upstream fetch path and the local cache key. The encoded string was then persisted verbatim as `proxy_cache_artifacts.path` and rendered as-is by `build_catalog_artifact_response` in `repositories.rs` (its `rsplit('/')` finds no separator, so the whole encoded string becomes the displayed name).

The issue report identified four call sites; there are five. The fifth is `npm_publish_time_for_version` (the tarball-download age-gate's packument probe). Left unfixed it would have kept caching scoped packuments under the encoded key, double-caching every scoped packument alongside the metadata handlers' decoded entry and doubling upstream fetches on the age-gated download path.

## Fix

All five sites — `get_package_metadata` (Remote branch and Virtual-member branch), `fetch_remote_packument`, `fetch_virtual_packument`, and `npm_publish_time_for_version` — now use the existing fetch/cache split primitive `proxy_fetch_capped_with_cache_key_and_accept_budgeted` (already used by the PyPI handler for the same purpose): the encoded name stays on the upstream URL, the canonical decoded `@scope/name` becomes the cache key and catalog path.

## Gate/divergence analysis (why this is not a security bypass)

Checked every consumer of the two string forms against the "policy check sees a different string than the fetch" bug class:

- npm scope policy (`policy.allows`), curation on-demand entries (`build_npm_curation_entry`), and quarantine/age-gate all key on the **decoded** name the router provides — consistent with each other before and after this change.
- The cache TTL classifier (`classify_npm`) deliberately treats `@scope/<pkg>`, `@scope%2f<pkg>`, and bare names identically (mutable packument), so no TTL divergence in either direction.
- All five packument sites used the encoded key **consistently**, so there was no split-brain cache before the fix either — the defect was the catalog/display leak plus the age-gate probe's key.

## Cache-key migration note

Existing entries cached under the old `%2F` key are packuments — classified mutable with a TTL — so they expire and self-heal naturally; no migration is needed. Their stale catalog rows disappear when the entries are invalidated/expired, exactly as noted in the issue.

## Testing

New DB-backed guard `test_remote_scoped_packument_cached_under_decoded_name` (runs under the `--lib` coverage gate):

- wiremock upstream matches **only** the encoded literal path `/@e2escope%2Fscopedpkg` with `expect(1)` — proving the upstream request stays encoded and that a second scoped request is served from the cache written under the decoded key (a key mismatch would refetch and trip `expect(1)`).
- Asserts the catalog row is `@e2escope/scopedpkg` and that no row retains `%2F`.
- Positive control in the same fixture: an unscoped `plainpkg` resolves and catalogs under its plain name (a separator-free name cannot diverge, so it pins the unaffected path).

Revert-proof (faithful): production code restored byte-identically to merge-base (the segment before the single `#[cfg(test)] mod tests` marker is 188,386 bytes in both; the reverted tree's diff vs merge-base is 186 insertions, 0 deletions, all inside the test module). On that tree the guard FAILS on the claim under test:

```
scoped packument must be catalogued under its decoded name; rows: ["@e2escope%2Fscopedpkg", "plainpkg"]
```

With the fix restored it passes (0.34–0.47s per run against a live Postgres, `AK_TESTS_REQUIRE_DB=1`). Full `cargo nextest run --workspace --lib` green locally; `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` clean. No `sqlx::query!` macro text was touched (the test uses runtime `query_scalar`), so no offline metadata changes.

Note: no 1.7.3 milestone exists in the repo (open patch milestone is 1.7.2), so the milestone is left unset.
