### PR TITLE
fix(ci): clear go-git CVE-2026-71556 from the bundled scanner CLIs, and make a measured-red Docker Publish blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,20 @@ jobs:
       - name: Check Trivy gate severity filter
         run: ./scripts/ci/check-trivy-gate-severity.sh
 
+      # Same species as the check above, one layer out (#3308). That one asks
+      # "does the publish gate apply the filter it declares?"; this one asks
+      # "does the PRE-TAG gate block on what it just measured?" It did not:
+      # release-preflight.sh printed "a tag cut will likely stall" and
+      # "READY: ... Safe to cut the tag." in the same run, because the
+      # measured-red branch called `warn` (non-incrementing) instead of `bad`.
+      #
+      # It needs a test rather than a live run because the interesting case is
+      # invisible whenever main is green: with a green Docker Publish the buggy
+      # and fixed scripts are byte-identical in behaviour. Stubs `gh`, so no
+      # network and no dependence on main's current health. ~1s.
+      - name: Check release-preflight blocks on a measured red
+        run: bash scripts/ci/test-release-preflight.sh
+
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -35,6 +35,14 @@ jobs:
           ref: main
           fetch-depth: 1
 
+      # Runs first, and offline. If check 3 has regressed into a soft warn
+      # again (#3308), this fails here rather than silently blessing a cut
+      # below. The interesting case -- a MEASURED-RED Docker Publish -- is
+      # invisible whenever main happens to be green, so it has to be tested
+      # against stubs rather than waited for.
+      - name: Self-test the preflight gate
+        run: bash scripts/ci/test-release-preflight.sh
+
       - name: Run release preflight
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,9 +4,10 @@
 #
 # * Every entry below is a Go-dependency CVE compiled INTO one of the vendored
 #   scanner CLIs that AK images ship and invoke:
-#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.116.0, backend images)
-#     - /usr/local/bin/trivy  (ghcr.io/aquasecurity/trivy:0.72.0,
-#       scanner-adapter image only — the backend images do NOT bundle trivy)
+#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.117.0, backend images)
+#     - /usr/local/bin/trivy  (ghcr.io/artifact-keeper/trivy, pinned by digest
+#       in docker/Dockerfile.scanner-adapter — scanner-adapter image only; the
+#       backend images do NOT bundle trivy)
 #   Both are short-lived CLI subprocesses the services shell out to. They are
 #   NOT part of the network-reachable service surface (axum HTTP :8080 / gRPC
 #   :9090 / adapter HTTP :8080). The vulnerable code paths (docker client
@@ -23,12 +24,31 @@
 #   every build), or in the UBI/Alpine base OS packages. Only
 #   vendored-scanner-binary CVEs that have no fixed *tool release* are listed.
 #
-# * Both tools are pinned to the latest upstream release (grype v0.116.0,
-#   trivy 0.72.0, bumped for #2391). For the CVEs below the dependency fix
-#   exists upstream but no tagged tool release has been rebuilt against it
-#   yet (or, where noted, no upstream fix exists at all). They drop off
-#   automatically when the tools ship a release rebuilt against the fixed
-#   dependency — re-evaluate this whole file on every scanner bump.
+# * grype is pinned to the latest upstream release (v0.117.0, bumped for #3307).
+#   trivy is no longer taken from Aqua's release stream at all: since #3123 the
+#   scanner-adapter ships ghcr.io/artifact-keeper/trivy, our own build of the
+#   pinned upstream tag with declared dependency overrides. That means a trivy
+#   Go-dependency CVE with a fixed dependency version is now FIXABLE by us and
+#   must NOT be added here — file it as an override in that repo's
+#   overrides.yaml instead. This file is for findings with no fix available in
+#   the tool we can actually build.
+#
+# * For the CVEs below the dependency fix exists upstream but no tagged grype
+#   release has been rebuilt against it yet (or, where noted, no upstream fix
+#   exists at all). They drop off when grype ships a release rebuilt against
+#   the fixed dependency — re-evaluate this whole file on every scanner bump.
+#
+# * ⚠ ENTRIES HERE CANNOT CURRENTLY BE DELETED, even once they are provably
+#   dead. scripts/ci/release-preflight.sh check 1 is a HARD gate that requires
+#   main's suppression set to be a SUPERSET of every active release/* branch's.
+#   release/1.5.x and release/1.6.x still carry the older set, so removing a
+#   retired token from main makes the pre-tag check fail with "main is MISSING
+#   suppressions". The rule was written to stop a hotfix suppression being lost
+#   on the way to main (#3039), and for that it is right — but it also ratchets
+#   the set monotonically upward, which is the wrong direction for a security
+#   gate. Entries that measurement shows are no longer present in any shipped
+#   image are therefore marked RETIRED below and kept in place rather than
+#   removed. Do not read a RETIRED entry as an active exception. See #3309.
 #
 # * The CI publish GATE scans with `ignore-unfixed: true` and
 #   `severity: CRITICAL,HIGH`, so the genuinely no-fix-available and
@@ -47,14 +67,19 @@
 #   there without gating.
 #
 # Grype tracker: https://github.com/anchore/grype/releases
-# Trivy tracker: ghcr.io/aquasecurity/trivy tags (GitHub repo has no releases)
+# Trivy tracker: https://github.com/artifact-keeper/trivy — overrides.yaml is
+#   the live record of what we diverge from upstream on, and its
+#   upstream-watch workflow tracks new Aqua releases.
 
 # ---------------------------------------------------------------------------
-# grype v0.116.0 binary — Go stdlib @ go1.26.3
-# Fixed in Go 1.26.4/1.26.5 (1.25.11/1.25.12). grype v0.116.0 (latest) is
-# still built with go1.26.3. Drops off when grype ships a release built on
-# Go >= 1.26.5. (CVE-2026-39822 / CVE-2026-42505 also cover the trivy 0.72.0
-# binary, which is built with go1.26.4.)
+# grype v0.117.0 binary — Go stdlib @ go1.26.3
+# Fixed in Go 1.26.4/1.26.5 (1.25.11/1.25.12). grype v0.117.0 (latest) is
+# still built with go1.26.3 — the v0.116.0 -> v0.117.0 bump for #3307 did not
+# move the toolchain. Drops off when grype ships a release built on Go >=
+# 1.26.5. Re-measured against ghcr.io/anchore/grype:v0.117.0 on 2026-08-13:
+# all five still present, CVE-2026-27145 / -39822 / -42504 at HIGH+fixed (i.e.
+# these three are the ones actually holding the gate open), -42505 / -42507 at
+# MEDIUM.
 CVE-2026-27145
 CVE-2026-39822
 CVE-2026-42504
@@ -62,10 +87,12 @@ CVE-2026-42505
 CVE-2026-42507
 
 # ---------------------------------------------------------------------------
-# grype v0.116.0 binary — github.com/docker/docker @ v28.5.2+incompatible
+# grype v0.117.0 binary — github.com/docker/docker @ v28.5.2+incompatible
 # CVE-2026-41567 / -41568 / -42306: NO upstream-fixed docker release exists yet
 # (FixedVersion=none). CVE-2026-33997 / -34040 are fixed in docker 29.3.1 but
-# grype v0.116.0 (latest) has not rebuilt against it. Code path: grype's
+# grype v0.117.0 (latest) has not rebuilt against it — still v28.5.2. Of these,
+# only CVE-2026-34040 is HIGH+fixed and therefore actually gating; the rest are
+# unfixed (dropped by --ignore-unfixed) or MEDIUM. Code path: grype's
 # Docker engine client for `docker:` image sources; the backend invokes grype
 # against on-disk artifacts/SBOMs, not the Docker daemon.
 CVE-2026-33997
@@ -75,18 +102,47 @@ CVE-2026-41568
 CVE-2026-42306
 
 # ---------------------------------------------------------------------------
-# grype v0.116.0 binary — google.golang.org/grpc @ v1.80.0
-# GHSA-hrxh-6v49-42gf (gRPC-Go: xDS RBAC and HTTP/2 vulnerabilities): fixed in
-# grpc-go v1.82.1, but grype v0.116.0 (latest) has not rebuilt against it.
-# Neither affected path is reachable in how AK drives grype: it is not an
-# xDS/service-mesh client (the RBAC authz path is dead code), and it runs as a
-# short-lived local CLI over on-disk artifacts/SBOMs with a pre-seeded offline
-# DB — it exposes no HTTP/2 server surface to untrusted peers. Drops off when
-# grype ships a release built on grpc-go >= 1.82.1. Re-evaluate on bump (#2391).
+# RETIRED 2026-08-13 (#3307) — grype binary, google.golang.org/grpc
+# GHSA-hrxh-6v49-42gf (gRPC-Go: xDS RBAC and HTTP/2 vulnerabilities) was
+# suppressed while grype v0.116.0 shipped grpc-go v1.80.0. grype v0.117.0
+# ships grpc-go v1.82.1, which IS the fixed version, and a scan of
+# ghcr.io/anchore/grype:v0.117.0 on 2026-08-13 does not report it at any
+# severity. This suppression is dead.
+#
+# It is kept only because release/1.6.x still lists it and preflight check 1
+# hard-fails when main is not a superset (see the ⚠ note in the header).
+# Delete it, not re-justify it, once #3309 lands or 1.6.x is retired.
 GHSA-hrxh-6v49-42gf
 
+# ===========================================================================
+# RETIRED 2026-08-13 (#3307): everything below this line.
+#
+# All of it was written against ghcr.io/aquasecurity/trivy:0.72.0, which the
+# scanner-adapter image stopped shipping at #3123. It now ships
+# ghcr.io/artifact-keeper/trivy — our own build of the pinned upstream tag on a
+# UBI 9 base, with declared dependency overrides.
+#
+# Measured on 2026-08-13 against the exact digest pinned in
+# docker/Dockerfile.scanner-adapter, with no ignorefile and all severities:
+# NOT ONE of the CVEs below appears in the image. Different base OS, different
+# Go toolchain, different (newer) upstream trivy tag, and oras-go already
+# overridden to 2.6.2 in the build itself. They are not suppressed findings —
+# they are absent findings.
+#
+# Kept in place, not deleted, purely because release/1.5.x and release/1.6.x
+# still list them and preflight check 1 hard-fails when main is not a superset
+# of every release branch (see the ⚠ note in the header). Deleting them is
+# #3309's job.
+#
+# Nothing below should be cited as precedent for a new suppression. A trivy
+# Go-dependency CVE with a fixed dependency version is now FIXABLE — it belongs
+# in artifact-keeper/trivy's overrides.yaml. That is exactly how CVE-2026-71556
+# (go-git, the finding that blocked this release) was handled: overridden and
+# rebuilt, not suppressed.
+# ===========================================================================
+
 # ---------------------------------------------------------------------------
-# trivy 0.72.0 binary (scanner-adapter image) — oras.land/oras-go/v2 @ v2.6.0
+# RETIRED — trivy 0.72.0 binary (scanner-adapter image) — oras.land/oras-go/v2 @ v2.6.0
 # Fixed in oras-go 2.6.1; trivy 0.72.0 (latest) has not rebuilt against it.
 # Code path: ORAS OCI-artifact client used for trivy's own DB/plugin
 # distribution; the adapter only points trivy at AK's registry for scans.
@@ -96,7 +152,7 @@ CVE-2026-50162
 GHSA-vh4v-2xq2-g5cg
 
 # ---------------------------------------------------------------------------
-# trivy 0.72.0 binary (scanner-adapter image): golang.org/x/text @ v0.38.0
+# RETIRED — trivy 0.72.0 binary (scanner-adapter image): golang.org/x/text @ v0.38.0
 # Fixed in x/text 0.39.0. trivy 0.72.0 is the latest upstream release and has
 # not been rebuilt against it, so there is no tool version to bump to. Drops
 # off when Aqua ships a trivy release built on x/text >= 0.39.0.
@@ -112,7 +168,7 @@ GHSA-vh4v-2xq2-g5cg
 CVE-2026-56852
 
 # ---------------------------------------------------------------------------
-# trivy 0.72.0 binary (scanner-adapter image): golang.org/x/net @ v0.55.0
+# RETIRED — trivy 0.72.0 binary (scanner-adapter image): golang.org/x/net @ v0.55.0
 # Same vendored-binary scope as the x/text entry above: present only in the
 # bundled trivy CLI, not in the adapter's own binary (no dependencies) and not
 # in the backend or openscap images (0 findings, no bundled trivy, #1544).
@@ -133,7 +189,7 @@ CVE-2026-56852
 CVE-2026-46600
 
 # ---------------------------------------------------------------------------
-# trivy 0.72.0 binary (scanner-adapter image) — sigstore verification stack
+# RETIRED — trivy 0.72.0 binary (scanner-adapter image) — sigstore verification stack
 # github.com/sigstore/sigstore-go @ v1.1.4 (fixed 1.2.0) and
 # github.com/sigstore/timestamp-authority/v2 @ v2.0.6 (fixed 2.1.0); trivy
 # 0.72.0 (latest) has not rebuilt against them. MEDIUM severity — listed for

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -175,15 +175,23 @@ RUN find /mnt/rootfs -xdev -perm /6000 -type f -exec chmod a-s {} + && \
 # binary's HIGH-severity Go-dependency CVEs and ~150 MB of image size with no
 # functional loss. See issues #1544 and #2088.
 #
-# Grype is pinned to v0.116.0, the latest upstream release. It is rebuilt
-# against fixed containerd/go-git/x-crypto versions (clearing those CVEs from
-# v0.114.0) and bumps golang.org/x/text to v0.39.0, clearing CVE-2026-56852
-# (infinite loop in norm.Iter on invalid UTF-8) that the v0.115.0 binary
-# carried via x/text v0.38.0 (#2749). It still bundles Go 1.26.3 stdlib and
-# docker v28.5.2; those residual CVEs have no fixed grype release yet and are
-# documented/suppressed in /.trivyignore rather than "bumped away".
-# Re-evaluate on every bump (#2391).
-FROM ghcr.io/anchore/grype:v0.116.0 AS grype-bin
+# Grype is pinned to v0.117.0, the latest upstream release. Bumped from
+# v0.116.0 for #3307: v0.116.0 bundles github.com/go-git/go-git/v5 v5.19.1,
+# and CVE-2026-71556 (HIGH, GHSA-hc8v-wwc9-vgxm -- worktree operations resolve
+# symlinks outside the worktree boundary) was published against it, failing the
+# Docker Publish Trivy gate and skipping every multi-arch manifest. v0.117.0
+# pins go-git v5.19.2, which is the fixed version. It also moves grpc-go
+# 1.80.0 -> 1.82.1, which retires the GHSA-hrxh-6v49-42gf suppression, and
+# x/text 0.39.0 -> 0.40.0.
+#
+# Note that nothing regressed to cause that: v0.116.0 scanned clean when it was
+# pinned and went red days later when the advisory was published. A clean scan
+# is a statement about a moment, not a property of a pin.
+#
+# It still bundles Go 1.26.3 stdlib and docker v28.5.2; those residual CVEs
+# have no fixed grype release yet and are documented/suppressed in /.trivyignore
+# rather than "bumped away". Re-evaluate that file on every bump (#2391).
+FROM ghcr.io/anchore/grype:v0.117.0 AS grype-bin
 
 # ---------- Stage 5b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -54,12 +54,20 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 # binary's HIGH-severity Go-dependency CVEs and image size with no functional
 # loss. See issue #1544.
 #
-# Grype is pinned to v0.115.0, the latest upstream release. It is rebuilt
-# against fixed containerd/go-git/x-crypto versions (clearing those CVEs from
-# v0.114.0), but still bundles Go 1.26.3 stdlib and docker v28.5.2; those
-# residual CVEs have no fixed grype release yet and are documented/suppressed
-# in /.trivyignore rather than "bumped away". Re-evaluate on every bump (#2391).
-FROM ghcr.io/anchore/grype:v0.116.0 AS grype-bin
+# Grype is pinned to v0.117.0, the latest upstream release. Bumped from
+# v0.116.0 for #3307 (CVE-2026-71556, HIGH: go-git v5.19.1 -> v5.19.2); see the
+# fuller note in Dockerfile.backend. Kept in lockstep with the UBI backend
+# image even though the alpine build and its Trivy gate are currently suspended
+# in docker-publish.yml -- a stale pin here becomes a surprise the day they are
+# re-enabled.
+#
+# The version in this comment had already drifted from the FROM below (it said
+# v0.115.0 while the pin was v0.116.0). Keep them in sync when bumping.
+#
+# It still bundles Go 1.26.3 stdlib and docker v28.5.2; those residual CVEs have
+# no fixed grype release yet and are documented/suppressed in /.trivyignore
+# rather than "bumped away". Re-evaluate that file on every bump (#2391).
+FROM ghcr.io/anchore/grype:v0.117.0 AS grype-bin
 
 # ---------- Stage 4b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted

--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -40,27 +40,50 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 
 # ---------- Stage 2: pull the matching trivy binary ----------
 # Our own build of upstream trivy v0.73.0 (artifact-keeper/trivy): the same
-# upstream source tag, built with our pinned Go toolchain plus one documented
-# dependency override, oras-go v2.6.1 -> v2.6.2, which clears CVE-2026-50163.
-# Upstream merged that bump on main but has not released it, and 0.73.0 is
-# still the latest release, so no upstream tag carries the fix. Leaving this on
-# ghcr.io/aquasecurity/trivy:0.73.0 fails the Docker Publish security gate,
-# which skips every multi-arch manifest and blocks the release chain.
+# upstream source tag, built with our pinned Go toolchain plus the documented
+# dependency overrides in that repo's overrides.yaml. Two of them now:
 #
-# Worth remembering: upstream 0.73.0 scanned clean when #3123 landed — the CVE
-# was published against its bundled oras-go afterwards. A clean scan at merge
-# time does not stay clean, which is why the source repo rebuilds and re-gates
-# on a schedule rather than trusting a one-time result.
+#   oras.land/oras-go/v2        v2.6.1  -> v2.6.2   (CVE-2026-50163)
+#   github.com/go-git/go-git/v5 v5.19.1 -> v5.19.2  (CVE-2026-71556 HIGH,
+#                                                    CVE-2026-71557)
+#
+# In BOTH cases upstream merged the bump on main and has not released it, and
+# v0.73.0 is still the latest release, so no upstream tag carries the fix.
+# That is the whole reason this image is ours: there is nothing to bump to.
+# Leaving this on ghcr.io/aquasecurity/trivy:0.73.0 fails the Docker Publish
+# security gate, which skips every multi-arch manifest and blocks the release
+# chain.
+#
+# Note that a suppression would have been *permitted* here by /.trivyignore's
+# own rule ("only vendored-scanner-binary CVEs that have no fixed tool release
+# are listed") — no fixed trivy release exists. It is still the wrong answer:
+# a fixed *dependency* exists, we can build against it, and an auditable
+# override that assert-buildinfo.sh proves is linked into the shipped binary
+# is a stronger claim than a comment saying we think the path is unreachable.
+# Suppress when there is no fix. Override when there is one and only the
+# packaging is missing.
+#
+# Worth remembering: upstream 0.73.0 scanned clean when #3123 landed, and our
+# own v0.73.0-r1 scanned clean when it was published on 2026-08-07 and went red
+# on 2026-08-13 (#3307) without a byte changing — the go-git advisory was
+# published against a dependency it already shipped. A clean scan at merge time
+# does not stay clean, which is why the source repo rebuilds and re-gates on a
+# schedule rather than trusting a one-time result.
 #
 # Pinned by DIGEST, not tag: that repo rebuilds weekly to pick up RPM errata,
 # so its tags are moving targets by design. buildx selects the TARGETPLATFORM
 # variant from the multi-arch index automatically, so the arm64 build gets the
 # arm64 trivy and the amd64 build gets amd64 — both are published.
+# This digest is the manifest-list digest of tag 0.73.0-r2 (note: no leading
+# `v` on the published tag — the publish job renders it with
+# docker/metadata-action `type=semver,pattern={{version}}`).
 #
 # Nothing couples the backend to a specific trivy version: the 0.71.2 strings
 # in backend/scanner-adapter tests are mock/stub fixtures, and the adapter
-# probes the real version at startup (ProbeVersion).
-FROM ghcr.io/artifact-keeper/trivy@sha256:202c9b4cbb16242cd9d8ee675efc23ba3491f919f4686a1dacaa7dd8605c74ad AS trivy
+# probes the real version at startup (ProbeVersion). Confirmed unchanged across
+# this bump — the rebuilt binary still reports `Version: 0.73.0`, because the
+# upstream source tag did not move; only two dependencies did.
+FROM ghcr.io/artifact-keeper/trivy@sha256:d6c56ef94c05f0d3511d74ecdf131aa89e9f01eb53e3cfc110327a48abb8d0fa AS trivy
 
 # ---------- Stage 3: minimal runtime ----------
 # alpine 3.20 reached EOL; 3.24 is the current stable with active security

--- a/scripts/ci/release-preflight.sh
+++ b/scripts/ci/release-preflight.sh
@@ -23,14 +23,38 @@
 #      the OpenAPI info version in backend/src/api/openapi.rs, and the
 #      artifact-keeper-backend entry in Cargo.lock must all agree. A partial
 #      bump ships a stale version string (see RELEASING.md step 2).
-#   3. MAIN DOCKER-PUBLISH HEALTH (best-effort/advisory): if `gh` is available
-#      and authenticated, report whether the most recent `Docker Publish` run
-#      on main published its multi-arch manifest (i.e. Security Scan passed).
-#      A red/skipped manifest here predicts the same stall on the tag.
+#   3. MAIN DOCKER-PUBLISH HEALTH (hard, when it can be measured): whether the
+#      most recent `Docker Publish` run on main published its multi-arch
+#      manifest (i.e. Security Scan passed). A red/skipped manifest here does
+#      not merely "predict" the same stall on the tag -- it is the same job,
+#      on the same images, with the same gate. If it is red, the cut stalls.
+#
+#      This check used to `warn` and let the script exit 0, so the tool printed
+#      "a tag cut will likely stall" and "READY: ... Safe to cut the tag." in
+#      the same breath (#3308). That is worse than having no preflight, because
+#      it launders a measured red into an explicit go-ahead -- exactly the
+#      "gate failure is cosmetic, promote anyway" reasoning the release freeze
+#      was written to remove after the v1.5.8 integrity failure.
+#
+#      Note the asymmetry this fixes. Check 1 (trivyignore drift) is a PROXY
+#      for "will Security Scan pass" and catches exactly one cause: a
+#      suppression stranded on release/*. Check 3 is the DIRECT measurement.
+#      Having the proxy hard and the measurement soft was backwards, and the
+#      gap was reachable: on 2026-08-13 a newly-published advisory (#3307)
+#      failed Security Scan on main while every hard check passed clean,
+#      because the CVE affected main and the release branches equally so there
+#      was no drift to find.
+#
+#      Three outcomes, deliberately kept distinct -- "I did not look",
+#      "I could not look" and "I looked and it is red" are different claims:
+#        * not measured (skipped, or `gh` absent)      -> note, not blocking
+#        * could not measure (the gh query failed)     -> INFRA, exit 2
+#        * measured red                                -> blocking, exit 1
 #
 # Exit-code contract (mirrors scripts/ci/check-migration-ledger.sh):
 #   0  ready       -- no blocking problem found.
-#   1  NOT READY   -- a real, blocking problem (drift or version mismatch).
+#   1  NOT READY   -- a real, blocking problem (drift, version mismatch, or a
+#                     measured-red Docker Publish on main).
 #                     Fix it on main before tagging; NEVER retry it away.
 #   2  INFRA       -- tooling/network failure (git ls-remote / gh / file reads
 #                     failed); retryable, NOT a readiness verdict.
@@ -38,7 +62,14 @@
 # Env overrides:
 #   PREFLIGHT_REPO   owner/name for the `gh api` calls (default: derived from
 #                    the origin remote, else artifact-keeper/artifact-keeper).
-#   PREFLIGHT_SKIP_DOCKER_HEALTH=1  skip check 3 (the advisory gh probe).
+#   PREFLIGHT_SKIP_DOCKER_HEALTH=1  do not run check 3 at all.
+#   PREFLIGHT_ALLOW_RED_PUBLISH=1   run check 3, report a red result, but do
+#                    not block on it. Deliberately SEPARATE from
+#                    PREFLIGHT_SKIP_DOCKER_HEALTH: "do not look" and "I looked,
+#                    it is red, proceeding anyway" are different decisions and
+#                    should read differently in the transcript. Using this is a
+#                    judgement call a human makes and owns; it is never a
+#                    default, and it is not a way to make a red main green.
 #
 set -euo pipefail
 
@@ -133,28 +164,45 @@ else
 fi
 echo
 
-# --- check 3: main docker-publish health (advisory) -------------------------
-echo "3) latest main Docker Publish health (advisory)"
+# --- check 3: main docker-publish health (hard when measurable) -------------
+echo "3) latest main Docker Publish health"
 if [[ "${PREFLIGHT_SKIP_DOCKER_HEALTH:-0}" == "1" ]]; then
-  note "skipped (PREFLIGHT_SKIP_DOCKER_HEALTH=1)"
+  note "NOT MEASURED (PREFLIGHT_SKIP_DOCKER_HEALTH=1) -- this check did not run,"
+  note "which is not the same as it passing."
 elif ! command -v gh >/dev/null 2>&1; then
-  note "gh not available -- skipping advisory check"
+  note "NOT MEASURED (gh not on PATH) -- this check did not run, which is not"
+  note "the same as it passing."
 else
   run_id="$(gh run list --repo "$REPO" --workflow "Docker Publish" --branch main --limit 1 \
               --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
   if [[ -z "$run_id" ]]; then
-    warn "could not query the latest main Docker Publish run -- skipping"
+    # gh is present but the query failed (auth, network, API). We could not
+    # measure, so we must not render a readiness verdict either way.
+    echo "INFRA: could not query the latest main Docker Publish run" >&2
+    exit 2
+  fi
+  sec="$(gh run view "$run_id" --repo "$REPO" --json jobs \
+          --jq '[.jobs[]|select(.name=="Security Scan")|(.conclusion//"?")]|first//"?"' 2>/dev/null || echo '?')"
+  man="$(gh run view "$run_id" --repo "$REPO" --json jobs \
+          --jq '[.jobs[]|select(.name|test("Backend Multi-Arch Manifest"))|(.conclusion//"skipped")]|first//"?"' 2>/dev/null || echo '?')"
+  note "run $run_id: Security Scan=$sec, Backend Multi-Arch Manifest=$man"
+  if [[ "$sec" == "?" || "$man" == "?" ]]; then
+    echo "INFRA: could not read job conclusions from run $run_id" >&2
+    exit 2
+  elif [[ "$sec" == "success" && "$man" == "success" ]]; then
+    ok "main images are publishing cleanly"
+  elif [[ "${PREFLIGHT_ALLOW_RED_PUBLISH:-0}" == "1" ]]; then
+    warn "main's last Docker Publish did NOT cleanly publish the manifest, but"
+    warn "PREFLIGHT_ALLOW_RED_PUBLISH=1 was set, so this is not blocking."
+    note "  -> whoever set that owns the stall if the cut hits the same gate."
+    note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
   else
-    sec="$(gh run view "$run_id" --repo "$REPO" --json jobs \
-            --jq '[.jobs[]|select(.name=="Security Scan")|(.conclusion//"?")]|first//"?"' 2>/dev/null || echo '?')"
-    man="$(gh run view "$run_id" --repo "$REPO" --json jobs \
-            --jq '[.jobs[]|select(.name|test("Backend Multi-Arch Manifest"))|(.conclusion//"skipped")]|first//"?"' 2>/dev/null || echo '?')"
-    note "run $run_id: Security Scan=$sec, Backend Multi-Arch Manifest=$man"
-    if [[ "$sec" == "success" && "$man" == "success" ]]; then
-      ok "main images are publishing cleanly"
-    else
-      warn "main's last Docker Publish did NOT cleanly publish the manifest -- a tag cut will likely stall the same way. Investigate before tagging."
-    fi
+    bad "main's last Docker Publish did NOT cleanly publish the manifest -- a tag cut WILL stall on the same gate."
+    note "  -> Security Scan hard-gates every multi-arch manifest, which gates"
+    note "     resolve-candidate-digest, which gates the whole release chain."
+    note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
+    note "  -> fix it on main and let Docker Publish go green before tagging (#3039, #3307)."
+    note "  -> PREFLIGHT_ALLOW_RED_PUBLISH=1 overrides this deliberately; do not use it to retry a red away."
   fi
 fi
 echo

--- a/scripts/ci/test-release-preflight.sh
+++ b/scripts/ci/test-release-preflight.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/release-preflight.sh check 3 (issue #3308).
+#
+# WHY THIS EXISTS
+#   Check 3 measures whether main's last Docker Publish published its manifest.
+#   It used to `warn` on a red result and let the script exit 0, so the tool
+#   printed "a tag cut will likely stall" and "READY: ... Safe to cut the tag."
+#   in the same run. That is worse than no preflight, because it launders a
+#   measured red into an explicit go-ahead.
+#
+#   The failure is invisible to any test that only checks the happy path: with
+#   a GREEN Docker Publish the buggy and the fixed script are identical. So the
+#   case that must be covered is specifically the MEASURED-RED one, and the
+#   test has to be able to fail. Revert line 156's `bad` back to `warn` and
+#   case 2 below goes red; that is the property being asserted.
+#
+# HOW
+#   The script reaches GitHub only through `gh`. We put a stub `gh` first on
+#   PATH that replays canned job conclusions, so no network and no repo state
+#   is involved. Checks 1 and 2 are neutralised (a temp repo with a matching
+#   version set and no release/* branches) so the exit code isolates check 3.
+#
+# Usage: bash scripts/ci/test-release-preflight.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release-preflight.sh"
+[ -f "$SCRIPT" ] || { echo "cannot find release-preflight.sh next to this test" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$*"; fails=$((fails + 1)); }
+
+# --- a minimal repo that satisfies checks 1 and 2 ---------------------------
+REPO_DIR="$WORK/repo"
+mkdir -p "$REPO_DIR/scripts/ci" "$REPO_DIR/backend/src/api"
+cp "$SCRIPT" "$REPO_DIR/scripts/ci/release-preflight.sh"
+printf 'version = "9.9.9"\n' > "$REPO_DIR/Cargo.toml"
+printf 'version = "9.9.9"\n' > "$REPO_DIR/backend/src/api/openapi.rs"
+printf 'name = "artifact-keeper-backend"\nversion = "9.9.9"\n' > "$REPO_DIR/Cargo.lock"
+# No .trivyignore => check 1 warns and skips, which is not blocking.
+git -C "$REPO_DIR" init -q
+git -C "$REPO_DIR" remote add origin https://github.com/artifact-keeper/artifact-keeper.git
+git -C "$REPO_DIR" -c user.email=t@t -c user.name=t add -A
+git -C "$REPO_DIR" -c user.email=t@t -c user.name=t commit -qm init
+
+# `git ls-remote --heads origin 'release/*'` must succeed and return nothing.
+STUB="$WORK/bin"; mkdir -p "$STUB"
+cat > "$STUB/git" <<'STUBGIT'
+#!/usr/bin/env bash
+for a in "$@"; do [ "$a" = "ls-remote" ] && exit 0; done
+exec /usr/bin/git "$@"
+STUBGIT
+chmod +x "$STUB/git"
+
+# --- gh stub: replays $FAKE_SECURITY_SCAN / $FAKE_MANIFEST ------------------
+cat > "$STUB/gh" <<'STUBGH'
+#!/usr/bin/env bash
+case "$1" in
+  run)
+    case "$2" in
+      list) echo "${FAKE_RUN_ID-12345}" ;;
+      view)
+        # Which of the two `gh run view` calls is this? The jq for Security
+        # Scan mentions that name; the other is the manifest.
+        if printf '%s ' "$@" | grep -q 'Security Scan'; then
+          echo "${FAKE_SECURITY_SCAN-success}"
+        else
+          echo "${FAKE_MANIFEST-success}"
+        fi
+        ;;
+    esac
+    ;;
+esac
+exit 0
+STUBGH
+chmod +x "$STUB/gh"
+
+run_case() {
+  ( cd "$REPO_DIR" && PATH="$STUB:$PATH" \
+      PREFLIGHT_REPO=artifact-keeper/artifact-keeper \
+      bash scripts/ci/release-preflight.sh >"$WORK/out.txt" 2>&1 )
+  echo $?
+}
+
+expect() { # <label> <expected-exit> <expected-substring>
+  local label="$1" want="$2" needle="$3" got
+  got="$(run_case)"
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  elif ! grep -qF "$needle" "$WORK/out.txt"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+echo "release-preflight check 3 (#3308)"
+
+# 1. Green publish stays READY. Guards against over-correcting into a gate
+#    that blocks every cut.
+FAKE_SECURITY_SCAN=success FAKE_MANIFEST=success \
+  expect "green Docker Publish -> READY" 0 "READY"
+
+# 2. THE REGRESSION. A measured red must block. Reverting `bad` to `warn` on
+#    the measured-red branch of check 3 turns this red.
+FAKE_SECURITY_SCAN=failure FAKE_MANIFEST=skipped \
+  expect "red Docker Publish -> NOT READY" 1 "NOT READY"
+
+# 3. Security Scan green but the manifest did not publish is still red: the
+#    manifest is the thing the release chain consumes.
+FAKE_SECURITY_SCAN=success FAKE_MANIFEST=skipped \
+  expect "manifest skipped -> NOT READY" 1 "NOT READY"
+
+# 4. Could not measure is NOT a readiness verdict -- it is INFRA (exit 2).
+#    Distinct from both "green" and "red"; retryable.
+FAKE_RUN_ID="" FAKE_SECURITY_SCAN=success FAKE_MANIFEST=success \
+  expect "unqueryable run -> INFRA" 2 "INFRA"
+
+# 5. The explicit human override reports the red but does not block. Separate
+#    from PREFLIGHT_SKIP_DOCKER_HEALTH on purpose: "I looked, it is red,
+#    proceeding" and "I did not look" must read differently.
+( cd "$REPO_DIR" && PATH="$STUB:$PATH" PREFLIGHT_REPO=x/y \
+    FAKE_SECURITY_SCAN=failure FAKE_MANIFEST=skipped PREFLIGHT_ALLOW_RED_PUBLISH=1 \
+    bash scripts/ci/release-preflight.sh >"$WORK/out.txt" 2>&1 )
+rc=$?
+if [ "$rc" -eq 0 ] && grep -qF "PREFLIGHT_ALLOW_RED_PUBLISH=1 was set" "$WORK/out.txt"; then
+  pass "explicit override -> READY, and says so (exit 0)"
+else
+  fail "explicit override: expected exit 0 with the override noted, got $rc"
+  sed 's/^/        /' "$WORK/out.txt" >&2
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "all release-preflight check-3 cases passed"
+  exit 0
+fi
+echo "$fails case(s) failed"
+exit 1


### PR DESCRIPTION
Closes #3307
Closes #3308

## The blocker

`Docker Publish` on main (run [31657226105](https://github.com/artifact-keeper/artifact-keeper/actions/runs/31657226105), head `7255a23c`) fails `Security Scan`. Both `Trivy gate - Backend` and `Trivy gate - Scanner Adapter` fail on the **same** finding:

```
github.com/go-git/go-git/v5  CVE-2026-71556  HIGH  fixed  v5.19.1  ->  5.19.2
```

Backend carries it in `usr/local/bin/grype`; scanner-adapter in `usr/local/bin/trivy`. Security Scan hard-gates every multi-arch manifest, so a v1.7.2 cut stalls the way v1.7.0-rc.1 did (#3039).

**Nothing regressed.** Neither image changed — `7255a23c` touches no Dockerfile. [GHSA-hc8v-wwc9-vgxm](https://github.com/advisories/GHSA-hc8v-wwc9-vgxm) was published against a dependency both images already shipped. A clean scan is a statement about a moment, not a property of an image.

## Version landscape

| Tool | First release carrying go-git 5.19.2 | Evidence |
|---|---|---|
| grype | **v0.117.0** (2026-08-10) | `go.mod` at v0.117.0 pins v5.19.2. v0.116.1 and v0.116.0 are both still on **v5.19.1**. |
| trivy | **none exists** | v0.73.0 (2026-08-03, latest) pins v5.19.1. `main` pins v5.19.2, unreleased. |

**Dependabot #3031 is not this fix.** It bumps grype v0.116.0 → v0.116.1, which is still on the vulnerable go-git. Measured, not inferred — see the table below. It should be closed or rebased onto v0.117.0.

## What changed

**Backend** (`Dockerfile.backend`, `Dockerfile.backend.alpine`) — grype v0.116.0 → **v0.117.0**. The comment blocks claiming "v0.116.0, the latest upstream release" and "no fixed grype release yet" were stale and are rewritten; the alpine file's comment had also drifted to `v0.115.0` while its pin said v0.116.0.

**Scanner adapter** (`Dockerfile.scanner-adapter`) — re-pinned to `artifact-keeper/trivy` **0.73.0-r2** (`sha256:d6c56ef9…`), which adds a go-git v5.19.2 override on top of the existing oras-go one. Built and published via artifact-keeper/trivy#3.

Since no fixed upstream trivy exists, `.trivyignore`'s own rule ("only vendored-scanner-binary CVEs that have **no** fixed *tool release* are listed") would technically have permitted a suppression here. It is still the wrong answer, and the Dockerfile now says why: a fixed *dependency* exists, we can build against it, and an override that `assert-buildinfo.sh` proves is linked into the shipped binary is a stronger claim than a comment asserting the code path is unreachable. **Suppress when there is no fix; override when there is one and only the packaging is missing.**

## Verification — measured, not inferred

Every row is the gate's exact configuration: `--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 --ignorefile .trivyignore`.

| Target | Gate exit | Detail |
|---|---|---|
| `grype:v0.116.0` (control) | **1** | reproduces the CI failure exactly |
| `grype:v0.116.1` (#3031's target) | **1** | **still v5.19.1** — this is why #3031 is not the fix |
| `grype:v0.117.0` | **0** | clean |
| `artifact-keeper/trivy@sha256:202c…` (old pin) | **1** | the finding was its *only* gating result |
| `artifact-keeper/trivy@sha256:d6c5…` (new pin) | **0** | redhat 0, `usr/local/bin/trivy` 0 |
| **scanner-adapter built from this branch** | **0** | alpine 0, `scanner-adapter` 0, `trivy` 0 |

Beyond the version string, the shipped binary's own build info:

```
dep  github.com/go-git/go-git/v5  v5.19.2  h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
```

### No new red traded in

The only HIGH+fixed findings remaining in grype v0.117.0 are `CVE-2026-27145`, `CVE-2026-39822`, `CVE-2026-42504` (stdlib, still go1.26.3) and `CVE-2026-34040` (docker, still v28.5.2) — all already suppressed, none new. The residual set is otherwise unfixed or below HIGH.

### Output shape is unchanged

The backend parses grype `-o json` into `GrypeReport`. Same lodash 4.17.4 fixture through v0.116.0 and v0.117.0: **10 matches each**, identical `vulnerability.{id,severity,fix}`, `artifact.{name,version,type,purl}`, and `relatedVulnerabilities` still **top-level on the match** — the exact trap #1375 fixed.

### The adapter still works

Built from this branch, it starts, probes `trivy version 0.73.0`, downloads its DB, serves `/api/v1/metadata`, and completes real scans over HTTP:

- scanning `grype:v0.116.0` through it → **14 findings, including CVE-2026-71556 (High) and CVE-2026-71557 (Medium)**
- scanning `grype:v0.117.0` through it → **11 findings, zero go-git**

The first is the positive control. Without it, "0 go-git findings" is equally consistent with a broken scanner returning nothing; with it, the clean result is real.

## .trivyignore

Re-measured and re-annotated per the file's own "re-evaluate this whole file on every scanner bump".

Nine tokens are now **provably dead**: `GHSA-hrxh-6v49-42gf` (grype v0.117.0 ships grpc-go v1.82.1, the fixed version) and the entire trivy block, which was written against `ghcr.io/aquasecurity/trivy:0.72.0` — an image we stopped shipping at #3123. Scanning the pinned digest with no ignorefile and all severities finds **none** of them. They are absent findings, not suppressed ones.

They are marked **RETIRED** rather than deleted. `release-preflight.sh` check 1 hard-fails when main is not a superset of every `release/*` branch, and 1.5.x/1.6.x still list them, so deleting them here breaks the pre-tag check. The suppression token set is therefore **byte-identical** to before (19 tokens) and check 1 still passes. Actually removing them is #3309.

## Also: the preflight soft-fail (#3308)

`release-preflight.sh` measured the red Docker Publish and then printed:

```
[warn] main's last Docker Publish did NOT cleanly publish the manifest
       -- a tag cut will likely stall the same way.
READY: no blocking problems. Safe to cut the tag.
```

Line 156 called `warn` (which does not increment `problems`) where it needed `bad`. It now blocks. Three outcomes are kept deliberately distinct, because *"I did not look"*, *"I could not look"* and *"I looked and it is red"* are different claims:

| Outcome | Verdict |
|---|---|
| not measured (skipped / `gh` absent) | note, not blocking |
| could not measure (query failed) | **INFRA, exit 2** — not a readiness verdict |
| measured red | **exit 1, NOT READY** |

`PREFLIGHT_ALLOW_RED_PUBLISH=1` is a separately-named human override, deliberately not the same switch as `PREFLIGHT_SKIP_DOCKER_HEALTH`.

Worth noting *why* the hard checks did not catch this: check 1 is a **proxy** for "will Security Scan pass" and detects exactly one cause — a suppression stranded on `release/*`. Check 3 is the **direct measurement**. Having the proxy hard and the measurement soft was backwards, and this incident is the proof: #3307 affects main and the release branches equally, so there was no drift, and check 1 passed clean while the release was definitively blocked.

Live run of the fixed script against the real red main:

```
1) .trivyignore forward-port drift ...
[ok]   trivyignore drift: main is a superset of every release/*
2) version-set consistency ...
[ok]   version set is consistent at 1.7.1
3) latest main Docker Publish health
  run 31657226105: Security Scan=failure, Backend Multi-Arch Manifest=skipped
[FAIL] main's last Docker Publish did NOT cleanly publish the manifest -- a tag cut WILL stall on the same gate.

NOT READY: 1 blocking problem(s). Fix on main before tagging.
```

### The test is revert-proved

`scripts/ci/test-release-preflight.sh` covers all five cases against a stubbed `gh`, wired into `release-preflight.yml` ahead of the real check. Restoring the single `bad` to `warn` — the exact pre-fix shape — reproduces the original contradictory output and turns **two** cases red, while the **green-path case still passes**. That asymmetry is the point: it shows the test isolates the measured-red property rather than merely detecting that the script runs.

## Follow-ups filed

- #3309 — check 1's superset rule makes `.trivyignore` entries un-removable; the nine dead tokens above are stuck on main until it lands.
- artifact-keeper/trivy — `verify-image.sh` still asserts only a single hardcoded `OVERRIDE_MODULE`. Not a coverage hole (`assert-buildinfo.sh` iterates `overrides.yaml` generically and did verify go-git), but worth generalising before a third override.

Adjacent, for cross-reference: #3310 on `continue-on-error` outliving its justification is the same species of soft-fail as #3308.

## Notes

No Rust or Cargo changes — `cargo build` / `cargo fmt` are not applicable to this diff.
