### PR TITLE
chore(release): prepare 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.2] - 2026-08-13
 
 ### Upgrade note — migration 193 blocks OCI writes while it runs, and the backend is not listening yet
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.7.1",
+        version = "1.7.2",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Version bump and changelog close-out for v1.7.2. Milestone 43 is at **0 open / 123 closed**.

## What changed

| Location | |
|---|---|
| `Cargo.toml:6` | `[workspace.package] version` |
| `Cargo.lock` | the `artifact-keeper-backend` `[[package]]` stanza |
| `backend/src/api/openapi.rs:27` | the utoipa info version |
| `CHANGELOG.md:8` | `[Unreleased]` → `[1.7.2] - 2026-08-13` |

`openapi.rs` is the one worth naming: it is hardcoded and decoupled from `CARGO_PKG_VERSION`, so it does not follow the workspace bump, and it is the spot that has historically been missed — the Swagger `info.version` silently stays on the previous release.

## Why this was edited by hand rather than with a substitution

A search for the literal `1.7.1` returns five files. Three are the real version. `CHANGELOG.md` is prose. The fifth is **`backend/src/api/handlers/hex.rs`**, which accounts for seven matches as *Phoenix package fixtures* in doc comments and test assertions — `[{"name":"phoenix","versions":["1.7.0","1.7.1"]}]`. A repo-wide `sed` rewrites those to `1.7.2` and the tests still compile, so the corruption is silent.

Verified after the edit: `hex.rs` is untouched and still carries all seven.

That collision is not specific to this release — it recurs whenever a version number happens to match a fixture, so the search is worth re-running each cycle rather than trusting that the last cut was safe.

## CI

The diff stays inside the Release-Bump Gate's allowed patterns — `^version = "X.Y.Z"$` at column 0 for `Cargo.toml` and `Cargo.lock`, `^\s*version = "X.Y.Z",$` for `openapi.rs`, and `CHANGELOG.md` unrestricted — so the bump-only fast path applies.

## What this does not do

**It does not tag or publish.** The tag and the release trigger are deliberately left to a human. Note that the repository's `Immutable release tags (v*)` ruleset was moved from `disabled` to `active` earlier today: `update`, `deletion` and `non_fast_forward` are blocked on `refs/tags/v*` with no bypass actors, while `creation` is deliberately not among the rules, so cutting the tag still works but a released tag can no longer be rewritten or deleted.
