### PR TITLE
docs(release): add curated release notes for 1.7.2

### DIFF
--- a/.github/release-notes/1.7.2.md
+++ b/.github/release-notes/1.7.2.md
@@ -1,0 +1,212 @@
+# Artifact Keeper 1.7.2
+
+**1.7.2 is a large bug-fix and hardening patch — 81 commits, no headline feature.** Most of what matters here is security and operator-facing: a set of authorization gaps closed on the OCI/Docker pull path and around private-repository visibility, a round of proxy-cache and content-encoding correctness fixes, and several behaviour changes that will be visible on your dashboards and in your pipelines the day you deploy. Several of those changes require action *before* you upgrade, so start with the checklist below rather than the feature list.
+
+## Before you upgrade
+
+Four things need a decision or an action. Everything else in this release deploys unattended.
+
+1. **Migration 193 stalls OCI writes and the backend is not listening while it runs.** `docker push` hangs, `docker pull` keeps working. On Kubernetes, raise your startup/liveness thresholds *first* — a probe that kills the pod mid-build produces a crash loop that never converges. You can avoid the stall entirely by building the index out of band before you deploy. [Details](#migration-193-blocks-oci-writes-while-it-runs).
+2. **Authenticated principals now need a grant to pull private OCI/Docker repositories.** A CI service account holding only an API token and no role assignment or fine-grained rule will start getting denied — and the denial usually looks like a `404`, not an authorization failure. Find and grant those principals before upgrading. [Details](#authenticated-callers-now-need-a-grant-to-pull-private-ocidocker-repositories).
+3. **Inventory PyPI project names that were never valid.** Names outside the PEP 508 pattern are now rejected on read and write. Any such artifact that was already stored becomes reachable at no URL, with no migration to repair it. Run the inventory query before you upgrade, not after. [Details](#smaller-changes-with-operator-impact).
+4. **Re-baseline your storage alerts.** `total_storage_bytes` changes basis and steps up by your entire OCI blob volume on upgrade day. It is display-only — no repository becomes over-quota — but it will page someone. [Details](#smaller-changes-with-operator-impact).
+
+Rolling back is also worth reading before you need it: **a 1.7.1 binary will refuse to start against a 1.7.2 database unless you set `SKIP_MIGRATIONS=true`.** The data is fine and all three new migrations are additive; what blocks the rollback is the migration ledger. [Details](#rolling-back-to-171-requires-skip_migrationstrue).
+
+## The big picture
+
+- **OCI/Docker `/v2` reads are authorized, not merely checked for anonymity** (#3261). Previously the only check on the pull path was whether the caller was *anonymous* — so **any authenticated principal could pull any private image**, by name or by digest, and `GET /v2/<name>/tags/list` handed a private repository's tag names to the same audience. Alongside it, a **public Virtual repository laundered a private member's bytes**: an anonymous caller could receive a private member's manifest and layers through a public virtual parent. All five read verbs now run the same permission check the OCI write gate already used, and virtual member walks filter through the same helper Maven, npm, PyPI, Debian and goproxy use. Writes were never affected. **This does not make private OCI repositories fully protected** — see the residual below.
+
+- **One residual is deliberately still open, and it narrows the claim above** (#3269, targeted at 1.8.0). `GET /v2/_catalog` still returns every repository key to any authenticated caller, with no per-repository filtering. The `404 NAME_UNKNOWN` denial on `/v2/<name>` was made byte-identical to a genuinely missing repository so a denial could not be used to probe which private repositories exist — a real property at that seam, but it protects nothing an authenticated caller can get in one request to `/v2/_catalog`. The accurate summary is narrower than "private OCI repositories are now protected": private image *content* is protected, the repository *namespace* is not. Treat every repository key as visible to every authenticated principal, and do not rely on an unguessable repository name as a layer of defence.
+
+- **Quarantine status, SBOM listings and Virtual repository membership no longer leak across visibility boundaries** (#3174, #3163, #3081, #3177, #3178). One root confusion in several places: `can_access_repo` answers "is this repository within my token's scope?", which is `true` for every browser session, every unscoped API token and every admin — and it was being used as a *visibility* gate. Any authenticated caller holding an artifact UUID could read another tenant's quarantine reason (which carries the malware or CVE finding behind the hold), page a private repository's whole dependency inventory, enumerate a virtual repository's private members and their Maven coordinates, read their exact byte sizes, and in one path resolve their bytes. All of these now evaluate the same public-∪-roles-∪-rules predicate the repository listing uses, denials collapse into the `404` a genuine miss produces, and the member walk fails closed on a database error.
+
+- **The inline scan-and-block download gate reaches paths that were bypassing it** (#3220, #3143, #3142). A scan-policy block on a hosted repository was bypassable by pulling the same artifact through any virtual repository that listed it as a member — `403` on the direct route, `200` with the bytes on the virtual one, same repository and same policy. The Generic and Terraform byte paths called the raw quarantine predicate instead of the shared gate, and a presigned-S3 deployment would have answered Generic with a `302` straight to the object with no policy check at all. And `block_on_fail` read one global newest scan row, so a clean scan by engine B masked engine A's crash. **These only bite deployments that configured a scan policy** — nothing seeds a default row, so `SELECT count(*) FROM scan_policies` sizes your entire exposure.
+
+- **The PyPI name-handling bug class is closed structurally rather than patched again** (#3183, #3186, #3198, #3107). Two name normalizers disagreed, and the download path keyed its gates on one and its upstream fetch on the other — so a request spelled `acme%20sdk` evaluated dependency-confusion isolation and curation against a name nobody owns, then resolved and served the private package those gates exist to protect. Rather than making the two coercions agree a fifth time, project names are now validated against PEP 508 on every route that takes one, before any gate or lookup; the twine upload route validates the same way (it previously *coerced*, publishing `acme!sdk`, `acme@sdk` and `acme sdk` into an existing project's namespace); and uploads must carry embedded metadata that agrees with their declared name and version.
+
+- **Proxy-cache integrity, on both the write and the read side** (#3152, #3147, #2929, #2928). Streamed cache writes went to the live key and were classified afterwards, with a best-effort delete on reject — so a rejected writer's truncated bytes could become the permanent current version, twice observed in production. Writes now stage under a private prefix and the live key is only ever touched by a copy after the write commits. Independently, three readers reached cached content without consulting the metadata sidecar that vouches for it, including a stale-if-error path that served unvalidated bytes, bytes under a negative-cache marker, and entries under an active age hold. Digests already on hand — cargo's index `cksum`, NuGet's stored `checksum_sha256` — are now actually enforced instead of decorative.
+
+- **Content-encoding correctness across the proxy surface** (#3149, #3211, #3184, #3193, #3260, #2920). A long tail of the same defect: response builders read the *coded* `Content-Length` off a streaming fetch and dropped `Content-Encoding` one line later, so clients wrote bytes they could not inflate. The shared HTTP client pins `Accept-Encoding: identity` and does no transparent decoding, so the coding was genuinely on the wire and the header was the only thing missing. Fixed across cargo, npm, PyPI (including PEP 658 metadata, where a coded wheel also made a present, valid wheel answer `404 Metadata not available`), OCI, generic, Maven `download_root`, goproxy, RubyGems and Hex — with the seams widened in place so every caller must now state whether it forwards verbatim or parses.
+
+- **Storage accounting tells the truth** (#3134, #3249). `total_storage_bytes` was aggregated over `artifacts` only, but OCI layer and config blobs live in `oci_blobs` — only manifests land in `artifacts` — so a Docker repository reported a few KiB of manifests while holding gigabytes of layers. The total is now summed from the same trigger-maintained ledger the per-repository figures and quota admission already read. **API consumers: `proxy_storage_bytes` is now a breakdown of the total, not a disjoint bucket — stop adding the two.**
+
+- **The CI gates that were reporting green without running.** Backend integration tests ran only on pushes to `main`, and `ci-complete` treated the skip as a pass — so a PR could break every integration test and still show all-green. The container build and smoke chain had the identical shape: a `push`-only condition under a section header reading "PR only". The container CVE gate declared `CRITICAL,HIGH` but failed on fixable findings of any severity. All three are fixed, with the integration suite failing *open to running* and `ci-complete` failing *closed* on a skip.
+
+## Security fixes — am I affected?
+
+Beyond the OCI read gate and the visibility fixes above:
+
+- **SSO logins with an empty subject no longer collapse onto one account** (#3204). Nothing validated that a SAML `NameID` was non-empty — and the NameID *is* the account key. An empty one is not "a user with no identifier", it is the same lookup key for every such assertion: the first empty-NameID login provisioned a row and everyone else at that IdP silently resolved to it. All four XML shapes reached the lookup as `""`. Empty and whitespace-only NameIDs are now rejected at the parse boundary, `transient`-format NameIDs are rejected as unsuitable for a durable account row, and the equivalent empty-`sub` hole on the OIDC side is closed at `get_or_create_user`. **Affected if** your IdP can emit an assertion with an absent or empty NameID.
+- **The fine-grained permissions API is admin-only** (#3229). `GET /api/v1/permissions`, `GET /{id}` and `DELETE /{id}` were not admin-gated: the two reads extracted no auth context at all, so any authenticated principal could page the whole ACL table and learn which principals hold `admin` on which repositories, and `DELETE` checked only a scope that is satisfied unconditionally by every interactive session — so any logged-in non-admin could delete arbitrary permission rows. **Affected if** a non-admin principal calls those three endpoints. No shipped workflow does: the web UI reads the list only from its admin route group and the CLI `permission` command is an admin command.
+- **Hosted npm publishes reject non-ASCII package names** (#3007). The hosted publish validator checked length and path shape but not character set, so a Unicode homoglyph name could reach publication while the proxy path already applied a stricter validator — an asymmetry at the primary write boundary.
+- **Attaching a member to a virtual repository is authorized against repository visibility** (#3177), and `create_repository`'s member loop had no member check at all — so a principal could compose a virtual repository out of repositories it cannot read.
+- **The OCI cleanup sweep can no longer delete a blob that was re-pushed underneath it** (#3085, #3187). A push that committed a row for the same storage key during the sweep's walk lost its bytes; the guarded row delete then correctly refused to remove the journal row, saving the row and not the data. Closed with a two-phase tombstone in which the push participates at commit time. The trade is stated plainly and is listed under operator impact below: a push that loses the race is now refused with a retryable `503`.
+- **Backups never report success when artifact bytes are missing** (#3170, #3171). A failed storage read was discarded — not counted, not logged, not in the manifest. The job reported `completed` with `artifact_count=0` and the restore reported `errors=[]`. That is the worst failure a backup can have, because it is discovered at restore time when there is no recourse. Read failures are now logged, counted into a new `artifacts_unreadable` manifest field, and **fail the job** unless partial backups were explicitly opted into.
+
+**A repository-scoped API token presented directly to `/v2/` did not stay inside its declared scope** (#3316). When an API token is handed straight to the OCI endpoints — the Docker `Bearer` slot, or the Basic-auth password slot that service accounts and `curl` use — the token's repository allow-list was silently discarded when OCI claims were re-minted, so a token scoped to one repository could **read and write any other repository its owning identity can reach**. The `/v2/token` exchange path threaded the ceiling correctly; the direct-credential path never went through it. The action ceiling (read-only vs write) travels through a separate channel and was never affected — only the repository ceiling was lost. This is **pre-existing in all prior versions** rather than a 1.7.2 regression, and it is fixed here: all three direct-credential paths now carry the token's allow-list onto the claims the gate reads, so the repository-scope ceiling described under #3261 applies whether the token is exchanged at `/v2/token` or presented directly. **Affected if** any CI system authenticates to `/v2/` with a repository-scoped API token rather than through the token exchange.
+
+## Smaller changes with operator impact
+
+Each is documented in full in the [CHANGELOG](CHANGELOG.md); collected here is only the part you have to act on.
+
+- **Storage alerts will fire on upgrade day, and it is not an incident** (#3134, #3249). The dashboard total steps up by your entire OCI blob volume, proxy-cached bytes fold in, and the daily snapshot changes basis on the same day, so growth charts show a one-day vertical step. It is display-only — quota admission reads the per-repository ledger and is unchanged, so **no repository becomes over-quota**. Record the pre-upgrade values, silence storage-growth alerts for 48 hours, annotate the series at the cut. Historical rows are deliberately not backfilled: the source tables hold no history, so a backfill could only fabricate one.
+- **PyPI project names that were never valid become permanently unreachable** (#3186, #3198). Read routes reject a name failing the PEP 508 pattern with `404` before any lookup; uploads reject with `400`. Malformed names were previously coerced rather than validated, and some were *stored* — an artifact whose project name is empty or otherwise outside the pattern still consumes quota but is now reachable at no URL, with no migration to repair it. This is the correct fix and it is a silent data-visibility loss, so inventory before you upgrade. The CHANGELOG carries the exact query; zero rows means nothing becomes unreachable.
+- **An OpenSCAP `critical` rule failure now costs 25 security-score points, where it cost 0** (#3294). The adapter had no `critical` arm and filed such a result at `info`, which is inert — no penalty weight, no gate's severity array, no count projection. On an otherwise-clean repository, 1 such finding now takes it from grade A to B, 2 to C, 3 to D, 4 to F, and a single one violates a scan policy at **any** `max_severity` where as `info` it violated none — reaching the download gate, both promotion CVE gates, the approval gate and any minimum-score quality gate. **Affected only if** you run OpenSCAP (opt-in, registers only when `OPENSCAP_URL` is set) *and* your SCAP content declares `severity="critical"`, which is outside the XCCDF 1.2 vocabulary and appears only in custom or vendor-extended content. Stock SSG content is unaffected. Nothing is backfilled, so this lands one repository at a time as artifacts are re-scanned and can be staged.
+- **The OCI push path can now answer `503`, on a path that never did before** (#3187). When a push races the cleanup sweep reclaiming the same storage key, the monolithic blob `POST` and the chunked completion return `503` with code `BLOB_UPLOAD_INVALID` and `Retry-After: 1`. The window is narrow, but `BLOB_UPLOAD_INVALID` reads as terminal to some clients — **add a retry around `docker push` if you do not have one.**
+- **The S3 bulk request timeout default moves from 30s to 1800s** (#3180). A wedged S3 endpoint previously failed a bulk request in 30 seconds; it can now hold the connection for up to 30 minutes, which turns a fast fail into connection-pool and task pileup during a partial object-store brownout. Control-plane calls keep the short 30-second cliff, so this applies only to payload movement. If you sized your pool around a 30-second worst case, set `S3_BULK_TIMEOUT_SECS` deliberately rather than inheriting the new default.
+- **Two OCI `/v2` error paths now return the spec error envelope** (#3110). Status codes are unchanged; only the bodies are. The API-token scope denial returned a bare string and the curation block leaked a REST-shaped body onto the OCI wire; both now render the `{"errors":[{"code",...}]}` document the distribution spec requires, with the blocking rule's reason carried in `message` *and* `detail` — which an operator debugging a blocked `docker pull` previously did not get at all. `docker`, `podman` and other spec-conformant clients are unaffected. **Affected only if** something in your tooling parses those bodies rather than the status code.
+- **`helm push oci://` into a classic Helm repository now returns `400`, and charts pushed that way disappear from the index** (#3150). Legacy OCI manifest rows are excluded from `index.yaml` generation, so the operator-visible event is "our charts vanished from `helm repo update` and our publish job started failing". The index those rows produced was never valid; reads stay open so the bytes can be pulled back out. Re-publish affected charts to a `helm_oci` repository, or push them as classic charts.
+- **Docker lifecycle retention changed shape** (#2998, #3026). `max_versions` treated every tag as its own one-item partition and never pruned anything; it now partitions by image name. `max_age_days` aged a moving tag such as `latest` by the original row's `created_at`, so a just-re-pushed tag looked 91 days old; live OCI tag-backed manifests are now aged by last successful push. Worth knowing because it changes what retention deletes — and because if images vanish for one principal and not another after this upgrade, **check grants before you check retention**: the OCI read gate above is the far more likely cause and produces a `404` that looks exactly like a deletion.
+- **Curation freshness dropped 12x by default — but that landed in 1.7.1, not here.** `curation_sync_interval_secs` was previously read and never used, so every enabled staging repository re-synced on every 5-minute tick; it is now honoured, and the column default is **3600**. Unless you explicitly set the field, curation freshness is roughly 1 hour rather than 5 minutes, and the failure signature is "a package we blocked upstream an hour ago is still installable" — with no metric, no log line and no alert for it. This is called out here because the 1.7.1 notes did not carry it; if you are already on 1.7.1 you are already affected. Check `SELECT id, curation_sync_interval_secs, curation_last_synced_at FROM repositories WHERE curation_enabled;` and lower the interval where an hour is too slow.
+
+## Upgrade notes
+
+### Migration 193 blocks OCI writes while it runs
+
+`193_oci_blobs_storage_key_index.sql` builds a plain `CREATE INDEX` on `oci_blobs`. Plan a write window, and on Kubernetes raise your startup/liveness thresholds first.
+
+Migrations run before the HTTP listener binds, so for the whole index build **the backend is not listening at all** — health probes get connection-refused, not a `503`, because there is no server to answer them. `CREATE INDEX CONCURRENTLY` is deliberately not used: `sqlx::migrate!` runs each file in a transaction and Postgres rejects `CONCURRENTLY` there. A plain `CREATE INDEX` takes a `SHARE` lock, so **writes to `oci_blobs` block and reads do not** — `docker pull` keeps working while `docker push` hangs, and that asymmetry is the diagnostic signature.
+
+**The failure mode is a crash loop, not a slow start.** The runner raises `lock_timeout` to 5 minutes; if a long-running transaction holds a conflicting lock for longer, the migration errors and the process exits. Kubernetes restarts it, it takes the lock timeout again, and the deployment never comes up. Drain long transactions touching `oci_blobs` before deploying. A `livenessProbe` with a short `failureThreshold` has the same effect from the other direction: the pod is killed mid-build, the partial index is discarded, and the replacement starts from zero — on a large registry that never converges.
+
+No build-time estimate is given, because none has been measured; `SELECT count(*) FROM oci_blobs;` on your running 1.7.1 instance is the only honest input. **To avoid the stall entirely**, build the index out of band beforehand — `CREATE INDEX CONCURRENTLY idx_oci_blobs_storage_key ON oci_blobs (storage_key);` — and the migration's `IF NOT EXISTS` becomes a no-op. Do build it one way or the other: without it the OCI cleanup sweep's liveness re-check falls back to a sequential scan (measured at ~163x slower over a 1,000-row batch on 300k blobs), and on a large registry a batch approaches the claim TTL, leases lapse mid-sweep and storage reclamation stops making progress. Skipping it trades a bounded write stall for an unbounded GC stall (#3085).
+
+### Rolling back to 1.7.1 requires `SKIP_MIGRATIONS=true`
+
+The 1.7.2 schema is forward-compatible with a 1.7.1 binary, but a 1.7.1 binary will **refuse to start** against a 1.7.2 database unless you set `SKIP_MIGRATIONS=true`. You set the flag that sounds dangerous in order to roll back safely; that inversion is exactly what nobody works out mid-incident.
+
+**The data is fine.** All three new migrations are additive — 193 creates an index, 194 adds a nullable timestamp and a partial index, 195 adds six columns to `curation_packages` that either carry a safe default or accept `NULL`. Nothing is dropped, renamed or retyped, there is no data migration to undo and no restore-from-backup step. What blocks the rollback is the **migration ledger**: sqlx validates the applied set against the versions embedded in the binary and errors on any applied version it does not know about. `SKIP_MIGRATIONS=true` takes a branch that never constructs the migrator, so nothing validates the ledger. Rolling forward again is simply removing the flag. Do **not** delete rows from `_sqlx_migrations` as an alternative — sqlx will then try to re-run those files against a schema that already contains their objects.
+
+### Authenticated callers now need a grant to pull private OCI/Docker repositories
+
+See the security section above for what changed. Operationally:
+
+**Am I affected?** Yes, if any principal pulls from a private OCI/Docker repository while holding no role assignment, no fine-grained `read`/`admin` rule and no repository ownership — a CI service account carrying only an API token and no grant is the usual case. Give those principals a grant before upgrading. Anonymous pulls, public repositories, admin pulls, repository owners and every already-granted principal are unaffected, and the `401` + `WWW-Authenticate: Bearer` challenge that drives the `docker login` handshake is untouched. Vulnerability scanning of private images also keeps working.
+
+**Find them first.** The CHANGELOG carries a query that inverts the permission check over everyone who has actually pulled from a private OCI-backed repository, so it returns principals that will *start* being denied rather than every ungranted account in the instance. Read its output as a floor, not a census: download statistics record a manifest `GET` and not a `HEAD`, anonymous pulls carry no user, and a service account that has not pulled inside the window will not appear.
+
+**If you miss one, the symptom will not look like an authorization failure.** The `403 DENIED` arm only fires when the repository carries fine-grained rules. Grants usually come from role assignments instead, so the common denial is `404 NAME_UNKNOWN` — with a body byte-identical to a genuinely missing repository, `docker login` still succeeding, and **no server-side log line on a denial**. The first hypothesis will be "GC deleted our images", and Docker lifecycle retention *also* changed in this release, so that hypothesis will look plausible for longer than it should.
+
+## What's Changed
+
+**Security**
+
+- Authorize OCI/Docker `/v2` reads instead of gating on anonymity alone, and stop a public Virtual repository laundering a private member's bytes — https://github.com/artifact-keeper/artifact-keeper/pull/3268
+- Gate quarantine status and SBOM listing on repository visibility, not token scope — https://github.com/artifact-keeper/artifact-keeper/pull/3201
+- Scope virtual-repository member and artifact listings to caller-visible members — https://github.com/artifact-keeper/artifact-keeper/pull/3173
+- Scope virtual-repository storage totals to members the caller can see — https://github.com/artifact-keeper/artifact-keeper/pull/3162
+- Gate virtual-repository member reads and attaches on repository visibility — https://github.com/artifact-keeper/artifact-keeper/pull/3205
+- Admin-gate the fine-grained permissions list/get, and require admin on delete — https://github.com/artifact-keeper/artifact-keeper/pull/3236
+- Reject empty SAML `NameID` / empty OIDC `sub` before the `external_id` lookup — https://github.com/artifact-keeper/artifact-keeper/pull/3234
+- Key the PyPI download path's fetch on the normalized project name — https://github.com/artifact-keeper/artifact-keeper/pull/3190
+- Validate PyPI project names per PEP 508 and make the normalizer divergence unrepresentable — https://github.com/artifact-keeper/artifact-keeper/pull/3196
+- Validate the PyPI upload project name against PEP 508 — https://github.com/artifact-keeper/artifact-keeper/pull/3227
+- Enforce that PyPI distribution metadata matches the declared name/version on upload — https://github.com/artifact-keeper/artifact-keeper/pull/3239
+- Reject non-ASCII hosted npm package names — https://github.com/artifact-keeper/artifact-keeper/pull/3189
+- Apply the scan download gate on virtual-repository member downloads — https://github.com/artifact-keeper/artifact-keeper/pull/3235
+- Apply the scan download gate on the Generic and Terraform paths — https://github.com/artifact-keeper/artifact-keeper/pull/3217
+- Key `block_on_fail` on the latest scan row per `scan_type` — https://github.com/artifact-keeper/artifact-keeper/pull/3218
+- Gate the sidecar-bypassing proxy-cache read paths on the metadata sidecar — https://github.com/artifact-keeper/artifact-keeper/pull/3216
+- Publish streamed proxy-cache writes via a staging key, never live — https://github.com/artifact-keeper/artifact-keeper/pull/3153
+- Enforce known digests and bound streamed cache writes — https://github.com/artifact-keeper/artifact-keeper/pull/3172
+- Never report a backup successful when artifact bytes are missing — https://github.com/artifact-keeper/artifact-keeper/pull/3195
+
+**Added**
+
+- Verify publisher attestations in curation (PyPI PEP 740 verified in process; npm attestations ingested but not verified) — https://github.com/artifact-keeper/artifact-keeper/pull/3199
+- Rename repositories on import via `repo_mappings`, and stop `dry_run` writing — https://github.com/artifact-keeper/artifact-keeper/pull/3038
+- Serve Galaxy v3 import status, so `ansible-galaxy collection publish` completes — https://github.com/artifact-keeper/artifact-keeper/pull/3288
+- Dedicated S3 timeout knobs (`S3_BULK_TIMEOUT_SECS`, `S3_CONTROL_TIMEOUT_SECS`) — https://github.com/artifact-keeper/artifact-keeper/pull/3222
+- `TRIVY_ADAPTER_REGISTRY_URL` override for the scanner-adapter — https://github.com/artifact-keeper/artifact-keeper/pull/3240
+
+**OCI / Docker**
+
+- Emit the spec error envelope on `/v2` scope-denial and curation-block paths — https://github.com/artifact-keeper/artifact-keeper/pull/3274
+- Honor `scan_on_proxy` in the blob-level scan re-block — https://github.com/artifact-keeper/artifact-keeper/pull/3245
+- Apply the manifest gate's verdict-freshness rule to the blob re-block — https://github.com/artifact-keeper/artifact-keeper/pull/3292
+- Keep digest-addressed proxied manifests immutable in the proxy cache, with pull-through regression guards — https://github.com/artifact-keeper/artifact-keeper/pull/3238
+- Re-check blob liveness immediately before the cleanup storage delete — https://github.com/artifact-keeper/artifact-keeper/pull/3158
+- Close the cleanup-key pre-delete window with a two-phase tombstone — https://github.com/artifact-keeper/artifact-keeper/pull/3212
+- Retain Docker tags per image — https://github.com/artifact-keeper/artifact-keeper/pull/2999
+- Age Docker tags by last push for `max_age_days` — https://github.com/artifact-keeper/artifact-keeper/pull/3027
+- Reject OCI pushes to classic Helm repositories — https://github.com/artifact-keeper/artifact-keeper/pull/3151
+
+**Formats and protocols**
+
+- Serve Galaxy discovery at `/api` without a trailing slash and accept the `Token` auth scheme — https://github.com/artifact-keeper/artifact-keeper/pull/3278
+- Forward upstream `Content-Encoding` on npm, PyPI, OCI, generic and cargo-index downloads — https://github.com/artifact-keeper/artifact-keeper/pull/3176
+- Forward upstream `Content-Encoding` on cargo `.crate` downloads — https://github.com/artifact-keeper/artifact-keeper/pull/2922
+- Forward upstream `Content-Encoding` on the buffered scanned serve paths — https://github.com/artifact-keeper/artifact-keeper/pull/3194
+- Forward upstream `Content-Encoding` on PyPI PEP 658 metadata, and decode coded wheels before extraction — https://github.com/artifact-keeper/artifact-keeper/pull/3210
+- Declare upstream `Content-Encoding` on Maven `download_root` forwards — https://github.com/artifact-keeper/artifact-keeper/pull/3241
+- Declare upstream `Content-Encoding` on verbatim goproxy, RubyGems and Hex forwards — https://github.com/artifact-keeper/artifact-keeper/pull/3272
+- Resolve PEP 658 metadata through a virtual repository's members — https://github.com/artifact-keeper/artifact-keeper/pull/3179
+- Add HTTP caching (`ETag` + `Cache-Control` + `304`) to npm packument responses — https://github.com/artifact-keeper/artifact-keeper/pull/3051
+- Cache remote scoped packuments under the decoded `@scope/name` — https://github.com/artifact-keeper/artifact-keeper/pull/3301
+- Accept an inactive npm scope-policy payload on non-remote create/update — https://github.com/artifact-keeper/artifact-keeper/pull/3304
+- Repair a missing cached `.nupkg` via the discovered `PackageBaseAddress`, streaming — https://github.com/artifact-keeper/artifact-keeper/pull/2919
+- Accept non-string dependency forms in `pubspec.yaml`, unblocking Flutter publishes — https://github.com/artifact-keeper/artifact-keeper/pull/3155
+- Derive `/api/v1/formats` from the compiled-in handler registry (13 of 37 handlers were reported, and ~24 could never be disabled) — https://github.com/artifact-keeper/artifact-keeper/pull/3228
+- Spare a Maven checksum sidecar whenever its base object is spared — https://github.com/artifact-keeper/artifact-keeper/pull/3192
+- Accept both `files[]` key spellings in Maven flat-object delete guards — https://github.com/artifact-keeper/artifact-keeper/pull/3159
+- Close two more Maven sidecar/rollup guard gaps in the delete paths — https://github.com/artifact-keeper/artifact-keeper/pull/3225
+
+**Storage, identity and operability**
+
+- Never answer a `HEAD` with a method-scoped presigned redirect (Maven) — https://github.com/artifact-keeper/artifact-keeper/pull/3208
+- Never answer a `HEAD` with a method-scoped presigned redirect (generic, PyPI, virtual member cache) — https://github.com/artifact-keeper/artifact-keeper/pull/3226
+- Copy objects over 5 GiB server-side via `UploadPartCopy` instead of restreaming through the app — https://github.com/artifact-keeper/artifact-keeper/pull/3237
+- Stop the 30s S3 client timeout capping multi-GB blob transfers — https://github.com/artifact-keeper/artifact-keeper/pull/3222
+- Include OCI blob bytes in the dashboard Storage Used total — https://github.com/artifact-keeper/artifact-keeper/pull/3251
+- Guard the daily storage snapshot's ledger accounting and document the basis change — https://github.com/artifact-keeper/artifact-keeper/pull/3276
+- Give each claim-less federated user a distinct stored email — https://github.com/artifact-keeper/artifact-keeper/pull/3161
+- Key the SAML no-email placeholder address on the `NameID`, not the username — https://github.com/artifact-keeper/artifact-keeper/pull/3202
+- Populate service-account principal names on permission responses — https://github.com/artifact-keeper/artifact-keeper/pull/3200
+- Collapse per-request `/health` dependency probes behind a short TTL cache — https://github.com/artifact-keeper/artifact-keeper/pull/3219
+- Hand the scanner-adapter a registry URL reachable from its own container — https://github.com/artifact-keeper/artifact-keeper/pull/3240
+- Give `rollup_scan_status` a neutral `not_applicable` arm, and correct the `block_on_policy_violation` docs — https://github.com/artifact-keeper/artifact-keeper/pull/3247
+- Classify OpenSCAP `critical` correctly and recognise `Negligible` deliberately — https://github.com/artifact-keeper/artifact-keeper/pull/3293
+- Remove the stale "permission enforcement is NOT active" startup warning — https://github.com/artifact-keeper/artifact-keeper/pull/3250
+
+**CI and release assurance**
+
+- Run backend integration tests on backend-touching PRs, and fail `ci-complete` closed on a skip — https://github.com/artifact-keeper/artifact-keeper/pull/3165
+- Run the container build and smoke chain on pull requests — https://github.com/artifact-keeper/artifact-keeper/pull/3203
+- Make the container CVE gate honour its declared `CRITICAL,HIGH` severity — https://github.com/artifact-keeper/artifact-keeper/pull/3213
+- Clear go-git CVE-2026-71556 from the bundled scanner CLIs, and make a measured-red Docker Publish blocking — https://github.com/artifact-keeper/artifact-keeper/pull/3315
+- Stop the shared-cargo-registry mutation flake and unmask coverage build failures — https://github.com/artifact-keeper/artifact-keeper/pull/3248
+- Scope GC footprint assertions to seeded digests — https://github.com/artifact-keeper/artifact-keeper/pull/3242
+- Scope admin empty-set `COALESCE` aggregates to a fixture UUID — https://github.com/artifact-keeper/artifact-keeper/pull/3279
+- Confine config test env mutation to the calling thread — https://github.com/artifact-keeper/artifact-keeper/pull/3207
+- Restore the library test build after parallel-merge signature drift — https://github.com/artifact-keeper/artifact-keeper/pull/3215
+
+See the [CHANGELOG](CHANGELOG.md) for the full, itemized list with the mechanism behind each entry.
+
+**Full Changelog**: https://github.com/artifact-keeper/artifact-keeper/compare/v1.7.1...v1.7.2
+
+---
+
+### Sponsors
+
+Thank you to our sponsors for supporting ongoing development of Artifact Keeper.
+
+**Backers**
+
+- Ash A. ([@dragonpaw](https://github.com/dragonpaw))
+- Gabriel Rodriguez ([@injectedfusion](https://github.com/injectedfusion))
+
+[Become a sponsor](https://github.com/sponsors/artifact-keeper) to support the project and get your name listed here.
+
+### Thank You
+
+This release was shaped by external contributors and issue reporters. Thank you:
+
+- **[@cazlo](https://github.com/cazlo)** — publisher-attestation verification in curation (#3199), non-ASCII hosted npm package names (#3189), service-account principal names (#3200)
+- **[@junsung-cho](https://github.com/junsung-cho)** — OCI pushes rejected on classic Helm repositories (#3151), Docker tag age from last push (#3027)
+- **[@ysolomon-plat](https://github.com/ysolomon-plat)** — staging-key publish for streamed proxy-cache writes (#3153)
+- **[@jfgordon2](https://github.com/jfgordon2)** — PEP 658 metadata through virtual repository members (#3179)
+- **[@arslanbekov](https://github.com/arslanbekov)** — npm packument HTTP caching (#3051)
+- **[@nicola-preda](https://github.com/nicola-preda)** — repository renaming on import via `repo_mappings` (#3038)
+- **[@andrlange](https://github.com/andrlange)** — non-string dependency forms in `pubspec.yaml` (#3155)
+- **[@ivolnistov](https://github.com/ivolnistov)** — Docker tag retention per image (#2999)


### PR DESCRIPTION
Adds `.github/release-notes/1.7.2.md`, the curated release body for v1.7.2.

## Why this file needs to exist

`release.yml` prefers a curated body at `.github/release-notes/<version>.md` and falls back to auto-generated notes when there isn't one. The directory currently contains **only `1.7.0.md`** — so 1.7.1 shipped on the fallback.

That is not a cosmetic difference. Auto-generated notes do not maintain `CHANGELOG.md`, so after 1.7.1 shipped, **eight entries stayed behind in `[Unreleased]` and were silently re-claimed by 1.7.2** — including an upgrade note telling operators to act *before upgrading to 1.7.2* when anyone already on 1.7.1 had been affected for a week. That was fixed separately in #3318, but the mechanism recurs on every release that ships without a curated body.

## How it was written

Derived from `git log v1.7.1..main` and cross-checked against the CHANGELOG, not from the changelog alone — since the changelog was the artifact that had drifted.

Three things worth reviewing specifically:

- **It opens with "Before you upgrade", not a feature list.** This release carries four items needing an operator decision before deploying (a write-blocking migration, a grant requirement for private OCI pulls, a PyPI-name inventory, and a storage-metric re-baseline). Putting them after the narrative would defeat the point of writing them.
- **The headline states what it does *not* buy.** The OCI read-authorization entry ends with "This does not make private OCI repositories fully protected", and the `/v2/_catalog` residual (#3269) sits immediately beneath it explaining why that residual narrows the claim. That was the easiest paragraph in the document to leave out.
- **The #3316 entry describes the fix that shipped**, rather than the pre-fix limitation it was originally drafted against — the fix landed in this release after the draft was written.

Checked for company or customer names and for AI attribution: none present.
