### PR TITLE
fix(security): address four repository advisories for 1.7.4

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -34,7 +34,7 @@ use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
 use crate::error::AppError;
 use crate::formats::maven::{generate_metadata_xml, MavenCoordinates, MavenHandler};
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 
 // TODO: Remaining format handlers (beyond maven, npm, pypi, cargo) still use
 // plain-text error responses and should be migrated to AppError (#553).
@@ -870,6 +870,75 @@ fn content_type_for_path(path: &str) -> &'static str {
     } else {
         "application/octet-stream"
     }
+}
+
+// ---------------------------------------------------------------------------
+// .sha1 sidecar verification for proxied package assets (GHSA-qxv7-p3mq-88fv)
+// ---------------------------------------------------------------------------
+
+/// Parse a Maven `.sha1` sidecar body into the digest the proxy-cache commit
+/// gate compares against. Sidecars are either the bare hex digest or the
+/// two-field `<hex>  <filename>` (`md5sum`-style) form; only the first
+/// whitespace-separated token is considered, and only when it is bare
+/// lowercase SHA-1 hex — a value in any other shape is not treated as
+/// authoritative, the same provenance rule
+/// `proxy_helpers::normalize_expected_sha256` applies.
+fn parse_maven_sha1_sidecar(
+    body: &[u8],
+) -> Option<crate::services::proxy_service::CacheCommitDigest> {
+    use crate::services::proxy_service::CacheCommitDigest;
+
+    let text = std::str::from_utf8(body).ok()?;
+    let token = text.split_whitespace().next()?;
+    if token.len() == 40
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return Some(CacheCommitDigest::Sha1Hex(token.to_string()));
+    }
+    None
+}
+
+/// Resolve the upstream `.sha1` sidecar for a proxied Maven package asset so
+/// the streamed download can gate its proxy-cache commit on it —
+/// serve-but-don't-cache on a mismatch, mirroring Cargo's #2929 `cksum` gate
+/// (GHSA-qxv7-p3mq-88fv). Maven clients fetch `.sha1` files as independent
+/// downloads and verify them locally; before this, nothing cross-checked the
+/// sidecar server-side, so a `.jar`/`.pom` whose bytes disagreed with its
+/// sidecar was committed to the cache and served warm from then on.
+///
+/// Only RELEASE-versioned package assets are gated. Checksum/signature
+/// sidecars and `maven-metadata.xml` are excluded by the catalog's own skip
+/// rules (`maven_proxy_package_name`), and `-SNAPSHOT` assets are mutable —
+/// a racing re-deploy would pin a stale sidecar and refuse to cache a
+/// legitimate body. The sidecar fetch rides the proxy cache (a Maven/Gradle
+/// client requests the sidecar anyway, so it is usually warm or
+/// negative-cached), and any failure — absent, unparseable, upstream error —
+/// returns `None`: the download proceeds unverified, exactly as before.
+async fn resolve_maven_sha1_sidecar(
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+) -> Option<crate::services::proxy_service::CacheCommitDigest> {
+    crate::services::proxy_service::maven_proxy_package_name(path)?;
+    let coords = crate::formats::maven::MavenHandler::parse_coordinates(path).ok()?;
+    if coords.version.ends_with("-SNAPSHOT") {
+        return None;
+    }
+    let (content, _ct, _budget_permit) = proxy_helpers::proxy_fetch_capped_budgeted(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &format!("{}.sha1", path),
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    .ok()?;
+    parse_maven_sha1_sidecar(&content)
 }
 
 // ---------------------------------------------------------------------------
@@ -1796,6 +1865,42 @@ async fn serve_artifact(
                     // #895: stream large bodies; pass content_type_for_path
                     // so .pom -> text/xml, .jar -> application/java-archive
                     // when upstream omits Content-Type (closes review N2).
+                    //
+                    // GHSA-qxv7-p3mq-88fv: when the upstream's `.sha1`
+                    // sidecar for this package asset resolves, gate the
+                    // proxy-cache commit on it — a body whose SHA-1 disagrees
+                    // with the sidecar is streamed to the client (which
+                    // verifies it) but never cached. No sidecar -> the
+                    // unverified fetch, exactly as before.
+                    if let Some(expected) =
+                        resolve_maven_sha1_sidecar(proxy, repo.id, repo_key, upstream_url, path)
+                            .await
+                    {
+                        let gated_repo = proxy_helpers::build_remote_repo_with_format(
+                            repo.id,
+                            repo_key,
+                            upstream_url,
+                            RepositoryFormat::Maven,
+                        );
+                        let result = proxy
+                            .fetch_artifact_streaming_with_cache_path_gated_digest(
+                                &gated_repo,
+                                path,
+                                path,
+                                Some(expected),
+                            )
+                            .await
+                            .map_err(IntoResponse::into_response)?;
+                        return proxy_helpers::build_streaming_response_with_disposition(
+                            result,
+                            content_type_for_path(path),
+                            None,
+                        )
+                        .map_err(|e| {
+                            AppError::Internal(format!("failed to build response: {}", e))
+                                .into_response()
+                        });
+                    }
                     return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
@@ -2809,6 +2914,70 @@ mod tests {
     fn test_parse_metadata_path_version_level_snapshot() {
         let result = parse_metadata_path("com/test/artifacthub/0.0.1-SNAPSHOT/maven-metadata.xml");
         assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // .sha1 sidecar parsing (GHSA-qxv7-p3mq-88fv)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_maven_sha1_sidecar_bare_and_two_field() {
+        use crate::services::proxy_service::CacheCommitDigest;
+
+        let sha = "a".repeat(40);
+        // Bare digest (Central's shape).
+        assert_eq!(
+            parse_maven_sha1_sidecar(sha.as_bytes()),
+            Some(CacheCommitDigest::Sha1Hex(sha.clone()))
+        );
+        // Two-field `md5sum`-style: `<hex>  <filename>` — only the digest
+        // token is authoritative.
+        let two_field = format!("{sha}  my-lib-1.0.0.jar\n");
+        assert_eq!(
+            parse_maven_sha1_sidecar(two_field.as_bytes()),
+            Some(CacheCommitDigest::Sha1Hex(sha))
+        );
+    }
+
+    #[test]
+    fn test_parse_maven_sha1_sidecar_rejects_non_canonical() {
+        // Uppercase hex is not the canonical form the gate compares.
+        assert_eq!(parse_maven_sha1_sidecar("A".repeat(40).as_bytes()), None);
+        // Wrong length (SHA-256 pasted into a .sha1, truncation).
+        assert_eq!(parse_maven_sha1_sidecar("a".repeat(64).as_bytes()), None);
+        assert_eq!(parse_maven_sha1_sidecar(b"abc123"), None);
+        // Empty / non-UTF-8 bodies have no enforceable digest.
+        assert_eq!(parse_maven_sha1_sidecar(b""), None);
+        assert_eq!(parse_maven_sha1_sidecar(&[0xff, 0xfe, 0x00]), None);
+    }
+
+    #[test]
+    fn test_parse_maven_sha1_sidecar_snapshot_and_sidecar_paths_are_not_gated() {
+        // The path-level eligibility rules behind resolve_maven_sha1_sidecar:
+        // checksum sidecars and maven-metadata are skipped by the catalog's
+        // own package-name rule, and -SNAPSHOT versions are mutable, so
+        // gating them could pin a stale sidecar against a re-deployed body.
+        assert!(
+            crate::services::proxy_service::maven_proxy_package_name(
+                "com/example/my-lib/1.0.0/my-lib-1.0.0.jar.sha1"
+            )
+            .is_none(),
+            "a .sha1 request itself must never be sidecar-gated"
+        );
+        assert!(
+            crate::services::proxy_service::maven_proxy_package_name(
+                "com/example/my-lib/maven-metadata.xml"
+            )
+            .is_none(),
+            "maven-metadata.xml must never be sidecar-gated"
+        );
+        assert!(
+            crate::services::proxy_service::maven_proxy_package_name(
+                "com/example/my-lib/1.0.0/my-lib-1.0.0.jar"
+            )
+            .is_some(),
+            "a release jar IS eligible for sidecar gating"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -900,6 +900,159 @@ fn build_tarball_upstream_path(package_name: &str, filename: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Tarball integrity gating (GHSA-qxv7-p3mq-88fv)
+// ---------------------------------------------------------------------------
+
+/// Parse an npm `dist.integrity` SRI string into the strongest supported
+/// [`CacheCommitDigest`]. SRI permits several space-separated
+/// `algo-base64` tokens; SHA-512 wins over SHA-256 over SHA-1. SHA-384 has
+/// no tee-hasher support and is skipped (a weaker sibling token is used when
+/// present). Base64 payloads are decoded to the lowercase hex the gate
+/// compares; malformed tokens are ignored — an unusable integrity field
+/// degrades to the pre-existing unverified fetch, never to an error.
+fn parse_npm_sri(integrity: &str) -> Option<crate::services::proxy_service::CacheCommitDigest> {
+    use crate::services::proxy_service::CacheCommitDigest;
+    use base64::Engine as _;
+
+    let mut best: Option<(u8, CacheCommitDigest)> = None;
+    for token in integrity.split_whitespace() {
+        let Some((algo, payload)) = token.split_once('-') else {
+            continue;
+        };
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(payload)
+            .ok();
+        let candidate = match (algo, decoded) {
+            ("sha512", Some(bytes)) if bytes.len() == 64 => {
+                Some((3u8, CacheCommitDigest::Sha512Hex(hex::encode(bytes))))
+            }
+            ("sha256", Some(bytes)) if bytes.len() == 32 => {
+                Some((2u8, CacheCommitDigest::Sha256Hex(hex::encode(bytes))))
+            }
+            ("sha1", Some(bytes)) if bytes.len() == 20 => {
+                Some((1u8, CacheCommitDigest::Sha1Hex(hex::encode(bytes))))
+            }
+            _ => None,
+        };
+        if let Some((rank, digest)) = candidate {
+            // MSRV 1.75: `Option::is_none_or` is 1.82 — keep `map_or`.
+            if best.as_ref().map_or(true, |(r, _)| rank > *r) {
+                best = Some((rank, digest));
+            }
+        }
+    }
+    best.map(|(_, digest)| digest)
+}
+
+/// Validate a legacy npm `dist.shasum` as bare lowercase SHA-1 hex — the
+/// canonical form the commit gate compares. Same rationale as
+/// `proxy_helpers::normalize_expected_sha256`: a value not already in the
+/// comparison's canonical form did not come from this codebase's hashing
+/// path, so it is not treated as authoritative.
+fn normalize_npm_shasum(raw: &str) -> Option<String> {
+    let candidate = raw.trim();
+    if candidate.len() == 40
+        && candidate
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        return Some(candidate.to_string());
+    }
+    None
+}
+
+/// Match a packument's `versions.*.dist` entries to a tarball request by the
+/// tarball URL's FILENAME — never by parsing a version out of the requested
+/// filename (hyphenated names and prerelease tags make that ambiguous; the
+/// curation gate refuses to for the same reason, #2930). `dist.integrity`
+/// (SRI) is preferred over the legacy `dist.shasum` (SHA-1 hex).
+fn npm_integrity_for_filename(
+    packument: &serde_json::Value,
+    filename: &str,
+) -> Option<crate::services::proxy_service::CacheCommitDigest> {
+    use crate::services::proxy_service::CacheCommitDigest;
+
+    let versions = packument.get("versions")?.as_object()?;
+    for version in versions.values() {
+        let Some(dist) = version.get("dist") else {
+            continue;
+        };
+        let tarball = dist.get("tarball").and_then(|t| t.as_str()).unwrap_or("");
+        let tarball_name = tarball
+            .split(['#', '?'])
+            .next()
+            .unwrap_or(tarball)
+            .rsplit('/')
+            .next()
+            .unwrap_or("");
+        if tarball_name.is_empty() || tarball_name != filename {
+            continue;
+        }
+        if let Some(digest) = dist
+            .get("integrity")
+            .and_then(|i| i.as_str())
+            .and_then(parse_npm_sri)
+        {
+            return Some(digest);
+        }
+        if let Some(digest) = dist
+            .get("shasum")
+            .and_then(|s| s.as_str())
+            .and_then(normalize_npm_shasum)
+        {
+            return Some(CacheCommitDigest::Sha1Hex(digest));
+        }
+    }
+    None
+}
+
+/// Resolve the registry-published integrity for the tarball `filename` of
+/// `package_name` from the packument, so the streamed tarball fetch can gate
+/// its proxy-cache commit on it — serve-but-don't-cache on a mismatch, the
+/// same posture as Cargo's #2929 `cksum` gate (GHSA-qxv7-p3mq-88fv). Before
+/// this, the tarball fetch hardcoded `expected_checksum: None`, so the
+/// `dist.integrity` the server itself served in the packument was decorative:
+/// a tarball whose bytes disagreed with it was committed to the cache and
+/// served warm from then on.
+///
+/// The packument is re-read through the same cache-keyed metadata helper the
+/// metadata handler uses, so an npm client — which always fetches the
+/// packument immediately before the tarball — finds it warm. The cached copy
+/// is the RAW upstream document (tarball-URL rewriting happens after the
+/// cache read), so the digests are the upstream's own values. Best-effort by
+/// construction: any failure (fetch/parse error, version entry missing, no
+/// usable digest) returns `None` and the download proceeds unverified,
+/// exactly as before.
+async fn resolve_npm_tarball_integrity(
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    package_name: &str,
+    filename: &str,
+) -> Option<crate::services::proxy_service::CacheCommitDigest> {
+    // Fetch/cache split (#3297): `%2F`-encoded name upstream, decoded
+    // `@scope/name` as the local cache key — identical to the metadata
+    // handler, so this rides the same cache entry.
+    let encoded_name = encode_package_name_for_upstream(package_name);
+    let (content, _ct, _budget_permit) =
+        proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
+            proxy,
+            repo_id,
+            repo_key,
+            upstream_url,
+            &encoded_name,
+            package_name,
+            None,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        )
+        .await
+        .ok()?;
+    let packument: serde_json::Value = serde_json::from_slice(&content).ok()?;
+    npm_integrity_for_filename(&packument, filename)
+}
+
+// ---------------------------------------------------------------------------
 // Repository resolution
 // ---------------------------------------------------------------------------
 
@@ -3142,16 +3295,40 @@ async fn serve_tarball(
             // even though other download paths already stream. Stream it (teed
             // into the proxy cache under `fetch_path`) so a large tarball
             // succeeds with 200 and subsequent pulls are served warm.
-            let result = proxy_helpers::proxy_fetch_streaming_with_cache_key(
+            //
+            // GHSA-qxv7-p3mq-88fv: gate the proxy-cache commit on the
+            // packument's `dist.integrity` (SRI) / `dist.shasum` for this
+            // exact tarball filename. Resolved AFTER the age gate so a
+            // last-known-good substitution is gated on its OWN integrity.
+            // npm's digests are SHA-512/SHA-1, which the storage layer never
+            // observes, so the fetch goes through the digest-flexible gated
+            // variant rather than the SHA-256-only proxy_helpers wrapper; a
+            // mismatch is served to the client (npm verifies the SRI itself)
+            // but never cached.
+            let expected_integrity = resolve_npm_tarball_integrity(
                 proxy,
                 repo.id,
                 repo_key,
                 upstream_url,
-                &fetch_path,
-                &fetch_path,
-                RepositoryFormat::Npm,
+                package_name,
+                &response_filename,
             )
-            .await?;
+            .await;
+            let gated_repo = proxy_helpers::build_remote_repo_with_format(
+                repo.id,
+                repo_key,
+                upstream_url,
+                RepositoryFormat::Npm,
+            );
+            let result = proxy
+                .fetch_artifact_streaming_with_cache_path_gated_digest(
+                    &gated_repo,
+                    &fetch_path,
+                    &fetch_path,
+                    expected_integrity,
+                )
+                .await
+                .map_err(IntoResponse::into_response)?;
 
             // The upstream registry may return application/octet-stream for
             // npm tarballs, which also gets persisted by the proxy cache.
@@ -5454,6 +5631,111 @@ mod tests {
         let ok = parse_npm_policy_list(repo_id, NPM_ALLOWED_SCOPES_KEY, "[\"@Types\"]")
             .expect("well-formed JSON must parse");
         assert_eq!(ok, vec!["@types"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // GHSA-qxv7-p3mq-88fv: tarball integrity gating (unit level)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_npm_sri_prefers_sha512_and_decodes_to_hex() {
+        use crate::services::proxy_service::CacheCommitDigest;
+        use base64::Engine as _;
+
+        let sha512_b64 =
+            base64::engine::general_purpose::STANDARD.encode(sha2::Sha512::digest(b"tarball"));
+        let sha1_b64 =
+            base64::engine::general_purpose::STANDARD.encode(sha1::Sha1::digest(b"tarball"));
+        // Weakest-first ordering must not matter: sha512 wins.
+        let sri = format!("sha1-{sha1_b64} sha512-{sha512_b64}");
+        let digest = parse_npm_sri(&sri).expect("a sha512 token must parse");
+        assert_eq!(
+            digest,
+            CacheCommitDigest::Sha512Hex(hex::encode(sha2::Sha512::digest(b"tarball")))
+        );
+    }
+
+    #[test]
+    fn test_parse_npm_sri_skips_malformed_and_unsupported_tokens() {
+        use crate::services::proxy_service::CacheCommitDigest;
+
+        // Garbage and unsupported sha384 alone -> None (unverified fetch).
+        assert_eq!(parse_npm_sri("not-an-sri-token"), None);
+        assert_eq!(
+            parse_npm_sri(
+                "sha384-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBB="
+            ),
+            None
+        );
+        // A sha256 SRI decodes to the hex the storage-observed gate compares.
+        let sha256_b64 = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            sha2::Sha256::digest(b"tarball"),
+        );
+        assert_eq!(
+            parse_npm_sri(&format!("sha256-{sha256_b64}")),
+            Some(CacheCommitDigest::Sha256Hex(hex::encode(
+                sha2::Sha256::digest(b"tarball")
+            )))
+        );
+    }
+
+    #[test]
+    fn test_npm_integrity_for_filename_matches_by_tarball_basename() {
+        use crate::services::proxy_service::CacheCommitDigest;
+
+        let shasum = hex::encode(sha1::Sha1::digest(b"tarball-bytes"));
+        let packument = serde_json::json!({
+            "name": "my-pkg",
+            "versions": {
+                // Hyphenated name: a version parse of the filename would
+                // mis-split "my-pkg-1.0.0.tgz"; basename matching must not.
+                "1.0.0": {"dist": {"tarball": "https://reg.example/my-pkg/-/my-pkg-1.0.0.tgz",
+                                   "shasum": &shasum}},
+                "2.0.0": {"dist": {"tarball": "https://reg.example/my-pkg/-/my-pkg-2.0.0.tgz",
+                                   "shasum": "0000000000000000000000000000000000000000"}},
+            }
+        });
+        assert_eq!(
+            npm_integrity_for_filename(&packument, "my-pkg-1.0.0.tgz"),
+            Some(CacheCommitDigest::Sha1Hex(shasum.clone()))
+        );
+        // A filename no version serves resolves to no gate.
+        assert_eq!(
+            npm_integrity_for_filename(&packument, "my-pkg-9.9.9.tgz"),
+            None
+        );
+        // Scoped tarball URL shapes match by basename too.
+        let scoped = serde_json::json!({
+            "versions": {"1.0.0": {"dist": {
+                "tarball": "https://reg.example/@scope/pkg/-/pkg-1.0.0.tgz",
+                "shasum": &shasum}}}}
+        );
+        assert_eq!(
+            npm_integrity_for_filename(&scoped, "pkg-1.0.0.tgz"),
+            Some(CacheCommitDigest::Sha1Hex(shasum))
+        );
+    }
+
+    #[test]
+    fn test_npm_integrity_for_filename_prefers_sri_over_shasum() {
+        use crate::services::proxy_service::CacheCommitDigest;
+        use base64::Engine as _;
+
+        let sha512_b64 =
+            base64::engine::general_purpose::STANDARD.encode(sha2::Sha512::digest(b"real"));
+        let packument = serde_json::json!({
+            "versions": {"1.0.0": {"dist": {
+                "tarball": "https://reg.example/p/-/p-1.0.0.tgz",
+                "integrity": format!("sha512-{sha512_b64}"),
+                "shasum": "0000000000000000000000000000000000000000"}}}}
+        );
+        assert_eq!(
+            npm_integrity_for_filename(&packument, "p-1.0.0.tgz"),
+            Some(CacheCommitDigest::Sha512Hex(hex::encode(
+                sha2::Sha512::digest(b"real")
+            )))
+        );
     }
 
     /// DB-backed (#2327 secondary): a virtual repo with two Remote members —
@@ -7862,6 +8144,123 @@ mod tests {
         }
 
         // `.expect(1)` on the mock is verified on server drop.
+        drop(mock_server);
+        cleanup().await;
+    }
+
+    /// GHSA-qxv7-p3mq-88fv: a remote npm tarball whose bytes disagree with
+    /// the packument's `dist.integrity` must be SERVED (the client verifies
+    /// the SRI itself) but NEVER CACHED — a second pull refetches upstream
+    /// instead of serving the poisoned bytes warm. The matching-integrity
+    /// companion pull must cache normally. DB-backed; skips when no
+    /// `DATABASE_URL` is configured.
+    #[tokio::test]
+    async fn test_remote_tarball_integrity_mismatch_served_but_not_cached() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use base64::Engine as _;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+
+        let mock_server = MockServer::start().await;
+        let tarball_bytes = b"pkged-up-tarball-bytes".to_vec();
+        // The packument pins an integrity that does NOT match the served
+        // bytes (here: the SRI of a different body entirely).
+        let mismatched_sri = format!(
+            "sha512-{}",
+            base64::engine::general_purpose::STANDARD.encode(sha2::Sha512::digest(b"other bytes"))
+        );
+        Mock::given(method("GET"))
+            .and(path("/intpkg"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "name": "intpkg",
+                "dist-tags": {"latest": "1.0.0"},
+                "versions": {"1.0.0": {"dist": {
+                    "tarball": format!("{}/intpkg/-/intpkg-1.0.0.tgz", mock_server.uri()),
+                    "integrity": mismatched_sri,
+                }}},
+            })))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/intpkg/-/intpkg-1.0.0.tgz"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(tarball_bytes.clone()),
+            )
+            // The integrity gate must refuse every cache commit, so BOTH
+            // pulls reach upstream.
+            .expect(2)
+            .mount(&mock_server)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock_server.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+
+        let cleanup_pool = fx.pool.clone();
+        let cleanup_repo = fx.repo_id;
+        let cleanup_user = fx.user_id;
+        let cleanup_dir = fx.storage_dir.clone();
+        let cleanup = || async move {
+            tdh::cleanup(&cleanup_pool, cleanup_repo, cleanup_user).await;
+            let _ = std::fs::remove_dir_all(&cleanup_dir);
+        };
+
+        for i in 0..2 {
+            let result = super::download_tarball(
+                axum::extract::State(state.clone()),
+                axum::Extension(tdh::admin_auth_ext()),
+                axum::extract::Path((
+                    fx.repo_key.clone(),
+                    "intpkg".to_string(),
+                    "intpkg-1.0.0.tgz".to_string(),
+                )),
+                Default::default(),
+            )
+            .await;
+
+            let response = match result {
+                Ok(r) => r,
+                Err(r) => {
+                    let status = r.status();
+                    cleanup().await;
+                    panic!(
+                        "pull {i}: mismatched-integrity tarball must still be served, got {status}"
+                    );
+                }
+            };
+            assert_eq!(response.status(), StatusCode::OK);
+            let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read streamed body");
+            assert_eq!(
+                body_bytes.as_ref(),
+                tarball_bytes.as_slice(),
+                "pull {i}: the client receives the upstream bytes (it verifies the SRI itself)"
+            );
+            // Let the background tee writer settle (and, pre-fix, wrongly
+            // commit the mismatched bytes) before the next pull probes the
+            // cache. NOT `wait_for_cache_commit`: the whole point is that no
+            // commit may happen, and that helper panics in exactly that case.
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        }
+
+        // `.expect(2)` on the tarball mock is verified on server drop: had
+        // either pull committed the mismatched bytes, the second pull would
+        // have been served from cache and upstream would have seen ONE hit.
         drop(mock_server);
         cleanup().await;
     }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3255,6 +3255,13 @@ struct PypiRemoteFetchTarget {
     /// Stable proxy-cache key (`simple/{project}/{filename}`), independent
     /// of the actual upstream URL layout.
     cache_path: String,
+    /// SHA-256 the upstream simple index pinned for this file in its
+    /// `#sha256=` fragment (GHSA-qxv7-p3mq-88fv). `Some` gates the
+    /// streaming proxy-cache commit: a body whose digest disagrees with the
+    /// index is streamed to the client (which verifies it independently)
+    /// but never persisted. `None` — no usable fragment, e.g. a PEP 658
+    /// `.metadata` resolution — fetches unverified, as before.
+    expected_sha256: Option<String>,
 }
 
 /// Resolve the real download URL for a file hosted by a remote PyPI
@@ -3355,10 +3362,19 @@ async fn resolve_pypi_remote_fetch_target(
         None => fallback(),
     };
 
+    // GHSA-qxv7-p3mq-88fv: the same index page that vouched for the download
+    // URL also pins the file's SHA-256 in the anchor fragment — the digest
+    // pip verifies the download against. Lift it so the streamed fetch gates
+    // the proxy-cache commit on it; before this, the fragment was forwarded
+    // to clients but never checked server-side, so a body that disagreed
+    // with the index was cached and served warm from then on.
+    let expected_sha256 = find_upstream_sha256_for_file(&index_html, filename);
+
     Ok(PypiRemoteFetchTarget {
         fetch_base,
         fetch_path,
         cache_path,
+        expected_sha256,
     })
 }
 
@@ -3436,13 +3452,17 @@ async fn fetch_from_pypi_remote_streaming(
     )
     .await?;
 
-    proxy_helpers::proxy_fetch_streaming_with_cache_key(
+    // GHSA-qxv7-p3mq-88fv: gate the proxy-cache commit on the index-pinned
+    // SHA-256 when the upstream simple page carried one — serve-but-don't-cache
+    // on a mismatch, the same posture as Cargo's #2929 `cksum` gate.
+    proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
         proxy,
         repo_id,
         repo_key,
         &target.fetch_base,
         &target.fetch_path,
         &target.cache_path,
+        target.expected_sha256,
         format,
     )
     .await
@@ -4257,21 +4277,30 @@ static HREF_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r##"(?is)<a\s+[^>]*?\bhref\s*=\s*(?:"([^"#]*)|'([^'#]*)|([^\s>#]+))"##).unwrap()
 });
 
-// URL lands in group 2 (double-quoted), 3 (single-quoted), or 4 (unquoted);
-// group 1 = attributes before `href`, group 5 = attributes after.
-static REWRITE_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?is)<a\s+([^>]*?)\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))([^>]*)>"#)
-        .unwrap()
-});
+/// Anchor START-tag matcher for the simple-index REBUILD paths
+/// (`rewrite_upstream_urls`, GHSA-4cw7-mgqj-hgmg, and the #2967 R3
+/// ownership rebuild `filter_remote_case_a_html`). Matches `<a ...>` with NO
+/// required `</a>`, so an unclosed/malformed upstream anchor is still parsed
+/// rather than passing through unexamined.
+static SIMPLE_ANCHOR_START_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?is)<a\b[^>]*>").unwrap());
 
-/// Matches an upstream `<base ...>` element. A `<base href>` re-anchors every
-/// relative/root-relative link on the page; because `rewrite_upstream_urls`
-/// emits ROOT-RELATIVE download URLs (`/pypi/<repo>/...`), a surviving `<base>`
-/// would make the client resolve them against the upstream origin instead of
-/// Artifact Keeper — a proxy bypass that also discloses the upstream host and
-/// breaks air-gapped installs. We strip it. Same class as the #2801
-/// Content-Type sniff fix, for the `<base>` vector.
-static BASE_TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?is)<base\b[^>]*>").unwrap());
+/// Quote-agnostic, case-insensitive `href` extractor applied to a single
+/// anchor start-tag. The value lands in group 1 (double-quoted), 2
+/// (single-quoted), or 3 (unquoted).
+static SIMPLE_HREF_ATTR_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?i)\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"#).unwrap());
+
+/// `data-*` attribute extractor applied to a single anchor start-tag, for
+/// the simple-index rebuild: group 1 is the attribute name (emitted
+/// lowercased), groups 2/3/4 its double-quoted / single-quoted / unquoted
+/// value. A bare attribute (PEP 714 permits `data-core-metadata` with no
+/// value) captures the name only. This is how `data-requires-python`,
+/// `data-dist-info-metadata` / `data-core-metadata`, `data-gpg-sig`, etc.
+/// survive the rebuild without any other upstream markup surviving with
+/// them (GHSA-4cw7-mgqj-hgmg).
+static SIMPLE_DATA_ATTR_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?is)\b(data-[a-z0-9-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?"#).unwrap()
+});
 
 /// Split a URL into its base (scheme + host) and path components.
 ///
@@ -4344,6 +4373,43 @@ fn find_upstream_url_for_file(
     None
 }
 
+/// Extract the `#sha256=` fragment the upstream simple index advertises for
+/// `filename`, normalized to the bare lowercase hex the proxy-cache commit
+/// gate compares against (GHSA-qxv7-p3mq-88fv). This is the same digest the
+/// rewritten index hands to pip as a URL fragment — the client verifies it,
+/// and the download path now gates the cache commit on it too. Returns
+/// `None` when no anchor names the file or its fragment is absent or not a
+/// canonical SHA-256 — the caller then fetches unverified, exactly as it did
+/// before the gate existed.
+fn find_upstream_sha256_for_file(index_html: &str, filename: &str) -> Option<String> {
+    for tag in SIMPLE_ANCHOR_START_RE.find_iter(index_html) {
+        let Some(href_caps) = SIMPLE_HREF_ATTR_RE.captures(tag.as_str()) else {
+            continue;
+        };
+        let href_raw = href_caps
+            .get(1)
+            .or_else(|| href_caps.get(2))
+            .or_else(|| href_caps.get(3))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let href = decode_html_entities_minimal(href_raw);
+        let Some((url_part, fragment)) = href.split_once('#') else {
+            continue;
+        };
+        let url_no_query = url_part.split('?').next().unwrap_or(url_part);
+        if url_no_query.rsplit('/').next().unwrap_or("") != filename {
+            continue;
+        }
+        let Some(digest) = fragment.strip_prefix("sha256=") else {
+            continue;
+        };
+        if let Some(normalized) = proxy_helpers::normalize_expected_sha256(digest) {
+            return Some(normalized);
+        }
+    }
+    None
+}
+
 /// Resolve a PEP 658 metadata filename from the corresponding wheel URL.
 /// PyPI advertises the metadata hash on the wheel anchor but usually does not
 /// include a separate `.whl.metadata` anchor in the Simple API page.
@@ -4363,24 +4429,6 @@ fn find_upstream_metadata_url(
     Some(url.into())
 }
 
-/// Rewrite download URLs in upstream PyPI simple index HTML to route through
-/// Artifact Keeper's proxy endpoint.
-///
-/// Upstream sources return links that would bypass the cache:
-///   - External PyPI: `<a href="https://files.pythonhosted.org/packages/...">`
-///   - Local AK repos: `<a href="/pypi/upstream-key/simple/pkg/file#hash">`
-///
-/// This function rewrites both forms to paths under the current (remote) repo:
-/// `/pypi/{repo_key}/simple/{project}/{filename}#sha256=...` so downloads go
-/// through Artifact Keeper and get cached.
-///
-/// Absolute URLs (`http://`, `https://`) and root-relative paths starting with
-/// `/pypi/` are rewritten. Plain relative URLs and anchors are left unchanged.
-///
-/// PEP 658 metadata attributes (`data-dist-info-metadata` and
-/// `data-core-metadata`) are preserved on rewritten links. The download path
-/// resolves `.metadata` filenames through the same upstream Simple API page,
-/// so removing these attributes would prevent installers from using PEP 658.
 /// Classification of a proxied PyPI simple-index body sniffed from its
 /// content, used when the upstream `Content-Type` is neither PEP 691 JSON nor
 /// PEP 503 HTML. See #2801: corporate outbound proxies / quirky mirrors
@@ -4438,58 +4486,118 @@ fn bad_upstream_simple_index() -> Response {
         .into_response()
 }
 
+/// Rewrite download URLs in upstream PyPI simple index HTML to route through
+/// Artifact Keeper's proxy endpoint — by REBUILDING a fresh minimal PEP 503
+/// page from the parsed anchors, never by editing the upstream markup in
+/// place (GHSA-4cw7-mgqj-hgmg). Mirrors the #2967 R3 ownership rebuild
+/// (`filter_remote_case_a_html`).
+///
+/// SECURITY. The previous in-place rewriter passed every upstream byte
+/// through except `<base>` tags and the href values it recognized. A proxied
+/// index is served from THIS registry's origin, so any surviving upstream
+/// markup — a `<script>`, an `onerror=` handler, a `<form>` — is stored XSS
+/// against anyone (admins included) browsing the index; and a filename or
+/// `#fragment` containing the upstream's own href quote character broke out
+/// of the rewritten attribute into arbitrary attacker-controlled markup. The
+/// rebuild emits only what it can vouch for:
+///
+///   * one `<a>` per upstream anchor whose href yields a non-empty filename,
+///     the href rebuilt as `/pypi/{repo_key}/simple/{project}/{filename}
+///     {#fragment}` — the same local download path the in-place rewriter
+///     produced, so absolute, root-relative and plain-relative upstream hrefs
+///     (pypi.org, Nexus, Artifactory, devpi, another AK repo) all keep
+///     routing through the proxy, and no upstream host/path/query survives;
+///   * the anchor's `data-*` attributes (`data-requires-python`, the PEP
+///     658/714 `data-dist-info-metadata` / `data-core-metadata`, …), each
+///     entity-decoded then re-escaped into a fresh double-quoted value, so a
+///     single-quoted upstream value cannot break out of its attribute;
+///   * the filename, HTML-escaped, as the link text (PEP 503).
+///
+/// Everything else — `<base>`, `<script>`, event handlers, non-`data-*`
+/// attributes, wrapper markup — is dropped with the rest of the upstream
+/// page. The emitted skeleton keeps the `<head>`/`<body>` markers (and the
+/// `pypi:repository-version` meta) that `merge_local_into_remote_simple_html`
+/// splices local entries and operator `tracks` into.
 fn rewrite_upstream_urls(html: &str, repo_key: &str, project: &str) -> String {
     let normalized = PypiHandler::normalize_name(project);
 
-    // Neutralize any upstream `<base href>` first: our rewritten download links
-    // are root-relative, so a surviving `<base>` re-anchors them onto the
-    // upstream origin (proxy bypass + host disclosure). Strip to a FIXPOINT:
-    // removing one `<base>` can splice surrounding bytes into a NEW one
-    // (`<ba<base x>se href=...>`), so loop until nothing more matches.
-    let mut html = html.to_string();
-    loop {
-        let stripped = BASE_TAG_RE.replace_all(&html, "").into_owned();
-        if stripped == html {
-            break;
+    let mut anchors = String::new();
+    for tag in SIMPLE_ANCHOR_START_RE.find_iter(html) {
+        let tag = tag.as_str();
+        let Some(href_caps) = SIMPLE_HREF_ATTR_RE.captures(tag) else {
+            continue;
+        };
+        let href_raw = href_caps
+            .get(1)
+            .or_else(|| href_caps.get(2))
+            .or_else(|| href_caps.get(3))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        // Minimal entity-decode BEFORE deriving the file identity from the
+        // href — the same treatment the #2967 rebuild gives it; everything
+        // re-emitted below is escaped again.
+        let href = decode_html_entities_minimal(href_raw);
+        // Keep the upstream fragment (#sha256=...) so pip can verify the
+        // bytes AK proxies; strip it — and any query — before taking the
+        // basename.
+        let fragment = match href.find('#') {
+            Some(pos) => &href[pos..],
+            None => "",
+        };
+        let url_part = href.split('#').next().unwrap_or(&href);
+        let url_no_query = url_part.split('?').next().unwrap_or(url_part);
+        let filename = url_no_query.rsplit('/').next().unwrap_or("").trim();
+        // Not a file link (navigation, `../`, a bare host): there is no
+        // download entry to rebuild, and nothing else about the anchor may
+        // survive either. A "filename" containing HTML metacharacters or
+        // whitespace is no filename at all — it is an attribute-breakout
+        // payload riding the href (GHSA-4cw7-mgqj-hgmg), and the anchor is
+        // dropped rather than escaped-and-emitted (the same posture
+        // `is_safe_upload_filename` takes at the ingest choke-point, #3107).
+        if filename.is_empty()
+            || filename
+                .chars()
+                .any(|c| matches!(c, '<' | '>' | '"' | '\'') || c.is_whitespace() || c.is_control())
+        {
+            continue;
         }
-        html = stripped;
+
+        // Preserve ONLY the anchor's `data-*` attributes, each re-emitted
+        // escaped into a double-quoted value (or bare, as PEP 714 permits).
+        let mut data_attrs = String::new();
+        for attr in SIMPLE_DATA_ATTR_RE.captures_iter(tag) {
+            let name = attr[1].to_ascii_lowercase();
+            let value = attr
+                .get(2)
+                .or_else(|| attr.get(3))
+                .or_else(|| attr.get(4))
+                .map(|m| m.as_str());
+            match value {
+                Some(v) => data_attrs.push_str(&format!(
+                    " {}=\"{}\"",
+                    name,
+                    html_escape(&decode_html_entities_minimal(v))
+                )),
+                None => data_attrs.push_str(&format!(" {}", name)),
+            }
+        }
+
+        anchors.push_str(&format!(
+            "<a href=\"/pypi/{}/simple/{}/{}{}\"{}>{}</a><br/>\n",
+            repo_key,
+            normalized,
+            html_escape(filename),
+            html_escape(fragment),
+            data_attrs,
+            html_escape(filename),
+        ));
     }
 
-    REWRITE_RE
-        .replace_all(&html, |caps: &regex::Captures| {
-            let before_href = &caps[1];
-            // The href value is in whichever quote-alternation group matched
-            // (double / single / unquoted); `after` is the trailing group.
-            let full_url = caps
-                .get(2)
-                .or_else(|| caps.get(3))
-                .or_else(|| caps.get(4))
-                .map(|m| m.as_str())
-                .unwrap_or("");
-            let after_href = caps.get(5).map(|m| m.as_str()).unwrap_or("");
-
-            // Split off the fragment (#sha256=...) if present
-            let (url_path, fragment) = match full_url.find('#') {
-                Some(pos) => (&full_url[..pos], &full_url[pos..]),
-                None => (full_url, ""),
-            };
-
-            // Extract the filename from the URL path
-            let filename = url_path.rsplit('/').next().unwrap_or(url_path);
-
-            if filename.is_empty() {
-                // Not a file URL, leave unchanged
-                return caps[0].to_string();
-            }
-
-            let rewritten = format!(
-                "/pypi/{}/simple/{}/{}{}",
-                repo_key, normalized, filename, fragment
-            );
-
-            format!("<a {}href=\"{}\"{}>", before_href, rewritten, after_href)
-        })
-        .into_owned()
+    // Fresh minimal PEP 503 document containing ONLY Artifact-Keeper-pathed
+    // anchors — the same skeleton `filter_remote_case_a_html` emits.
+    format!(
+        "<!DOCTYPE html>\n<html>\n<head>\n<meta name=\"pypi:repository-version\" content=\"1.0\"/>\n</head>\n<body>\n{anchors}</body>\n</html>\n"
+    )
 }
 
 /// PEP 691 JSON simple-index media type.
@@ -4880,14 +4988,10 @@ fn filter_remote_case_a_html(
     repo_key: &str,
     normalized: &str,
 ) -> String {
-    static ANCHOR_START: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?is)<a\b[^>]*>").unwrap());
-    static HREF_ATTR: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r#"(?i)\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"#).unwrap());
-
     let mut survivors = String::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for tag in ANCHOR_START.find_iter(html) {
-        let Some(href_caps) = HREF_ATTR.captures(tag.as_str()) else {
+    for tag in SIMPLE_ANCHOR_START_RE.find_iter(html) {
+        let Some(href_caps) = SIMPLE_HREF_ATTR_RE.captures(tag.as_str()) else {
             continue;
         };
         let href_raw = href_caps
@@ -6311,13 +6415,27 @@ mod tests {
     // rewrite_upstream_urls
     // -----------------------------------------------------------------------
 
+    /// Expected shape of a REGENERATED simple-index page (GHSA-4cw7-mgqj-hgmg):
+    /// `rewrite_upstream_urls` no longer edits the upstream page in place — it
+    /// emits a fresh minimal PEP 503 document containing ONLY the rebuilt
+    /// anchors. The skeleton carries the `</head>` / `</body>` markers
+    /// `merge_local_into_remote_simple_html` splices into.
+    fn rebuilt_simple_page(anchors: &str) -> String {
+        format!(
+            "<!DOCTYPE html>\n<html>\n<head>\n<meta name=\"pypi:repository-version\" content=\"1.0\"/>\n</head>\n<body>\n{anchors}</body>\n</html>\n"
+        )
+    }
+
     #[test]
     fn test_rewrite_absolute_url_with_hash() {
         let html = r#"<a href="https://files.pythonhosted.org/packages/ab/cd/numpy-1.3.0.tar.gz#sha256=abc123">numpy-1.3.0.tar.gz</a>"#;
         let result = rewrite_upstream_urls(html, "pypi-remote", "numpy");
         assert_eq!(
             result,
-            r#"<a href="/pypi/pypi-remote/simple/numpy/numpy-1.3.0.tar.gz#sha256=abc123">numpy-1.3.0.tar.gz</a>"#
+            rebuilt_simple_page(
+                r#"<a href="/pypi/pypi-remote/simple/numpy/numpy-1.3.0.tar.gz#sha256=abc123">numpy-1.3.0.tar.gz</a><br/>
+"#
+            )
         );
     }
 
@@ -6327,7 +6445,10 @@ mod tests {
         let result = rewrite_upstream_urls(html, "pypi-remote", "numpy");
         assert_eq!(
             result,
-            r#"<a href="/pypi/pypi-remote/simple/numpy/numpy-1.3.0.tar.gz">numpy-1.3.0.tar.gz</a>"#
+            rebuilt_simple_page(
+                r#"<a href="/pypi/pypi-remote/simple/numpy/numpy-1.3.0.tar.gz">numpy-1.3.0.tar.gz</a><br/>
+"#
+            )
         );
     }
 
@@ -6372,7 +6493,10 @@ mod tests {
         let result = rewrite_upstream_urls(html, "repo", "pkg");
         assert_eq!(
             result,
-            r#"<a href="/pypi/repo/simple/pkg/pkg-1.0.tar.gz">pkg-1.0.tar.gz</a>"#
+            rebuilt_simple_page(
+                r#"<a href="/pypi/repo/simple/pkg/pkg-1.0.tar.gz">pkg-1.0.tar.gz</a><br/>
+"#
+            )
         );
     }
 
@@ -6387,15 +6511,22 @@ mod tests {
 
     #[test]
     fn test_rewrite_no_links() {
+        // GHSA-4cw7-mgqj-hgmg: a page with no file anchors regenerates as an
+        // EMPTY listing — the upstream `<h1>` (and any other markup) no longer
+        // passes through.
         let html = "<html><body><h1>No links here</h1></body></html>";
         let result = rewrite_upstream_urls(html, "repo", "pkg");
-        assert_eq!(result, html);
+        assert_eq!(result, rebuilt_simple_page(""));
+        assert!(
+            !result.contains("<h1>"),
+            "upstream markup survived: {result}"
+        );
     }
 
     #[test]
     fn test_rewrite_empty_string() {
         let result = rewrite_upstream_urls("", "repo", "pkg");
-        assert_eq!(result, "");
+        assert_eq!(result, rebuilt_simple_page(""));
     }
 
     #[test]
@@ -6423,8 +6554,11 @@ mod tests {
         // data-requires-python should be preserved
         assert!(result.contains("data-requires-python"));
 
-        // Non-link content should be preserved
-        assert!(result.contains("<h1>Links for numpy</h1>"));
+        // GHSA-4cw7-mgqj-hgmg: non-link upstream content does NOT survive —
+        // the page is regenerated from parsed anchors, so the upstream's
+        // `<h1>`/`<title>` are gone. The repository-version meta that remains
+        // is OUR OWN skeleton's, not the upstream's.
+        assert!(!result.contains("<h1>Links for numpy</h1>"));
         assert!(result.contains("pypi:repository-version"));
     }
 
@@ -6466,7 +6600,10 @@ mod tests {
         let result = rewrite_upstream_urls(html, "pypi-remote", "numpy");
         assert_eq!(
             result,
-            r#"<a href="/pypi/pypi-remote/simple/numpy/numpy-1.3.0.tar.gz#sha256=abc123">numpy-1.3.0.tar.gz</a>"#
+            rebuilt_simple_page(
+                r#"<a href="/pypi/pypi-remote/simple/numpy/numpy-1.3.0.tar.gz#sha256=abc123">numpy-1.3.0.tar.gz</a><br/>
+"#
+            )
         );
     }
 
@@ -6476,7 +6613,10 @@ mod tests {
         let result = rewrite_upstream_urls(html, "remote-repo", "pkg");
         assert_eq!(
             result,
-            r#"<a href="/pypi/remote-repo/simple/pkg/pkg-2.0.whl">pkg-2.0.whl</a>"#
+            rebuilt_simple_page(
+                r#"<a href="/pypi/remote-repo/simple/pkg/pkg-2.0.whl">pkg-2.0.whl</a><br/>
+"#
+            )
         );
     }
 
@@ -6541,9 +6681,10 @@ mod tests {
             r#"href="/pypi/remote-pypi/simple/mypackage/mypackage-1.0.0-py3-none-any.whl#sha256=bbb222""#
         ));
 
-        // data-requires-python and other structure should be preserved
+        // data-requires-python is preserved; the upstream page structure is
+        // NOT (GHSA-4cw7-mgqj-hgmg — the page is regenerated).
         assert!(result.contains("data-requires-python"));
-        assert!(result.contains("<h1>Links for mypackage</h1>"));
+        assert!(!result.contains("<h1>Links for mypackage</h1>"));
     }
 
     #[test]
@@ -6593,8 +6734,9 @@ mod tests {
         assert!(result.contains(r#"data-dist-info-metadata="sha256=5620""#));
         assert!(result.contains(r#"data-core-metadata="sha256=5620""#));
 
-        // Structure should be preserved
-        assert!(result.contains("<h1>Links for six</h1>"));
+        // Upstream page structure does NOT survive the regeneration
+        // (GHSA-4cw7-mgqj-hgmg).
+        assert!(!result.contains("<h1>Links for six</h1>"));
     }
 
     // -----------------------------------------------------------------------
@@ -7123,6 +7265,112 @@ mod tests {
         assert!(out.contains("/pypi/repo/simple/pkg/pkg-3.0.whl"), "{out}");
     }
 
+    // -----------------------------------------------------------------------
+    // GHSA-4cw7-mgqj-hgmg: proxied simple-index stored XSS
+    //
+    // The proxied page is served from THIS registry's origin, so any upstream
+    // markup that survives the render runs with the registry's privileges.
+    // The rewriter now REGENERATES the page from parsed anchors instead of
+    // editing the upstream markup in place. These tests pin that contract.
+    // -----------------------------------------------------------------------
+
+    // The advisory's breakout: a single-quoted upstream href carries a double
+    // quote, so the old in-place rewriter's `href="..."` re-emission let the
+    // value escape its attribute into attacker markup. The "filename" of such
+    // an href is no plausible filename, so the anchor is dropped wholesale.
+    #[test]
+    fn test_rewrite_regeneration_blocks_single_quote_href_breakout() {
+        let html = concat!(
+            "<a href='pkg-1.0.whl\"><img src=x onerror=alert(1)>'>pkg-1.0.whl</a>\n",
+            "<script>alert(2)</script>",
+        );
+        let out = rewrite_upstream_urls(html, "repo", "pkg");
+        assert_eq!(
+            out,
+            rebuilt_simple_page(""),
+            "a breakout-payload href must yield NO anchor: {out}"
+        );
+        assert!(
+            !out.contains("<img"),
+            "event-handler markup survived: {out}"
+        );
+        assert!(!out.contains("onerror"), "event handler survived: {out}");
+        assert!(!out.contains("<script"), "script tag survived: {out}");
+        assert!(
+            !out.contains("alert("),
+            "attacker payload survived in any form: {out}"
+        );
+    }
+
+    // An event handler riding a legitimate anchor's attribute list: only
+    // `data-*` attributes are carried into the rebuilt page, so the handler
+    // is dropped with the rest of the upstream markup.
+    #[test]
+    fn test_rewrite_regeneration_drops_anchor_event_handlers() {
+        let html = r#"<a href="https://files.example.com/pkg-1.0.whl#sha256=aa" onmouseover="alert(1)" data-requires-python="&gt;=3.8">pkg-1.0.whl</a>"#;
+        let out = rewrite_upstream_urls(html, "repo", "pkg");
+        assert!(
+            !out.contains("onmouseover"),
+            "event handler survived: {out}"
+        );
+        assert!(
+            !out.contains("files.example.com"),
+            "offsite host survived: {out}"
+        );
+        assert!(
+            out.contains(r#"href="/pypi/repo/simple/pkg/pkg-1.0.whl#sha256=aa""#),
+            "rebuilt href missing: {out}"
+        );
+        // data-* attributes DO survive (escaped).
+        assert!(
+            out.contains(r#"data-requires-python="&gt;=3.8""#),
+            "data-requires-python lost: {out}"
+        );
+    }
+
+    // A single-quoted `data-requires-python` value containing a double quote
+    // must not break out of the double-quoted attribute it is re-emitted
+    // into: the raw quote is escaped, so the `" onmouseover="` breakout
+    // sequence never appears.
+    #[test]
+    fn test_rewrite_regeneration_escapes_data_attr_breakout() {
+        let html = "<a href='pkg-1.0.whl' data-requires-python='&gt;=3.8\" onmouseover=\"alert(1)'>pkg-1.0.whl</a>";
+        let out = rewrite_upstream_urls(html, "repo", "pkg");
+        assert!(
+            !out.contains("\" onmouseover"),
+            "attribute breakout survived: {out}"
+        );
+        assert!(
+            !out.contains("onmouseover=\""),
+            "live event-handler attribute survived: {out}"
+        );
+        assert!(
+            out.contains("data-requires-python=\"&gt;=3.8&quot;"),
+            "the (escaped) value must be re-emitted quoted: {out}"
+        );
+    }
+
+    // The regenerated page must keep the skeleton markers downstream code
+    // splices into: `</head>` / `</body>` for the virtual-repo local merge,
+    // and the PEP 503 doctype.
+    #[test]
+    fn test_rewrite_regeneration_keeps_pep503_skeleton_markers() {
+        let out = rewrite_upstream_urls("", "repo", "pkg");
+        assert!(out.starts_with("<!DOCTYPE html>"), "{out}");
+        assert!(
+            out.contains("</head>"),
+            "merge splice marker missing: {out}"
+        );
+        assert!(
+            out.contains("</body>"),
+            "merge splice marker missing: {out}"
+        );
+        assert!(
+            out.contains("pypi:repository-version"),
+            "repository-version meta missing: {out}"
+        );
+    }
+
     #[test]
     fn test_case_a_filter_remote_body_dispatch_sniffs_and_fails_closed() {
         let owned = linux_owner_profile();
@@ -7506,6 +7754,55 @@ mod tests {
         let index_url = "https://nexus.example.com/repository/pypi/simple/other/";
         let result = find_upstream_url_for_file(html, "nonexistent-1.0.tar.gz", Some(index_url));
         assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // find_upstream_sha256_for_file (GHSA-qxv7-p3mq-88fv)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_find_upstream_sha256_extracts_fragment_for_filename() {
+        let sha = "a".repeat(64);
+        let html = format!(
+            r#"<a href="https://files.example.com/packages/ab/six-1.0.tar.gz#sha256={sha}">six-1.0.tar.gz</a>"#
+        );
+        assert_eq!(
+            find_upstream_sha256_for_file(&html, "six-1.0.tar.gz"),
+            Some(sha)
+        );
+        // A different file on the same page is not matched.
+        assert_eq!(find_upstream_sha256_for_file(&html, "six-2.0.tar.gz"), None);
+    }
+
+    #[test]
+    fn test_find_upstream_sha256_rejects_non_canonical_or_absent() {
+        // No fragment -> None (the download proceeds unverified, as before).
+        let html = r#"<a href="https://files.example.com/six-1.0.tar.gz">six-1.0.tar.gz</a>"#;
+        assert_eq!(find_upstream_sha256_for_file(html, "six-1.0.tar.gz"), None);
+        // Uppercase digests are not the canonical form the gate compares.
+        let upper = "A".repeat(64);
+        let html = format!(
+            r#"<a href="https://files.example.com/six-1.0.tar.gz#sha256={upper}">six-1.0.tar.gz</a>"#
+        );
+        assert_eq!(find_upstream_sha256_for_file(&html, "six-1.0.tar.gz"), None);
+        // Truncated digests are not SHA-256.
+        let html = r#"<a href="https://files.example.com/six-1.0.tar.gz#sha256=abc123">six-1.0.tar.gz</a>"#;
+        assert_eq!(find_upstream_sha256_for_file(html, "six-1.0.tar.gz"), None);
+        // An md5 fragment is not a SHA-256 pin.
+        let html =
+            r#"<a href="https://files.example.com/six-1.0.tar.gz#md5=deadbeef">six-1.0.tar.gz</a>"#;
+        assert_eq!(find_upstream_sha256_for_file(html, "six-1.0.tar.gz"), None);
+    }
+
+    #[test]
+    fn test_find_upstream_sha256_handles_relative_and_single_quoted_hrefs() {
+        let sha = "b".repeat(64);
+        let html =
+            format!("<a href='../../packages/six-1.0.tar.gz#sha256={sha}'>six-1.0.tar.gz</a>");
+        assert_eq!(
+            find_upstream_sha256_for_file(&html, "six-1.0.tar.gz"),
+            Some(sha)
+        );
     }
 
     #[test]
@@ -11038,7 +11335,8 @@ mod tests {
     /// The simple index page has no matching href, so `resolve_pypi_remote_fetch_target`
     /// falls through to the stable `simple/{project}/{filename}` fallback path.
     /// This avoids the SSRF check (which hard-blocks loopback) while still
-    /// exercising `fetch_from_pypi_remote_streaming` and `proxy_fetch_streaming_with_cache_key`.
+    /// exercising `fetch_from_pypi_remote_streaming` and
+    /// `proxy_fetch_streaming_with_cache_key_verified`.
     ///
     /// Skipped when `DATABASE_URL` is unset (CI always sets it).
     #[tokio::test]
@@ -14394,7 +14692,9 @@ mod tests {
     // Simple index must be neutralized, or it re-anchors our root-relative
     // rewritten download URLs onto the upstream origin — a proxy bypass that
     // discloses the upstream host and breaks air-gapped installs. RED before
-    // the BASE_TAG_RE strip, GREEN after. Sibling of the #2801 sniff fix.
+    // the BASE_TAG_RE strip, GREEN after; the GHSA-4cw7-mgqj-hgmg regeneration
+    // made the strip moot (no upstream markup survives at all). Sibling of the
+    // #2801 sniff fix.
     #[test]
     fn test_rewrite_upstream_urls_neutralizes_base_href() {
         let upstream = concat!(

--- a/backend/src/api/handlers/wasm_proxy.rs
+++ b/backend/src/api/handlers/wasm_proxy.rs
@@ -9,10 +9,12 @@ use axum::{
     extract::{Path, State},
     http::{HeaderMap, Method, Response, StatusCode},
     routing::any,
-    Router,
+    Extension, Router,
 };
 
 use crate::api::extractors::RequestBaseUrl;
+use crate::api::handlers::repositories::require_visible;
+use crate::api::middleware::auth::{unauthorized_response, AuthExtension};
 use crate::api::SharedState;
 use crate::error::AppError;
 use crate::services::repository_service::RepositoryService;
@@ -50,10 +52,37 @@ fn normalize_path(sub_path: &str) -> String {
     }
 }
 
-/// Convert HTTP headers to a list of string pairs, skipping non-UTF-8 values.
+/// Headers the /ext proxy forwards into plugin memory.
+///
+/// GHSA-9rqp-mgmw-5879: the proxy previously copied ALL client request
+/// headers into the WASM request, including `Authorization: Bearer`,
+/// `Cookie`, and `Proxy-Authorization` — handing the caller's credentials to
+/// plugin code that has no legitimate need for them (and that a malicious or
+/// compromised plugin could exfiltrate). Only the benign protocol /
+/// content-negotiation headers a protocol plugin legitimately needs are
+/// forwarded; credential and hop-by-hop headers are never copied. Header
+/// names in a `HeaderMap` are already lowercase, so the allowlist is matched
+/// lowercase.
+const FORWARDED_HEADER_ALLOWLIST: &[&str] = &[
+    "accept",
+    "accept-encoding",
+    "accept-language",
+    "content-length",
+    "content-type",
+    "host",
+    "if-modified-since",
+    "if-none-match",
+    "if-range",
+    "range",
+    "user-agent",
+];
+
+/// Convert HTTP headers to a list of string pairs, skipping non-UTF-8 values
+/// and any header outside [`FORWARDED_HEADER_ALLOWLIST`].
 fn headers_to_pairs(headers: &HeaderMap) -> Vec<(String, String)> {
     headers
         .iter()
+        .filter(|(k, _)| FORWARDED_HEADER_ALLOWLIST.contains(&k.as_str()))
         .filter_map(|(k, v)| v.to_str().ok().map(|v| (k.to_string(), v.to_string())))
         .collect()
 }
@@ -100,6 +129,7 @@ async fn handle_wasm_request(
     headers: HeaderMap,
     base_url: RequestBaseUrl,
     Path(params): Path<Vec<(String, String)>>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     body: Bytes,
 ) -> Result<Response<Body>, Response<Body>> {
     let format_key = extract_param(&params, "format_key");
@@ -139,6 +169,19 @@ async fn handle_wasm_request(
 
     if let Some(msg) = check_format_key_match(repo_key, repo_format_key.as_deref(), format_key) {
         return Err(error_response(StatusCode::BAD_REQUEST, &msg));
+    }
+
+    // 3b. Defense in depth (GHSA-9rqp-mgmw-5879): enforce the canonical
+    // visibility gate in the handler itself, not just in
+    // `repo_visibility_middleware`. This handler hands the plugin the repo's
+    // full artifact metadata, so it must not rely solely on the middleware
+    // having resolved the right path segment. Reuse the REST
+    // `require_visible` helper rather than open-coding a policy: public repos
+    // are open to everyone (including anonymous); private repos require an
+    // authenticated caller with admin rights or a role assignment, and
+    // repository-scoped API tokens must cover this repo.
+    if let Err(e) = require_visible(&repo, &auth, &repo_service).await {
+        return Err(visibility_denial_response(&auth, e));
     }
 
     // 4. Gather artifact metadata from DB
@@ -257,6 +300,29 @@ async fn fetch_repo_artifacts(
             )
         })
         .collect())
+}
+
+/// Map a `require_visible` denial on an /ext request to the same answer the
+/// rest of the codebase gives (GHSA-9rqp-mgmw-5879). Anonymous callers get
+/// the identical 401 + `WWW-Authenticate` challenge `repo_visibility_middleware`
+/// emits, so package clients still retry with credentials; authenticated
+/// callers without a grant get the existence-hiding 404, matching both the
+/// REST path and the middleware's rule-less private-repo branch. A DB failure
+/// inside the access check fails closed with a 500, never open.
+fn visibility_denial_response(auth: &Option<AuthExtension>, err: AppError) -> Response<Body> {
+    match err {
+        AppError::NotFound(msg) => {
+            if auth.is_none() {
+                unauthorized_response()
+            } else {
+                error_response(StatusCode::NOT_FOUND, &msg)
+            }
+        }
+        other => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("Repository access check failed: {}", other),
+        ),
+    }
 }
 
 /// Build a JSON error response.
@@ -413,12 +479,129 @@ mod tests {
     #[test]
     fn test_headers_to_pairs_skips_non_utf8() {
         let mut headers = HeaderMap::new();
-        headers.insert("good", HeaderValue::from_static("valid"));
-        headers.insert("binary", HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap());
+        headers.insert("accept", HeaderValue::from_static("valid"));
+        headers.insert(
+            "user-agent",
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
         let pairs = headers_to_pairs(&headers);
         assert_eq!(pairs.len(), 1);
-        assert_eq!(pairs[0].0, "good");
+        assert_eq!(pairs[0].0, "accept");
         assert_eq!(pairs[0].1, "valid");
+    }
+
+    // -----------------------------------------------------------------------
+    // headers_to_pairs credential filtering (GHSA-9rqp-mgmw-5879)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_headers_to_pairs_never_forwards_credentials() {
+        // GHSA-9rqp-mgmw-5879: before the fix every client header was copied
+        // into plugin memory, so a plugin received the caller's
+        // `Authorization: Bearer` token (and any cookie / proxy credential).
+        // Credential headers must be stripped; benign protocol headers pass.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer secret-token"),
+        );
+        headers.insert("cookie", HeaderValue::from_static("session=abc"));
+        headers.insert(
+            "proxy-authorization",
+            HeaderValue::from_static("Basic eA=="),
+        );
+        headers.insert("x-api-key", HeaderValue::from_static("ak_secret"));
+        headers.insert("x-nuget-apikey", HeaderValue::from_static("nuget-secret"));
+        headers.insert("accept", HeaderValue::from_static("text/html"));
+        headers.insert("user-agent", HeaderValue::from_static("pip/24.0"));
+        headers.insert("range", HeaderValue::from_static("bytes=0-1023"));
+        let pairs = headers_to_pairs(&headers);
+        assert_eq!(
+            pairs.len(),
+            3,
+            "only the benign allowlisted headers may reach the plugin"
+        );
+        for (name, value) in &pairs {
+            assert!(
+                FORWARDED_HEADER_ALLOWLIST.contains(&name.as_str()),
+                "non-allowlisted header '{}' leaked into the WASM request",
+                name
+            );
+            assert!(
+                !value.contains("secret") && !value.contains("session=abc"),
+                "credential material leaked into the WASM request"
+            );
+        }
+        assert!(pairs.iter().any(|(k, _)| k == "accept"));
+        assert!(pairs.iter().any(|(k, _)| k == "user-agent"));
+        assert!(pairs.iter().any(|(k, _)| k == "range"));
+    }
+
+    #[test]
+    fn test_build_wasm_request_omits_authorization_header() {
+        // GHSA-9rqp-mgmw-5879, end-to-end through build_wasm_request: the
+        // caller's Authorization header must not be present in the headers
+        // the plugin sees.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer secret-token"),
+        );
+        headers.insert("accept", HeaderValue::from_static("application/json"));
+        let (req, _ctx) = build_wasm_request(
+            &headers,
+            &Method::GET,
+            "http://localhost:8080",
+            "/simple/".to_string(),
+            Bytes::new(),
+            "pypi-custom",
+            "my-pypi",
+        );
+        assert_eq!(req.headers.len(), 1);
+        assert_eq!(req.headers[0].0, "accept");
+        assert!(!req.headers.iter().any(|(k, _)| k == "authorization"));
+    }
+
+    // -----------------------------------------------------------------------
+    // visibility_denial_response (GHSA-9rqp-mgmw-5879)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_visibility_denial_anonymous_gets_401_challenge() {
+        // Anonymous on an inaccessible repo: the same 401 + WWW-Authenticate
+        // challenge repo_visibility_middleware emits, so package clients
+        // retry with credentials instead of treating the repo as missing.
+        let resp = visibility_denial_response(
+            &None,
+            AppError::NotFound("Repository 'private' not found".to_string()),
+        );
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert!(resp.headers().get("WWW-Authenticate").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_visibility_denial_authenticated_gets_existence_hiding_404() {
+        // Authenticated WITHOUT a grant: existence-hiding 404, matching the
+        // REST `require_visible` contract — the caller must not be able to
+        // distinguish "private repo I can't see" from "no such repo".
+        let auth = Some(AuthExtension {
+            user_id: uuid::Uuid::new_v4(),
+            username: "alice".to_string(),
+            ..Default::default()
+        });
+        let resp = visibility_denial_response(
+            &auth,
+            AppError::NotFound("Repository 'private' not found".to_string()),
+        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_visibility_denial_db_error_fails_closed_500() {
+        // A DB failure inside the access check must fail closed (500), never
+        // fall through to serving the repo.
+        let resp = visibility_denial_response(&None, AppError::Database("down".to_string()));
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1426,6 +1426,18 @@ pub(crate) fn extract_repo_key(path: &str) -> &str {
         segments.next(); // "t"
         segments.next(); // "<TOKEN>"
     }
+    // WASM plugin proxy routes are nested as
+    //   /ext/<format_key>/<repo_key>/...
+    // so the repository key is the THIRD path segment, not the second
+    // (GHSA-9rqp-mgmw-5879). Returning the second segment (the plugin format
+    // key) made the visibility middleware resolve a nonexistent repo and fall
+    // into its no-repo branch: anonymous callers were 401'd, but ANY
+    // authenticated caller passed through with no visibility/permission check
+    // on the actual target repo — including private repos. Skip the
+    // format-key segment so the real repository key is evaluated.
+    if format == "ext" {
+        segments.next(); // "<format_key>"
+    }
     segments.next().unwrap_or("")
 }
 
@@ -1601,7 +1613,10 @@ fn is_non_mutating_format_post(path: &str) -> bool {
 /// Build a 401 response with `WWW-Authenticate` challenges for both Basic
 /// and Bearer schemes.  Package manager clients use the challenge to decide
 /// how to retry with credentials.
-fn unauthorized_response() -> Response {
+///
+/// `pub(crate)` so the WASM proxy handler (`/ext/*`) can emit the identical
+/// anonymous-denial response as this middleware (GHSA-9rqp-mgmw-5879).
+pub(crate) fn unauthorized_response() -> Response {
     Response::builder()
         .status(StatusCode::UNAUTHORIZED)
         .header("WWW-Authenticate", "Basic realm=\"artifact-keeper\"")
@@ -3282,6 +3297,31 @@ mod tests {
         // A conda channel that merely happens to be named "t" (no token
         // segment shape) still resolves to that key when addressed plainly.
         assert_eq!(extract_repo_key("/conda/t"), "");
+    }
+
+    #[test]
+    fn test_extract_repo_key_ext_wasm_proxy() {
+        // GHSA-9rqp-mgmw-5879: /ext routes are nested
+        // `/ext/<format_key>/<repo_key>/...`, so the repository key is the
+        // THIRD segment. Before the fix the generic rule returned the second
+        // segment (the plugin format key), no repo matched, and the
+        // visibility middleware's no-repo branch let ANY authenticated caller
+        // through to any repo — including private ones.
+        assert_eq!(
+            extract_repo_key("/ext/pypi-custom/my-repo/simple/"),
+            "my-repo"
+        );
+        assert_eq!(
+            extract_repo_key("/ext/rpm-custom/centos-repo/repodata/repomd.xml"),
+            "centos-repo"
+        );
+        // Exact-mount forms (no sub-path) resolve the same way.
+        assert_eq!(extract_repo_key("/ext/pypi-custom/my-repo"), "my-repo");
+        assert_eq!(extract_repo_key("/ext/pypi-custom/my-repo/"), "my-repo");
+        // Missing repo segment: empty key, middleware passes through and the
+        // router/handler 404s — unchanged from other formats.
+        assert_eq!(extract_repo_key("/ext/pypi-custom"), "");
+        assert_eq!(extract_repo_key("/ext"), "");
     }
 
     #[test]
@@ -6010,6 +6050,168 @@ mod tests {
             resp.status(),
             StatusCode::OK,
             "a role assignment must restore native-path access to the private repo"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// Regression for GHSA-9rqp-mgmw-5879: the /ext WASM proxy routes are
+    /// nested `/ext/<format_key>/<repo_key>/...`, but `extract_repo_key`
+    /// returned the SECOND segment (the plugin format key) as the repo key.
+    /// No repo matched, so `repo_visibility_middleware` fell into its no-repo
+    /// branch and let ANY authenticated caller through with no visibility or
+    /// permission check on the real target repo — a full private-repo read
+    /// bypass (the handler then hands the plugin the repo's entire artifact
+    /// metadata list). After the fix the middleware resolves the third
+    /// segment and applies the standard gate: anonymous -> 401, an
+    /// authenticated non-admin WITHOUT a grant -> existence-hiding 404 (same
+    /// as the REST `require_visible` model), a granted member -> pass.
+    ///
+    /// DB-backed: no-ops when `DATABASE_URL` is unset; runs for real in the
+    /// CI coverage job (which seeds Postgres before `cargo llvm-cov --lib`).
+    #[tokio::test]
+    async fn test_ext_wasm_proxy_route_enforces_repo_visibility() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::models::user::{AuthProvider, User};
+        use crate::services::permission_service::PermissionService;
+        use std::sync::Arc;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (user_id, username) = tdh::create_user(&pool).await; // non-admin
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "local", "pypi").await; // is_public defaults false
+
+        // Mint a real access JWT for this non-admin user. AuthService is built
+        // on the real pool so the replica-safe invalidation check succeeds.
+        let auth_service = Arc::new(AuthService::new(
+            pool.clone(),
+            make_test_config_for_middleware(),
+        ));
+        let now = chrono::Utc::now();
+        let user = User {
+            id: user_id,
+            username: username.clone(),
+            email: format!("{}@test.local", username),
+            password_hash: None,
+            auth_provider: AuthProvider::Local,
+            external_id: None,
+            display_name: None,
+            is_active: true,
+            is_admin: false,
+            is_service_account: false,
+            must_change_password: false,
+            totp_secret: None,
+            totp_enabled: false,
+            totp_backup_codes: None,
+            totp_verified_at: None,
+            failed_login_attempts: 0,
+            locked_until: None,
+            last_failed_login_at: None,
+            password_changed_at: now,
+            last_login_at: Some(now),
+            created_at: now,
+            updated_at: now,
+        };
+        let bearer = format!(
+            "Bearer {}",
+            auth_service.generate_tokens(&user).unwrap().access_token
+        );
+
+        // Fresh state per request: a pre-populated cache so the middleware
+        // skips the DB repo lookup, with the private repo's real id so the
+        // role_assignments query resolves against it.
+        async fn mk_state(
+            pool: &sqlx::PgPool,
+            auth: Arc<AuthService>,
+            repo_key: &str,
+            repo_id: Uuid,
+            storage_path: String,
+        ) -> RepoVisibilityState {
+            let cache: RepoCache =
+                Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+            let entry = CachedRepo {
+                id: repo_id,
+                format: "pypi".to_string(),
+                repo_type: "local".to_string(),
+                upstream_url: None,
+                storage_path,
+                storage_backend: "filesystem".to_string(),
+                is_public: false,
+                index_upstream_url: None,
+            };
+            cache
+                .write()
+                .await
+                .insert(repo_key.to_string(), (entry, std::time::Instant::now()));
+            RepoVisibilityState {
+                auth_service: auth,
+                db: pool.clone(),
+                repo_cache: cache,
+                permission_service: Arc::new(PermissionService::new(pool.clone())),
+            }
+        }
+
+        // The /ext WASM proxy shape: plugin format key first, repo key second.
+        let ext_uri = format!("/ext/pypi-custom/{}/simple/", repo_key);
+        let storage = storage_dir.to_string_lossy().into_owned();
+
+        // 1) Anonymous caller -> 401 (the middleware's standard private-repo
+        //    denial, with the credential challenge).
+        let state = mk_state(
+            &pool,
+            auth_service.clone(),
+            &repo_key,
+            repo_id,
+            storage.clone(),
+        )
+        .await;
+        let resp = run_through_visibility(state, empty_get(&ext_uri)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "anonymous /ext read of a private repo must be 401"
+        );
+
+        // 2) Authenticated non-admin WITHOUT a role assignment -> 404. This is
+        //    the core GHSA-9rqp-mgmw-5879 regression assertion: before the fix
+        //    the middleware resolved the format key ("pypi-custom") as the
+        //    repo, matched nothing, and let this request THROUGH (200).
+        let authed_req = || {
+            axum::http::Request::builder()
+                .method(Method::GET)
+                .uri(&ext_uri)
+                .header("Authorization", &bearer)
+                .body(axum::body::Body::empty())
+                .unwrap()
+        };
+        let state = mk_state(
+            &pool,
+            auth_service.clone(),
+            &repo_key,
+            repo_id,
+            storage.clone(),
+        )
+        .await;
+        let resp = run_through_visibility(state, authed_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "authenticated non-admin without a grant must NOT read a private \
+             repo through /ext (existence-hiding 404, same as REST)"
+        );
+
+        // 3) Grant a role assignment -> access restored (200 = reached the
+        //    handler), matching the native-format and REST paths.
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = mk_state(&pool, auth_service, &repo_key, repo_id, storage).await;
+        let resp = run_through_visibility(state, authed_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a role assignment must restore /ext access to the private repo"
         );
 
         tdh::cleanup(&pool, repo_id, user_id).await;

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -213,6 +213,72 @@ impl StreamingFetchResult {
     }
 }
 
+/// A content digest a streaming proxy-cache commit can be gated on.
+///
+/// #2274 introduced the gate for bare SHA-256 hex, which the storage layer
+/// observes for free. GHSA-qxv7-p3mq-88fv extends it to the digest
+/// algorithms ecosystems actually publish for their immutable artifacts:
+/// npm records tarball integrity as an SRI `sha512-<base64>`
+/// (`dist.integrity`) or legacy SHA-1 hex (`dist.shasum`) in the packument,
+/// and Maven publishes SHA-1 `.sha1` sidecars. The storage layer never
+/// computes those, so for the non-SHA-256 variants the tee hashes the bytes
+/// it hands to the cache writer itself and the writer compares before
+/// committing. All variants carry the expected digest as lowercase hex.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheCommitDigest {
+    /// Bare lowercase SHA-256 hex, compared against the storage layer's
+    /// observed checksum — the original #2274 gate (OCI blob digests,
+    /// Cargo sparse-index `cksum` #2929, PyPI `#sha256=` fragments).
+    Sha256Hex(String),
+    /// Lowercase SHA-512 hex (npm `dist.integrity` SRI, decoded from its
+    /// base64 payload by the caller).
+    Sha512Hex(String),
+    /// Lowercase SHA-1 hex (npm `dist.shasum`, Maven `.sha1` sidecars).
+    Sha1Hex(String),
+}
+
+impl CacheCommitDigest {
+    /// The expected digest as lowercase hex, regardless of algorithm.
+    fn as_hex(&self) -> &str {
+        match self {
+            Self::Sha256Hex(h) | Self::Sha512Hex(h) | Self::Sha1Hex(h) => h,
+        }
+    }
+}
+
+/// Running hasher for the non-SHA-256 commit gates (GHSA-qxv7-p3mq-88fv):
+/// the tee feeds it every byte it hands to the cache writer and finalizes
+/// it at upstream EOF. SHA-256 expectations never get one — the storage
+/// layer's observed checksum covers those.
+enum TeeDigestHasher {
+    Sha1(sha1::Sha1),
+    Sha512(sha2::Sha512),
+}
+
+impl TeeDigestHasher {
+    fn for_expected(expected: &CacheCommitDigest) -> Option<Self> {
+        match expected {
+            CacheCommitDigest::Sha1Hex(_) => Some(Self::Sha1(sha1::Sha1::default())),
+            CacheCommitDigest::Sha512Hex(_) => Some(Self::Sha512(sha2::Sha512::default())),
+            CacheCommitDigest::Sha256Hex(_) => None,
+        }
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Sha1(h) => sha1::Digest::update(h, bytes),
+            Self::Sha512(h) => sha2::Digest::update(h, bytes),
+        }
+    }
+
+    fn finalize_hex(self) -> String {
+        match self {
+            Self::Sha1(h) => hex::encode(sha1::Digest::finalize(h)),
+            Self::Sha512(h) => hex::encode(sha2::Digest::finalize(h)),
+        }
+    }
+}
+
 /// Metadata fields known up-front when teeing an upstream stream into
 /// the proxy cache. The size + sha-256 fields of [`CacheMetadata`] are
 /// observed during the stream itself and filled in by the writer task
@@ -230,16 +296,16 @@ struct CacheMetadataTemplate {
     /// which does not currently surface the header into the tee template.
     last_modified: Option<String>,
     ttl_secs: i64,
-    /// Optional content-addressable checksum the cache commit is gated on
-    /// (#2274). Bare lowercase SHA-256 hex (no `sha256:` prefix). When
-    /// `Some`, [`CachePersister::tee_stream`] persists the cached object
-    /// ONLY if the streamed body's SHA-256 equals this value; a mismatch is
-    /// treated like a rejected write (object deleted, no metadata sidecar)
-    /// so a digest-addressed fetch that returns wrong bytes cannot poison
-    /// the proxy cache. `None` preserves the pre-existing behaviour for every
-    /// other streaming caller (deb/pypi/plain-Remote), which gate only on the
-    /// upstream Content-Length.
-    expected_checksum: Option<String>,
+    /// Optional content digest the cache commit is gated on (#2274, widened
+    /// past SHA-256 by GHSA-qxv7-p3mq-88fv). When `Some`,
+    /// [`CachePersister::tee_stream`] persists the cached object ONLY if the
+    /// streamed body matches it; a mismatch is treated like a rejected write
+    /// (object deleted, no metadata sidecar) so a digest-addressed fetch
+    /// that returns wrong bytes cannot poison the proxy cache. `None`
+    /// preserves the pre-existing behaviour for every other streaming
+    /// caller (deb/pypi/plain-Remote), which gate only on the upstream
+    /// Content-Length.
+    expected_checksum: Option<CacheCommitDigest>,
     /// Owning repository id for the persisted proxy-cache catalog row
     /// (#2218/#2270). Threaded so the streaming Commit arm can upsert
     /// `proxy_cache_artifacts` with the TRUE `bytes_written`/checksum.
@@ -1633,6 +1699,21 @@ impl CachePersister {
         // cached SHA-256).
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes>>(TEE_CHANNEL_DEPTH);
 
+        // GHSA-qxv7-p3mq-88fv: for a non-SHA-256 expected digest the storage
+        // layer never observes the hash (put_stream reports SHA-256 only), so
+        // the tee hashes every byte it hands to the cache writer and
+        // publishes the finalized hex digest through this slot at upstream
+        // EOF — BEFORE `tx` is dropped, so when `put_stream` returns the
+        // writer either reads the completed digest or finds `None` (client
+        // disconnect mid-stream, or a cache write abandoned under the #2928
+        // ceiling), which fails the gate closed and skips the cache commit.
+        let tee_hasher = template
+            .expected_checksum
+            .as_ref()
+            .and_then(TeeDigestHasher::for_expected);
+        let tee_digest_slot = Arc::new(std::sync::Mutex::new(None::<String>));
+        let tee_digest_slot_writer = Arc::clone(&tee_digest_slot);
+
         // Spawn the storage writer. It consumes the channel as a stream
         // and calls put_stream against a private staging key, never
         // `cache_key` directly (see the `copy` call below). On completion,
@@ -1658,19 +1739,39 @@ impl CachePersister {
                 Ok(result) => match classify_stream_write(result.bytes_written, expected_len) {
                     StreamWriteOutcome::Commit => {
                         // #2274 digest-gated commit: when the caller pinned an
-                        // expected content-addressable checksum (the OCI
+                        // expected content-addressable digest (the OCI
                         // virtual-repo blob fallback passes the requested blob
-                        // digest), refuse to persist a body whose streamed
-                        // SHA-256 does not match it. The bytes were already
-                        // forwarded to the client — which independently verifies
-                        // the digest — but the proxy cache must never be poisoned
-                        // with mismatched content addressed by that digest. Treat
-                        // a mismatch exactly like the truncated/empty reject path:
-                        // discard the staging object and skip the sidecar so
-                        // the next request refetches (self-heal); `cache_key`
-                        // was never touched.
-                        if let Some(expected) = template.expected_checksum.as_deref() {
-                            if result.checksum_sha256 != expected {
+                        // digest; npm/PyPI/Maven pass the registry-published
+                        // tarball/file digest, GHSA-qxv7-p3mq-88fv), refuse to
+                        // persist a body whose digest does not match it. The
+                        // bytes were already forwarded to the client — which
+                        // independently verifies the digest — but the proxy
+                        // cache must never be poisoned with mismatched content
+                        // addressed by that digest. Treat a mismatch exactly
+                        // like the truncated/empty reject path: discard the
+                        // staging object and skip the sidecar so the next
+                        // request refetches (self-heal); `cache_key` was never
+                        // touched.
+                        //
+                        // The observed digest comes from the storage layer for
+                        // SHA-256 and from the tee-side hasher (finalized into
+                        // `tee_digest_slot_writer` at upstream EOF) for
+                        // SHA-1/SHA-512. A missing tee digest — the client
+                        // disconnected mid-stream, or the cache write was
+                        // abandoned — cannot match, so the gate fails closed.
+                        if let Some(expected) = template.expected_checksum.as_ref() {
+                            let observed_hex = match expected {
+                                CacheCommitDigest::Sha256Hex(_) => {
+                                    Some(result.checksum_sha256.clone())
+                                }
+                                CacheCommitDigest::Sha512Hex(_) | CacheCommitDigest::Sha1Hex(_) => {
+                                    tee_digest_slot_writer
+                                        .lock()
+                                        .ok()
+                                        .and_then(|slot| slot.clone())
+                                }
+                            };
+                            if observed_hex.as_deref() != Some(expected.as_hex()) {
                                 tracing::warn!(
                                     cache_key = %cache_key_for_writer,
                                     "streamed body checksum does not match the requested digest; \
@@ -1844,6 +1945,10 @@ impl CachePersister {
         // sees the error and aborts cleanly) and surface to the client.
         let tee_stream = async_stream::try_stream! {
             let mut upstream = upstream;
+            // GHSA-qxv7-p3mq-88fv: hash the bytes actually handed to the
+            // cache writer (never bytes withheld past the #2928 ceiling) so
+            // the writer can gate a non-SHA-256 commit on the result.
+            let mut tee_hasher = tee_hasher;
             // #2928: cumulative bytes handed to the cache writer, and the
             // latch that says we have stopped doing so. Counted on the tee
             // side rather than after `put_stream` returns, because the whole
@@ -1890,6 +1995,9 @@ impl CachePersister {
                             // its receiver), drop the caching half silently
                             // and keep yielding to the client.
                             if !cache_abandoned {
+                                if let Some(hasher) = tee_hasher.as_mut() {
+                                    hasher.update(&slice);
+                                }
                                 let _ = tx.send(Ok(slice.clone())).await;
                             }
                             yield slice;
@@ -1913,6 +2021,17 @@ impl CachePersister {
                         let _ = tx.send(storage_msg).await;
                         Err(e)?;
                     }
+                }
+            }
+            // upstream EOF: publish the tee-computed digest (when a
+            // non-SHA-256 commit gate is in play) BEFORE dropping tx, so the
+            // writer's `put_stream` can only complete after the digest it is
+            // about to compare is visible. A stream abandoned under the
+            // #2928 ceiling publishes nothing — its writer is already on the
+            // error arm, and an empty slot fails the gate closed regardless.
+            if let (Some(hasher), false) = (tee_hasher, cache_abandoned) {
+                if let Ok(mut slot) = tee_digest_slot.lock() {
+                    *slot = Some(hasher.finalize_hex());
                 }
             }
             // upstream EOF: drop tx so the writer sees end-of-stream
@@ -2294,8 +2413,39 @@ impl UpstreamClient {
                 // realm to an internal address.
                 crate::api::validation::validate_outbound_url(realm, "OCI token realm")?;
 
+                // GHSA-78h6-3wp8-2542: the realm is UPSTREAM-CONTROLLED, and
+                // SSRF validation alone does not stop a public-but-hostile
+                // realm — it only keeps the token request off internal
+                // addresses. Forwarding the configured upstream's Basic
+                // credentials to whatever host the realm names would hand
+                // them to an attacker who controls (or has compromised) the
+                // registry's 401 responses. Pin the credential forwarding to
+                // the configured upstream's ORIGIN (scheme + host + port,
+                // the same notion nuget's `same_upstream_origin` enforces for
+                // discovered feed resources, #2925/#3130): when the realm is
+                // a different origin, attempt the token exchange WITHOUT
+                // credentials rather than failing outright — anonymous token
+                // endpoints (Docker Hub's auth.docker.io among them) answer
+                // such requests, and a realm that genuinely requires the
+                // upstream's credentials simply rejects the exchange, which
+                // fails closed. There is deliberately no cross-host
+                // allowance: this codebase pins credentials to the
+                // operator-configured origin everywhere else.
+                let realm_auth = if Self::realm_matches_upstream_origin(realm, url) {
+                    upstream_auth.clone()
+                } else {
+                    tracing::warn!(
+                        target: "security",
+                        realm = %redact_url_for_diagnostics(realm),
+                        "OCI bearer realm is a different origin than the configured upstream; \
+                         requesting the token WITHOUT the upstream's Basic credentials \
+                         (GHSA-78h6-3wp8-2542)"
+                    );
+                    None
+                };
+
                 let token = self
-                    .obtain_bearer_token(realm, &service, &scope, upstream_auth)
+                    .obtain_bearer_token(realm, &service, &scope, &realm_auth)
                     .await?;
 
                 // Retry with the bearer token only. The original upstream
@@ -2530,6 +2680,32 @@ impl UpstreamClient {
         }
 
         params
+    }
+
+    /// Whether an upstream-supplied OCI bearer `realm` shares an ORIGIN
+    /// (scheme + host + port, host compared case-insensitively, default ports
+    /// normalized) with the upstream request URL that produced the 401 —
+    /// i.e. with the operator-configured upstream the request URL was built
+    /// from. Credentials configured for the upstream are forwarded to the
+    /// token endpoint only when this holds (GHSA-78h6-3wp8-2542); a
+    /// cross-origin realm gets an anonymous token request instead. Strict
+    /// origin match, no suffix allowance: a private registry whose token
+    /// endpoint legitimately lives on another host keeps working only for
+    /// anonymous-scope tokens, which is the fail-closed trade-off this
+    /// advisory calls for. Unparseable URLs never match.
+    fn realm_matches_upstream_origin(realm: &str, upstream_url: &str) -> bool {
+        match (
+            reqwest::Url::parse(realm),
+            reqwest::Url::parse(upstream_url),
+        ) {
+            (Ok(realm), Ok(upstream)) => {
+                realm.scheme() == upstream.scheme()
+                    && realm.host_str().map(str::to_ascii_lowercase)
+                        == upstream.host_str().map(str::to_ascii_lowercase)
+                    && realm.port_or_known_default() == upstream.port_or_known_default()
+            }
+            _ => false,
+        }
     }
 
     /// Check if upstream ETag has changed (returns true if changed/newer).
@@ -3344,6 +3520,30 @@ impl ProxyService {
         cache_path: &str,
         expected_checksum: Option<String>,
     ) -> Result<StreamingFetchResult> {
+        self.fetch_artifact_streaming_with_cache_path_gated_digest(
+            repo,
+            fetch_path,
+            cache_path,
+            expected_checksum.map(CacheCommitDigest::Sha256Hex),
+        )
+        .await
+    }
+
+    /// Algorithm-flexible sibling of
+    /// [`Self::fetch_artifact_streaming_with_cache_path_gated`]
+    /// (GHSA-qxv7-p3mq-88fv): the npm packument pins tarballs by SRI
+    /// SHA-512 / legacy SHA-1 and Maven by SHA-1 sidecars — digests the
+    /// storage layer never observes — so this variant takes a
+    /// [`CacheCommitDigest`] and has the tee hash the forwarded bytes for
+    /// the non-SHA-256 algorithms. Serve-but-don't-cache posture on a
+    /// mismatch is identical.
+    pub async fn fetch_artifact_streaming_with_cache_path_gated_digest(
+        &self,
+        repo: &Repository,
+        fetch_path: &str,
+        cache_path: &str,
+        expected_checksum: Option<CacheCommitDigest>,
+    ) -> Result<StreamingFetchResult> {
         // #1631 layer 2 (#1694): single-flight the cold-cache streaming path so
         // N concurrent requests for the same uncached object open upstream ONCE.
         // The streaming coordinator's followers subscribe to the leader's
@@ -3408,7 +3608,7 @@ impl ProxyService {
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
-        expected_checksum: Option<String>,
+        expected_checksum: Option<CacheCommitDigest>,
     ) -> Result<Option<StreamingFetchResult>> {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
@@ -3652,7 +3852,7 @@ impl ProxyService {
         cache_path: &str,
         cache_key: String,
         metadata_key: String,
-        expected_checksum: Option<String>,
+        expected_checksum: Option<CacheCommitDigest>,
     ) -> Result<StreamHandle> {
         // Package Age Policy (#1770): the streaming path has no buffered
         // upstream `Last-Modified` to base a release-date hold on (#1771), so
@@ -3893,7 +4093,7 @@ impl ProxyService {
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
-        expected_checksum: Option<String>,
+        expected_checksum: Option<CacheCommitDigest>,
     ) -> Result<StreamingFetchResult> {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
@@ -10525,8 +10725,9 @@ mod tests {
         let storage = Arc::new(RealStorageService::new(backend.clone()));
 
         let mut mismatched_template = template();
-        mismatched_template.expected_checksum =
-            Some("0000000000000000000000000000000000000000000000000000000000000".to_string());
+        mismatched_template.expected_checksum = Some(CacheCommitDigest::Sha256Hex(
+            "0000000000000000000000000000000000000000000000000000000000000".to_string(),
+        ));
 
         let upstream = upstream_chunks(vec![&b"first-chunk"[..]]);
         let mut client = CachePersister::new(test_catalog_pool(), storage).tee_stream(
@@ -10558,6 +10759,128 @@ mod tests {
              cache-key: got {:?}",
             deletes[0]
         );
+    }
+
+    /// GHSA-qxv7-p3mq-88fv: the gate must also fire for a non-SHA-256 expected
+    /// digest (npm `dist.integrity` is SRI SHA-512; `dist.shasum` and Maven
+    /// `.sha1` sidecars are SHA-1) — the storage layer only observes SHA-256,
+    /// so these are compared against the tee-side hasher's result. A mismatch
+    /// degrades exactly like the #2274 reject: served to the client, never
+    /// cached.
+    #[tokio::test]
+    async fn test_tee_sha512_gate_mismatch_is_not_cached() {
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        let mut mismatched_template = template();
+        mismatched_template.expected_checksum = Some(CacheCommitDigest::Sha512Hex(hex::encode(
+            sha2::Sha512::digest(b"some other body"),
+        )));
+
+        let upstream = upstream_chunks(vec![&b"first-chunk"[..]]);
+        let mut client = CachePersister::new(test_catalog_pool(), storage).tee_stream(
+            upstream,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            mismatched_template,
+            Some(11),
+            None,
+        );
+        // The client still receives the full body (serve-but-don't-cache).
+        let mut received: Vec<u8> = Vec::new();
+        while let Some(chunk) = client.next().await {
+            received.extend_from_slice(&chunk.expect("client chunk"));
+        }
+        assert_eq!(received, b"first-chunk");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            backend.metadata_writes.lock().await.is_empty(),
+            "a SHA-512-gated mismatch must not write a metadata sidecar"
+        );
+        assert!(
+            backend.copies.lock().await.is_empty(),
+            "a SHA-512-gated mismatch must never publish onto the live key"
+        );
+    }
+
+    /// GHSA-qxv7-p3mq-88fv: SHA-1 gate variant (npm `dist.shasum` / Maven
+    /// `.sha1` sidecar) — same mismatch posture.
+    #[tokio::test]
+    async fn test_tee_sha1_gate_mismatch_is_not_cached() {
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        let mut mismatched_template = template();
+        mismatched_template.expected_checksum = Some(CacheCommitDigest::Sha1Hex(hex::encode(
+            sha1::Sha1::digest(b"some other body"),
+        )));
+
+        let upstream = upstream_chunks(vec![&b"first-chunk"[..]]);
+        let mut client = CachePersister::new(test_catalog_pool(), storage).tee_stream(
+            upstream,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            mismatched_template,
+            Some(11),
+            None,
+        );
+        while let Some(chunk) = client.next().await {
+            let _ = chunk.unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            backend.metadata_writes.lock().await.is_empty(),
+            "a SHA-1-gated mismatch must not write a metadata sidecar"
+        );
+        assert!(
+            backend.copies.lock().await.is_empty(),
+            "a SHA-1-gated mismatch must never publish onto the live key"
+        );
+    }
+
+    /// GHSA-qxv7-p3mq-88fv: a body whose tee-computed SHA-512 MATCHES the
+    /// expected digest commits normally — the gate must admit good bytes, or
+    /// every npm tarball would be a permanent cache miss.
+    #[tokio::test]
+    async fn test_tee_sha512_gate_match_commits() {
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        let mut matched_template = template();
+        matched_template.expected_checksum = Some(CacheCommitDigest::Sha512Hex(hex::encode(
+            sha2::Sha512::digest(b"first-chunk"),
+        )));
+
+        let upstream = upstream_chunks(vec![&b"first-chunk"[..]]);
+        let mut client = CachePersister::new(test_catalog_pool(), storage).tee_stream(
+            upstream,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            matched_template,
+            Some(11),
+            None,
+        );
+        while let Some(chunk) = client.next().await {
+            let _ = chunk.unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let writes = backend.metadata_writes.lock().await;
+        assert_eq!(
+            writes.len(),
+            1,
+            "a matching SHA-512 gate must commit the metadata sidecar"
+        );
+        assert_eq!(writes[0].0, "meta-key");
+        let copies = backend.copies.lock().await;
+        assert_eq!(
+            copies.len(),
+            1,
+            "a matching SHA-512 gate must publish onto the live key"
+        );
+        assert_eq!(copies[0].1, "cache-key");
     }
 
     /// An error mid-upstream-stream must surface to the client AND
@@ -13880,6 +14203,134 @@ mod tests {
         assert_eq!(
             *ttl, MAX_TOKEN_TTL_SECS,
             "an oversized expires_in must be capped at MAX_TOKEN_TTL_SECS",
+        );
+    }
+
+    // -- GHSA-78h6-3wp8-2542: realm-origin credential pinning -----------------
+    //
+    // The full `exchange_bearer_then` path cannot run against wiremock: its
+    // realm SSRF check hard-blocks loopback (see the note above
+    // `test_buffered_fetch_rejects_ssrf_bearer_realm`). The fix is therefore
+    // pinned at its two seams: the origin matcher that decides whether the
+    // configured upstream's credentials may follow the realm, and
+    // `obtain_bearer_token`'s credential attachment, which the exchange now
+    // drives with `None` for a cross-origin realm.
+
+    #[test]
+    fn test_realm_matches_upstream_origin_accepts_same_origin() {
+        assert!(UpstreamClient::realm_matches_upstream_origin(
+            "https://registry.example.com/token",
+            "https://registry.example.com/v2/lib/img/manifests/latest"
+        ));
+        // Default ports normalize: an explicit :443 on one side is the same
+        // origin.
+        assert!(UpstreamClient::realm_matches_upstream_origin(
+            "https://registry.example.com/token",
+            "https://registry.example.com:443/v2/x"
+        ));
+        // Host comparison is case-insensitive.
+        assert!(UpstreamClient::realm_matches_upstream_origin(
+            "https://REGISTRY.example.com/token",
+            "https://registry.example.com/v2/x"
+        ));
+    }
+
+    #[test]
+    fn test_realm_matches_upstream_origin_rejects_cross_origin() {
+        // The attack shape: a compromised/hostile registry answering 401 with
+        // `realm="https://attacker.example/token"` must not receive the
+        // configured upstream's Basic credentials.
+        assert!(!UpstreamClient::realm_matches_upstream_origin(
+            "https://attacker.example/token",
+            "https://registry.example.com/v2/x"
+        ));
+        // Docker Hub's own split (realm on auth.docker.io, pulls from
+        // registry-1.docker.io) is cross-origin, so the token request goes
+        // out WITHOUT the configured credentials: anonymous token endpoints
+        // answer it, and a realm that genuinely requires the credentials
+        // fails closed. Deliberate — the codebase pins credentials to the
+        // operator-configured origin everywhere else (#2925/#3130).
+        assert!(!UpstreamClient::realm_matches_upstream_origin(
+            "https://auth.docker.io/token",
+            "https://registry-1.docker.io/v2/library/alpine/manifests/latest"
+        ));
+        // A scheme downgrade to the same host is not the same origin.
+        assert!(!UpstreamClient::realm_matches_upstream_origin(
+            "http://registry.example.com/token",
+            "https://registry.example.com/v2/x"
+        ));
+        // A different port is not the same origin.
+        assert!(!UpstreamClient::realm_matches_upstream_origin(
+            "https://registry.example.com:4443/token",
+            "https://registry.example.com/v2/x"
+        ));
+        // Unparseable URLs never match (fail closed).
+        assert!(!UpstreamClient::realm_matches_upstream_origin(
+            "not a url",
+            "https://registry.example.com/v2/x"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_obtain_bearer_token_attaches_basic_credentials_only_when_given() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        for token_path in ["/token", "/token-anon"] {
+            Mock::given(method("GET"))
+                .and(path(token_path))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "token": "t",
+                })))
+                .mount(&server)
+                .await;
+        }
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+
+        // Same-origin realm: the exchange passes the configured auth through,
+        // and the token endpoint receives the Basic credentials.
+        let auth = Some(crate::services::upstream_auth::UpstreamAuthType::Basic {
+            username: "svc".to_string(),
+            password: "s3cret".to_string(),
+        });
+        let realm = format!("{}/token", server.uri());
+        client
+            .obtain_bearer_token(&realm, "", "", &auth)
+            .await
+            .expect("credentialed token exchange must succeed");
+
+        // Cross-origin realm (GHSA-78h6-3wp8-2542): the exchange passes
+        // `None`, and the token request must carry NO Authorization header.
+        let anon_realm = format!("{}/token-anon", server.uri());
+        client
+            .obtain_bearer_token(&anon_realm, "", "", &None)
+            .await
+            .expect("anonymous token exchange must succeed");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 2);
+        let by_path = |p: &str| requests.iter().find(|r| r.url.path() == p).unwrap();
+        // Compute the expected header at runtime rather than hardcoding a
+        // base64 `user:pass` literal — secret scanners (rightly) flag those.
+        use base64::Engine as _;
+        let expected_auth = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode("svc:s3cret")
+        );
+        assert_eq!(
+            by_path("/token").headers.get("authorization").unwrap(),
+            &expected_auth,
+            "a same-origin realm must receive the configured Basic credentials"
+        );
+        assert!(
+            by_path("/token-anon")
+                .headers
+                .get("authorization")
+                .is_none(),
+            "a cross-origin realm must NOT receive the configured credentials"
         );
     }
 


### PR DESCRIPTION
Closes #3348

Fixes for four draft security advisories, ahead of the 1.7.4 cut.

- **GHSA-9rqp-mgmw-5879** — `/ext/:format/:repo` WASM protocol proxy evaluated the format key as the repo key, so any authenticated caller bypassed repo visibility and reached private-repo artifact metadata through v2 plugins; caller `Authorization` headers were also forwarded into plugin memory. Fix: correct segment resolution in `extract_repo_key`, `require_visible` enforcement in the handler, header allowlist. Confirmed exploitable against v1.7.2 with a live PoC plugin; regression-tested with positive and negative controls (DB-backed fixture).
- **GHSA-78h6-3wp8-2542** — OCI bearer-realm token exchange forwarded stored upstream Basic credentials to arbitrary cross-origin realms. Fix: strict origin match; cross-origin realms get an unauthenticated token request (fail closed).
- **GHSA-4cw7-mgqj-hgmg** — proxied PyPI simple-index HTML passed upstream markup through with only anchors rewritten (stored XSS + href attribute breakout). Fix: index pages are regenerated from parsed anchors with escaped values; all other upstream markup dropped.
- **GHSA-qxv7-p3mq-88fv** — immutable proxy-cache commits for npm/PyPI/Maven were not integrity-verified. Fix: extend the Cargo #2929 / OCI #2274 digest gate to npm (`dist.integrity`/`shasum`), PyPI (`#sha256=` fragment), and Maven (`.sha1` sidecar); mismatch → serve-but-don't-cache.

Local verification: `cargo check`, `cargo clippy` clean, `cargo test --lib` 15,171 passed / 0 failed, `cargo fmt --check` clean.

Deferred follow-ups (out of scope here): npm/PyPI/Maven *virtual-repo* arms and the npm scan-on-proxy path remain ungated (requires shared-resolver changes); cross-origin OCI token endpoints that require configured credentials now fail closed — worth a line in the 1.7.4 release notes.
