### PR TITLE
fix(ci): suppress CVE-2026-39821 in the bundled grype binary

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -73,18 +73,43 @@
 
 # ---------------------------------------------------------------------------
 # grype v0.117.0 binary — Go stdlib @ go1.26.3
-# Fixed in Go 1.26.4/1.26.5 (1.25.11/1.25.12). grype v0.117.0 (latest) is
-# still built with go1.26.3 — the v0.116.0 -> v0.117.0 bump for #3307 did not
-# move the toolchain. Drops off when grype ships a release built on Go >=
-# 1.26.5. Re-measured against ghcr.io/anchore/grype:v0.117.0 on 2026-08-13:
-# all five still present, CVE-2026-27145 / -39822 / -42504 at HIGH+fixed (i.e.
-# these three are the ones actually holding the gate open), -42505 / -42507 at
-# MEDIUM.
+# Fixed in Go 1.26.4/1.26.5/1.26.6 (1.25.11/1.25.12/1.25.13). grype v0.117.0
+# (latest, published 2026-08-10) is still built with go1.26.3 — the v0.116.0 ->
+# v0.117.0 bump for #3307 did not move the toolchain. Drops off when grype ships
+# a release built on Go >= 1.26.6. Re-measured against
+# ghcr.io/anchore/grype:v0.117.0 on 2026-08-14 (trivy 0.69.3, --ignore-unfixed):
+# CVE-2026-27145 / -39821 / -39822 / -42504 at HIGH+fixed (i.e. these four are
+# the ones actually holding the gate open), -42505 / -42507 at MEDIUM.
+#
+# CVE-2026-39821 (x/net/idna, privilege escalation via incorrect Punycode label
+# processing) is NEW as of the 2026-08-14 DB and is what failed the 1.7.4
+# publish. It needs Go 1.26.6, one line past the 1.26.5 this block previously
+# anticipated. Anchore has shipped no rebuilt release, so there is no tool
+# version to bump to — checked against the grype releases feed on 2026-08-14.
+#
+# Scope: unlike the trivy entries below, a positive runtime argument applies
+# here. The backend images set GRYPE_DB_AUTO_UPDATE=false and
+# GRYPE_CHECK_FOR_APP_UPDATE=false against a DB pre-seeded at build time
+# (Dockerfile.backend stage 5b, #1001), and the backend invokes grype against
+# on-disk artifacts and SBOMs. grype therefore issues no outbound HTTP at
+# runtime, so the net/http hostname path these stdlib CVEs sit in is not
+# driven. This is scope, not a fix: the vulnerable code is still linked in.
+#
+# Tracked for a real fix in #3352 (build grype from source with a patched
+# toolchain, as #3123 already does for trivy).
 CVE-2026-27145
+CVE-2026-39821
 CVE-2026-39822
 CVE-2026-42504
 CVE-2026-42505
 CVE-2026-42507
+
+# NOTE — CVE-2026-46600 also appears in this grype binary's Go stdlib (HIGH,
+# fixed in Go 1.26.6), not only in the vendored trivy CLI it is filed under in
+# the RETIRED section below. It is not duplicated here because the ID is
+# already suppressed file-wide; recorded so that deleting the retired trivy
+# block does not silently un-suppress a live grype finding. Same runtime scope
+# as the block above.
 
 # ---------------------------------------------------------------------------
 # grype v0.117.0 binary — github.com/docker/docker @ v28.5.2+incompatible


### PR DESCRIPTION
Closes #3353

Unblocks the 1.7.4 tag. `Security Scan` fails on `main` with a single finding in the vendored grype CLI:

```
usr/local/bin/grype (gobinary)
Total: 1 (HIGH: 1, CRITICAL: 0)

stdlib  CVE-2026-39821  HIGH  fixed  v1.26.3 -> 1.25.13, 1.26.6, 1.27.0-rc.3
golang.org/x/net/idna: Privilege escalation via incorrect Punycode label processing
```

All six platform images built successfully and the UBI 9.8 layer scans at 0 findings. The CVE is new in the Trivy DB — no code changed.

## Not a bump

`ghcr.io/anchore/grype:v0.117.0` is the latest upstream release (2026-08-10) and is already what we pin. It is built with Go 1.26.3; the fix needs Go 1.26.6. There is no tool version to move to, which is exactly the case `.trivyignore` documents itself as existing for.

Re-measured against `ghcr.io/anchore/grype:v0.117.0` on 2026-08-14 (trivy 0.69.3, `--ignore-unfixed`), per the file's "re-evaluate on every scanner bump" rule:

| CVE | Severity | Status |
|---|---|---|
| CVE-2026-27145 | HIGH | already suppressed |
| **CVE-2026-39821** | **HIGH** | **new — this PR** |
| CVE-2026-39822 | HIGH | already suppressed |
| CVE-2026-42504 | HIGH | already suppressed |
| CVE-2026-42505 | MEDIUM | already suppressed |
| CVE-2026-42507 | MEDIUM | already suppressed |

## Scope recorded, honestly

The block now carries a positive runtime argument the trivy entries cannot claim for themselves: the backend images set `GRYPE_DB_AUTO_UPDATE=false` and `GRYPE_CHECK_FOR_APP_UPDATE=false` against a DB pre-seeded at build time (#1001), and the backend invokes grype against on-disk artifacts and SBOMs. grype issues no outbound HTTP at runtime, so the `net/http` hostname path these stdlib CVEs sit in is not driven.

That is scope, not a fix, and the comment says so — the vulnerable code is still linked in.

## Incidental finding

`CVE-2026-46600` is filed in this file under the retired *trivy* block, but the re-measurement shows it is also present in grype's stdlib (HIGH, fixed in Go 1.26.6). It is already suppressed file-wide so nothing changes today, but deleting the retired trivy block later would silently un-suppress a live grype finding. Recorded as a comment so that cleanup does not become a regression.

## Durable fix

#3352 — build grype from source with a current toolchain, as #3123 already does for trivy, so a Go stdlib advisory becomes a rebuild instead of a suppression. This PR is the release-unblocking half.