### PR TITLE
fix(maven): treat non-unique SNAPSHOT artifacts as mutable in the cache classifier

### DIFF
--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -729,6 +729,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn checked_cleanup_allows_nonunique_snapshot_redeploy_different_bytes() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let repo = make_repo(&pool, "maven").await;
+        // Non-unique SNAPSHOT artifact: redeployed in place per Maven semantics.
+        let path = "com/x/app/1.0.0-SNAPSHOT/app-1.0.0-SNAPSHOT.jar";
+        insert_tombstone(
+            &pool,
+            repo,
+            path,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .await;
+
+        // Redeploy with DIFFERENT bytes -> allowed (SNAPSHOTs are mutable).
+        let res = cleanup_soft_deleted_artifact_checked(
+            &pool,
+            &RepositoryFormat::Maven,
+            repo,
+            path,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+        .await;
+        assert!(
+            res.is_ok(),
+            "non-unique SNAPSHOT redeploy over a tombstone must be allowed, got {res:?}",
+        );
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(repo)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            remaining, 0,
+            "SNAPSHOT tombstone purged so redeploy can land"
+        );
+
+        cleanup_repo(&pool, repo).await;
+    }
+
+    #[tokio::test]
     async fn checked_cleanup_no_tombstone_proceeds() {
         let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
             return;

--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -294,10 +294,16 @@ fn classify_maven(lower: &str) -> Mutability {
     if leaf.starts_with("maven-metadata.xml") {
         return Mutability::mutable_default();
     }
-    // A SNAPSHOT path that is NOT a concrete timestamped artifact is mutable
-    // (the directory listing / metadata is republished). Concrete timestamped
-    // SNAPSHOT artifacts (e.g. `app-1.0-20240101.120000-3.jar`) are immutable.
-    if lower.contains("-snapshot/") && !has_artifact_extension(leaf) {
+    // Files inside a `-SNAPSHOT/` version directory. A NON-UNIQUE SNAPSHOT
+    // artifact keeps the literal `-SNAPSHOT` token in its filename
+    // (e.g. `app-1.0-SNAPSHOT.jar`) and Maven redeploys it in place — mutable,
+    // as are its checksum/signature sidecars and the directory
+    // metadata/listing. A UNIQUE (timestamped) SNAPSHOT artifact
+    // (`app-1.0-20240101.120000-3.jar`) has a one-shot filename — the token is
+    // replaced by the timestamp — and stays immutable, like a released
+    // coordinate.
+    if lower.contains("-snapshot/") && (leaf.contains("-snapshot") || !has_artifact_extension(leaf))
+    {
         return Mutability::mutable_default();
     }
     if has_artifact_extension(leaf) {
@@ -525,6 +531,11 @@ mod tests {
         ));
         assert!(is_explicitly_mutable_index(&Pypi, "simple/requests/"));
         assert!(is_explicitly_mutable_index(&Npm, "left-pad"));
+        // A NON-UNIQUE SNAPSHOT artifact is redeployed in place -> true.
+        assert!(is_explicitly_mutable_index(
+            &Maven,
+            "com/x/app/1.0-SNAPSHOT/app-1.0-SNAPSHOT.jar"
+        ));
         // Versioned / content-addressed artifacts -> false (protected).
         assert!(!is_explicitly_mutable_index(
             &Maven,
@@ -583,6 +594,29 @@ mod tests {
                 Maven,
                 "com/example/app/1.0-SNAPSHOT/app-1.0-20240101.120000-3.jar",
                 true,
+            ),
+            // Non-unique SNAPSHOT artifacts keep the literal `-SNAPSHOT` token
+            // in the filename and are redeployed in place -> mutable, along
+            // with their checksum sidecars and secondary artifacts.
+            (
+                Maven,
+                "com/example/app/1.0-SNAPSHOT/app-1.0-SNAPSHOT.jar",
+                false,
+            ),
+            (
+                Maven,
+                "com/example/app/1.0-SNAPSHOT/app-1.0-SNAPSHOT.pom",
+                false,
+            ),
+            (
+                Maven,
+                "com/example/app/1.0-SNAPSHOT/app-1.0-SNAPSHOT-sources.jar",
+                false,
+            ),
+            (
+                Maven,
+                "com/example/app/1.0-SNAPSHOT/app-1.0-SNAPSHOT.jar.sha1",
+                false,
             ),
             (Gradle, "org/foo/bar/2.1/bar-2.1.jar", true),
             (Sbt, "org/foo/bar/maven-metadata.xml", false),


### PR DESCRIPTION
## Summary

Fixes #3295.

Redeploying a non-unique Maven SNAPSHOT artifact (e.g. `app-1.0-SNAPSHOT.jar`) over a previously deleted version was rejected with `409 "Artifact version already exists and is immutable"`. Per Maven SNAPSHOT semantics, a non-unique SNAPSHOT keeps the literal `-SNAPSHOT` token in its filename and is redeployed in place — it is a mutable coordinate, not a released one.

Root cause: `classify_maven` in `backend/src/services/cache_classifier.rs` classified **any** file with a Maven artifact extension as `Immutable`; its SNAPSHOT-directory mutable branch only covered non-artifact files (metadata/listings). A non-unique SNAPSHOT jar/pom therefore fell through to `Immutable`, and the shared release-immutability guard (`cleanup_soft_deleted_artifact_checked`) then 409'd a redeploy over a soft-deleted tombstone.

Fix (single condition in the shared classifier): a file inside a `-SNAPSHOT/` version directory whose filename still carries the `-snapshot` token is classified mutable. Unique (timestamped) SNAPSHOT artifacts (`app-1.0-20240101.120000-3.jar` — the token is replaced by the timestamp) and release coordinates are unchanged and stay `Immutable`, so release immutability is preserved. Because every consumer (upload guard, service-backed mirror, proxy cache, overwrite-permission check) reads through `classify()` / `is_explicitly_mutable_index()`, the correction flows through at one point.

Deliberate, benign consequence: the proxy cache now revalidates remote non-unique SNAPSHOT artifacts on TTL instead of caching them forever, which matches Maven's volatile-SNAPSHOT semantics and removes a latent stale-SNAPSHOT cache issue.

No migration; no sqlx prepared-query changes (the changed function is pure; new DB-backed tests use runtime `sqlx::query`).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Red on `main`, green here:
- `services::cache_classifier::tests::classify_matches_table` — new rows: non-unique SNAPSHOT `.jar`/`.pom`/`-sources.jar`/`.jar.sha1` under a `-SNAPSHOT/` directory classify mutable; existing timestamped-SNAPSHOT and release rows kept immutable (regression guards).
- `services::cache_classifier::tests::explicitly_mutable_index_only_for_real_index_files` — new assertion: `is_explicitly_mutable_index(Maven, ".../1.0-SNAPSHOT/app-1.0-SNAPSHOT.jar") == true`.
- `api::handlers::tests::checked_cleanup_allows_nonunique_snapshot_redeploy_different_bytes` (DB-backed) — tombstone + different incoming bytes at a non-unique SNAPSHOT path now purges and proceeds; was `Err(Conflict)` on `main`. The existing `checked_cleanup_blocks_immutable_swap_different_bytes` (release path) stays green — release redeploys with different bytes still 409.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full `cargo nextest run --workspace --lib` with a real database (`AK_TESTS_REQUIRE_DB=1`): 15172 passed. Manually verified on an isolated deployment: SNAPSHOT deploy → version delete → redeploy with new bytes now succeeds and serves the new bytes (was 409); the same flow on a release coordinate still returns 409 immutable.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
