### PR TITLE
fix(huggingface): strip Xet fields from proxied metadata so clients fall back to /resolve (#3334)

### DIFF
--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -547,9 +547,69 @@ async fn proxy_model_tree(
     proxy_hf_metadata_json(state, repo, &upstream_path).await
 }
 
+/// Object keys removed from proxied Hugging Face metadata documents (#3334).
+///
+/// `xetHash` is per-file and appears on tree entries and model-info siblings;
+/// `xetEnabled` is the repo-level flag on model-info.
+const XET_METADATA_KEYS: [&str; 2] = ["xetHash", "xetEnabled"];
+
+/// Recursively drop [`XET_METADATA_KEYS`] from every object in `value`.
+///
+/// Tree responses are arrays of entries, model-info is an object with a
+/// `siblings` array, and `tree?expand=true` nests further still, so the walk
+/// has to cover objects and arrays at any depth rather than the two shapes
+/// known today.
+fn remove_xet_keys(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.retain(|key, _| !XET_METADATA_KEYS.contains(&key.as_str()));
+            for nested in map.values_mut() {
+                remove_xet_keys(nested);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                remove_xet_keys(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Strip Xet fields from an upstream metadata document so clients keep using
+/// the ordinary `/resolve/` download path (#3334).
+///
+/// `huggingface_hub >= 1.26` caches the tree listing on disk, reads `xetHash`
+/// back out of that cache, and from then on skips the HEAD call and asks for a
+/// Xet read token at `api/models/{id}/xet-read-token/{rev}` - a route this
+/// proxy does not implement, so the download dies on a bare 404.
+///
+/// Stripping the `X-Xet-Hash` response header would not help: `ProxyService`
+/// already drops it, and on this path the client never reads response headers.
+/// The leak is in the JSON body, which is why the fix lives here.
+///
+/// Proxying `xet-read-token` was considered and rejected. Once a client holds a
+/// Xet token it pulls chunks straight from `cas-server.xethub.hf.co`, bypassing
+/// the proxy entirely: no caching, and every client needs direct egress, which
+/// is the opposite of what an air-gapped or controlled-egress deployment
+/// installs a proxy for.
+///
+/// Bytes that do not parse as JSON come back untouched. A metadata passthrough
+/// that works today must not start failing because of this filter.
+fn strip_xet_metadata(bytes: Bytes) -> Bytes {
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return bytes;
+    };
+    remove_xet_keys(&mut value);
+    match serde_json::to_vec(&value) {
+        Ok(rewritten) => Bytes::from(rewritten),
+        Err(_) => bytes,
+    }
+}
+
 /// Shared body of [`proxy_model_info`] and [`proxy_model_tree`]: fetch a
 /// buffered JSON metadata document from a Remote repo's upstream and hand it
-/// back verbatim.
+/// back with Xet fields removed by [`strip_xet_metadata`].
 ///
 /// Keeping the Remote/upstream/proxy-wired guards and the capped fetch in one
 /// place is what makes the two endpoints propagate upstream failures
@@ -586,7 +646,7 @@ async fn proxy_hf_metadata_json(
         Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, "application/json")
-            .body(Body::from(bytes))
+            .body(Body::from(strip_xet_metadata(bytes)))
             .unwrap(),
     ))
 }
@@ -2961,6 +3021,65 @@ mod tests {
         assert_eq!(entries[1]["path"], "model.safetensors");
     }
 
+    /// #3334: the tree passthrough must not forward `xetHash`. A client that
+    /// sees it caches the listing, skips the HEAD call on every later download
+    /// and asks for a Xet read token this proxy does not serve, so the download
+    /// dies on a 404 instead of falling back to `/resolve/`.
+    #[tokio::test]
+    async fn test_huggingface_tree_strips_xet_fields_from_upstream() {
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(f) = tdh::Fixture::setup("remote", "huggingface").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/api/models/openai-community/gpt2/tree/main"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"type": "file", "oid": "abc", "size": 665, "path": "config.json"},
+                {
+                    "type": "file",
+                    "oid": "def",
+                    "size": 548105171,
+                    "path": "model.safetensors",
+                    "xetHash": "607a30d783dfa663caf39e06633721c8d4cfcd7e",
+                    "lfs": {"oid": "248dfc39", "size": 548105171, "pointerSize": 135},
+                },
+            ])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&f, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{}/api/models/openai-community/gpt2/tree/main",
+                f.repo_key
+            )),
+        )
+        .await;
+
+        f.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(
+            !text.contains("xetHash"),
+            "xetHash must not reach the client: {text}"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entries = json.as_array().expect("tree must stay a JSON array");
+        assert_eq!(entries.len(), 2, "stripping must not drop entries");
+        assert_eq!(entries[1]["path"], "model.safetensors");
+        assert_eq!(
+            entries[1]["lfs"]["oid"], "248dfc39",
+            "the /resolve fallback still needs the rest of the entry"
+        );
+    }
+
     #[tokio::test]
     #[allow(clippy::disallowed_methods)]
     // streaming-invariant: test-only body buffering for assertions (#1608).
@@ -3005,5 +3124,117 @@ mod tests {
             "[]",
             "an empty list would tell the client the revision has no files"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Xet field stripping in proxied metadata (#3334)
+    // -----------------------------------------------------------------------
+
+    /// A tree entry as the Hub actually serves it. `xetHash` is the field that
+    /// sends `huggingface_hub >= 1.26` down the Xet path.
+    #[test]
+    fn test_strip_xet_metadata_removes_xet_hash_from_tree_entry() {
+        let upstream = br#"[
+            {
+                "type": "file",
+                "oid": "7c5d3f4b8b76583b422fcb9189ad6c89d5d97a094541ce8932dce3ecabde1421",
+                "size": 548105171,
+                "path": "model.safetensors",
+                "xetHash": "607a30d783dfa663caf39e06633721c8d4cfcd7e",
+                "lfs": {
+                    "oid": "248dfc3911869ec493c76e65bf2fcf7f615828b0254c12b473182f0f81d3a707",
+                    "size": 548105171,
+                    "pointerSize": 135
+                }
+            }
+        ]"#;
+
+        let stripped = strip_xet_metadata(Bytes::from_static(upstream));
+        let json: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+        let entry = &json[0];
+
+        assert!(entry.get("xetHash").is_none(), "xetHash must not survive");
+        assert_eq!(entry["path"], "model.safetensors");
+        assert_eq!(entry["size"], 548105171u64);
+        assert_eq!(
+            entry["lfs"]["oid"], "248dfc3911869ec493c76e65bf2fcf7f615828b0254c12b473182f0f81d3a707",
+            "the LFS pointer is what the /resolve fallback needs; it must stay"
+        );
+    }
+
+    /// Model-info carries `xetEnabled` at the top level and one `xetHash` per
+    /// sibling, so the walk has to reach both depths.
+    #[test]
+    fn test_strip_xet_metadata_removes_nested_xet_fields() {
+        let upstream = br#"{
+            "id": "openai-community/gpt2",
+            "sha": "607a30d783dfa663caf39e06633721c8d4cfcd7e",
+            "xetEnabled": true,
+            "siblings": [
+                {"rfilename": "config.json"},
+                {"rfilename": "model.safetensors", "xetHash": "abc123"}
+            ],
+            "nested": {"deeper": [[{"xetHash": "def456", "keep": 1}]]}
+        }"#;
+
+        let stripped = strip_xet_metadata(Bytes::from_static(upstream));
+        let json: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+
+        assert!(json.get("xetEnabled").is_none());
+        assert!(json["siblings"][1].get("xetHash").is_none());
+        assert!(
+            json["nested"]["deeper"][0][0].get("xetHash").is_none(),
+            "the walk must descend through arrays of arrays"
+        );
+        assert_eq!(json["nested"]["deeper"][0][0]["keep"], 1);
+        assert_eq!(json["id"], "openai-community/gpt2");
+        assert_eq!(json["sha"], "607a30d783dfa663caf39e06633721c8d4cfcd7e");
+        assert_eq!(json["siblings"][0]["rfilename"], "config.json");
+        assert_eq!(json["siblings"][1]["rfilename"], "model.safetensors");
+    }
+
+    /// Only the two Xet keys go. Lookalike names and any value that merely
+    /// mentions Xet are none of this function's business.
+    #[test]
+    fn test_strip_xet_metadata_preserves_non_xet_keys_and_values() {
+        let upstream = br#"{
+            "xetHashAlgorithm": "blake3",
+            "notXetHash": "keep me",
+            "description": "xetHash appears in this string value",
+            "xet": {"still": "here"}
+        }"#;
+
+        let stripped = strip_xet_metadata(Bytes::from_static(upstream));
+        let json: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+
+        assert_eq!(json["xetHashAlgorithm"], "blake3");
+        assert_eq!(json["notXetHash"], "keep me");
+        assert_eq!(json["description"], "xetHash appears in this string value");
+        assert_eq!(json["xet"]["still"], "here");
+    }
+
+    /// Fail open: anything that is not JSON is handed back untouched rather
+    /// than turned into an error.
+    #[test]
+    fn test_strip_xet_metadata_passes_non_json_through_unchanged() {
+        let raw = Bytes::from_static(b"<html>not json at all</html>");
+        assert_eq!(strip_xet_metadata(raw.clone()), raw);
+
+        let truncated = Bytes::from_static(br#"{"xetHash": "abc"#);
+        assert_eq!(strip_xet_metadata(truncated.clone()), truncated);
+
+        let empty = Bytes::new();
+        assert_eq!(strip_xet_metadata(empty.clone()), empty);
+    }
+
+    /// A document with nothing to strip still has to come back intact.
+    #[test]
+    fn test_strip_xet_metadata_leaves_xet_free_document_intact() {
+        let upstream = Bytes::from_static(br#"[{"type":"file","path":"config.json"}]"#);
+        let stripped = strip_xet_metadata(upstream.clone());
+        let json: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+
+        assert_eq!(json[0]["type"], "file");
+        assert_eq!(json[0]["path"], "config.json");
     }
 }


### PR DESCRIPTION
## Summary

`hf download` against a remote HuggingFace repository failed with a bare 404 for any Xet-backed model, which today is most of the Hub. The proxy handed upstream tree and model-info JSON back verbatim, and that JSON carries a per-file `xetHash`. `huggingface_hub` 1.26 and later caches the tree listing on disk, reads the hash back out of that cache, skips the HEAD call entirely, and asks for a Xet read token at `api/models/{id}/xet-read-token/{rev}`. That route does not exist here, so the download aborted partway through.

`proxy_hf_metadata_json` now runs the fetched bytes through a new `strip_xet_metadata`, which parses the document and removes `xetHash` and `xetEnabled` from every object at any depth. That covers all three shapes the Hub serves: the tree array, the model-info object with its `siblings` array, and the deeper nesting of `tree?expand=true`. With no Xet fields visible, clients use the ordinary `/resolve/` path, which already works. Bytes that do not parse as JSON come back untouched, so a passthrough that works today cannot start failing because of the filter. The size cap and error propagation in `proxy_hf_metadata_json` are unchanged.

Two things this deliberately does not do, both explained in code comments next to the fix:

- Stripping the `X-Xet-Hash` response header would not help. `ProxyService` already drops it via a closed allowlist, and on this code path the client never reads response headers. The leak is in the JSON body.
- Proxying `xet-read-token` is rejected. Once a client holds a Xet token it fetches chunks directly from `cas-server.xethub.hf.co`, bypassing the proxy entirely. That loses caching and requires direct client egress, which defeats the purpose of an air-gapped or controlled-egress deployment.

This removes the need for the `HF_HUB_DISABLE_XET=1` client-side workaround from the issue.

Closes #3334

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_huggingface_tree_strips_xet_fields_from_upstream` drives the real route with a wiremock upstream that returns a tree entry containing `xetHash`, and asserts the string never reaches the client while the rest of the entry (including the LFS pointer the `/resolve` fallback needs) survives. Verified failing without the fix:

```
thread '...test_huggingface_tree_strips_xet_fields_from_upstream' panicked:
xetHash must not reach the client: [{"oid":"abc",...},{...,"xetHash":"607a30d7..."}]
test result: FAILED. 0 passed; 1 failed
```

and passing with it.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Five pure unit tests cover the helper: a realistic tree-entry fixture loses `xetHash` and keeps everything else, nested `xetEnabled`/`xetHash` are removed through arrays of arrays, lookalike keys (`xetHashAlgorithm`, `notXetHash`, `xet`) and string values mentioning `xetHash` are preserved, non-JSON and truncated and empty bodies pass through byte-identical, and a Xet-free document is unaffected. The route-level test above was run against a live PostgreSQL at localhost:30432 rather than skipped.

Not tested here: an end-to-end run of a real `hf` client against the proxy. The unit and route tests pin the server-side behaviour the client depends on, but the full client flow described in the issue has not been re-run.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No routes, request types or response types changed. The response body of two existing endpoints has two fields removed from it.
