### PR TITLE
chore(release): prepare 1.7.5

### DIFF
--- a/.github/release-notes/1.7.5.md
+++ b/.github/release-notes/1.7.5.md
@@ -1,0 +1,72 @@
+# Artifact Keeper 1.7.5
+
+A security release: **three advisories**, plus fixes to PyPI PEP 658 metadata handling. No schema migrations.
+
+Most deployments can take this without changing anything. Two situations need a look first — both are below.
+
+## Advisories
+
+| | Affected if | Action |
+|---|---|---|
+| **GHSA-fv45-mwhh-q23r**<br>Percent-encoded repository keys bypassed visibility | You host private repositories | Upgrade. Nothing else |
+| **GHSA-8jm4-4x6c-6787**<br>Rate limiting trusted a client-supplied `X-Forwarded-For` prefix | You run more than one proxy hop in front of Artifact Keeper | Upgrade **and** check your config — see below |
+| **GHSA-95fx-g94v-8jqg**<br>Backup restore ingested tables outside the export allowlist | You restore backup archives | Upgrade, and read the scope note below |
+
+An authenticated caller with no grant could read a private repository through `GHSA-fv45` by percent-encoding a character in the key (`/maven/privat%65/...`). That one is closed by upgrading, full stop.
+
+## Check before you deploy: multi-hop proxies
+
+If Artifact Keeper sits behind **more than one** proxy, every trusted hop must be listed in `RATE_LIMIT_TRUSTED_PROXY_CIDRS`. The resolver now walks the forwarded chain from the right and stops at the first hop it does not trust — so an unlisted hop is treated as the client.
+
+**List proxies as `/32`, never as a subnet real clients can originate from.** A broad range like `10.0.0.0/8` means any client inside it keeps the walk going further left into text the client controls.
+
+The default single-Caddy compose deployment is unaffected and needs no change.
+
+## Check before you deploy: PyPI metadata caching
+
+PEP 658 `.whl.metadata` sidecars are now cached, which makes `uv lock` and pip resolution against a remote PyPI repository noticeably faster — previously every request re-fetched upstream twice.
+
+They are also now classified **immutable**, matching how proxied package files are already treated. The tradeoff: a stored sidecar is no longer revalidated, so a bad one will not heal on its own. If you ever need to clear one:
+
+```
+POST /api/v1/repositories/{key}/cache/invalidate?path=simple/{project}/{dist}.metadata
+```
+
+## On the backup advisory
+
+Worth being precise, because the fix is narrower than the headline suggests. Restore now rejects tables outside the export allowlist — but that allowlist necessarily *contains* `users`, `roles`, `user_roles`, `permission_grants` and `api_tokens`, because a backup that cannot restore identity is not a backup.
+
+So this narrows which tables an archive can reach; it does **not** make a hostile archive safe. Archive integrity is the real control and is not yet implemented — the manifest checksum is currently never verified (#3373).
+
+**Treat backup archives as privileged material.** Restore only archives you produced and can vouch for, and store them where they cannot be tampered with.
+
+## What's Changed
+
+**Security**
+
+- Percent-decode the repository key in the visibility middleware before lookup, failing closed with an existence-hiding 404 (GHSA-fv45-mwhh-q23r)
+- Select the client IP by walking `X-Forwarded-For` right-to-left across every field line, skipping trusted hops (GHSA-8jm4-4x6c-6787)
+- Enforce the export-table allowlist on the backup restore path (GHSA-95fx-g94v-8jqg)
+- Keep PyPI virtual metadata resolution pinned to the member that owns the distribution, so a momentarily unavailable object cannot cause another member's metadata to be served in its place
+
+**Fixed**
+
+- Serve PEP 658 `.whl.metadata` from the proxy cache instead of re-resolving it upstream on every request (#3300)
+- Return 404 rather than a permanent 500 when a metadata source object is missing, so the upstream fallback can run (#3366)
+
+See the [CHANGELOG](CHANGELOG.md) for the mechanism behind each entry, the reasoning, and the exact scope of every fix.
+
+**Full Changelog**: https://github.com/artifact-keeper/artifact-keeper/compare/v1.7.4...v1.7.5
+
+---
+
+### Sponsors
+
+Thank you to our sponsors for supporting ongoing development of Artifact Keeper.
+
+**Backers**
+
+- Ash A. ([@dragonpaw](https://github.com/dragonpaw))
+- Gabriel Rodriguez ([@injectedfusion](https://github.com/injectedfusion))
+
+[Become a sponsor](https://github.com/sponsors/artifact-keeper) to support the project and get your name listed here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.5] - 2026-08-14
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.7.4",
+        version = "1.7.5",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Version bump and release notes for 1.7.5.

## Contents

Three advisories (#3370) — GHSA-fv45 percent-encoded key visibility bypass, GHSA-8jm4 `X-Forwarded-For` trust, GHSA-95fx backup restore allowlist. Two PyPI PEP 658 fixes (#3333, #3367). Three review follow-ups (#3374).

No schema migrations.

## Changes

- `[Unreleased]` promoted to `## [1.7.5] - 2026-08-14`
- Version set bumped by hand in `Cargo.toml`, `Cargo.lock` (backend stanza) and `backend/src/api/openapi.rs` — never a repo-wide sed, since `hex.rs` carries Phoenix fixtures with 1.7.x strings that a sed corrupts *and still compiles*
- `.github/release-notes/1.7.5.md` added

## Note on the release notes

Deliberately about half the length of 1.7.4's. The release page answers "am I affected" and "what do I check before deploying"; the CHANGELOG keeps the mechanism, reasoning and scope. Two items get real estate because they need a decision before deploying:

- **multi-hop proxy config** — every trusted hop must now be listed in `RATE_LIMIT_TRUSTED_PROXY_CIDRS`, as `/32` rather than a subnet real clients can originate from
- **PyPI metadata caching** — sidecars are now immutable, so a bad one no longer self-heals

The backup advisory gets a short scope note because the fix is narrower than its title reads: the allowlist necessarily contains the identity tables, so it does not make a hostile archive safe. Archive integrity is tracked in #3373.