### PR TITLE
fix(auth): stop the Basic-auth popup for browsers, expire env-seeded OIDC providers, expose the break-glass flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,6 +270,11 @@ JWT_EXPIRATION_SECS=86400
 #   OIDC_PKCE_ENABLED: ${OIDC_PKCE_ENABLED:-}
 
 # To enable OIDC, OIDC_ISSUER, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET are required.
+# The env-seeded provider is reconciled on every boot: removing OIDC_ISSUER /
+# OIDC_CLIENT_ID / OIDC_CLIENT_SECRET and restarting DISABLES the provider row
+# the environment created (#2819), restoring local login. Providers created or
+# later edited/toggled via the admin API are owned by the admin and are never
+# auto-disabled.
 # OIDC_ISSUER=https://auth.example.com
 # OIDC_CLIENT_ID=artifact-registry
 # OIDC_CLIENT_SECRET=xxx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`auth.admin_break_glass_enabled` in `GET /api/v1/system/config`** (#2571). The public system-config endpoint now advertises whether the verified-admin break-glass local login is available, mirroring `local_login_gate` for an admin caller: `true` unless an SSO provider is enabled *and* the operator opted into strict SSO-only via `SSO_DISABLE_ADMIN_BREAK_GLASS` (#2018). This is the backend flag the login UI needs to render a discoverable "Sign in with admin" button next to the SSO buttons instead of hiding break-glass behind the undocumented `?fallback=local` parameter. Display-only: the login endpoint keeps enforcing the same policy server-side, so the flag never widens access. The existing `local_login_enabled` flag is unchanged and still only advertises the full local form on explicit `ALLOW_LOCAL_ADMIN_LOGIN=true` opt-in.
+
+### Fixed
+
+- **No more native Basic-auth popup over the login screen when guest access is disabled** (#2936, #3082). With `AK_GUEST_ACCESS_ENABLED=false`, the guest-access guard answered every unauthenticated request — including the web UI's own `fetch()` calls — with `401` + `WWW-Authenticate: Basic`, and browsers respond to that challenge by raising their native credential dialog before the user ever sees the login/OIDC page. The guard (and the optional-auth middleware's invalid-credential 401) now classify browser-originated requests via a pure header check — any Fetch Metadata header (`Sec-Fetch-Mode`/`Sec-Fetch-Site`, forbidden headers that every modern browser sends and no package client does) or an `Accept` listing `text/html` — and omit the `Basic` (and cargo-only `Cargo`) challenge for them, keeping the `Bearer` challenge for RFC 7235 compliance. Browsers therefore land on the web UI's login/OIDC flow directly. Package-manager clients (pip, npm, docker, cargo, maven, conan, …) are never classified as browsers and keep the byte-identical challenge set they had before, so credential retry semantics are unchanged.
+- **An OIDC provider seeded from `OIDC_*` env vars no longer outlives its configuration** (#2819, migration 197). `bootstrap_oidc_from_env` created/reconciled a provider row on boot, but removing `OIDC_ISSUER`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET` and restarting left that row enabled: the login page kept advertising a flow that could no longer complete while `local_login_enabled` stayed `false` because an enabled provider row still existed — locking operators out of the UI. Env-seeded rows are now marked (`oidc_configs.env_seeded`), and a boot without the env vars disables — never deletes — any still-enabled marked row, restoring local login; re-adding the env vars re-enables it through the normal reconcile path. Admin ownership is respected in both directions: rows created via the admin API are never touched (the column defaults to `false`), and editing or re-enabling a previously env-seeded provider through the admin API clears the marker so later boots leave it alone.
+
 ## [1.7.5] - 2026-08-14
 
 ### Security

--- a/backend/migrations/197_oidc_env_seeded.sql
+++ b/backend/migrations/197_oidc_env_seeded.sql
@@ -1,0 +1,24 @@
+-- Migration 197: track OIDC providers seeded from OIDC_* environment
+-- variables (#2819).
+--
+-- `bootstrap_oidc_from_env` creates/reconciles a provider row from
+-- OIDC_ISSUER / OIDC_CLIENT_ID / OIDC_CLIENT_SECRET on every boot, but before
+-- this migration nothing recorded that the row came from the environment.
+-- Removing the env vars and restarting therefore left the row enabled: the
+-- login page kept advertising a provider that could no longer complete a
+-- flow, while `local_login_enabled` stayed false because an enabled provider
+-- row still existed — locking operators out of the UI.
+--
+-- `env_seeded = TRUE` marks rows the env bootstrap owns. On a boot where the
+-- OIDC_* env vars are absent, any still-enabled `env_seeded` row is disabled
+-- (never deleted, so linked identities and audit history survive). Rows an
+-- administrator edits or toggles via the admin API drop the marker — the
+-- admin has taken ownership, and later env-var removal leaves them alone.
+--
+-- Default FALSE: every pre-existing row is treated as admin-owned. An
+-- env-managed deployment reasserts the marker on its next boot (the
+-- bootstrap reconciles the env-named provider on every start), so the
+-- conservative default only delays reconciliation by one restart and can
+-- never disable a provider an operator created by hand.
+ALTER TABLE oidc_configs
+    ADD COLUMN IF NOT EXISTS env_seeded BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/api/handlers/system_config.rs
+++ b/backend/src/api/handlers/system_config.rs
@@ -83,6 +83,18 @@ pub struct AuthConfig {
     /// access by itself. LDAP is separate — the UI shows the credentials form
     /// for enabled LDAP providers regardless of this flag.
     pub local_login_enabled: bool,
+    /// Whether the verified-admin break-glass local login path is available
+    /// (issue #2571). Unlike `local_login_enabled` — which only advertises
+    /// the full local form on explicit `ALLOW_LOCAL_ADMIN_LOGIN=true` opt-in —
+    /// this reflects the default #443 break-glass: with SSO enabled it is
+    /// `true` unless the operator opted into strict SSO-only via
+    /// `SSO_DISABLE_ADMIN_BREAK_GLASS`. The login UI uses it to render a
+    /// discoverable "Sign in with admin" affordance next to the SSO buttons
+    /// instead of requiring the undocumented `?fallback=local` parameter.
+    /// Display-only: the login endpoint independently enforces the same
+    /// policy (`api::handlers::auth::local_login_gate`), so this flag never
+    /// grants access by itself.
+    pub admin_break_glass_enabled: bool,
 }
 
 /// Whether the local username/password login form should be offered to the
@@ -102,6 +114,17 @@ fn local_login_form_enabled(
     disable_admin_break_glass: bool,
 ) -> bool {
     !sso_enabled || (allow_local_admin_login && !disable_admin_break_glass)
+}
+
+/// Whether the verified-admin break-glass local login is available (issue
+/// #2571). Mirrors `api::handlers::auth::local_login_gate` for a *verified
+/// admin* caller: without SSO local login is unrestricted; with SSO enabled
+/// the default #443 break-glass stays available unless the operator enforced
+/// strict SSO-only via `SSO_DISABLE_ADMIN_BREAK_GLASS` (#2018). Advertising
+/// it lets the login UI offer a discoverable "Sign in with admin" button
+/// while the login endpoint keeps enforcing the policy server-side.
+fn admin_break_glass_available(sso_enabled: bool, disable_admin_break_glass: bool) -> bool {
+    !(sso_enabled && disable_admin_break_glass)
 }
 
 /// Runtime configuration values.
@@ -207,6 +230,10 @@ pub async fn get_system_config(
         local_login_enabled: local_login_form_enabled(
             sso_provider_enabled,
             config.allow_local_admin_login,
+            config.sso_disable_admin_break_glass,
+        ),
+        admin_break_glass_enabled: admin_break_glass_available(
+            sso_provider_enabled,
             config.sso_disable_admin_break_glass,
         ),
     };
@@ -325,6 +352,7 @@ mod tests {
                 ldap_enabled: false,
                 sso_enabled: false,
                 local_login_enabled: true,
+                admin_break_glass_enabled: true,
             },
             oidc_issuer: None,
             permissions: Some(PermissionsConfig {
@@ -393,6 +421,7 @@ mod tests {
                 ldap_enabled: true,
                 sso_enabled: true,
                 local_login_enabled: false,
+                admin_break_glass_enabled: true,
             },
             oidc_issuer: Some("https://auth.example.com".to_string()),
             permissions: Some(PermissionsConfig {
@@ -474,6 +503,7 @@ mod tests {
             ldap_enabled: false,
             sso_enabled: true,
             local_login_enabled: true,
+            admin_break_glass_enabled: true,
         };
         let json = serde_json::to_string(&auth).unwrap();
         assert!(json.contains("\"oidc_enabled\":true"));
@@ -500,6 +530,7 @@ mod tests {
                 ldap_enabled: false,
                 sso_enabled: true,
                 local_login_enabled: false,
+                admin_break_glass_enabled: false,
             },
             ..minimal_response()
         };
@@ -871,6 +902,50 @@ mod tests {
         assert!(!local_login_form_enabled(true, true, true));
     }
 
+    // -----------------------------------------------------------------------
+    // admin_break_glass_available — "Sign in with admin" affordance (#2571)
+    //
+    // Display-only, mirrors local_login_gate for a verified admin:
+    // enforcement stays in handlers::auth, so nothing here widens access.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_admin_break_glass_no_sso_always_available() {
+        // Without SSO, local login (admin included) is unrestricted.
+        assert!(admin_break_glass_available(false, false));
+        assert!(admin_break_glass_available(false, true));
+    }
+
+    #[test]
+    fn test_admin_break_glass_default_available_with_sso() {
+        // The #443 default: SSO enabled still leaves the verified-admin
+        // break-glass available, so the UI may advertise the button even
+        // though `local_login_enabled` stays false without the explicit
+        // ALLOW_LOCAL_ADMIN_LOGIN opt-in.
+        assert!(admin_break_glass_available(true, false));
+    }
+
+    #[test]
+    fn test_admin_break_glass_strict_sso_disables() {
+        // SSO_DISABLE_ADMIN_BREAK_GLASS (#2018): strict SSO-only removes the
+        // break-glass, and the flag must not advertise a button that the
+        // login endpoint would reject.
+        assert!(!admin_break_glass_available(true, true));
+    }
+
+    #[test]
+    fn test_auth_config_serializes_admin_break_glass_flag() {
+        let auth = AuthConfig {
+            oidc_enabled: true,
+            ldap_enabled: false,
+            sso_enabled: true,
+            local_login_enabled: false,
+            admin_break_glass_enabled: true,
+        };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert!(json.contains("\"admin_break_glass_enabled\":true"));
+    }
+
     /// DB-backed (#2621): the handler must compute `auth.local_login_enabled`
     /// from the *enabled-provider* source of truth (same as the login gate)
     /// combined with the ALLOW_LOCAL_ADMIN_LOGIN / strict-SSO config flags.
@@ -918,6 +993,10 @@ mod tests {
             obj["auth"]["local_login_enabled"], false,
             "SSO enabled without ALLOW_LOCAL_ADMIN_LOGIN: form must stay hidden"
         );
+        assert_eq!(
+            obj["auth"]["admin_break_glass_enabled"], true,
+            "SSO enabled: the default #443 admin break-glass must be advertised (#2571)"
+        );
 
         // SSO enabled + ALLOW_LOCAL_ADMIN_LOGIN=true: the broken case from
         // issue #2621 — the form must now be advertised.
@@ -939,6 +1018,10 @@ mod tests {
         assert_eq!(
             obj["auth"]["local_login_enabled"], false,
             "strict SSO-only must hide the form even with the opt-in flag"
+        );
+        assert_eq!(
+            obj["auth"]["admin_break_glass_enabled"], false,
+            "strict SSO-only (#2018) must not advertise the admin break-glass button"
         );
 
         let _ = sqlx::query("DELETE FROM ldap_configs WHERE name = $1")

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1315,8 +1315,12 @@ pub async fn optional_auth_middleware(
     // must produce 401. We allow a ticket to rescue the request because a
     // browser may include a stale Authorization cookie alongside a fresh
     // download ticket — the ticket is what authorizes the read.
+    //
+    // Header-aware: a browser fetch carrying a stale token must not trigger
+    // the native Basic popup over the web UI's own login flow (#2936/#3082);
+    // package clients keep the full challenge set.
     if credential_invalid && auth_ext.is_none() {
-        return unauthorized_response();
+        return unauthorized_response_for(request.headers());
     }
 
     request.extensions_mut().insert(auth_ext);
@@ -1676,6 +1680,35 @@ fn is_non_mutating_format_post(path: &str) -> bool {
     }
 }
 
+/// True when the request plausibly originates from an interactive web browser
+/// rather than a package-manager client (#2936 / #3082).
+///
+/// Browsers pop up a native credential dialog whenever a 401 carries a
+/// `WWW-Authenticate: Basic` challenge — including for `fetch()`/XHR calls
+/// made by the web UI — hijacking the login screen with a Basic auth box.
+/// Package clients (pip, npm, docker, cargo, maven, …) rely on those
+/// challenges to decide how to retry with credentials, so the challenge is
+/// only suppressed when the request is identifiably browser-originated:
+///
+/// * any Fetch Metadata header (`Sec-Fetch-Mode` / `Sec-Fetch-Site`) — these
+///   are forbidden request headers that every modern browser attaches to
+///   every request (navigations *and* `fetch()`/XHR) in secure contexts, and
+///   that no package-manager client sends;
+/// * an `Accept` header explicitly listing `text/html` — the classic HTML
+///   navigation signal, covering older browsers and plain-HTTP deployments
+///   where Fetch Metadata is not sent.
+///
+/// Pure and header-only so the negotiation is unit-testable.
+pub(crate) fn is_browser_request(headers: &HeaderMap) -> bool {
+    if headers.contains_key("sec-fetch-mode") || headers.contains_key("sec-fetch-site") {
+        return true;
+    }
+    headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.to_ascii_lowercase().contains("text/html"))
+}
+
 /// Build a 401 response with `WWW-Authenticate` challenges for both Basic
 /// and Bearer schemes.  Package manager clients use the challenge to decide
 /// how to retry with credentials.
@@ -1683,17 +1716,39 @@ fn is_non_mutating_format_post(path: &str) -> bool {
 /// `pub(crate)` so the WASM proxy handler (`/ext/*`) can emit the identical
 /// anonymous-denial response as this middleware (GHSA-9rqp-mgmw-5879).
 pub(crate) fn unauthorized_response() -> Response {
-    Response::builder()
-        .status(StatusCode::UNAUTHORIZED)
-        .header("WWW-Authenticate", "Basic realm=\"artifact-keeper\"")
-        .header(
-            "WWW-Authenticate",
-            "Bearer realm=\"artifact-keeper\", charset=\"UTF-8\"",
-        )
+    challenge_unauthorized_response(true)
+}
+
+/// Header-aware variant of [`unauthorized_response`]: browser-originated
+/// requests (see [`is_browser_request`]) get a 401 *without* the `Basic`
+/// challenge so the browser shows the web UI's login screen instead of a
+/// native Basic auth popup (#2936 / #3082). Every other caller — package
+/// managers included — receives the identical challenges as before.
+pub(crate) fn unauthorized_response_for(headers: &HeaderMap) -> Response {
+    challenge_unauthorized_response(!is_browser_request(headers))
+}
+
+/// Shared 401 builder. `challenge_basic = false` omits the `Basic` (and the
+/// cargo-only `Cargo`) challenge for browser requests, keeping the `Bearer`
+/// challenge so the response stays RFC 7235-compliant without triggering the
+/// native browser credential dialog (only `Basic` does that).
+fn challenge_unauthorized_response(challenge_basic: bool) -> Response {
+    let mut builder = Response::builder().status(StatusCode::UNAUTHORIZED);
+    if challenge_basic {
+        builder = builder.header("WWW-Authenticate", "Basic realm=\"artifact-keeper\"");
+    }
+    builder = builder.header(
+        "WWW-Authenticate",
+        "Bearer realm=\"artifact-keeper\", charset=\"UTF-8\"",
+    );
+    if challenge_basic {
         // Signals cargo 1.67+ to use the Cargo token protocol (sends the token
         // as the raw Authorization header value) rather than aborting on the
-        // Basic/Bearer challenges it does not understand.
-        .header("WWW-Authenticate", "Cargo")
+        // Basic/Bearer challenges it does not understand. Browsers never speak
+        // the cargo protocol, so this challenge is browser-suppressed too.
+        builder = builder.header("WWW-Authenticate", "Cargo");
+    }
+    builder
         .header(axum::http::header::CONTENT_TYPE, "text/plain")
         .body(axum::body::Body::from("Authentication required"))
         .unwrap()
@@ -3690,6 +3745,116 @@ mod tests {
             www_auth_values.iter().any(|v| v.starts_with("Cargo")),
             "expected a Cargo WWW-Authenticate challenge"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // is_browser_request / unauthorized_response_for (#2936 / #3082)
+    // -----------------------------------------------------------------------
+
+    fn challenges_of(resp: &Response) -> Vec<String> {
+        resp.headers()
+            .get_all("WWW-Authenticate")
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn test_is_browser_request_sec_fetch_mode() {
+        // Modern browsers attach Fetch Metadata to every request, including
+        // the web UI's fetch()/XHR calls (Sec-Fetch-Mode: cors).
+        let mut headers = HeaderMap::new();
+        headers.insert("sec-fetch-mode", "cors".parse().unwrap());
+        headers.insert("accept", "*/*".parse().unwrap());
+        assert!(is_browser_request(&headers));
+    }
+
+    #[test]
+    fn test_is_browser_request_sec_fetch_site_only() {
+        let mut headers = HeaderMap::new();
+        headers.insert("sec-fetch-site", "same-origin".parse().unwrap());
+        assert!(is_browser_request(&headers));
+    }
+
+    #[test]
+    fn test_is_browser_request_html_navigation_accept() {
+        // Plain-HTTP deployments where Fetch Metadata is absent: an HTML
+        // navigation still declares text/html in Accept.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+                .parse()
+                .unwrap(),
+        );
+        assert!(is_browser_request(&headers));
+    }
+
+    #[test]
+    fn test_is_browser_request_rejects_package_clients() {
+        // pip / npm / cargo / docker style requests: no Fetch Metadata, no
+        // text/html Accept. These MUST keep their native auth challenges.
+        assert!(!is_browser_request(&HeaderMap::new()));
+
+        let mut pip = HeaderMap::new();
+        pip.insert("accept", "*/*".parse().unwrap());
+        pip.insert("user-agent", "pip/24.0".parse().unwrap());
+        assert!(!is_browser_request(&pip));
+
+        let mut docker = HeaderMap::new();
+        docker.insert(
+            "accept",
+            "application/vnd.oci.image.index.v1+json".parse().unwrap(),
+        );
+        assert!(!is_browser_request(&docker));
+
+        let mut npm = HeaderMap::new();
+        npm.insert("accept", "application/json".parse().unwrap());
+        assert!(!is_browser_request(&npm));
+    }
+
+    #[test]
+    fn test_unauthorized_response_for_browser_omits_basic_and_cargo() {
+        // A browser request must not receive the Basic challenge (it would
+        // pop the native credential dialog over the login screen), nor the
+        // cargo-only challenge; the Bearer challenge keeps the response
+        // RFC 7235-compliant without triggering a popup.
+        let mut headers = HeaderMap::new();
+        headers.insert("sec-fetch-mode", "navigate".parse().unwrap());
+        headers.insert("accept", "text/html".parse().unwrap());
+        let resp = unauthorized_response_for(&headers);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let challenges = challenges_of(&resp);
+        assert!(
+            !challenges.iter().any(|v| v.starts_with("Basic")),
+            "browser 401 must not carry a Basic challenge, got: {challenges:?}"
+        );
+        assert!(
+            !challenges.iter().any(|v| v.starts_with("Cargo")),
+            "browser 401 must not carry a Cargo challenge, got: {challenges:?}"
+        );
+        assert!(
+            challenges.iter().any(|v| v.starts_with("Bearer")),
+            "browser 401 must keep the Bearer challenge, got: {challenges:?}"
+        );
+    }
+
+    #[test]
+    fn test_unauthorized_response_for_package_client_keeps_all_challenges() {
+        // Non-browser callers get the byte-identical challenge set as the
+        // headerless unauthorized_response().
+        let mut headers = HeaderMap::new();
+        headers.insert("accept", "*/*".parse().unwrap());
+        let resp = unauthorized_response_for(&headers);
+        assert_eq!(
+            challenges_of(&resp),
+            challenges_of(&unauthorized_response())
+        );
+        let challenges = challenges_of(&resp);
+        assert!(challenges.iter().any(|v| v.starts_with("Basic")));
+        assert!(challenges.iter().any(|v| v.starts_with("Bearer")));
+        assert!(challenges.iter().any(|v| v.starts_with("Cargo")));
     }
 
     #[test]

--- a/backend/src/api/middleware/guest_access.rs
+++ b/backend/src/api/middleware/guest_access.rs
@@ -51,7 +51,8 @@ use axum::{
 use serde_json::json;
 
 use crate::api::middleware::auth::{
-    extract_visibility_token, service_unavailable_response, try_resolve_auth_outcome, AuthOutcome,
+    extract_visibility_token, is_browser_request, service_unavailable_response,
+    try_resolve_auth_outcome, AuthOutcome,
 };
 use crate::services::auth_service::AuthService;
 
@@ -101,7 +102,16 @@ fn is_allowlisted(path: &str) -> bool {
 /// Includes `WWW-Authenticate` headers (Basic, Bearer, Cargo) so
 /// RFC 7235-compliant clients (Maven, pip, npm, etc.) can determine
 /// the auth scheme and retry with credentials.
-fn unauthorized_response() -> Response {
+///
+/// When the request is browser-originated (`for_browser`, see
+/// [`is_browser_request`]), the `Basic` and `Cargo` challenges are omitted so
+/// the browser does not raise its native Basic credential popup over the web
+/// UI's own login screen (#2936 / #3082). The `Bearer` challenge is kept for
+/// RFC 7235 compliance — it never triggers a popup — and the web UI reacts to
+/// the 401 body by routing to its login / OIDC flow. Package-manager clients
+/// (pip, npm, docker, cargo, maven, …) are never classified as browsers and
+/// keep the full challenge set.
+fn unauthorized_response(for_browser: bool) -> Response {
     let mut response = (
         StatusCode::UNAUTHORIZED,
         Json(json!({
@@ -111,17 +121,21 @@ fn unauthorized_response() -> Response {
     )
         .into_response();
 
-    response.headers_mut().insert(
-        header::WWW_AUTHENTICATE,
-        HeaderValue::from_static("Basic realm=\"artifact-keeper\""),
-    );
+    if !for_browser {
+        response.headers_mut().append(
+            header::WWW_AUTHENTICATE,
+            HeaderValue::from_static("Basic realm=\"artifact-keeper\""),
+        );
+    }
     response.headers_mut().append(
         header::WWW_AUTHENTICATE,
         HeaderValue::from_static("Bearer realm=\"artifact-keeper\", charset=\"UTF-8\""),
     );
-    response
-        .headers_mut()
-        .append(header::WWW_AUTHENTICATE, HeaderValue::from_static("Cargo"));
+    if !for_browser {
+        response
+            .headers_mut()
+            .append(header::WWW_AUTHENTICATE, HeaderValue::from_static("Cargo"));
+    }
 
     response
 }
@@ -133,7 +147,10 @@ fn unauthorized_response() -> Response {
 /// retryable **503**, NOT a 401. Collapsing it into the "unauthenticated" 401
 /// would make valid credentials fail under transient auth-cap saturation. Kept
 /// as a pure function so the mapping is unit-testable without a live auth backend.
-fn guard_short_circuit(outcome: &AuthOutcome) -> Option<Response> {
+///
+/// `for_browser` selects the popup-free challenge variant of the 401 for
+/// browser-originated requests (#2936 / #3082); it never changes the status.
+fn guard_short_circuit(outcome: &AuthOutcome, for_browser: bool) -> Option<Response> {
     match outcome {
         // A principal resolved — let the request through; inner middlewares
         // re-resolve and populate request extensions for handlers.
@@ -141,7 +158,9 @@ fn guard_short_circuit(outcome: &AuthOutcome) -> Option<Response> {
         // Transient bcrypt-capacity shed: retryable 503, never a 401.
         AuthOutcome::Overloaded => Some(service_unavailable_response()),
         // No/invalid credential presented: guest access is disabled → 401.
-        AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => Some(unauthorized_response()),
+        AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => {
+            Some(unauthorized_response(for_browser))
+        }
     }
 }
 
@@ -182,7 +201,12 @@ pub async fn guest_access_guard(
     // `allow_basic_api_token=false` and still refuse an API token as the Basic
     // password on the management API.
     let outcome = try_resolve_auth_outcome(&state.auth_service, extracted, true).await;
-    match guard_short_circuit(&outcome) {
+    // Browser-originated requests get the popup-free 401 variant so the web
+    // UI can show its login / OIDC screen instead of the native Basic dialog
+    // (#2936 / #3082). Classified from request headers only (Fetch Metadata /
+    // `Accept: text/html`), so package clients are unaffected.
+    let for_browser = is_browser_request(request.headers());
+    match guard_short_circuit(&outcome, for_browser) {
         Some(response) => response,
         None => next.run(request).await,
     }
@@ -262,8 +286,8 @@ mod tests {
         // retryable 503 through the guard. Collapsing it into the
         // GUEST_ACCESS_DISABLED 401 is what broke preemptive-auth clients
         // (twine, uv/pip token-in-url, CI X-API-Key) under concurrent load.
-        let resp =
-            guard_short_circuit(&AuthOutcome::Overloaded).expect("Overloaded must short-circuit");
+        let resp = guard_short_circuit(&AuthOutcome::Overloaded, false)
+            .expect("Overloaded must short-circuit");
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert!(
             resp.headers().contains_key(axum::http::header::RETRY_AFTER),
@@ -273,14 +297,14 @@ mod tests {
 
     #[test]
     fn short_circuit_no_credential_is_401() {
-        let resp = guard_short_circuit(&AuthOutcome::NoCredential)
+        let resp = guard_short_circuit(&AuthOutcome::NoCredential, false)
             .expect("NoCredential must short-circuit");
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[test]
     fn short_circuit_invalid_credential_is_401() {
-        let resp = guard_short_circuit(&AuthOutcome::InvalidCredential)
+        let resp = guard_short_circuit(&AuthOutcome::InvalidCredential, false)
             .expect("InvalidCredential must short-circuit");
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
@@ -289,7 +313,7 @@ mod tests {
 
     #[test]
     fn unauthorized_response_status_and_body() {
-        let resp = unauthorized_response();
+        let resp = unauthorized_response(false);
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         let ct = resp
             .headers()
@@ -301,7 +325,7 @@ mod tests {
 
     #[test]
     fn unauthorized_response_includes_www_authenticate_basic() {
-        let resp = unauthorized_response();
+        let resp = unauthorized_response(false);
         let challenges: Vec<&str> = resp
             .headers()
             .get_all(header::WWW_AUTHENTICATE)
@@ -317,7 +341,7 @@ mod tests {
 
     #[test]
     fn unauthorized_response_includes_www_authenticate_bearer() {
-        let resp = unauthorized_response();
+        let resp = unauthorized_response(false);
         let challenges: Vec<&str> = resp
             .headers()
             .get_all(header::WWW_AUTHENTICATE)
@@ -333,7 +357,7 @@ mod tests {
 
     #[test]
     fn unauthorized_response_includes_www_authenticate_cargo() {
-        let resp = unauthorized_response();
+        let resp = unauthorized_response(false);
         let challenges: Vec<&str> = resp
             .headers()
             .get_all(header::WWW_AUTHENTICATE)
@@ -344,6 +368,67 @@ mod tests {
             challenges.contains(&"Cargo"),
             "expected Cargo challenge, got: {:?}",
             challenges
+        );
+    }
+
+    // -- browser variant of the 401 (#2936 / #3082) --
+
+    #[test]
+    fn unauthorized_response_browser_omits_basic_and_cargo_keeps_bearer() {
+        // A browser must not receive the Basic challenge (it raises the
+        // native credential popup over the web UI's login screen), nor the
+        // cargo-only challenge; Bearer stays for RFC 7235 compliance.
+        let resp = unauthorized_response(true);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let challenges: Vec<&str> = resp
+            .headers()
+            .get_all(header::WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert!(
+            !challenges.iter().any(|v| v.starts_with("Basic")),
+            "browser 401 must not carry a Basic challenge, got: {:?}",
+            challenges
+        );
+        assert!(
+            !challenges.contains(&"Cargo"),
+            "browser 401 must not carry a Cargo challenge, got: {:?}",
+            challenges
+        );
+        assert!(
+            challenges.contains(&"Bearer realm=\"artifact-keeper\", charset=\"UTF-8\""),
+            "browser 401 must keep the Bearer challenge, got: {:?}",
+            challenges
+        );
+    }
+
+    #[test]
+    fn unauthorized_response_browser_keeps_json_body_marker() {
+        // The web UI keys off the GUEST_ACCESS_DISABLED error to route to its
+        // login/OIDC flow; the browser variant must keep the same JSON shape.
+        let resp = unauthorized_response(true);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .map(|v| v.to_str().unwrap_or("").to_string())
+            .unwrap_or_default();
+        assert!(ct.starts_with("application/json"));
+    }
+
+    #[test]
+    fn short_circuit_browser_flag_selects_popup_free_401() {
+        let resp = guard_short_circuit(&AuthOutcome::NoCredential, true)
+            .expect("NoCredential must short-circuit");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            !resp
+                .headers()
+                .get_all(header::WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .any(|v| v.starts_with("Basic")),
+            "browser short-circuit must not carry a Basic challenge"
         );
     }
 
@@ -428,6 +513,73 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn guard_blocks_browser_without_basic_challenge_when_disabled() {
+        // Browser fetch()/navigation (identified by Fetch Metadata) must get
+        // a 401 WITHOUT a Basic challenge so no native popup appears and the
+        // web UI can route to its login/OIDC screen (#2936 / #3082).
+        let app = make_app(make_state(false));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repositories")
+                    .header("sec-fetch-mode", "cors")
+                    .header("sec-fetch-site", "same-origin")
+                    .header("accept", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            !resp
+                .headers()
+                .get_all(header::WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .any(|v| v.starts_with("Basic")),
+            "browser request must not receive a Basic challenge"
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_blocks_package_client_with_basic_challenge_when_disabled() {
+        // Package-manager clients (no Fetch Metadata, no text/html Accept)
+        // must keep the native Basic/Bearer/Cargo challenges so they can
+        // retry with credentials.
+        let app = make_app(make_state(false));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repositories")
+                    .header("accept", "*/*")
+                    .header("user-agent", "pip/24.0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let challenges: Vec<String> = resp
+            .headers()
+            .get_all(header::WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .map(String::from)
+            .collect();
+        assert!(
+            challenges.iter().any(|v| v.starts_with("Basic")),
+            "package client must keep the Basic challenge, got: {:?}",
+            challenges
+        );
+        assert!(
+            challenges.iter().any(|v| v == "Cargo"),
+            "package client must keep the Cargo challenge, got: {:?}",
+            challenges
+        );
     }
 
     #[tokio::test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1493,7 +1493,25 @@ async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
 
     let req = match build_oidc_bootstrap_request() {
         Some(r) => r,
-        None => return Ok(()),
+        None => {
+            // #2819: the OIDC_* env vars are absent (removed or never set).
+            // Any provider a previous boot seeded from the environment must
+            // not outlive its configuration: disable (never delete) rows the
+            // bootstrap owns, so the login page stops advertising a flow
+            // that can no longer complete and local login recovers once no
+            // enabled provider remains. Admin-created providers — and
+            // env-seeded rows an admin later edited or toggled (which clears
+            // the `env_seeded` marker) — are untouched.
+            for name in AuthConfigService::disable_env_seeded_oidc(db).await? {
+                tracing::warn!(
+                    "Disabled OIDC provider '{}': it was seeded from OIDC_* environment \
+                     variables that are no longer set. Re-set the env vars to re-enable it, \
+                     or re-enable it via the admin API to take manual ownership.",
+                    name
+                );
+            }
+            return Ok(());
+        }
     };
 
     // Reconcile the env-managed provider (matched by name) on every boot so
@@ -1506,6 +1524,9 @@ async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
     match plan_provider_reconcile(&req.name, &pairs) {
         ReconcileAction::Create => {
             let config = AuthConfigService::create_oidc(db, req).await?;
+            // Record env ownership so removing the env vars later disables
+            // this row rather than leaving it advertised forever (#2819).
+            AuthConfigService::mark_oidc_env_seeded(db, config.id).await?;
             tracing::info!(
                 "Bootstrapped OIDC provider '{}' (id={}) from environment variables",
                 config.name,
@@ -1515,6 +1536,9 @@ async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
         ReconcileAction::Update(id) => {
             let name = req.name.clone();
             let cfg = AuthConfigService::update_oidc(db, id, req.into()).await?;
+            // `update_oidc` clears the env-ownership marker (admin updates
+            // take ownership); the bootstrap is the env, so re-assert it.
+            AuthConfigService::mark_oidc_env_seeded(db, cfg.id).await?;
             tracing::info!(
                 "Reconciled env-managed OIDC provider '{}' (id={}) from environment variables",
                 name,

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -713,13 +713,18 @@ impl AuthConfigService {
             existing.client_secret_encrypted
         };
 
+        // `env_seeded = FALSE` (#2819): an update through this path means a
+        // caller other than the env bootstrap has taken ownership of the row,
+        // so a later boot without OIDC_* env vars must not auto-disable it.
+        // The env bootstrap itself re-asserts the marker via
+        // `mark_oidc_env_seeded` right after calling this.
         let row = sqlx::query_as::<_, OidcConfigRow>(
             r#"
             UPDATE oidc_configs
             SET name = $1, issuer_url = $2, client_id = $3, client_secret_encrypted = $4,
                 scopes = $5, attribute_mapping = $6, is_enabled = $7, auto_create_users = $8,
                 pkce_enabled = $9, map_groups_to_groups = $10, allow_legacy_rsa_keys = $11,
-                updated_at = NOW()
+                env_seeded = FALSE, updated_at = NOW()
             WHERE id = $12
             RETURNING id, name, issuer_url, client_id, client_secret_encrypted,
                       scopes, attribute_mapping, is_enabled, auto_create_users,
@@ -764,9 +769,12 @@ impl AuthConfigService {
         id: Uuid,
         toggle: ToggleRequest,
     ) -> Result<OidcConfigResponse> {
+        // `env_seeded = FALSE` (#2819): an explicit admin toggle takes
+        // ownership of the row, so a boot without OIDC_* env vars will not
+        // re-disable a provider an administrator deliberately re-enabled.
         let row = sqlx::query_as::<_, OidcConfigRow>(
             r#"
-            UPDATE oidc_configs SET is_enabled = $1, updated_at = NOW()
+            UPDATE oidc_configs SET is_enabled = $1, env_seeded = FALSE, updated_at = NOW()
             WHERE id = $2
             RETURNING id, name, issuer_url, client_id, client_secret_encrypted,
                       scopes, attribute_mapping, is_enabled, auto_create_users,
@@ -782,6 +790,52 @@ impl AuthConfigService {
         .ok_or_else(|| AppError::NotFound(format!("OIDC config {id} not found")))?;
 
         Ok(Self::oidc_row_to_response(row))
+    }
+
+    /// Mark an OIDC provider row as owned by the OIDC_* env bootstrap
+    /// (#2819). Called by `bootstrap_oidc_from_env` right after it creates or
+    /// reconciles the env-named provider, so a later boot *without* the env
+    /// vars knows the row may be auto-disabled via
+    /// [`Self::disable_env_seeded_oidc`]. Admin-API updates and toggles clear
+    /// the marker (they take ownership).
+    pub async fn mark_oidc_env_seeded(pool: &PgPool, id: Uuid) -> Result<()> {
+        sqlx::query("UPDATE oidc_configs SET env_seeded = TRUE WHERE id = $1")
+            .bind(id)
+            .execute(pool)
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to mark OIDC config env-seeded: {e}"))
+            })?;
+        Ok(())
+    }
+
+    /// Disable every still-enabled OIDC provider that was seeded from OIDC_*
+    /// env vars (#2819). Called on boot when the env vars are absent, so an
+    /// env-configured provider does not outlive its configuration: the login
+    /// page stops advertising a flow that can no longer complete, and
+    /// `local_login_enabled` recovers once no enabled provider remains.
+    ///
+    /// Rows are disabled — never deleted — so linked identities and audit
+    /// history survive, and re-adding the env vars re-enables the provider on
+    /// the next boot via the normal reconcile path. Admin-created providers
+    /// (`env_seeded = FALSE`, the column default) are never touched.
+    ///
+    /// Returns the names of the providers that were disabled.
+    pub async fn disable_env_seeded_oidc(pool: &PgPool) -> Result<Vec<String>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            r#"
+            UPDATE oidc_configs
+            SET is_enabled = FALSE, updated_at = NOW()
+            WHERE env_seeded = TRUE AND is_enabled = TRUE
+            RETURNING name
+            "#,
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!("Failed to disable env-seeded OIDC configs: {e}"))
+        })?;
+        Ok(rows.into_iter().map(|(name,)| name).collect())
     }
 
     fn oidc_row_to_response(row: OidcConfigRow) -> OidcConfigResponse {
@@ -3205,6 +3259,153 @@ mod tests {
             // New columns survive the toggle.
             assert!(toggled.pkce_enabled);
             assert!(!toggled.map_groups_to_groups);
+            cleanup_oidc(&pool, created.id).await;
+        }
+
+        // -------------------------------------------------------------------
+        // Env-seeded provider lifecycle (#2819): a provider bootstrapped from
+        // OIDC_* env vars must be auto-disabled once the env vars are gone,
+        // while admin-owned providers are never touched.
+        // -------------------------------------------------------------------
+
+        async fn env_seeded_of(pool: &PgPool, id: Uuid) -> bool {
+            sqlx::query_scalar("SELECT env_seeded FROM oidc_configs WHERE id = $1")
+                .bind(id)
+                .fetch_one(pool)
+                .await
+                .expect("read env_seeded")
+        }
+
+        async fn is_enabled_of(pool: &PgPool, id: Uuid) -> bool {
+            sqlx::query_scalar("SELECT is_enabled FROM oidc_configs WHERE id = $1")
+                .bind(id)
+                .fetch_one(pool)
+                .await
+                .expect("read is_enabled")
+        }
+
+        #[tokio::test]
+        async fn test_disable_env_seeded_oidc_disables_only_marked_rows() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            if !encryption_key_available() {
+                return;
+            }
+            // disable_env_seeded_oidc is a whole-table sweep; serialize
+            // against other suites that seed env-marked providers.
+            let _guard = db_helpers::sso_provider_serial_lock().await;
+
+            let seeded = AuthConfigService::create_oidc(&pool, make_create_req("env-seeded"))
+                .await
+                .expect("create env-seeded provider");
+            AuthConfigService::mark_oidc_env_seeded(&pool, seeded.id)
+                .await
+                .expect("mark env_seeded");
+            let admin_owned = AuthConfigService::create_oidc(&pool, make_create_req("admin-owned"))
+                .await
+                .expect("create admin-owned provider");
+
+            let disabled_names = AuthConfigService::disable_env_seeded_oidc(&pool)
+                .await
+                .expect("disable_env_seeded_oidc");
+
+            assert!(
+                disabled_names.contains(&seeded.name),
+                "env-seeded provider must be reported as disabled, got {disabled_names:?}"
+            );
+            assert!(
+                !disabled_names.contains(&admin_owned.name),
+                "admin-owned provider must not be touched, got {disabled_names:?}"
+            );
+            assert!(
+                !is_enabled_of(&pool, seeded.id).await,
+                "env-seeded provider must be disabled once the env vars are gone"
+            );
+            assert!(
+                is_enabled_of(&pool, admin_owned.id).await,
+                "admin-owned provider must stay enabled"
+            );
+
+            // A second sweep is a no-op: the row is already disabled.
+            let second = AuthConfigService::disable_env_seeded_oidc(&pool)
+                .await
+                .expect("second sweep");
+            assert!(
+                !second.contains(&seeded.name),
+                "already-disabled provider must not be re-reported"
+            );
+
+            cleanup_oidc(&pool, seeded.id).await;
+            cleanup_oidc(&pool, admin_owned.id).await;
+        }
+
+        #[tokio::test]
+        async fn test_update_oidc_takes_ownership_from_env() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            if !encryption_key_available() {
+                return;
+            }
+            let created = AuthConfigService::create_oidc(&pool, make_create_req("env-owned-upd"))
+                .await
+                .expect("create_oidc");
+            AuthConfigService::mark_oidc_env_seeded(&pool, created.id)
+                .await
+                .expect("mark env_seeded");
+            assert!(env_seeded_of(&pool, created.id).await);
+
+            // An admin-API update clears the marker: the row is now
+            // admin-owned and must survive env-var removal.
+            let update = UpdateOidcConfigRequest {
+                issuer_url: Some("https://issuer2.test.local".to_string()),
+                name: None,
+                client_id: None,
+                client_secret: None,
+                scopes: None,
+                attribute_mapping: None,
+                attribute_mapping_replace: None,
+                is_enabled: None,
+                auto_create_users: None,
+                pkce_enabled: None,
+                map_groups_to_groups: None,
+                allow_legacy_rsa_keys: None,
+            };
+            AuthConfigService::update_oidc(&pool, created.id, update)
+                .await
+                .expect("update_oidc");
+            assert!(
+                !env_seeded_of(&pool, created.id).await,
+                "an admin update must clear env_seeded"
+            );
+            cleanup_oidc(&pool, created.id).await;
+        }
+
+        #[tokio::test]
+        async fn test_toggle_oidc_takes_ownership_from_env() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            if !encryption_key_available() {
+                return;
+            }
+            let created = AuthConfigService::create_oidc(&pool, make_create_req("env-owned-tgl"))
+                .await
+                .expect("create_oidc");
+            AuthConfigService::mark_oidc_env_seeded(&pool, created.id)
+                .await
+                .expect("mark env_seeded");
+
+            // An explicit admin toggle (e.g. re-enabling after the sweep
+            // disabled it) takes ownership so later boots leave it alone.
+            AuthConfigService::toggle_oidc(&pool, created.id, ToggleRequest { enabled: true })
+                .await
+                .expect("toggle_oidc");
+            assert!(
+                !env_seeded_of(&pool, created.id).await,
+                "an admin toggle must clear env_seeded"
+            );
             cleanup_oidc(&pool, created.id).await;
         }
 


### PR DESCRIPTION
## Summary

One consolidated fix for the guest-access / OIDC auth-UX cluster — all four issues live in the same auth-challenge subsystem.

**No Basic-auth popup over the login screen when guest access is disabled (#2936, #3082).**
With `AK_GUEST_ACCESS_ENABLED=false` the guest-access guard answered every unauthenticated request — including the web UI's own `fetch()` calls — with `401` + `WWW-Authenticate: Basic`, and browsers react to a Basic challenge by raising their native credential dialog before the user ever reaches the login/OIDC page. The guard (and the optional-auth middleware's invalid-credential 401) now classify browser-originated requests with a pure, unit-tested header check (`is_browser_request`): any Fetch Metadata header (`Sec-Fetch-Mode` / `Sec-Fetch-Site` — forbidden request headers every modern browser sends on navigations *and* `fetch()`/XHR, and that no package client sends) or an `Accept` listing `text/html`. For those requests the `Basic` (and cargo-only `Cargo`) challenge is omitted while the `Bearer` challenge is kept for RFC 7235 compliance, so the browser lands on the web UI's login/OIDC flow directly.

**Package-manager clients are deliberately unaffected**: pip, npm, docker, cargo, maven and conan send neither Fetch Metadata nor a `text/html` Accept, so they are never classified as browsers and receive the byte-identical `Basic`/`Bearer`/`Cargo` challenge set they got before. A test asserts the non-browser response equals the previous `unauthorized_response()` challenge set exactly.

**Env-seeded OIDC provider no longer outlives its env vars (#2819, migration 197).**
`bootstrap_oidc_from_env` created/reconciled a provider row on boot, but removing `OIDC_ISSUER`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET` and restarting left that row enabled: the login page kept advertising a flow that could no longer complete while `local_login_enabled` stayed `false` because an enabled provider row still existed — locking operators out of the UI entirely. Env-seeded rows are now marked (`oidc_configs.env_seeded`, default `FALSE`); a boot without the env vars disables — never deletes — any still-enabled marked row, so linked identities and audit history survive and local login recovers. Re-adding the env vars re-enables the provider through the existing reconcile path.

Admin ownership is respected in both directions: rows created via the admin API are never touched (the column defaults to `FALSE`, so every pre-existing row is treated as admin-owned), and editing or toggling a previously env-seeded provider through the admin API clears the marker so later boots leave it alone. Documented in `.env.example`.

**Backend flag for the "Sign in with admin" button (#2571).**
The login page itself lives in artifact-keeper-web, so this PR ships the backend half the issue asks for: `GET /api/v1/system/config` now returns `auth.admin_break_glass_enabled`, mirroring `local_login_gate` for a verified admin — `true` unless an SSO provider is enabled **and** the operator opted into strict SSO-only via `SSO_DISABLE_ADMIN_BREAK_GLASS` (#2018). The UI can gate a discoverable "Sign in with admin" affordance on it instead of the undocumented `?fallback=local` parameter. This is distinct from the existing `local_login_enabled`, which only advertises the full local form on explicit `ALLOW_LOCAL_ADMIN_LOGIN=true` opt-in and is unchanged. Display-only — the login endpoint keeps enforcing the same policy server-side, so the flag never widens access. The web-side button remains to be done in artifact-keeper-web.

Fixes #2936
Fixes #3082
Fixes #2819
Closes #2571

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

For #2936/#3082: `guard_blocks_browser_without_basic_challenge_when_disabled` (router-level via `ServiceExt::oneshot`; fails on `main`, where the guard always emits the Basic challenge), paired with `guard_blocks_package_client_with_basic_challenge_when_disabled` to pin the package-client behaviour that must NOT change, plus the `is_browser_request` matrix and the `unauthorized_response_for` challenge-set assertions in `middleware/auth.rs`.

For #2819: `test_disable_env_seeded_oidc_disables_only_marked_rows` (DB-backed; fails on `main`, where the column and sweep do not exist and the row stays enabled), plus `test_update_oidc_takes_ownership_from_env` / `test_toggle_oidc_takes_ownership_from_env` for the admin-ownership transfer.

For #2571: full `admin_break_glass_available` matrix plus two assertions added to the existing DB-backed `test_handler_local_login_enabled_matrix_db`.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — DB-backed tests via `test_db_helpers::try_pool()`, which run in the coverage CI job
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --lib` green (15249 passed, 0 failed)
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations — no new endpoints; the existing `/api/v1/system/config` gains one field
- [x] Request/response types have `#[derive(ToSchema)]` — `AuthConfig` already derives `ToSchema`; the new `admin_break_glass_enabled` field is documented inline
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — migration 197 is a single additive `ADD COLUMN IF NOT EXISTS ... NOT NULL DEFAULT FALSE`
