### PR TITLE
fix(test): remove two sources of shared-database test interference

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -2250,12 +2250,13 @@ mod tests {
         let _guard = tdh::totp_policy_serial_lock().await;
         let restore = totp_policy::stored_policy(&pool).await;
 
+        // Deliberately NOT flagged `is_admin` in the database: the admin check
+        // is route middleware, and `admin_security`'s accessible-users test
+        // asserts a global count that every active admin enters. Creating one
+        // here would make that pre-existing race fire. Nothing under test reads
+        // the column -- `check_policy_activation` keys on the actor's TOTP
+        // state, not their role.
         let (user_id, username) = tdh::create_user(&pool).await;
-        sqlx::query("UPDATE users SET is_admin = true WHERE id = $1")
-            .bind(user_id)
-            .execute(&pool)
-            .await
-            .expect("promote to admin");
         totp_policy::store_policy(&pool, TotpPolicy::Disabled, user_id)
             .await
             .expect("seed disabled");
@@ -2325,9 +2326,10 @@ mod tests {
 
         let read = read.expect("read policy").0;
         assert_eq!(read.policy, TotpPolicy::Disabled);
-        // The blast-radius counts must at least see the admin we created.
-        assert!(read.local_admins >= 1);
-        assert!(read.local_users >= read.local_admins);
+        // The blast-radius counts must see the local user we created, and the
+        // admin subset can never exceed the whole.
+        assert!(read.local_users >= 1);
+        assert!(read.local_admins <= read.local_users);
     }
 
     /// While `TOTP_POLICY` pins the policy, the API reports it as
@@ -2343,11 +2345,12 @@ mod tests {
         let _guard = tdh::totp_policy_serial_lock().await;
 
         let (user_id, username) = tdh::create_user(&pool).await;
-        sqlx::query("UPDATE users SET is_admin = true, totp_enabled = true WHERE id = $1")
+        // `is_admin` is deliberately left alone -- see the sibling test.
+        sqlx::query("UPDATE users SET totp_enabled = true WHERE id = $1")
             .bind(user_id)
             .execute(&pool)
             .await
-            .expect("promote + enrol");
+            .expect("enrol caller");
 
         let state = tdh::build_state_with(pool.clone(), "/tmp/admin-totp-pinned", |cfg| {
             cfg.totp_policy = Some(TotpPolicy::RequiredForAll);

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -1152,13 +1152,19 @@ mod tests {
     }
 
     /// #2805, DB-backed: the whole point of the policy is what `POST /login`
-    /// does with it. Under `required_for_admins` a covered admin who has not
-    /// enrolled must get an enrollment ticket instead of a session — and must
-    /// NOT get a hard rejection, which is the shape that would lock an
-    /// operator out. The same account under `disabled` gets an ordinary
-    /// session, proving the default path is untouched.
+    /// does with it. A covered user who has not enrolled must get an enrollment
+    /// ticket instead of a session — and must NOT get a hard rejection, which
+    /// is the shape that would lock an operator out. The same account under
+    /// `disabled` gets an ordinary session, proving the default path is
+    /// untouched.
+    ///
+    /// Uses `required_for_all` and a NON-admin account deliberately: the
+    /// handler wiring under test is identical for both policies, the
+    /// admin-vs-everyone split is exhaustively covered without a database by
+    /// `services::totp_policy`, and seeding an extra active admin here would
+    /// make `admin_security`'s global accessible-user count race.
     #[tokio::test]
-    async fn test_login_diverts_unenrolled_admin_into_enrollment_under_policy() {
+    async fn test_login_diverts_unenrolled_user_into_enrollment_under_policy() {
         use crate::api::handlers::test_db_helpers as tdh;
         use axum::body::to_bytes;
 
@@ -1173,7 +1179,7 @@ mod tests {
         let hash = AuthService::hash_password(password).await.unwrap();
         sqlx::query(
             "INSERT INTO users (id, username, email, password_hash, auth_provider, is_active, \
-             is_admin) VALUES ($1, $2, $3, $4, 'local', true, true)",
+             is_admin) VALUES ($1, $2, $3, $4, 'local', true, false)",
         )
         .bind(user_id)
         .bind(&username)
@@ -1181,14 +1187,14 @@ mod tests {
         .bind(&hash)
         .execute(&pool)
         .await
-        .expect("seed admin");
+        .expect("seed user");
 
         let dir = std::env::temp_dir().join(format!("ph-2805-{user_id}"));
         // The policy is pinned through config so this test does not contend
         // for the shared `system_settings` row.
         let enforcing =
             tdh::build_state_with(pool.clone(), dir.to_string_lossy().as_ref(), |cfg| {
-                cfg.totp_policy = Some(totp_policy::TotpPolicy::RequiredForAdmins)
+                cfg.totp_policy = Some(totp_policy::TotpPolicy::RequiredForAll)
             });
         let permissive = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
         // Same signing key the handler used, so the ticket below actually

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -147,6 +147,48 @@ pub async fn blob_gc_serial_lock() -> BlobGcSerialGuard {
     }
 }
 
+/// Advisory-lock key for [`oci_reindex_serial_lock`] (#3402).
+///
+/// Distinct from the other test lock keys and from the application advisory
+/// locks, so the OCI-reindex test cluster serializes only against itself.
+const OCI_REINDEX_TEST_LOCK_KEY: i64 = 0x4F43_3402; // "OC" + issue #3402
+
+/// Cross-process serialization guard for the DB-backed OCI migration-reindex
+/// tests (#3402).
+///
+/// Exactly the [`blob_gc_serial_lock`] shape, for exactly the same reason:
+/// `oci_migration_reindex::run_repair` scans and mutates `oci_tags` and
+/// `artifacts` **instance-wide** — its queries join `repositories` rather than
+/// binding a repository id, because in production it legitimately repairs the
+/// whole instance. Every test in the module calls it. Run concurrently against
+/// one shared database, sibling A's `run_repair` registers or reconciles the
+/// rows sibling B seeded before B asserts on them, so B sees
+/// `orphan_tags_reconciled: 0` for an orphan that was already cleaned up. The
+/// observable tell is that `candidates_scanned` varies run to run (2, 3, …) for
+/// a test that seeds a fixed number of candidates.
+///
+/// Serializing the module is the fix that does not change production
+/// behaviour. Scoping `run_repair` to one repository would make the test pass
+/// by narrowing a repair job whose whole purpose is to be instance-wide.
+///
+/// The lock releases when the guard drops (connection closes), including on
+/// panic.
+pub struct OciReindexSerialGuard {
+    _conn: Option<sqlx::PgConnection>,
+}
+
+/// Acquire the process-wide OCI-reindex test lock, blocking until it is free.
+///
+/// Returns an inert guard (no lock held) when `DATABASE_URL` is unset or the
+/// database is unreachable, mirroring [`try_pool`]. Call this as the first line
+/// of a DB-backed `oci_migration_reindex` test and bind the result for the
+/// whole test body.
+pub async fn oci_reindex_serial_lock() -> OciReindexSerialGuard {
+    OciReindexSerialGuard {
+        _conn: serial_lock_session(OCI_REINDEX_TEST_LOCK_KEY).await,
+    }
+}
+
 /// Advisory-lock key for [`totp_policy_serial_lock`] (#2805).
 ///
 /// Distinct from the other test lock keys and from the application advisory

--- a/backend/src/services/oci_migration_reindex.rs
+++ b/backend/src/services/oci_migration_reindex.rs
@@ -757,6 +757,10 @@ mod tests {
         let Some(pool) = tdh::try_pool().await else {
             return;
         };
+        // #3402: `run_repair` is instance-wide, and every test in this module
+        // calls it. Serialize the module so a sibling's repair cannot register
+        // or reconcile the rows this test just seeded.
+        let _serial = tdh::oci_reindex_serial_lock().await;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let repo_id = Uuid::new_v4();
@@ -919,6 +923,10 @@ mod tests {
         let Some(pool) = tdh::try_pool().await else {
             return;
         };
+        // #3402: `run_repair` is instance-wide, and every test in this module
+        // calls it. Serialize the module so a sibling's repair cannot register
+        // or reconcile the rows this test just seeded.
+        let _serial = tdh::oci_reindex_serial_lock().await;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let repo_id = Uuid::new_v4();
@@ -1039,6 +1047,10 @@ mod tests {
         let Some(pool) = tdh::try_pool().await else {
             return;
         };
+        // #3402: `run_repair` is instance-wide, and every test in this module
+        // calls it. Serialize the module so a sibling's repair cannot register
+        // or reconcile the rows this test just seeded.
+        let _serial = tdh::oci_reindex_serial_lock().await;
         let tmp = tempfile::tempdir().expect("tempdir");
         let repo_id = Uuid::new_v4();
         let repo_key = format!("reidxorph-{}", &repo_id.to_string()[..8]);


### PR DESCRIPTION
## Summary

Test-only. Removes two sources of shared-database test interference in `cargo test --workspace --lib`. No production code changes.

### 1. `oci_migration_reindex` order-sensitivity (#3402)

Reproduced on a clean `main` checkout against a dedicated Postgres, on a branch touching no OCI code:

```
---- services::oci_migration_reindex::tests::test_run_repair_drops_orphan_tag_keeps_healthy ----
orphan tag must be reconciled, stats: RepairStats { candidates_scanned: 3, manifests_registered: 3,
blobs_registered: 3, children_registered: 1, candidates_skipped: 0, candidates_failed: 0,
hollow_tags_flagged: 0, orphan_tags_reconciled: 0 }
```

**Mechanism.** `run_repair`'s queries join `repositories` rather than binding a repository id — they are instance-wide by design, because in production this job repairs the whole instance. **All three tests in the module call it.** Run concurrently against one shared database, sibling A's `run_repair` registers or reconciles the rows sibling B just seeded, so B asserts on an orphan that was already cleaned up and sees `orphan_tags_reconciled: 0`. The observable tell is that `candidates_scanned` **varies run to run** (2 in one run, 3 in another) for a test that seeds a fixed number of candidates — direct evidence that the scan sees other tests' rows.

**Fix.** A session advisory lock on the module, exactly the existing `blob_gc_serial_lock` shape and for exactly the same documented reason ("the blob-GC service operates on the WHOLE database… one test's apply-mode pass would mark/sweep another test's freshly-seeded orphan blob"). Guard releases on drop, including on panic, and is inert without `DATABASE_URL`.

**Deliberately not done:** #3402 lists scoping the repair scan to one repository as the preferred fix. I did not do that — it would make the tests pass by narrowing a repair job whose entire purpose is to be instance-wide, i.e. changing production semantics to suit a test. Serialization is the option that leaves production behaviour untouched, and #3402 lists it as acceptable.

**Residual risk, stated honestly:** this serializes the module against *itself*. Six other modules also write `oci_tags` (`oci_v2`, `storage_gc_service`, `lifecycle_service`, `manifest_blob_refs_backfill`, `oci_referenced_content`, `repositories`). Sibling interference was the dominant mechanism and two full-suite runs are clean, but if this recurs the next step is widening the same lock to every module that writes `oci_tags`, rather than reaching for the production-scoping change.

### 2. Follow-up to #3401 — my own tests were raising a pre-existing race

`admin_security::test_accessible_users_enumeration_db` asserts a **global active-user count** across two adjacent queries (`assert_eq!(p1.total, Some(total))`), and every active admin is enumerated via `via: "admin"`. It takes no serial lock, so it races with anything that creates an active admin. Observed failing as `left: Some(53), right: Some(54)`.

The 2FA policy tests merged in #3401 seed an **active admin**, which measurably raised how often that fires — and that is now on `main` affecting everyone's CI. Fixed on my side rather than by touching the other test:

- The two `admin` policy tests no longer set `is_admin` in the database. Nothing under test reads it — the admin check is route middleware (`admin_middleware`), and `check_policy_activation` keys on the actor's TOTP state, not their role. The count assertions became `local_users >= 1` and `local_admins <= local_users`, which still exercise the counting SQL.
- The login test uses `required_for_all` with a non-admin account. The handler wiring under test is identical for both policies, and the admin-vs-everyone split is already covered exhaustively **without a database** by `services::totp_policy`.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This PR *is* the test fix: the changed files are test code and a test helper, and the bug being fixed is the tests' own interference. There is no product behaviour to regress against.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified against a dedicated Postgres 16 with all migrations applied, with **`AK_TESTS_REQUIRE_DB=1`** set so DB-backed tests panic rather than silently no-op, and `SQLX_OFFLINE=true`:

- **Before** (clean `main` + only the #3401 follow-up): `oci_migration_reindex::test_run_repair_drops_orphan_tag_keeps_healthy` **FAILED**.
- **After**: two consecutive full-suite runs, `oci_migration_reindex` clean in both, `admin_security` clean in both.
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean.

### Separately: the `nuget` `_db_tests` flakes are NOT database interference

I had previously suspected them of the same cause. That was wrong, and the evidence says so plainly:

```
---- api::handlers::nuget::push_db_tests::push_multiple_versions_collapses_into_one_package_row ----
first push failed: 503 Service Unavailable
```

`503` here is the **bcrypt auth-concurrency load-shed** in `auth_service` (wait for a permit, then shed to `ServiceUnavailable`). These tests go through `router_with_auth`, so every request runs bcrypt against a process-wide semaphore; under full-suite parallelism it saturates and sheds. A serial lock would not fix this and would plausibly make it worse by holding permits longer. Left alone here on purpose — it needs its own fix (raise `auth_max_concurrency` for tests, or use a cheaper test cost factor) and I did not want to bury a different root cause inside a de-flake PR. `storage_gc_service` and `sync_worker` were also seen flaking and are likewise out of scope.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No CHANGELOG entry: the CHANGELOG documents notable changes to the product, and this changes only the test harness. Happy to add one if the project prefers otherwise.

Fixes #3402
