### PR TITLE
fix(ci): select the Docker Publish run by head_sha on release/1.7.x

### DIFF
--- a/scripts/ci/release-preflight.sh
+++ b/scripts/ci/release-preflight.sh
@@ -14,20 +14,41 @@
 # nothing checked it before tagging. This gate is that check.
 #
 # What it verifies:
-#   1. TRIVYIGNORE DRIFT (hard): main's CVE/GHSA suppression set must be a
-#      SUPERSET of every active `release/*` branch's. A CVE suppressed on a
-#      hotfix branch but not forward-ported to main means main's images fail
-#      Security Scan -> no release can be cut from main. This is the exact
-#      #3039 gap. Enumeration mirrors check-migration-ledger.sh.
+#   1. TRIVYIGNORE DRIFT (hard): every suppression on every active `release/*`
+#      branch must be ACCOUNTED FOR on main -- either as a live suppression
+#      token, or as an explicit `# RETIRED: <token>` tombstone line. A CVE
+#      suppressed on a hotfix branch and neither carried nor tombstoned on
+#      main means main's images fail Security Scan -> no release can be cut
+#      from main. This is the exact #3039 gap. Enumeration mirrors
+#      check-migration-ledger.sh.
+#
+#      The tombstone form exists because a plain superset rule makes the set
+#      monotonic (#3309): a suppression provably dead for main's images could
+#      never be DELETED while any release branch still listed it, so the file
+#      drifted from "the residual set" toward "everything ever worked
+#      around". A `# RETIRED: <token>` line is the machine-read record that
+#      main removed the token DELIBERATELY (the finding is absent from main's
+#      images), as opposed to never having received it (the #3039 forward-port
+#      miss, which still hard-fails). Retiring is a reviewable diff, and a
+#      token listed BOTH live and retired is a contradiction and fails.
 #   2. VERSION-SET CONSISTENCY (hard): the workspace version in Cargo.toml,
 #      the OpenAPI info version in backend/src/api/openapi.rs, and the
 #      artifact-keeper-backend entry in Cargo.lock must all agree. A partial
 #      bump ships a stale version string (see RELEASING.md step 2).
-#   3. MAIN DOCKER-PUBLISH HEALTH (hard, when it can be measured): whether the
-#      most recent `Docker Publish` run on main published its multi-arch
-#      manifest (i.e. Security Scan passed). A red/skipped manifest here does
-#      not merely "predict" the same stall on the tag -- it is the same job,
-#      on the same images, with the same gate. If it is red, the cut stalls.
+#   3. DOCKER-PUBLISH HEALTH FOR THIS COMMIT (hard, when it can be measured):
+#      whether the `Docker Publish` run for the EXACT commit being tagged
+#      (HEAD) published its multi-arch manifest (i.e. Security Scan passed).
+#      A red/skipped manifest here does not merely "predict" the same stall
+#      on the tag -- it is the same job, on the same images, with the same
+#      gate. If it is red, the cut stalls.
+#
+#      Selection is by `head_sha`, NOT by recency (#3338). "Latest run on
+#      main" is a proxy that diverges from the question that matters whenever
+#      main has moved since the last publish, a publish is still in flight,
+#      or the list API answers stalely -- the v1.7.2 cut lost time to a
+#      blocking false red when the "latest run" query returned a ten-day-old
+#      run while the actual latest (and green) run existed. A tag is cut on a
+#      commit; the commit's own run is the measurement.
 #
 #      This check used to `warn` and let the script exit 0, so the tool printed
 #      "a tag cut will likely stall" and "READY: ... Safe to cut the tag." in
@@ -45,11 +66,23 @@
 #      because the CVE affected main and the release branches equally so there
 #      was no drift to find.
 #
-#      Three outcomes, deliberately kept distinct -- "I did not look",
-#      "I could not look" and "I looked and it is red" are different claims:
+#      Outcomes, deliberately kept distinct -- "I did not look", "I could not
+#      look", "there is nothing to look at yet" and "I looked and it is red"
+#      are different claims:
 #        * not measured (skipped, or `gh` absent)      -> note, not blocking
 #        * could not measure (the gh query failed)     -> INFRA, exit 2
+#        * no run for this commit (not built yet)      -> blocking, exit 1
+#          NOT a pass and NOT "ran and failed": the images for this commit do
+#          not exist, so a tag cut has nothing to resolve a digest from.
+#        * run still queued/in progress                -> blocking, exit 1
+#          (wait for it to finish and re-run; treating in-flight as absent
+#          or as green would launder an unfinished measurement)
 #        * measured red                                -> blocking, exit 1
+#      PREFLIGHT_ALLOW_RED_PUBLISH only overrides the MEASURED-RED outcome:
+#      "I looked, it is red, proceeding anyway" is a coherent human call.
+#      There is no override for not-built/in-flight, because there is no
+#      result to accept the risk of -- the digest resolution would simply
+#      fail.
 #
 #   4. VERSION-PINNED IMAGE COLLISION (hard, when it can be measured): for each
 #      component whose image tag comes from a checked-in VERSION file, whether
@@ -139,9 +172,18 @@ if [[ -z "$REPO" ]]; then
   [[ -z "$REPO" ]] && REPO="artifact-keeper/artifact-keeper"
 fi
 
-# extract sorted, unique CVE-/GHSA- tokens from stdin
+# extract sorted, unique CVE-/GHSA- tokens from stdin. `|| true` because a
+# file with zero tokens is an answer, not an error (grep exits 1 on no match,
+# which would abort the script under `set -euo pipefail`).
 suppression_tokens() {
-  grep -oE '^(CVE-[0-9]{4}-[0-9]+|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})' | sort -u
+  { grep -oE '^(CVE-[0-9]{4}-[0-9]+|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})' || true; } | sort -u
+}
+
+# extract sorted, unique tombstoned tokens (`# RETIRED: <token>` lines, #3309)
+# from stdin. Anything after the token (a date, an issue ref) is free text.
+retired_tokens() {
+  { grep -oE '^# RETIRED: (CVE-[0-9]{4}-[0-9]+|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})' || true; } \
+    | sed 's/^# RETIRED: //' | sort -u
 }
 
 echo "== release preflight =="
@@ -149,11 +191,23 @@ echo "repo: $REPO   ref: $(git rev-parse --short HEAD 2>/dev/null || echo '?')"
 echo
 
 # --- check 1: .trivyignore forward-port drift -------------------------------
-echo "1) .trivyignore forward-port drift (main must be a superset of release/*)"
+echo "1) .trivyignore forward-port drift (main must account for release/* suppressions)"
 if [[ ! -f .trivyignore ]]; then
   warn "no .trivyignore at repo root -- skipping drift check"
 else
   main_tokens="$(suppression_tokens < .trivyignore)"
+  main_retired="$(retired_tokens < .trivyignore)"
+  # A token both live and tombstoned is a contradiction: the file claims
+  # "this is an active exception" and "this was deliberately removed" at
+  # once. Fail rather than pick a winner (#3309).
+  contradiction="$(comm -12 <(printf '%s\n' "$main_tokens") <(printf '%s\n' "$main_retired") | grep -v '^$' || true)"
+  if [[ -n "$contradiction" ]]; then
+    bad ".trivyignore lists token(s) BOTH as live suppressions and as '# RETIRED:' tombstones:"
+    while IFS= read -r c; do [[ -n "$c" ]] && note "  - $c"; done <<< "$contradiction"
+    note "  -> delete one of the two lines per token; a token is live or retired, never both."
+  fi
+  # What main accounts for: live suppressions plus deliberate retirements.
+  covered="$(printf '%s\n%s\n' "$main_tokens" "$main_retired" | grep -v '^$' | sort -u)"
   # enumerate active release branches (works on a shallow checkout)
   if ! remote_refs="$(git ls-remote --heads origin 'release/*' 2>/dev/null)"; then
     echo "INFRA: git ls-remote for release/* failed" >&2
@@ -173,18 +227,27 @@ else
         continue
       fi
       rel_tokens="$(printf '%s\n' "$rel_content" | suppression_tokens)"
-      # tokens present on the release branch but MISSING from main
-      missing="$(comm -23 <(printf '%s\n' "$rel_tokens") <(printf '%s\n' "$main_tokens") | grep -v '^$' || true)"
+      # tokens present on the release branch but neither live nor tombstoned
+      # on main: the #3039 forward-port miss, still a hard failure.
+      missing="$(comm -23 <(printf '%s\n' "$rel_tokens") <(printf '%s\n' "$covered") | grep -v '^$' || true)"
+      # tokens the release branch still suppresses that main has RETIRED:
+      # accounted for, but say so -- a retirement is a claim about main's
+      # images, and it should be visible in the transcript, not silent.
+      retired_hits="$(comm -12 <(printf '%s\n' "$rel_tokens") <(printf '%s\n' "$main_retired") | grep -v '^$' || true)"
       if [[ -n "$missing" ]]; then
         bad "main is MISSING suppressions that $br has:"
         while IFS= read -r m; do [[ -n "$m" ]] && note "  - $m"; done <<< "$missing"
-        note "  -> forward-port these to main's .trivyignore before tagging (see #3039)"
+        note "  -> forward-port these to main's .trivyignore before tagging (see #3039),"
+        note "     or -- ONLY if the finding is measured absent from main's images --"
+        note "     record the removal as a '# RETIRED: <token>' tombstone (see #3309)."
         drift=$((drift + 1))
+      elif [[ -n "$retired_hits" ]]; then
+        note "$br: main covers all of its suppressions ($(printf '%s' "$retired_hits" | grep -c . ) via RETIRED tombstones)"
       else
         note "$br: main covers all of its suppressions"
       fi
     done <<< "$rel_branches"
-    [[ "$drift" -eq 0 ]] && ok "trivyignore drift: main is a superset of every release/*"
+    [[ "$drift" -eq 0 ]] && ok "trivyignore drift: main accounts for every release/* suppression"
   fi
 fi
 echo
@@ -206,8 +269,8 @@ else
 fi
 echo
 
-# --- check 3: main docker-publish health (hard when measurable) -------------
-echo "3) latest main Docker Publish health"
+# --- check 3: docker-publish health for HEAD (hard when measurable) ---------
+echo "3) Docker Publish health for the commit being tagged (HEAD)"
 if [[ "${PREFLIGHT_SKIP_DOCKER_HEALTH:-0}" == "1" ]]; then
   note "NOT MEASURED (PREFLIGHT_SKIP_DOCKER_HEALTH=1) -- this check did not run,"
   note "which is not the same as it passing."
@@ -215,36 +278,68 @@ elif ! command -v gh >/dev/null 2>&1; then
   note "NOT MEASURED (gh not on PATH) -- this check did not run, which is not"
   note "the same as it passing."
 else
-  run_id="$(gh run list --repo "$REPO" --workflow "Docker Publish" --branch main --limit 1 \
-              --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
-  if [[ -z "$run_id" ]]; then
-    # gh is present but the query failed (auth, network, API). We could not
-    # measure, so we must not render a readiness verdict either way.
-    echo "INFRA: could not query the latest main Docker Publish run" >&2
+  head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+  if [[ -z "$head_sha" ]]; then
+    echo "INFRA: could not resolve HEAD" >&2
     exit 2
   fi
-  sec="$(gh run view "$run_id" --repo "$REPO" --json jobs \
-          --jq '[.jobs[]|select(.name=="Security Scan")|(.conclusion//"?")]|first//"?"' 2>/dev/null || echo '?')"
-  man="$(gh run view "$run_id" --repo "$REPO" --json jobs \
-          --jq '[.jobs[]|select(.name|test("Backend Multi-Arch Manifest"))|(.conclusion//"skipped")]|first//"?"' 2>/dev/null || echo '?')"
-  note "run $run_id: Security Scan=$sec, Backend Multi-Arch Manifest=$man"
-  if [[ "$sec" == "?" || "$man" == "?" ]]; then
-    echo "INFRA: could not read job conclusions from run $run_id" >&2
+  # Select the run for THIS commit, never "the latest run" (#3338): recency
+  # is a proxy that diverges when main has moved, a publish is in flight, or
+  # the list API answers stalely -- and the divergence produced a blocking
+  # false red on the v1.7.2 cut. head_sha resolves to at most one run and
+  # needs no new machinery.
+  if ! run_info="$(gh api "repos/$REPO/actions/workflows/docker-publish.yml/runs?head_sha=$head_sha&per_page=1" \
+                    --jq '.workflow_runs[0] // empty | "\(.id) \(.status)"' 2>/dev/null)"; then
+    # gh is present but the query failed (auth, network, API). We could not
+    # measure, so we must not render a readiness verdict either way.
+    echo "INFRA: could not query Docker Publish runs for $head_sha" >&2
     exit 2
-  elif [[ "$sec" == "success" && "$man" == "success" ]]; then
-    ok "main images are publishing cleanly"
-  elif [[ "${PREFLIGHT_ALLOW_RED_PUBLISH:-0}" == "1" ]]; then
-    warn "main's last Docker Publish did NOT cleanly publish the manifest, but"
-    warn "PREFLIGHT_ALLOW_RED_PUBLISH=1 was set, so this is not blocking."
-    note "  -> whoever set that owns the stall if the cut hits the same gate."
-    note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
+  fi
+  if [[ -z "$run_info" ]]; then
+    # A fourth outcome, distinct from "ran and failed" (#3338): the query
+    # succeeded and there is NO run for this commit. The images a tag cut
+    # would pin do not exist, so resolve-candidate-digest has nothing to
+    # resolve. Not a pass; also not an infra retry.
+    bad "no Docker Publish run exists for HEAD ($(git rev-parse --short HEAD)) -- the images for this commit have NOT been built."
+    note "  -> a tag cut from this commit has no manifest to resolve a digest from."
+    note "  -> wait for (or trigger) Docker Publish on this exact commit, then re-run preflight."
   else
-    bad "main's last Docker Publish did NOT cleanly publish the manifest -- a tag cut WILL stall on the same gate."
-    note "  -> Security Scan hard-gates every multi-arch manifest, which gates"
-    note "     resolve-candidate-digest, which gates the whole release chain."
-    note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
-    note "  -> fix it on main and let Docker Publish go green before tagging (#3039, #3307)."
-    note "  -> PREFLIGHT_ALLOW_RED_PUBLISH=1 overrides this deliberately; do not use it to retry a red away."
+    read -r run_id run_status <<< "$run_info"
+    if [[ -z "$run_id" || -z "$run_status" ]]; then
+      echo "INFRA: unparseable Docker Publish run answer for $head_sha ('$run_info')" >&2
+      exit 2
+    fi
+    if [[ "$run_status" != "completed" ]]; then
+      # In flight is not absent and not green: block and say to wait rather
+      # than silently mis-classifying an unfinished measurement (#3338).
+      bad "Docker Publish for HEAD is still '$run_status' (run $run_id) -- its verdict does not exist yet."
+      note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
+      note "  -> wait for it to complete, then re-run preflight. Do not tag ahead of the gate."
+    else
+      sec="$(gh run view "$run_id" --repo "$REPO" --json jobs \
+              --jq '[.jobs[]|select(.name=="Security Scan")|(.conclusion//"?")]|first//"?"' 2>/dev/null || echo '?')"
+      man="$(gh run view "$run_id" --repo "$REPO" --json jobs \
+              --jq '[.jobs[]|select(.name|test("Backend Multi-Arch Manifest"))|(.conclusion//"skipped")]|first//"?"' 2>/dev/null || echo '?')"
+      note "run $run_id: Security Scan=$sec, Backend Multi-Arch Manifest=$man"
+      if [[ "$sec" == "?" || "$man" == "?" ]]; then
+        echo "INFRA: could not read job conclusions from run $run_id" >&2
+        exit 2
+      elif [[ "$sec" == "success" && "$man" == "success" ]]; then
+        ok "this commit's images published cleanly"
+      elif [[ "${PREFLIGHT_ALLOW_RED_PUBLISH:-0}" == "1" ]]; then
+        warn "Docker Publish for HEAD did NOT cleanly publish the manifest, but"
+        warn "PREFLIGHT_ALLOW_RED_PUBLISH=1 was set, so this is not blocking."
+        note "  -> whoever set that owns the stall if the cut hits the same gate."
+        note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
+      else
+        bad "Docker Publish for HEAD did NOT cleanly publish the manifest -- a tag cut WILL stall on the same gate."
+        note "  -> Security Scan hard-gates every multi-arch manifest, which gates"
+        note "     resolve-candidate-digest, which gates the whole release chain."
+        note "  -> run: $(printf '%s/actions/runs/%s' "https://github.com/$REPO" "$run_id")"
+        note "  -> fix it on main and let Docker Publish go green before tagging (#3039, #3307)."
+        note "  -> PREFLIGHT_ALLOW_RED_PUBLISH=1 overrides this deliberately; do not use it to retry a red away."
+      fi
+    fi
   fi
 fi
 echo

--- a/scripts/ci/test-release-preflight.sh
+++ b/scripts/ci/test-release-preflight.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Self-test for scripts/ci/release-preflight.sh checks 3 and 4
-# (issues #3308 and #3339).
+# Self-test for scripts/ci/release-preflight.sh checks 1, 3 and 4
+# (issues #3308, #3309, #3338 and #3339).
 #
 # WHY THIS EXISTS
 #   Check 3 measures whether main's last Docker Publish published its manifest.
@@ -48,22 +48,54 @@ git -C "$REPO_DIR" remote add origin https://github.com/artifact-keeper/artifact
 git -C "$REPO_DIR" -c user.email=t@t -c user.name=t add -A
 git -C "$REPO_DIR" -c user.email=t@t -c user.name=t commit -qm init
 
-# `git ls-remote --heads origin 'release/*'` must succeed and return nothing.
+# `git ls-remote --heads origin 'release/*'` must succeed; it returns
+# $FAKE_RELEASE_REFS (ls-remote wire format) so the check-1 cases can
+# simulate active release branches, and nothing by default.
 STUB="$WORK/bin"; mkdir -p "$STUB"
 cat > "$STUB/git" <<'STUBGIT'
 #!/usr/bin/env bash
-for a in "$@"; do [ "$a" = "ls-remote" ] && exit 0; done
+for a in "$@"; do
+  if [ "$a" = "ls-remote" ]; then
+    [ -n "${FAKE_RELEASE_REFS-}" ] && printf '%s\n' "$FAKE_RELEASE_REFS"
+    exit 0
+  fi
+done
 exec /usr/bin/git "$@"
 STUBGIT
 chmod +x "$STUB/git"
 
-# --- gh stub: replays $FAKE_SECURITY_SCAN / $FAKE_MANIFEST ------------------
+# --- gh stub ----------------------------------------------------------------
+# Replays:
+#   * the head_sha-scoped Docker Publish run query (#3338):
+#       FAKE_API_FAIL=1     -> the query itself fails       (INFRA path)
+#       FAKE_RUN_ID=""      -> no run exists for the commit (not-built path)
+#       FAKE_RUN_STATUS     -> run status (default completed)
+#   * job conclusions via $FAKE_SECURITY_SCAN / $FAKE_MANIFEST
+#   * a release branch's .trivyignore via $FAKE_REL_TRIVYIGNORE (#3309); the
+#     real call pipes `--jq .content` through `base64 -d`, so the stub emits
+#     the base64 of the fixture text.
 cat > "$STUB/gh" <<'STUBGH'
 #!/usr/bin/env bash
 case "$1" in
+  api)
+    case "$2" in
+      *actions/workflows/docker-publish.yml/runs*)
+        [ "${FAKE_API_FAIL-0}" = "1" ] && exit 1
+        run_id="${FAKE_RUN_ID-12345}"
+        [ -n "$run_id" ] && echo "$run_id ${FAKE_RUN_STATUS-completed}"
+        exit 0
+        ;;
+      *contents/.trivyignore*)
+        if [ -n "${FAKE_REL_TRIVYIGNORE-}" ]; then
+          printf '%s\n' "$FAKE_REL_TRIVYIGNORE" | base64
+          exit 0
+        fi
+        exit 1
+        ;;
+    esac
+    ;;
   run)
     case "$2" in
-      list) echo "${FAKE_RUN_ID-12345}" ;;
       view)
         # Which of the two `gh run view` calls is this? The jq for Security
         # Scan mentions that name; the other is the manifest.
@@ -104,7 +136,7 @@ expect() { # <label> <expected-exit> <expected-substring>
   fi
 }
 
-echo "release-preflight check 3 (#3308)"
+echo "release-preflight check 3 (#3308, #3338)"
 
 # 1. Green publish stays READY. Guards against over-correcting into a gate
 #    that blocks every cut.
@@ -123,8 +155,21 @@ FAKE_SECURITY_SCAN=success FAKE_MANIFEST=skipped \
 
 # 4. Could not measure is NOT a readiness verdict -- it is INFRA (exit 2).
 #    Distinct from both "green" and "red"; retryable.
+FAKE_API_FAIL=1 FAKE_SECURITY_SCAN=success FAKE_MANIFEST=success \
+  expect "unqueryable runs -> INFRA" 2 "INFRA"
+
+# 4b. THE #3338 DISTINCTION: the query succeeded and there is NO run for this
+#     commit. That is "not built yet" -- a fourth outcome. It must NOT read
+#     as INFRA (nothing to retry), and it must NOT read as a pass (the images
+#     the tag would pin do not exist).
 FAKE_RUN_ID="" FAKE_SECURITY_SCAN=success FAKE_MANIFEST=success \
-  expect "unqueryable run -> INFRA" 2 "INFRA"
+  expect "no run for this commit -> NOT READY (not built)" 1 "NOT been built"
+
+# 4c. A run that exists but has not finished has no verdict yet. Blocking:
+#     treating in-flight as absent or as green would launder an unfinished
+#     measurement (#3338).
+FAKE_RUN_STATUS=in_progress FAKE_SECURITY_SCAN=success FAKE_MANIFEST=success \
+  expect "run still in progress -> NOT READY (wait)" 1 "still 'in_progress'"
 
 # 5. The explicit human override reports the red but does not block. Separate
 #    from PREFLIGHT_SKIP_DOCKER_HEALTH on purpose: "I looked, it is red,
@@ -140,6 +185,73 @@ else
   fail "explicit override: expected exit 0 with the override noted, got $rc"
   sed 's/^/        /' "$WORK/out.txt" >&2
 fi
+
+echo
+echo "release-preflight check 1 (#3309)"
+
+# --- check 1 fixtures -------------------------------------------------------
+#   Check 1 used to demand that main's suppression token set be a strict
+#   SUPERSET of every release branch's, which made every token permanent: a
+#   suppression provably dead for main's images could not be deleted while
+#   any release branch still listed it (#3309, the nine stuck tokens). The
+#   fix accepts an explicit `# RETIRED: <token>` tombstone as accounting for
+#   a release-branch token. Both directions must hold: a tombstone permits a
+#   deliberate removal (case 2), and its existence must NOT swallow a real
+#   forward-port miss (case 1) -- delete the `retired_tokens` handling from
+#   check 1 and case 2 goes red; make it too broad and case 1 does.
+REL_REFS=$'0000000000000000000000000000000000000000\trefs/heads/release/1.6.x'
+
+expect1() { # <label> <expected-exit> <expected-substring> <main-trivyignore> <release-trivyignore>
+  local label="$1" want="$2" needle="$3" main_ti="$4" rel_ti="$5" got
+  printf '%s\n' "$main_ti" > "$REPO_DIR/.trivyignore"
+  ( cd "$REPO_DIR" && PATH="$STUB:$PATH" \
+      PREFLIGHT_REPO=artifact-keeper/artifact-keeper \
+      FAKE_RELEASE_REFS="$REL_REFS" \
+      FAKE_REL_TRIVYIGNORE="$rel_ti" \
+      PREFLIGHT_SKIP_VERSION_PIN=1 \
+      bash scripts/ci/release-preflight.sh >"$WORK/out.txt" 2>&1 )
+  got=$?
+  rm -f "$REPO_DIR/.trivyignore"
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  elif ! grep -qF "$needle" "$WORK/out.txt"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+# 1. THE #3039 CASE STILL HARD-FAILS: a suppression on release/* that main
+#    neither carries nor tombstones is a forward-port miss.
+expect1 "release token unaccounted on main -> NOT READY" 1 "main is MISSING suppressions" \
+  "CVE-2099-0001" \
+  "CVE-2099-0001
+CVE-2099-0002"
+
+# 2. THE #3309 FIX: a token main deliberately removed is accounted for by a
+#    machine-read tombstone, so removal is possible without disabling the
+#    gate -- and the transcript says the coverage came from a tombstone.
+expect1 "release token tombstoned on main -> READY" 0 "via RETIRED tombstones" \
+  "CVE-2099-0001
+# RETIRED: CVE-2099-0002 (2026-08-14, measured absent from main's images, #3309)" \
+  "CVE-2099-0001
+CVE-2099-0002"
+
+# 3. Live coverage still passes untouched (the pre-#3309 happy path).
+expect1 "release tokens all live on main -> READY" 0 "READY" \
+  "CVE-2099-0001
+CVE-2099-0002" \
+  "CVE-2099-0001
+CVE-2099-0002"
+
+# 4. A token listed BOTH live and retired is a contradiction, not a choice
+#    the gate silently makes for you.
+expect1 "token both live and tombstoned -> NOT READY" 1 "BOTH as live suppressions" \
+  "CVE-2099-0001
+# RETIRED: CVE-2099-0001" \
+  "CVE-2099-0001"
 
 echo
 echo "release-preflight check 4 (#3339)"


### PR DESCRIPTION
## Summary

Ports the release-preflight fixes from #3364 (plus #3339/#3340 refinements) onto `release/1.7.x`, so the pre-tag gate asks the right question when cutting a 1.7.x release.

**Why this is blocking right now:** `v1.7.5` is prepared on this branch (`chore(release): prepare 1.7.5`, #3379) but has never been tagged, and "Pre-tag readiness" fails with:

```
[FAIL] main's last Docker Publish did NOT cleanly publish the manifest
       -- a tag cut WILL stall on the same gate.
```

That is the #3338 defect: check 3 selected the Docker Publish run **by recency on `main`** rather than the run for the commit being tagged. For this cut the two diverge completely — the 1.7.5 tip's own Docker Publish **succeeded** (2026-08-14 19:31), while `main` is separately red for an unrelated reason (bundled grype carries 6 HIGH Go stdlib CVEs from its build toolchain; tracked as #3352). Judging a 1.7.x tag on main's publish health is measuring the wrong branch entirely.

With this change check 3 resolves `head_sha` and selects that commit's run, reporting *no run for this commit* and *run still in flight* as distinct blocking states.

**Release impact:** three security fixes are currently fixed-but-unreleased, all waiting on this tag — GHSA-8jm4-4x6c-6787 (X-Forwarded-For rate-limit bypass), GHSA-95fx-g94v-8jqg (backup restore table allowlist), and GHSA-fv45-mwhh-q23r (percent-encoded repository-key visibility bypass).

Scope is CI tooling only: two scripts, no product code, no migration.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`scripts/ci/test-release-preflight.sh` comes with the fix and covers both directions, including the two states this branch's copy could not distinguish (no run for the commit vs. run in flight). Executed on this branch: **all release-preflight cases passed**, including checks 1, 3 and 4.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes


Closes #3422
