### PR TITLE
fix(ci): keep scanner-adapter sources unchanged on release/1.7.x

### DIFF
--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -18,20 +18,9 @@
 # to the requested TARGET arch (fast, no emulation for the compile step).
 # Go 1.26 toolchain: the adapter is stdlib-only, so every Go CVE reported
 # against the compiled binary is a stdlib CVE baked in by the builder
-# toolchain. The floating `1.26` tag is deliberate — it always resolves to the
-# newest patch, which is what a security rebuild wants. Current floor is
-# **1.26.6**, not the 1.26.5 this comment used to name: the 2026-08 batch
-# (CVE-2026-33818/-56853/-56858/-56859/-56860/-56862, plus -39821/-46600)
-# needs 1.26.6, and that is the batch that blocked publishing in #3352.
-# Verified 2026-08-16: this image's `usr/local/bin/scanner-adapter` reports
-# stdlib v1.26.6 and scans clean. The go.mod `go` directive stays at the
-# minimum language version. See issues #2391 and #3352.
-#
-# Note the asymmetry with docker/Dockerfile.backend{,.alpine}, which build
-# grype on the same floating tag but ALSO assert a `GO_MIN_PATCH` floor. The
-# assertion is there because those images ship a binary whose stdlib CVEs were
-# a release blocker; if this adapter ever fails a scan on the same class, copy
-# that assertion here rather than pinning an exact patch.
+# toolchain. Track the current patched Go minor here (>= 1.26.5 clears the
+# 2026-07 stdlib batch, issue #2391); the go.mod `go` directive stays at the
+# minimum language version.
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 ARG TARGETOS


### PR DESCRIPTION
## Summary

Unblocks the `v1.7.5` release. Both tag workflows failed:

- **Docker Publish** → `Scanner Adapter Multi-Arch Manifest`:
  ```
  ghcr.io/artifact-keeper/artifact-keeper-scanner-adapter:1.2.3 already exists at
  04b6cba994ecc9f150775a2ddce8ee53db7bebff, but scanner-adapter sources changed.
  Bump docker/scanner-adapter/VERSION; exact version tags are never republished.
  ```
- **Release** → `Resolve candidate image digest`, which correctly refuses to proceed while docker-publish is red.

**Cause.** The #3423 backport (#3424) carried a **comment-only** edit to `docker/Dockerfile.scanner-adapter`. The gate added in #3340 treats any change under the adapter's source set as a source change, which is the right rule — it is what stops an exact version tag being silently republished with different content.

**Fix.** Revert that comment on this branch. It documents a Go patch floor that is meaningful on `main`, where the adapter sits beside the new grype source build; it has no effect here and is not part of the security fix. Reverting is preferable to bumping `VERSION`, which would republish an adapter image for a documentation change in a patch release and consume a version number on a maintenance branch.

Adapter sources now match the published `1.2.3` byte for byte, so the manifest step republishes nothing.

Nothing security-relevant changes: the grype source build in `Dockerfile.backend` and `Dockerfile.backend.alpine` is untouched, and that branch publish already passed `Security Scan` on `2a069e9`.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is a release-mechanics revert; the gate that caught it (#3340) is itself the regression test, and it worked exactly as designed.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #3429

Refs #3422
