### PR TITLE
chore(release): prepare 1.7.6 (v1.7.5 is a dead tag)

### DIFF
--- a/.github/release-notes/1.7.6.md
+++ b/.github/release-notes/1.7.6.md
@@ -1,8 +1,18 @@
-# Artifact Keeper 1.7.5
+# Artifact Keeper 1.7.6
 
 A security release: **three advisories**, plus fixes to PyPI PEP 658 metadata handling. No schema migrations.
 
 Most deployments can take this without changing anything. Two situations need a look first — both are below.
+
+## Why this is 1.7.6 and not 1.7.5
+
+`v1.7.5` was tagged and is a **dead tag**: do not use it. Its Docker Publish
+failed because a comment-only edit backported alongside the grype fix tripped
+the scanner-adapter version-collision gate, so no images and no release object
+were ever produced for it. Repository rulesets forbid deleting or moving a tag,
+so the version was burned rather than reused. Full detail in #3429.
+
+The content intended for 1.7.5 ships here, unchanged.
 
 ## Advisories
 
@@ -56,7 +66,7 @@ So this narrows which tables an archive can reach; it does **not** make a hostil
 
 See the [CHANGELOG](CHANGELOG.md) for the mechanism behind each entry, the reasoning, and the exact scope of every fix.
 
-**Full Changelog**: https://github.com/artifact-keeper/artifact-keeper/compare/v1.7.4...v1.7.5
+**Full Changelog**: https://github.com/artifact-keeper/artifact-keeper/compare/v1.7.4...v1.7.6
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.5] - 2026-08-14
+## [1.7.6] - 2026-08-17
+
+> **`v1.7.5` is a dead tag — do not use it.** It was tagged, its Docker Publish
+> failed on a scanner-adapter version-collision gate, and no images or release
+> object were ever produced. Repository rulesets forbid deleting or moving a
+> tag, so the version number was burned rather than reused. Everything intended
+> for 1.7.5 ships in 1.7.6 unchanged. See #3429.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.7.5"
+version = "1.7.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.7.5"
+version = "1.7.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.7.5",
+        version = "1.7.6",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
## Summary

Bumps `release/1.7.x` to **1.7.6** so the security content intended for 1.7.5 can actually ship.

**Why the version number changed.** `v1.7.5` was tagged at `2a069e9`, its Docker Publish failed on the scanner-adapter version-collision gate, and the Release workflow correctly refused to resolve a digest from a failed publish — so **no images and no release object were ever produced**. Full detail in #3429.

The tag cannot be moved or reused:

```
remote: - Cannot delete this tag
! [remote rejected] v1.7.5 (push declined due to repository rule violations)
```

A repository ruleset forbids deleting or force-moving tags — which is the correct policy, and the reason the version is burned rather than recycled. Reusing a tag that consumers may already have fetched is exactly what that rule exists to prevent, even though in this case nothing consumed it.

**Nothing about the content changes.** 1.7.6 carries precisely what 1.7.5 was meant to:

- GHSA-8jm4-4x6c-6787 — client-controlled `X-Forwarded-For` prefix bypassing IP rate limiting
- GHSA-95fx-g94v-8jqg — backup restore inserting outside `ALLOWED_EXPORT_TABLES`
- GHSA-fv45-mwhh-q23r — percent-encoded repository key bypassing private-repository visibility
- the grype source build (#3352) that unblocked image publication on this branch

The dead tag is called out in **both** the CHANGELOG entry and `.github/release-notes/1.7.6.md`, so an operator who finds `v1.7.5` in the tag list learns immediately not to use it.

Changes: version in `Cargo.toml` / `Cargo.lock` / `openapi.rs`, the CHANGELOG heading plus a dead-tag note, and the release-notes file renamed.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Version-only change; the adapter source set is deliberately untouched, so the collision gate that killed 1.7.5 cannot fire again here.

## API Changes
- [x] N/A - no API changes

Closes #3429