### PR TITLE
fix(migration): preserve paused/cancelled status on the final repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pausing or cancelling a migration job during its final repository no longer flips it to a terminal status** (#3380). A pause or cancel observed between artifacts returned the same result as a fully drained repository, so when the interruption landed during the final (or only) repository the worker stamped a terminal status and `finished_at` over `paused`/`cancelled`; resume then rejected the job, leaving delete as the only option — for single-repository jobs pause always ended the job. The interruption now propagates distinctly from repository processing, and the terminal write is guarded at the database level (`UPDATE … WHERE status NOT IN ('paused','cancelled')`), so a pause racing the final write cannot be clobbered either. Uninterrupted jobs keep the exact prior behavior.
+
 ## [1.8.1] - 2026-08-21
 
 ### Fixed

--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -702,6 +702,32 @@ impl MigrationService {
         Ok(())
     }
 
+    /// Finalize a job with a terminal status and stamp `finished_at`, unless
+    /// the operator has already paused or cancelled it — the guard keeps a
+    /// pause that races the worker's final write from being overwritten
+    /// (issue #3380). Returns whether the job was finalized.
+    #[instrument(skip(self), fields(job_id = %job_id, status = ?status))]
+    pub async fn finalize_job_status(
+        &self,
+        job_id: Uuid,
+        status: MigrationJobStatus,
+    ) -> Result<bool, MigrationError> {
+        info!(job_id = %job_id, status = ?status, "Finalizing job status");
+        let result = sqlx::query(
+            r#"
+            UPDATE migration_jobs
+            SET status = $1, finished_at = NOW()
+            WHERE id = $2 AND status NOT IN ('paused', 'cancelled')
+            "#,
+        )
+        .bind(status.to_string())
+        .bind(job_id)
+        .execute(&self.db)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Update job progress
     pub async fn update_job_progress(
         &self,
@@ -1616,6 +1642,99 @@ mod tests {
                 .await
                 .ok();
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Guarded finalize: paused/cancelled must never be overwritten by a
+    // terminal status (issue #3380)
+    // -----------------------------------------------------------------------
+
+    /// DB-backed proof for the #3380 finalize guard: `finalize_job_status`
+    /// must skip a job the operator paused or cancelled (the pause raced the
+    /// worker's final write), while a running job still finalizes with its
+    /// terminal status and a `finished_at`.
+    ///
+    /// No-ops when `DATABASE_URL` is unset so it skips cleanly off-CI.
+    #[tokio::test]
+    async fn test_finalize_job_status_skips_paused_and_cancelled_3380() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        async fn seed_job(pool: &PgPool, conn_id: Uuid, status: &str) -> Uuid {
+            sqlx::query_scalar(
+                "INSERT INTO migration_jobs (source_connection_id, job_type, config, status) \
+                 VALUES ($1, 'full', $2, $3) RETURNING id",
+            )
+            .bind(conn_id)
+            .bind(serde_json::json!({}))
+            .bind(status)
+            .fetch_one(pool)
+            .await
+            .expect("seed migration job")
+        }
+
+        let conn_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO source_connections (name, url, auth_type, credentials_enc, source_type) \
+             VALUES ($1, 'http://source.local', 'basic_auth', $2, 'nexus') RETURNING id",
+        )
+        .bind(format!("finalize-conn-{}", Uuid::new_v4()))
+        .bind(vec![1u8, 2, 3])
+        .fetch_one(&pool)
+        .await
+        .expect("seed source connection");
+
+        let svc = MigrationService::new(pool.clone());
+        let paused = seed_job(&pool, conn_id, "paused").await;
+        let cancelled = seed_job(&pool, conn_id, "cancelled").await;
+        let running = seed_job(&pool, conn_id, "running").await;
+
+        for (job_id, expected) in [(paused, "paused"), (cancelled, "cancelled")] {
+            let finalized = svc
+                .finalize_job_status(job_id, MigrationJobStatus::Completed)
+                .await
+                .expect("finalize");
+            assert!(!finalized, "{expected} job must not be finalized");
+            let (status, finished): (String, bool) = sqlx::query_as(
+                "SELECT status, finished_at IS NOT NULL FROM migration_jobs WHERE id = $1",
+            )
+            .bind(job_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read job row");
+            assert_eq!(status, expected, "operator-set status must survive");
+            assert!(!finished, "a skipped finalize must not stamp finished_at");
+        }
+
+        let finalized = svc
+            .finalize_job_status(running, MigrationJobStatus::Completed)
+            .await
+            .expect("finalize running job");
+        assert!(finalized, "a running job still finalizes");
+        let (status, finished): (String, bool) = sqlx::query_as(
+            "SELECT status, finished_at IS NOT NULL FROM migration_jobs WHERE id = $1",
+        )
+        .bind(running)
+        .fetch_one(&pool)
+        .await
+        .expect("read finalized job row");
+        assert_eq!(status, "completed");
+        assert!(finished, "finalize must stamp finished_at");
+
+        for job_id in [paused, cancelled, running] {
+            sqlx::query("DELETE FROM migration_jobs WHERE id = $1")
+                .bind(job_id)
+                .execute(&pool)
+                .await
+                .ok();
+        }
+        sqlx::query("DELETE FROM source_connections WHERE id = $1")
+            .bind(conn_id)
+            .execute(&pool)
+            .await
+            .ok();
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -145,6 +145,21 @@ struct RepoKeys {
     target: String,
 }
 
+/// Outcome of processing one repository's artifacts.
+///
+/// `Interrupted` propagates a pause/cancel observed between artifacts up to
+/// the job loop, which must stop without writing a terminal status. Before
+/// the two cases were distinguished, a mid-repository pause returned the same
+/// `Ok` as a fully drained listing and the job walked on to stamp the paused
+/// job Completed (issue #3380).
+#[derive(Debug)]
+enum RepoProcessOutcome {
+    /// The repository's artifact listing was drained to the end.
+    Completed,
+    /// A pause/cancel request stopped processing mid-listing.
+    Interrupted,
+}
+
 /// Conflict resolution strategy
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConflictResolution {
@@ -700,8 +715,19 @@ impl MigrationWorker {
                     )
                     .await
                 {
-                    Ok(_) => {
+                    Ok(RepoProcessOutcome::Completed) => {
                         tracing::info!(repo = %keys.target, "Repository artifacts processed");
+                    }
+                    Ok(RepoProcessOutcome::Interrupted) => {
+                        if self.cancel_token.is_cancelled() {
+                            tracing::info!(job_id = %job_id, "Migration cancelled by user");
+                            self.migration_service
+                                .update_job_status(job_id, MigrationJobStatus::Cancelled)
+                                .await?;
+                        } else {
+                            tracing::info!(job_id = %job_id, "Migration paused by user");
+                        }
+                        return Ok(());
                     }
                     Err(e) => {
                         tracing::error!(repo = %keys.target, error = %e, "Failed to process repository");
@@ -711,18 +737,19 @@ impl MigrationWorker {
             }
         }
 
-        // Update final status
+        // Update final status and stamp `finished_at`. The guarded write
+        // skips paused/cancelled jobs, so a pause landing after the last
+        // per-artifact check is not clobbered either (issue #3380).
         let final_status = determine_final_status(total_failed, total_completed);
 
-        self.migration_service
-            .update_job_status(job_id, final_status)
-            .await?;
-
-        // Mark job as finished
-        sqlx::query("UPDATE migration_jobs SET finished_at = NOW() WHERE id = $1")
-            .bind(job_id)
-            .execute(&self.db)
-            .await?;
+        if !self
+            .migration_service
+            .finalize_job_status(job_id, final_status)
+            .await?
+        {
+            tracing::info!(job_id = %job_id, "Migration paused or cancelled before finalization");
+            return Ok(());
+        }
 
         // Send final progress update
         if let Some(tx) = progress_tx {
@@ -771,7 +798,7 @@ impl MigrationWorker {
         skipped: &mut i32,
         transferred: &mut i64,
         progress_tx: Option<mpsc::Sender<ProgressUpdate>>,
-    ) -> Result<(), MigrationError> {
+    ) -> Result<RepoProcessOutcome, MigrationError> {
         // Read the source registry by source key (== target for unrenamed repos).
         let repo_key = keys.source.as_str();
         let mut offset = 0i64;
@@ -807,7 +834,7 @@ impl MigrationWorker {
             for artifact in &artifacts.results {
                 // Check for pause/cancel between artifacts
                 if self.cancel_token.is_cancelled() || self.is_paused(job_id).await? {
-                    return Ok(());
+                    return Ok(RepoProcessOutcome::Interrupted);
                 }
 
                 let artifact_path = build_artifact_path(&artifact.path, &artifact.name);
@@ -954,7 +981,7 @@ impl MigrationWorker {
             offset = new_offset;
         }
 
-        Ok(())
+        Ok(RepoProcessOutcome::Completed)
     }
 
     /// Check if a migration item was already completed (for resume support)
@@ -5258,6 +5285,339 @@ mod tests {
             .bind(conn_id)
             .execute(&pool)
             .await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #3380: pause/cancel mid-repository must not be overwritten by a
+    // terminal status (DB-gated via try_pool)
+    // -----------------------------------------------------------------------
+
+    /// How the mock source interrupts the worker while it is mid-repository.
+    #[derive(Clone, Copy)]
+    enum MockInterrupt {
+        /// Nothing interrupts: the listing drains empty (uninterrupted control).
+        None,
+        /// The operator paused/cancelled through the API — the mock flips the
+        /// `migration_jobs` row to this status, which is what both
+        /// `is_paused` and `finalize_job_status`'s guard read.
+        JobStatus(&'static str),
+        /// The worker's own cancellation token fires while the job row stays
+        /// `running`. Nothing in the database records the interruption, so
+        /// `finalize_job_status`'s `WHERE status NOT IN ('paused','cancelled')`
+        /// guard matches and only the `RepoProcessOutcome::Interrupted`
+        /// propagation can stop the terminal write.
+        CancelToken,
+    }
+
+    /// Mock source registry whose artifact listing interrupts the job as a
+    /// side effect, simulating an operator pressing pause/cancel while the
+    /// worker is mid-repository. The per-artifact check must interrupt the
+    /// job before the first transfer, so downloading panics.
+    struct InterruptingSource {
+        pool: sqlx::PgPool,
+        job_id: Uuid,
+        repo_key: String,
+        interrupt: MockInterrupt,
+        /// The same token the worker under test holds, so
+        /// [`MockInterrupt::CancelToken`] can fire it mid-listing.
+        cancel_token: CancellationToken,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::source_registry::SourceRegistry for InterruptingSource {
+        async fn ping(
+            &self,
+        ) -> Result<bool, crate::services::artifactory_client::ArtifactoryError> {
+            Ok(true)
+        }
+        async fn get_version(
+            &self,
+        ) -> Result<
+            crate::services::artifactory_client::SystemVersionResponse,
+            crate::services::artifactory_client::ArtifactoryError,
+        > {
+            unimplemented!("not called by process_job")
+        }
+        async fn list_repositories(
+            &self,
+        ) -> Result<
+            Vec<crate::services::artifactory_client::RepositoryListItem>,
+            crate::services::artifactory_client::ArtifactoryError,
+        > {
+            Ok(vec![mk_source_repo(&self.repo_key, "LOCAL", "Generic")])
+        }
+        async fn list_artifacts(
+            &self,
+            repo_key: &str,
+            offset: i64,
+            limit: i64,
+        ) -> Result<
+            crate::services::artifactory_client::AqlResponse,
+            crate::services::artifactory_client::ArtifactoryError,
+        > {
+            use crate::services::artifactory_client::{AqlRange, AqlResponse, AqlResult};
+            match self.interrupt {
+                MockInterrupt::None => {
+                    return Ok(AqlResponse {
+                        results: vec![],
+                        range: AqlRange {
+                            start_pos: offset,
+                            end_pos: offset,
+                            total: 0,
+                        },
+                    });
+                }
+                MockInterrupt::JobStatus(status) => {
+                    sqlx::query("UPDATE migration_jobs SET status = $1 WHERE id = $2")
+                        .bind(status)
+                        .bind(self.job_id)
+                        .execute(&self.pool)
+                        .await
+                        .expect("flip job status mid-listing");
+                }
+                MockInterrupt::CancelToken => self.cancel_token.cancel(),
+            }
+            Ok(AqlResponse {
+                results: vec![AqlResult {
+                    repo: repo_key.to_string(),
+                    path: "pkg/1.0".into(),
+                    name: "thing.tar.gz".into(),
+                    size: Some(1234),
+                    created: None,
+                    modified: None,
+                    sha256: None,
+                    actual_sha1: None,
+                }],
+                range: AqlRange {
+                    start_pos: offset,
+                    end_pos: offset + limit,
+                    total: 1,
+                },
+            })
+        }
+        async fn download_artifact(
+            &self,
+            _repo_key: &str,
+            _path: &str,
+        ) -> Result<bytes::Bytes, crate::services::artifactory_client::ArtifactoryError> {
+            panic!("an interrupted job must not transfer artifacts");
+        }
+        async fn get_properties(
+            &self,
+            _repo_key: &str,
+            _path: &str,
+        ) -> Result<
+            crate::services::artifactory_client::PropertiesResponse,
+            crate::services::artifactory_client::ArtifactoryError,
+        > {
+            panic!("an interrupted job must not read artifact properties");
+        }
+        fn source_type(&self) -> &'static str {
+            "interrupting-mock"
+        }
+    }
+
+    /// Seed a source connection + single-repo job, run it through
+    /// `process_job` against an [`InterruptingSource`], and return the job's
+    /// `(status, finished_at IS NOT NULL)` after the worker returns. Cleans
+    /// up the provisioned repository row; the job and connection are the
+    /// caller's to delete once done asserting.
+    async fn run_single_repo_job(
+        pool: &sqlx::PgPool,
+        prefix: &str,
+        interrupt: MockInterrupt,
+    ) -> (Uuid, Uuid, String, bool) {
+        let repo_key = format!("{prefix}-{}", Uuid::new_v4().simple());
+        let conn_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO source_connections (name, url, auth_type, credentials_enc, source_type) \
+             VALUES ($1, 'http://source.local', 'basic_auth', $2, 'nexus') RETURNING id",
+        )
+        .bind(format!("interrupt-conn-{}", Uuid::new_v4()))
+        .bind(vec![1u8, 2, 3])
+        .fetch_one(pool)
+        .await
+        .expect("seed source connection");
+        let job_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO migration_jobs (source_connection_id, job_type, config) \
+             VALUES ($1, 'full', $2) RETURNING id",
+        )
+        .bind(conn_id)
+        .bind(serde_json::json!({ "include_repos": [repo_key.as_str()] }))
+        .fetch_one(pool)
+        .await
+        .expect("seed migration job");
+
+        let staging = tempfile::tempdir().expect("tempdir");
+        let registry = Arc::new(StorageRegistry::new(
+            std::collections::HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        let cancel_token = CancellationToken::new();
+        let worker = MigrationWorker::new(
+            pool.clone(),
+            registry,
+            WorkerConfig {
+                staging_path: staging.path().to_str().unwrap().to_string(),
+                ..WorkerConfig::default()
+            },
+            cancel_token.clone(),
+        );
+
+        worker
+            .process_job(
+                job_id,
+                Arc::new(InterruptingSource {
+                    pool: pool.clone(),
+                    job_id,
+                    repo_key: repo_key.clone(),
+                    interrupt,
+                    cancel_token,
+                }),
+                ConflictResolution::Skip,
+                None,
+            )
+            .await
+            .expect("process_job must not error");
+
+        let (status, finished): (String, bool) = sqlx::query_as(
+            "SELECT status, finished_at IS NOT NULL FROM migration_jobs WHERE id = $1",
+        )
+        .bind(job_id)
+        .fetch_one(pool)
+        .await
+        .expect("read job row");
+
+        let _ = sqlx::query("DELETE FROM repositories WHERE key = $1")
+            .bind(&repo_key)
+            .execute(pool)
+            .await;
+
+        (job_id, conn_id, status, finished)
+    }
+
+    /// Delete a test job and then its source connection (FK order).
+    async fn cleanup_single_repo_job(pool: &sqlx::PgPool, job_id: Uuid, conn_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM migration_jobs WHERE id = $1")
+            .bind(job_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM source_connections WHERE id = $1")
+            .bind(conn_id)
+            .execute(pool)
+            .await;
+    }
+
+    /// Pausing a single-repo job mid-listing must leave it paused and
+    /// resumable. Pre-fix, the per-artifact pause check returned the same
+    /// `Ok` as a fully drained repository, so `process_job` walked on and
+    /// stamped the paused job Completed with a `finished_at` — after which
+    /// resume rejected the job and the UI offered only delete (issue #3380).
+    #[tokio::test]
+    async fn test_process_job_pause_during_final_repo_stays_paused_3380() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (job_id, conn_id, status, finished) =
+            run_single_repo_job(&pool, "pause-src", MockInterrupt::JobStatus("paused")).await;
+
+        assert_eq!(status, "paused", "pause must survive the final repository");
+        assert!(!finished, "a paused job must not be stamped finished");
+
+        cleanup_single_repo_job(&pool, job_id, conn_id).await;
+    }
+
+    /// Cancelling mid-listing takes the same interruption path (`is_paused`
+    /// matches both 'paused' and 'cancelled'): the job must stay cancelled
+    /// instead of being overwritten by Completed (issue #3380).
+    #[tokio::test]
+    async fn test_process_job_cancel_during_final_repo_stays_cancelled_3380() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (job_id, conn_id, status, finished) =
+            run_single_repo_job(&pool, "cancel-src", MockInterrupt::JobStatus("cancelled")).await;
+
+        assert_eq!(
+            status, "cancelled",
+            "cancel must survive the final repository"
+        );
+        assert!(
+            !finished,
+            "the worker must not stamp a cancelled job finished"
+        );
+
+        cleanup_single_repo_job(&pool, job_id, conn_id).await;
+    }
+
+    /// Control for #3380: a job that runs to the end still lands Completed
+    /// with `finished_at` stamped — the guarded finalize skips only
+    /// paused/cancelled jobs, never a running one.
+    #[tokio::test]
+    async fn test_process_job_uninterrupted_still_completes_with_finished_at() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (job_id, conn_id, status, finished) =
+            run_single_repo_job(&pool, "complete-src", MockInterrupt::None).await;
+
+        assert_eq!(status, "completed", "an uninterrupted job still completes");
+        assert!(finished, "an uninterrupted job still gets finished_at");
+
+        cleanup_single_repo_job(&pool, job_id, conn_id).await;
+    }
+
+    /// Isolation proof for this fix's *headline* mechanism (#3380): the
+    /// `RepoProcessOutcome::Interrupted` propagation must stop the terminal
+    /// write **on its own**, with no help from `finalize_job_status`'s
+    /// paused/cancelled guard.
+    ///
+    /// The two mechanisms are deliberately redundant for an operator-driven
+    /// pause: the job row already reads `paused`, so the guard alone keeps
+    /// that row correct and the pause/cancel tests above stay green even if
+    /// the interruption is swallowed and `process_job` walks on. Without a
+    /// case that separates them, deleting the `Interrupted` return would be
+    /// invisible to CI (the compiler would only note the variant is never
+    /// constructed).
+    ///
+    /// Here the interruption arrives on the worker's own cancellation token
+    /// while the job row is still `running`. Nothing in the database records
+    /// it, so the guard's `WHERE status NOT IN ('paused','cancelled')`
+    /// matches: if the repository loop reports `Completed`, the job is
+    /// finalized `completed` with `finished_at` and a cancelled migration is
+    /// reported as a clean success. Only the distinct `Interrupted` outcome
+    /// prevents that.
+    #[tokio::test]
+    async fn test_process_job_token_cancel_during_final_repo_is_not_finalized_3380() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (job_id, conn_id, status, finished) =
+            run_single_repo_job(&pool, "token-cancel-src", MockInterrupt::CancelToken).await;
+
+        assert_ne!(
+            status, "completed",
+            "a token cancel mid-repository must not be finalized as a success; \
+             the job row never leaves 'running', so only the Interrupted \
+             outcome can stop the terminal write"
+        );
+        assert_eq!(
+            status, "cancelled",
+            "the interruption must be recorded as a cancel"
+        );
+        assert!(
+            !finished,
+            "an interrupted job must not be stamped finished_at"
+        );
+
+        cleanup_single_repo_job(&pool, job_id, conn_id).await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A pause or cancel observed between artifacts returned the same `Ok(())` as a fully drained repository, so when the interruption landed during the final (or only) repository, `process_job` stamped a terminal status and `finished_at` over `paused`/`cancelled`. Resume then rejects the job (it requires `status='paused'`), leaving delete as the only option — for single-repository jobs, pause always ended the job. Fixes #3380.

`process_repository_artifacts` now reports the interruption distinctly (`RepoProcessOutcome::{Completed, Interrupted}`), and on `Interrupted` `process_job` returns without a terminal write, mirroring its existing between-repositories check. The terminal write itself moved into `MigrationService::finalize_job_status` — an atomic `UPDATE … WHERE status NOT IN ('paused','cancelled')` — so a pause racing the final write cannot be clobbered either. Uninterrupted jobs keep the exact prior behavior: final status, `finished_at`, and the final progress update.

## Known state this does not resolve: the inverse race

The two mechanisms cover the case where work remains when the interruption lands. There is a symmetric ordering they deliberately do not paper over, and operators should know it exists: if a pause is accepted **after** the last per-artifact check, every item of the job completes, `finalize_job_status` then matches 0 rows (the row already reads `paused`), and the job parks at `status = 'paused'` with `finished_at` NULL and no work left to do.

That is the correct outcome for this guard — the alternative is overwriting an operator decision — and it is recoverable rather than stuck: a single resume drives the job to `completed` in about a second with zero duplication, because `is_item_already_completed` skips every item the first pass finished. The visible artifact is a paused job that resumes into an immediate completion, which is a better failure than the one being fixed (a paused job that can only be deleted), but it is a state the UI can show and it is not obvious from the status alone.

## Merge order with #3445

#3445's description calls the two changes "deliberately disjoint … the two can land in either order". That is true of the **production** code — `migration_service.rs` and the non-test half of `migration_worker.rs` auto-merge coherently — but not of the file as a whole.

`git merge` of the two branches produces a **conflict**: 2 files, and 6 hunks in `backend/src/services/migration_worker.rs`, all of them inside `mod tests`. Both PRs append fixtures at the same insertion point at the end of the test module, and #3445 also rewrites the shared seed helper the two sets of tests would otherwise have in common (`staging_path` vs `batch_size`/`throttle_delay_ms`, `pool` vs `&pool`, and a different mock source type). Git interleaves the two test bodies mid-statement, so a mechanical "keep both sides" resolution does not compile — verified: `cargo check --lib --tests` on that resolution fails with `error: mismatched closing delimiter: '}'` before it reaches type checking.

**This PR should land first**, since it is the smaller of the two and #3445 builds progress reporting on top of the same job loop. Whoever rebases #3445 afterwards needs to hand-resolve the test module — keeping both sets of tests and one reconciled seed helper — and run a real `cargo check --lib --tests` plus the migration tests, not rely on the conflict looking like an adjacent-insert. A correctly hand-built merge does compile and both test sets pass, so the semantics genuinely do compose; only the text does not.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

On `main`, the new pause test observes the job land in a terminal status with `finished_at` set after a mid-listing pause on a single-repository job; on this branch it stays `paused` with `finished_at` NULL and resume's status precondition accepts it. A cancel twin covers the `cancelled` path, and an uninterrupted control asserts the terminal path is unchanged.

The two mechanisms above are redundant for an operator-driven pause, and that redundancy hides one of them from the tests: with the job row already reading `paused`, the database guard alone satisfies every assertion, so reverting *only* the `RepoProcessOutcome::Interrupted` return left all four tests green (the compiler's `variant Interrupted is never constructed` warning was the sole signal). `test_process_job_token_cancel_during_final_repo_is_not_finalized_3380` closes that gap by separating them: the interruption arrives on the worker's own cancellation token while the job row is still `running`, so `WHERE status NOT IN ('paused','cancelled')` matches and only the distinct `Interrupted` outcome can stop the terminal write. Reverting that single hunk and nothing else now fails exactly that test (`left: "completed"`), with the other four still passing. The token is a deliberate test lever rather than a live scenario — the cancel endpoint records the cancel in the database and the worker observes it through `is_paused` — so this pins the propagation mechanism itself, which is what the other four cannot distinguish.

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Four worker tests (pause / cancel / token-cancel isolation / uninterrupted control) plus a service-level test proving `finalize_job_status` declines paused/cancelled rows and still finalizes a running job, all following the existing DB-gated `try_pool` pattern in these files and all `--lib`, so they run in the unit-test and coverage jobs. Against a real Postgres with `AK_TESTS_REQUIRE_DB=1`: `cargo nextest run --workspace --lib` — 15718 passed, 0 failed. `cargo clippy --lib --tests -- -D warnings` and `cargo fmt --check` clean. No migration is added (the highest stays 205) and no `sqlx::query!` macros, so `.sqlx/` needs no regeneration.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
