### PR TITLE
chore(release): prepare 1.8.1

### DIFF
--- a/.github/release-notes/1.8.1.md
+++ b/.github/release-notes/1.8.1.md
@@ -1,0 +1,43 @@
+# Artifact Keeper 1.8.1
+
+A patch release with **one data-loss fix you should read before upgrading**, one security fix, and a reporting fix. No schema migrations.
+
+## Read this first — Maven storage GC could delete hand-repaired objects
+
+If you have ever repaired a Maven 404 by inserting a row into `maven_flat_object_owner`, **that object may already be gone**, and you should read this whole section.
+
+Since 1.7.0 the orphan Maven flat-object sweep enumerated its delete candidates from `maven_flat_object_owner` and tested only catalog anchors. But since #2574/#2585 an owner row is also what makes a legacy row-less object *readable* — and inserting one is the documented remediation for keys the catalog-only backfill cannot see. For exactly that class every arm of the predicate was true by construction and permanently, so **the row that made an object servable was the row that queued it for deletion**. An operator who fixed a fail-closed 404 by attributing the key got a 200 for one hour, then lost the bytes.
+
+**Two changes close it:**
+
+1. The sweep now reclaims only rows the system wrote and can re-derive — `primary_row`, `metadata_files`, `derived_checksum`, `metadata_rollup`, `write_claim`. Those are caches over other catalog state and are stale by definition once their anchors vanish. An operator-inserted row is a primary record, and **any source value the system does not write is now protected**, including ones a future external tool might stamp.
+2. The sweep is **opt-in**, behind `MAVEN_FLAT_GC_ENABLED`. Unset, it reports what it would reclaim and deletes nothing — matching the OCI blob sweep's existing posture of biasing toward leaking storage over losing data. On a migrated instance, catalog absence is the *expected* state of legitimate legacy data; that is why the attribution table exists, so absence alone must not be treated as proof of garbage.
+
+**Affected versions:** 1.7.0 through 1.8.0. Severity was not uniform — before 1.7.3 the candidate scan frequently never completed on large attribution tables, largely masking it. The 1.7.3 guard rebuild made the scan complete, so **an operator who upgraded to 1.7.3+ for those guard fixes received mass reclamation of hand-repaired data as a side effect.**
+
+**If you may be affected:** there is no recovery from within Artifact Keeper — the sweep hard-deletes the object and its attribution row together, with no tombstone or journal. Recovery depends on storage-side retention: S3/GCS/Azure object versioning, a lifecycle noncurrent window, a bucket replica, or a filesystem backup. Each reclaim did emit `Storage GC: reclaimed orphaned row-less Maven flat object` at INFO with the `storage_key`, so a backend log with sufficient retention reconstructs the key list to restore from.
+
+The same fix ships on the 1.7 line as **1.7.7**.
+
+## Security
+
+**RUSTSEC-2026-0258** — the bundled `h2` HTTP/2 implementation is updated from 0.4.13 to 0.4.16, closing an unbounded-empty-DATA-frame denial of service. This is worth taking promptly on any instance whose gRPC port is reachable from an untrusted network: `tonic` serves h2c only, with no TLS or upgrade negotiation, so the frame decoder is reached **before any application authentication runs**. Every prior release is affected. Upstream rates it Low — the frames are empty, so an attacker trades bandwidth for the server's per-frame bookkeeping rather than for payload.
+
+## Fixed
+
+**Proxied downloads are counted again.** The Downloads column read 0 for proxy and remote repositories in most formats, because the serve paths never recorded a download. Docker/OCI, cargo, NuGet, Debian, Helm and Go now record proxied serves, joining PyPI, npm, Maven, Ansible, Conda, CRAN, RPM and RubyGems. A class-level guard now fails the build if a new proxy serve path records nothing without an explicit marker, so the remaining formats are tracked rather than forgotten — see #3446 for the current list.
+
+## Thank You
+
+- **@ThaSami** for diagnosing the Maven GC data-loss bug (#3431) with a precision that made it verifiable in minutes — including the observation that 1.7.3 *activates* the deletion, which is what turned a latent defect into an urgent one.
+
+## Sponsors
+
+Thank you to our backers for supporting ongoing development:
+
+- **Ash A.** ([@dragonpaw](https://github.com/dragonpaw))
+- **Gabriel Rodriguez** ([@injectedfusion](https://github.com/injectedfusion))
+
+[Become a sponsor](https://github.com/sponsors/artifact-keeper)
+
+**Full changelog:** https://github.com/artifact-keeper/artifact-keeper/compare/v1.8.0...v1.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-19
+
 ### Fixed
 
 - **Storage GC no longer deletes Maven objects whose attribution row an operator wrote, and the flat-object sweep is now opt-in** (#3431, reported by [@ThaSami](https://github.com/ThaSami)). `cleanup_orphan_maven_flat_objects` enumerated its delete candidates **from `maven_flat_object_owner`** and reclaimed every row whose catalog anchors were gone — live, on the hourly scheduled pass. But since #2574/#2585 that same row is what makes a *row-less* legacy object **readable**: it is the last layer of read-time owner resolution, and inserting one is the documented remediation for keys the catalog-only backfill of migrations 163/170 cannot see. For exactly that class — an object whose only catalog record is its owner row — every anchor arm of the sweep's predicate is true by construction and permanently. The row that made the object servable was the row that queued it for deletion: an operator who repaired a fail-closed 404 by attributing the key got a 200 for one hour, and then lost the bytes. The flat key is the only physical copy, and the sweep deleted the attribution row with it, so nothing recorded that the key had ever been hand-attributed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "qrcodegen"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "qrcodegen"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.8.0",
+        version = "1.8.1",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
## Summary

Prepares **1.8.1**, a patch release whose headline is a **data-loss fix**.

- **#3431 (P0)** — Maven storage GC reclaimed operator-attributed row-less objects. The `maven_flat_object_owner` row that makes a legacy object *readable* was the same row that queued it for deletion, so repairing a 404 by attributing the key destroyed the bytes within the hour. Fixed by a system-source allowlist plus a `MAVEN_FLAT_GC_ENABLED` opt-in. Affected 1.7.0 – 1.8.0, actively destructive from 1.7.3 on.
- **#3449** — `h2` 0.4.13 → 0.4.16 for RUSTSEC-2026-0258. Reachable pre-auth via the h2c gRPC listener.
- **#3446** — proxied downloads recorded for Docker/OCI, cargo, NuGet, Debian, Helm and Go, plus a class guard.

Version set to `1.8.1` in `Cargo.toml`, `Cargo.lock` and `openapi.rs`; `## [Unreleased]` rolled to `## [1.8.1]`; curated notes added at `.github/release-notes/1.8.1.md` with the operator guidance, the affected-version range, and the honest recoverability answer (none from within the product — storage-side retention only).

A fresh empty `## [Unreleased]` is opened above the new section. Omitting exactly that in the 1.7.5 prep is what silently stranded 30 entries under a released version (#3433); `scripts/ci/check-changelog-unreleased.sh` now asserts it, and passes here.

Recognition sections follow the CLAUDE.md policy: **@ThaSami** credited for the #3431 diagnosis, sponsors from README.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

Release preparation only; the fixes and their tests landed in #3451, #3450 and #3447.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`main` was verified locally at `--test-threads=4` against a real PostgreSQL with `AK_TESTS_REQUIRE_DB=1`: **15689 passed, 0 failed**, `cargo audit` exit 0, fmt and clippy clean. (Full parallelism against a single shared database is not deterministic — see #3402 — so 4 threads is the trustworthy signal.)

## API Changes
- [x] N/A - no API changes

Version-only change. The scanner-adapter source set is untouched, so the collision gate that killed v1.7.5 cannot fire.

Closes #3458
