### PR TITLE
fix(release): port main's release-engineering fixes to release/1.7.x (publish trigger, backport gate, preflight ref)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,21 @@ jobs:
       - name: Check release-preflight gates block on what they measure
         run: bash scripts/ci/test-release-preflight.sh
 
+      # The release-branch gate only runs on PRs against `release/*` — a
+      # handful of runs per release, far too rare to notice a regression in.
+      # It matters most for the two exemptions #3422 added (release prep,
+      # narrowed backport), which must keep FAILING for everything they are
+      # not: a `chore(release):` commit that also touches source, a
+      # version-file-only commit under another subject, a cherry-pick trailer
+      # naming a sha main does not have. Builds throwaway git repos; ~2s.
+      #
+      # On THIS branch the wiring matters twice over: the gate's logic lived
+      # inline in release-branch-gate.yml, so it had no test at all and no way
+      # to be exercised without opening a release PR — which is how the 1.7.x
+      # line ended up needing `release-process: approved` on every backport.
+      - name: Check release-branch gate exemptions stay narrow
+        run: bash scripts/ci/test-check-release-branch-commits.sh
+
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,13 @@ name: Docker Publish
 
 on:
   push:
-    branches: [main, master, 'release/1.1.x']
+    # `release/**`, not a hardcoded series (#3422): a commit landing on
+    # release/1.7.x used to publish NOTHING, so release-preflight check 3
+    # correctly reported "no Docker Publish run exists for HEAD" (#3338) and
+    # every 1.7.x cut needed an undocumented manual workflow_dispatch first.
+    # Every maintenance branch now publishes on push exactly as release/1.1.x
+    # already did.
+    branches: [main, master, 'release/**']
     tags: ['v*']
     paths-ignore:
       - '**/*.md'
@@ -85,6 +91,12 @@ jobs:
       # dispatch). Non-empty flips the build jobs off and the merge jobs into
       # re-apply-existing-digest mode.
       promote_version: ${{ steps.promote.outputs.version }}
+      # The `X.Y-dev` floating alias for a maintenance branch push -- `1.1-dev`
+      # for release/1.1.x, `1.7-dev` for release/1.7.x -- and empty for every
+      # other ref. Computed once here rather than hardcoded per image, which
+      # is what left the `release/**` glob (#3422) publishing a series-dev tag
+      # for exactly one series.
+      series_dev_tag: ${{ steps.series.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -160,6 +172,26 @@ jobs:
           TAG=$(.github/scripts/validate-dispatch-tag.sh "$REQUESTED_TAG")
           echo "Manual tag accepted: ${TAG}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      # Derive the `X.Y-dev` alias from the branch name so a new maintenance
+      # line gets one the moment it is created, with no workflow edit. Only a
+      # `release/<major>.<minor>.x` branch qualifies; anything else (main, a
+      # tag, a dispatch, a stray `release/hotfix`) yields the empty string and
+      # the metadata line disables itself -- the same shape `dispatch_tag`
+      # already uses, so an empty raw value here is a pattern the workflow
+      # already relies on rather than a new risk.
+      - name: Derive the series-dev tag for maintenance branch pushes
+        id: series
+        env:
+          GH_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          tag=""
+          if [[ "$GH_REF" =~ ^refs/heads/release/([0-9]+\.[0-9]+)\.x$ ]]; then
+            tag="${BASH_REMATCH[1]}-dev"
+          fi
+          echo "series-dev tag: '${tag}'"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
   build-backend:
     name: Backend (${{ matrix.platform }})
@@ -1057,7 +1089,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
@@ -1074,7 +1106,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
@@ -1315,7 +1347,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
@@ -1332,7 +1364,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
@@ -1662,7 +1694,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.adapter_publish.outputs.publish_floating == 'true' }}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
       - name: Extract metadata (Docker Hub)
@@ -1680,7 +1712,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.adapter_publish.outputs.publish_floating == 'true' }}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
       - name: Create manifest list and push (ghcr.io)
@@ -1878,7 +1910,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 
@@ -1896,7 +1928,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=${{ needs.publish-preflight.outputs.series_dev_tag }},enable=${{ needs.publish-preflight.outputs.series_dev_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ needs.publish-preflight.outputs.dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' && needs.publish-preflight.outputs.dispatch_tag != '' }}
 

--- a/.github/workflows/release-branch-gate.yml
+++ b/.github/workflows/release-branch-gate.yml
@@ -6,6 +6,16 @@ name: Release Branch Gate
 # either already on `main` or are cherry-picks of commits already on `main`.
 # This enforces the "land on main first, then cherry-pick" workflow.
 #
+# Two shapes that legitimately CANNOT trace to main by patch-id are accepted
+# without the label (#3422): a release prep (`chore(release): ...` touching
+# only the version/changelog/release-notes file set — the version being
+# prepared exists only on the maintenance branch) and a narrowed backport (a
+# `(cherry picked from commit <sha>)` trailer naming a commit that is on main,
+# where hunks that could not apply were resolved away). Both are logged
+# explicitly so the narrowing stays visible. The logic and its self-test live
+# in scripts/ci/check-release-branch-commits.sh and its sibling test-*.sh, so
+# the gate can be exercised without opening a release PR.
+#
 # Why: PR #1068 was authored directly against `release/1.1.x` without
 # going through main. It bundled +1489 lines, broke remote-proxy fetches
 # across every package format, and forced a revert mid-release-candidate
@@ -67,83 +77,14 @@ jobs:
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-
-          # Commits introduced by this PR, excluding merge commits.
-          # Rev-list base..head gives commits reachable from head but not
-          # base, which is exactly the PR's contribution.
-          mapfile -t pr_commits < <(git rev-list --no-merges "${PR_BASE_SHA}..${PR_HEAD_SHA}")
-
-          if [ "${#pr_commits[@]}" -eq 0 ]; then
-            echo "::notice::PR contains no non-merge commits; nothing to verify."
-            exit 0
-          fi
-
-          # Build a set of patch-ids from a recent slice of main history so
-          # we can cheaply detect cherry-picks (which change SHAs but
-          # preserve patch content). 1500 commits covers ~3 months of main
-          # at typical velocity; tune up if main moves faster.
-          echo "Indexing patch-ids from origin/main (last 1500 commits)..."
-          declare -A main_patch_ids
-          while read -r main_sha; do
-            pid=$(git show "$main_sha" 2>/dev/null | git patch-id --stable 2>/dev/null | awk '{print $1}' || true)
-            if [ -n "$pid" ]; then
-              main_patch_ids["$pid"]="$main_sha"
-            fi
-          done < <(git rev-list --no-merges -n 1500 origin/main)
-
-          echo "Indexed ${#main_patch_ids[@]} patch-ids from main."
-          echo
-
-          fail=0
-          fail_lines=()
-          for sha in "${pr_commits[@]}"; do
-            subject=$(git log -1 --format='%s' "$sha" 2>/dev/null || echo '<no subject>')
-            short=$(git rev-parse --short "$sha")
-
-            # Path A: commit is literally an ancestor of origin/main (this
-            # happens when the PR brings forward already-merged main
-            # commits, e.g. a merge of main into release/1.1.x).
-            if git merge-base --is-ancestor "$sha" origin/main; then
-              echo "  ✓ ${short} on main: ${subject}"
-              continue
-            fi
-
-            # Path B: a commit with matching patch-id exists on main
-            # (cherry-pick or rebase).
-            pid=$(git show "$sha" 2>/dev/null | git patch-id --stable 2>/dev/null | awk '{print $1}' || true)
-            if [ -n "$pid" ] && [ -n "${main_patch_ids[$pid]:-}" ]; then
-              main_short=$(git rev-parse --short "${main_patch_ids[$pid]}")
-              echo "  ✓ ${short} cherry-pick of ${main_short} on main: ${subject}"
-              continue
-            fi
-
-            # Neither: this commit was authored directly against the
-            # release branch and never went through main. Fail the gate.
-            fail=$((fail + 1))
-            fail_lines+=("  ✗ ${short}: ${subject}")
-          done
-
-          if [ "$fail" -gt 0 ]; then
-            echo
-            echo "::error title=Release branch gate failed::${fail} commit(s) on this PR are not on main and are not cherry-picks of main commits."
-            printf '%s\n' "${fail_lines[@]}"
-            echo
-            echo "This branch (${PR_BASE_REF}) is a maintenance line. The expected workflow is:"
-            echo "  1. Land the change on main first."
-            echo "  2. Soak through main's CI (the CI workflow gates main)."
-            echo "  3. Cherry-pick (\`git cherry-pick <sha>\`) the main commit(s) to ${PR_BASE_REF}."
-            echo
-            echo "If this PR genuinely cannot go through main first (e.g., a fix"
-            echo "that ONLY applies to the maintenance branch), apply the label"
-            echo "  release-process: approved"
-            echo "and re-run this check. Document the rationale in the PR body."
-            echo
-            echo "Reference: artifact-keeper#1090 / artifact-keeper#1068 (the bypass that motivated this gate)"
+          # The checkout is the PR HEAD, so the script has to exist on the
+          # maintenance branch too. It arrives with this workflow when the
+          # gate is forward-ported; say so plainly rather than dying on
+          # "No such file or directory".
+          if [ ! -f scripts/ci/check-release-branch-commits.sh ]; then
+            echo "::error title=Release branch gate is incomplete::scripts/ci/check-release-branch-commits.sh is missing on this branch. Cherry-pick it alongside .github/workflows/release-branch-gate.yml (artifact-keeper#3422)."
             exit 1
           fi
-
-          echo
-          echo "::notice::All ${#pr_commits[@]} PR commit(s) trace back to main. Gate passed."
+          bash scripts/ci/check-release-branch-commits.sh "$PR_BASE_SHA" "$PR_HEAD_SHA"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -10,14 +10,32 @@ name: Release Preflight
 # from release/1.6.x to main).
 #
 # This publishes NOTHING. It only reads: the repo tree, the .trivyignore of
-# active release/* branches, the latest main Docker Publish run status, and
+# active release/* branches, the status of the Docker Publish run for the
+# exact commit being checked (selected by head_sha, not recency -- #3338), and
 # the manifests of already-published component images (check 4, #3339).
-# A red run means "do not tag yet"; a green run means main is safe to cut.
+# A red run means "do not tag yet"; a green run means the audited ref is safe
+# to cut.
+#
+# IT AUDITS THE REF IT WAS DISPATCHED ON. The checkout used to hardcode
+# `ref: main`, so dispatching this workflow from `release/1.7.x` ran the
+# maintenance branch's copy of the workflow against MAIN's tree: v1.7.5,
+# v1.7.6 and v1.7.7 each got a READY verdict that was a statement about a
+# different branch, and there was no way to preflight the branch actually
+# being cut. The `ref` input defaults to whatever ref the dispatch was made
+# on, and the verdict line now names the ref and sha it evaluated so a
+# transcript can never again be mistaken for one about another branch.
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to audit (branch, tag or sha). Defaults to the ref this workflow was dispatched on.'
+        required: false
+        type: string
+        default: ''
   # Also surface drift proactively on a schedule so a stale main is caught
   # before anyone even tries to cut. Advisory only -- never blocks a merge.
+  # A schedule always fires on the default branch, so this leg audits main.
   schedule:
     - cron: '17 13 * * 1-5'  # weekday mid-morning US, after the overnight merges
 
@@ -36,10 +54,16 @@ jobs:
     name: Pre-tag readiness
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main
+      # `inputs.ref || github.ref` rather than an input default: a
+      # workflow_dispatch `default:` is a literal string, so `${{ github.ref }}`
+      # written there would be checked out verbatim. The fallback expression is
+      # evaluated, so an unset input means "the ref I dispatched on" -- main
+      # from the Actions UI's default selection, release/1.7.x when the branch
+      # picker says release/1.7.x, and refs/heads/<default> on the schedule.
+      - name: Checkout the ref being audited
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: main
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 1
 
       # Runs first, and offline. If check 3 has regressed into a soft warn
@@ -54,6 +78,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PREFLIGHT_REPO: ${{ github.repository }}
+          # The ref this run is a statement about. It names the verdict line
+          # and it decides whether check 1 (a main-centric invariant) applies.
+          PREFLIGHT_REF: ${{ inputs.ref || github.ref }}
           # Used by check 4's registry probes. The checkout is depth-1, so the
           # commit a published tag was built from is not local; the check
           # fetches just that commit when it needs it, and reports INFRA if it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Release engineering on the 1.7.x maintenance line: pushes publish images again, backports can pass the gate, and a preflight verdict names the branch it is about** (#3422, #3338). GitHub runs a workflow file *at the ref that triggered it*, so the release-engineering fixes that landed on `main` were inert here and the two lines had silently diverged. Three consequences, each fixed:
+
+  **Docker Publish never ran.** The push trigger listed `release/1.1.x`, a branch that no longer exists, so a commit landing on `release/1.7.x` published nothing at all. Release preflight check 3 was right every time it said "no Docker Publish run exists for HEAD", and every 1.7.x cut worked around it with an undocumented manual `workflow_dispatch`. The trigger is now `release/**`, and the `X.Y-dev` floating alias is derived from the branch name (`1.7-dev` for `release/1.7.x`) instead of being hardcoded to one series, so a new maintenance line gets one the moment it is created.
+
+  **No compliant backport could pass the release-branch gate.** The gate's logic was inlined in `release-branch-gate.yml` and only accepted commits that are on `main` or match one by patch-id. A release prep (`chore(release): ...`) prepares a version that exists *only* on the maintenance branch, and a narrowed backport (hunks resolved away because the branch lacks the scaffolding the main change assumed) cannot match by patch-id by construction — so both shapes had to be waved through with the `release-process: approved` label, six times in five days. The gate is now `scripts/ci/check-release-branch-commits.sh`, which additionally accepts a release prep (subject prefix **and** an allowlisted version/changelog path set — both, so neither alone is a hole) and a narrowed backport carrying a `(cherry picked from commit <sha>)` trailer naming a commit that *is* on main, logged as "narrowed backport of \<sha\>" rather than passed silently. Its self-test runs in CI's Shell Tests job and asserts the exemptions from the failing side too.
+
+  **The preflight could not audit this branch.** `release-preflight.yml` hardcoded `ref: main` in its checkout, so dispatching it from `release/1.7.x` ran this branch's workflow against main's tree: the `READY` verdicts behind v1.7.5, v1.7.6 and v1.7.7 were statements about a different branch. The checkout now follows the ref the workflow was dispatched on (overridable with a `ref` input), the verdict names what it evaluated — `READY to cut from <ref>@<sha>` — and check 1 (`.trivyignore` forward-port drift, a main-centric invariant) reports NOT APPLICABLE rather than manufacturing findings when the audited ref is itself a `release/*` branch.
+
 ## [1.7.7] - 2026-08-19
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,18 +19,29 @@ Throughout, `X.Y.Z` is the version being released and the git tag is
 
    ```bash
    scripts/ci/release-preflight.sh          # local (needs an authenticated gh)
-   # or, from the Actions UI: run the "Release Preflight" workflow
+   # or, from the Actions UI: run the "Release Preflight" workflow, selecting
+   # the branch you are cutting from in the workflow's branch picker
    ```
 
-   It asserts main is actually releasable — `.trivyignore` covers every
-   active `release/*` branch's suppressions (the drift that stalled
-   v1.7.0-rc.1 at Security Scan, #3039), the version set is consistent,
-   main's last Docker Publish cleanly published its manifest, and no
-   component pinned by a checked-in `VERSION` file would try to republish an
-   exact tag that already exists with different content (the collision that
-   killed the v1.7.2 tag). A `NOT READY` (exit 1) means fix main first;
-   tagging over it costs a full re-cut cycle. An exit 2 is `INFRA` — a check
-   that could not be measured, which is neither a pass nor a failure.
+   **It audits the ref you point it at, and the verdict says which one** —
+   `READY to cut from release/1.7.x@<sha>`. The workflow used to hardcode
+   `ref: main` in its checkout, so dispatching it from a maintenance branch
+   produced a verdict about `main`; v1.7.5, v1.7.6 and v1.7.7 were each cut on
+   one. If the verdict does not name the branch you are about to tag, it is
+   not about your cut.
+
+   It asserts the audited ref is actually releasable — the version set is
+   consistent, that commit's own Docker Publish cleanly published its manifest
+   (selected by `head_sha`, not recency, #3338), and no component pinned by a
+   checked-in `VERSION` file would try to republish an exact tag that already
+   exists with different content (the collision that killed the v1.7.2 tag).
+   On `main` it additionally checks that `.trivyignore` covers every active
+   `release/*` branch's suppressions (the drift that stalled v1.7.0-rc.1 at
+   Security Scan, #3039); that check is skipped on a `release/*` ref, where
+   another branch's suppressions say nothing about the cut. A `NOT READY`
+   (exit 1) means fix the ref you are cutting from first; tagging over it
+   costs a full re-cut cycle. An exit 2 is `INFRA` — a check that could not be
+   measured, which is neither a pass nor a failure.
 
 2. **Bump the version set.** The version is displayed or pinned in several
    decoupled places; a partial bump ships a stale version string. Update

--- a/scripts/ci/check-release-branch-commits.sh
+++ b/scripts/ci/check-release-branch-commits.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Release branch gate (#1090 / #1068, extended by #3422).
+#
+# Verifies that every commit a PR adds to a `release/*` maintenance branch
+# traces back to `main`. Four ways a commit can qualify:
+#
+#   A. it is literally an ancestor of main (a merge-forward of main);
+#   B. a commit with the same `git patch-id` exists on main (a clean
+#      cherry-pick or rebase);
+#   C. it is a RELEASE-PREP commit — subject `chore(release): ...` touching
+#      only the version/changelog/release-notes file set. The version being
+#      prepared exists only on the maintenance branch, so there is nothing on
+#      main to trace to and there should not be. Before #3422 this had to be
+#      waved through with `release-process: approved` on every single cut;
+#      the 1.7.6 cut burned that label four times in one release;
+#   D. it is a NARROWED BACKPORT — a commit carrying a
+#      `(cherry picked from commit <sha>)` trailer whose sha is on main, but
+#      whose patch-id differs because hunks that could not apply were
+#      resolved away (a guard test depending on scaffolding the branch does
+#      not have, a CHANGELOG hunk targeting `[Unreleased]` when the branch
+#      needs `[1.7.6]`). The narrowing is real and worth seeing, so it is
+#      logged as "narrowed backport of <sha>" rather than passed silently.
+#
+# Anything else still fails: a commit authored directly against the
+# maintenance branch that never went through main is exactly what this gate
+# exists to stop (PR #1068 bundled +1489 lines that way and forced a revert
+# mid-RC cycle). The `release-process: approved` label remains the escape
+# hatch for the genuine remainder, and is handled by the workflow, not here.
+#
+# C is deliberately narrow in BOTH dimensions — subject prefix AND path set.
+# A `chore(release):` commit that also touches backend source is not a
+# release prep, and a version-file-only commit with some other subject is not
+# either. Widening one without the other would turn the exemption into a hole
+# a real drift could walk through.
+#
+# Usage:  check-release-branch-commits.sh <base-sha> <head-sha>
+#
+# Env:
+#   MAIN_REF          ref to trace against (default origin/main); the
+#                     self-test points this at fixture branches.
+#   MAIN_SCAN_DEPTH   how many main commits to index patch-ids from
+#                     (default 1500, ~3 months of main at typical velocity).
+#
+# Exit codes: 0 all commits trace back, 1 one or more do not, 2 infra
+# (MAIN_REF missing / unreadable range).
+set -euo pipefail
+
+MAIN_REF="${MAIN_REF:-origin/main}"
+MAIN_SCAN_DEPTH="${MAIN_SCAN_DEPTH:-1500}"
+
+BASE_SHA="${1:-}"
+HEAD_SHA="${2:-}"
+if [[ -z "$BASE_SHA" || -z "$HEAD_SHA" ]]; then
+  echo "INFRA: usage: $(basename "$0") <base-sha> <head-sha>" >&2
+  exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${MAIN_REF}^{commit}" > /dev/null; then
+  echo "INFRA: MAIN_REF '${MAIN_REF}' does not resolve to a commit" >&2
+  exit 2
+fi
+
+# Enumerated into a variable first, not straight into `mapfile` from a process
+# substitution: mapfile reports success even when the producer failed, which
+# would turn an unreadable range into "no commits to verify" — a silent pass.
+if ! rev_list="$(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}")"; then
+  echo "INFRA: cannot enumerate ${BASE_SHA}..${HEAD_SHA}" >&2
+  exit 2
+fi
+mapfile -t pr_commits <<< "$rev_list"
+# A single empty line from an empty rev-list becomes one empty element.
+if [[ ${#pr_commits[@]} -eq 1 && -z "${pr_commits[0]}" ]]; then
+  pr_commits=()
+fi
+
+if [[ ${#pr_commits[@]} -eq 0 ]]; then
+  echo "::notice::PR contains no non-merge commits; nothing to verify."
+  exit 0
+fi
+
+# ── Path C helpers ──────────────────────────────────────────────────────────
+
+# Every path a release-prep commit is allowed to touch. Bash `case` globs, so
+# `*` also spans `/`; that is fine here — each pattern is anchored on a
+# concrete filename or directory that only carries version metadata.
+release_prep_path() {
+  case "$1" in
+    Cargo.toml | Cargo.lock) return 0 ;;
+    openapi.rs | */openapi.rs) return 0 ;; # **/openapi.rs
+    CHANGELOG.md) return 0 ;;
+    .github/release-notes/*) return 0 ;;
+    docker/*/VERSION) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True when <sha> is a release-prep commit: `chore(release): ` subject AND
+# every changed path in the allowlist. An empty file list is NOT a release
+# prep — a commit that changes nothing has nothing to exempt.
+is_release_prep() {
+  local sha="$1" subject files f
+  subject="$(git log -1 --format='%s' "$sha")"
+  [[ "$subject" =~ ^chore\(release\):\  ]] || return 1
+
+  # -r (recurse into trees) and no -M: a rename is reported as its two paths
+  # rather than one, so both ends are checked against the allowlist. The
+  # 1.7.6 prep renames .github/release-notes/1.7.5.md -> 1.7.6.md.
+  mapfile -t files < <(git diff-tree --no-commit-id --name-only -r "$sha")
+  [[ ${#files[@]} -gt 0 ]] || return 1
+
+  for f in "${files[@]}"; do
+    [[ -n "$f" ]] || continue
+    release_prep_path "$f" || return 1
+  done
+  return 0
+}
+
+# ── Path D helpers ──────────────────────────────────────────────────────────
+
+# Echoes the sha of the last `(cherry picked from commit <sha>)` trailer in
+# the commit message, if any. Last rather than first: a chain of backports
+# accumulates trailers and the most recent one names the commit this one was
+# actually taken from.
+cherry_pick_source() {
+  git log -1 --format='%B' "$1" \
+    | sed -n 's/^[[:space:]]*(cherry picked from commit \([0-9a-f]\{7,40\}\))[[:space:]]*$/\1/p' \
+    | tail -n1
+}
+
+# ── Index main ──────────────────────────────────────────────────────────────
+
+echo "Indexing patch-ids from ${MAIN_REF} (last ${MAIN_SCAN_DEPTH} commits)..."
+declare -A main_patch_ids
+while read -r main_sha; do
+  pid=$(git show "$main_sha" 2> /dev/null | git patch-id --stable 2> /dev/null | awk '{print $1}' || true)
+  if [[ -n "$pid" ]]; then
+    main_patch_ids["$pid"]="$main_sha"
+  fi
+done < <(git rev-list --no-merges -n "$MAIN_SCAN_DEPTH" "$MAIN_REF")
+
+echo "Indexed ${#main_patch_ids[@]} patch-ids from ${MAIN_REF}."
+echo
+
+# ── Verify ──────────────────────────────────────────────────────────────────
+
+fail=0
+fail_lines=()
+for sha in "${pr_commits[@]}"; do
+  subject=$(git log -1 --format='%s' "$sha" 2> /dev/null || echo '<no subject>')
+  short=$(git rev-parse --short "$sha")
+
+  # Path A: already on main (e.g. a merge of main into the release branch).
+  if git merge-base --is-ancestor "$sha" "$MAIN_REF"; then
+    echo "  ✓ ${short} on main: ${subject}"
+    continue
+  fi
+
+  # Path B: same patch content exists on main (clean cherry-pick / rebase).
+  pid=$(git show "$sha" 2> /dev/null | git patch-id --stable 2> /dev/null | awk '{print $1}' || true)
+  if [[ -n "$pid" && -n "${main_patch_ids[$pid]:-}" ]]; then
+    main_short=$(git rev-parse --short "${main_patch_ids[$pid]}")
+    echo "  ✓ ${short} cherry-pick of ${main_short} on main: ${subject}"
+    continue
+  fi
+
+  # Path C: release-prep for a version that exists only on this branch.
+  if is_release_prep "$sha"; then
+    echo "  ✓ ${short} release prep (version/changelog paths only): ${subject}"
+    continue
+  fi
+
+  # Path D: narrowed backport — trailer names a commit that IS on main.
+  picked="$(cherry_pick_source "$sha")"
+  if [[ -n "$picked" ]] && git rev-parse --verify --quiet "${picked}^{commit}" > /dev/null \
+    && git merge-base --is-ancestor "$picked" "$MAIN_REF"; then
+    picked_short=$(git rev-parse --short "$picked")
+    echo "  ✓ ${short} narrowed backport of ${picked_short} on main" \
+      "(patch differs; hunks were resolved away): ${subject}"
+    continue
+  fi
+  if [[ -n "$picked" ]]; then
+    # A trailer that names something main does not have is worse than no
+    # trailer: it asserts a provenance that is not there. Say which sha.
+    fail_lines+=("  ✗ ${short}: ${subject} [cherry-pick trailer names ${picked}, which is not on ${MAIN_REF}]")
+    fail=$((fail + 1))
+    continue
+  fi
+
+  # None of the four: authored directly against the release branch.
+  fail=$((fail + 1))
+  fail_lines+=("  ✗ ${short}: ${subject}")
+done
+
+if [[ $fail -gt 0 ]]; then
+  echo
+  echo "::error title=Release branch gate failed::${fail} commit(s) on this PR are not on main, are not cherry-picks of main commits, and are neither a release prep nor a narrowed backport."
+  printf '%s\n' "${fail_lines[@]}"
+  echo
+  echo "This is a maintenance line. The expected workflow is:"
+  echo "  1. Land the change on main first."
+  echo "  2. Soak through main's CI (the CI workflow gates main)."
+  echo "  3. Cherry-pick (\`git cherry-pick -x <sha>\`) the main commit(s) here."
+  echo
+  echo "Two shapes are accepted without a patch-id match:"
+  echo "  - a release prep: subject \`chore(release): ...\` touching only"
+  echo "    Cargo.toml, Cargo.lock, **/openapi.rs, CHANGELOG.md,"
+  echo "    .github/release-notes/** and docker/*/VERSION;"
+  echo "  - a narrowed backport: a \`(cherry picked from commit <sha>)\`"
+  echo "    trailer naming a commit that is on main. \`git cherry-pick -x\`"
+  echo "    writes that trailer for you; keep it when you resolve hunks away."
+  echo
+  echo "If this PR genuinely cannot go through main first (e.g., a fix that"
+  echo "ONLY applies to the maintenance branch), apply the label"
+  echo "  release-process: approved"
+  echo "and re-run this check. Document the rationale in the PR body."
+  echo
+  echo "Reference: artifact-keeper#1090 / artifact-keeper#1068 / artifact-keeper#3422"
+  exit 1
+fi
+
+echo
+echo "::notice::All ${#pr_commits[@]} PR commit(s) trace back to ${MAIN_REF}. Gate passed."

--- a/scripts/ci/release-preflight.sh
+++ b/scripts/ci/release-preflight.sh
@@ -3,8 +3,8 @@
 # Pre-tag release readiness check (issue #3042).
 #
 # Run this BEFORE cutting a release/RC tag (see RELEASING.md). It asserts that
-# `main` is actually releasable, so a stale main does not cost a full re-cut
-# cycle. The motivating incident (#3039): v1.7.0-rc.1 stalled ~90 minutes at
+# THE REF BEING CUT is actually releasable, so a stale tree does not cost a
+# full re-cut cycle. The motivating incident (#3039): v1.7.0-rc.1 stalled ~90 minutes at
 # docker-publish's Security Scan because `main` was missing two trivy-CLI CVE
 # suppressions that lived only on `release/1.6.x` (#2997/#3040). Security Scan
 # HARD-gates the multi-arch manifest, which gates resolve-candidate-digest,
@@ -21,6 +21,14 @@
 #      main means main's images fail Security Scan -> no release can be cut
 #      from main. This is the exact #3039 gap. Enumeration mirrors
 #      check-migration-ledger.sh.
+#
+#      This one check is MAIN-CENTRIC and is skipped (loudly) when the audited
+#      ref is a `release/*` branch. Its subject is "can a cut from main clear
+#      Security Scan given what the maintenance branches suppress"; a
+#      maintenance branch's own images are scanned against its OWN
+#      .trivyignore, so another branch's suppressions say nothing about it and
+#      the branch comparing against itself is vacuous. Running it anyway would
+#      manufacture drift findings that no cut from that branch can act on.
 #
 #      The tombstone form exists because a plain superset rule makes the set
 #      monotonic (#3309): a suppression provably dead for main's images could
@@ -122,12 +130,18 @@
 # Exit-code contract (mirrors scripts/ci/check-migration-ledger.sh):
 #   0  ready       -- no blocking problem found.
 #   1  NOT READY   -- a real, blocking problem (drift, version mismatch, or a
-#                     measured-red Docker Publish on main).
-#                     Fix it on main before tagging; NEVER retry it away.
+#                     measured-red Docker Publish for the audited commit).
+#                     Fix it on the ref being cut before tagging; NEVER retry
+#                     it away.
 #   2  INFRA       -- tooling/network failure (git ls-remote / gh / file reads
 #                     failed); retryable, NOT a readiness verdict.
 #
 # Env overrides:
+#   PREFLIGHT_REF    the ref this run is a statement about. Names the verdict
+#                    line and decides whether check 1 applies. Defaults to the
+#                    checked-out branch name; a detached HEAD reports as
+#                    `HEAD`, which is not a `release/*` ref, so check 1 keeps
+#                    its historical behaviour when nothing says otherwise.
 #   PREFLIGHT_REPO   owner/name for the `gh api` calls (default: derived from
 #                    the origin remote, else artifact-keeper/artifact-keeper).
 #   PREFLIGHT_SKIP_DOCKER_HEALTH=1  do not run check 3 at all.
@@ -186,13 +200,39 @@ retired_tokens() {
     | sed 's/^# RETIRED: //' | sort -u
 }
 
+# --- which ref is this run a statement about? -------------------------------
+#
+# The workflow used to hardcode `ref: main` in its checkout, so a preflight
+# dispatched from release/1.7.x audited main and said READY about it. Naming
+# the ref in the verdict is what makes that mistake unrepeatable: a transcript
+# that says which ref it evaluated cannot be read as one about another.
+#
+# refs/heads/ is stripped so `refs/heads/release/1.7.x` and `release/1.7.x`
+# print (and match) identically no matter which of the two the caller passes.
+AUDIT_REF="${PREFLIGHT_REF:-}"
+if [[ -z "$AUDIT_REF" ]]; then
+  AUDIT_REF="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+fi
+AUDIT_REF="${AUDIT_REF#refs/heads/}"
+AUDIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo '?')"
+
+# True for a maintenance branch, false for main / a tag / a detached HEAD.
+is_release_branch_ref() { [[ "$AUDIT_REF" == release/* ]]; }
+
 echo "== release preflight =="
-echo "repo: $REPO   ref: $(git rev-parse --short HEAD 2>/dev/null || echo '?')"
+echo "repo: $REPO   ref: ${AUDIT_REF}@${AUDIT_SHA}"
 echo
 
 # --- check 1: .trivyignore forward-port drift -------------------------------
 echo "1) .trivyignore forward-port drift (main must account for release/* suppressions)"
-if [[ ! -f .trivyignore ]]; then
+if is_release_branch_ref; then
+  note "NOT APPLICABLE: this check asks whether MAIN accounts for the"
+  note "suppressions on every release/* branch, and the audited ref is"
+  note "${AUDIT_REF}. A maintenance branch's images are scanned against its own"
+  note ".trivyignore, so another branch's suppressions are not a claim about"
+  note "this cut -- and comparing the branch against itself is vacuous."
+  note "Run this check against main (its forward-port drift is main's problem)."
+elif [[ ! -f .trivyignore ]]; then
   warn "no .trivyignore at repo root -- skipping drift check"
 else
   main_tokens="$(suppression_tokens < .trivyignore)"
@@ -444,9 +484,14 @@ fi
 echo
 
 # --- verdict ----------------------------------------------------------------
+#
+# The ref and sha are part of the verdict, not decoration. A bare "READY" is
+# ambiguous about WHAT is ready, and that ambiguity is exactly how v1.7.5,
+# v1.7.6 and v1.7.7 were each cut from release/1.7.x on the strength of a
+# preflight transcript that had, in fact, audited main.
 if [[ "$problems" -gt 0 ]]; then
-  echo "${RED}NOT READY${RST}: $problems blocking problem(s). Fix on main before tagging."
+  echo "${RED}NOT READY${RST} to cut from ${AUDIT_REF}@${AUDIT_SHA}: $problems blocking problem(s). Fix them on ${AUDIT_REF} before tagging."
   exit 1
 fi
-echo "${GRN}READY${RST}: no blocking problems. Safe to cut the tag."
+echo "${GRN}READY${RST} to cut from ${AUDIT_REF}@${AUDIT_SHA}: no blocking problems."
 exit 0

--- a/scripts/ci/test-check-release-branch-commits.sh
+++ b/scripts/ci/test-check-release-branch-commits.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/check-release-branch-commits.sh (#1090, #3422).
+#
+# The gate is only exercised on PRs against `release/*`, which is a handful of
+# runs per release — far too rare for a regression to surface on its own. So
+# the interesting cases are built here as real (tiny) git repos rather than
+# waited for:
+#
+#   - the two exemptions #3422 adds must PASS (release prep, narrowed
+#     backport) — these were bypassed with `release-process: approved` four
+#     times during the 1.7.6 cut because the gate could not express them;
+#   - and, more importantly, they must stay NARROW: a `chore(release):`
+#     subject that also touches source, or a version-file-only commit under
+#     some other subject, or a cherry-pick trailer naming a sha main does not
+#     have, must all still FAIL. An exemption that is not tested from the
+#     failing side is a hole, not an exemption.
+#
+# Usage: bash scripts/ci/test-check-release-branch-commits.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-release-branch-commits.sh"
+[ -f "$SCRIPT" ] || {
+  echo "cannot find check-release-branch-commits.sh next to this test" >&2
+  exit 2
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+fail() {
+  printf '  \033[31mFAIL\033[0m  %s\n' "$*"
+  fails=$((fails + 1))
+}
+
+# ── fixture repo ────────────────────────────────────────────────────────────
+#
+# main:            m1 -> m2(feature) -> m3(feature2)
+# release/1.9.x:   m1 -> (branch commits, one per case)
+#
+# Every case commits onto a fresh branch off `base` so the cases cannot
+# interfere with each other.
+REPO="$WORK/repo"
+mkdir -p "$REPO"
+cd "$REPO" || exit 2
+git init -q -b main .
+git config user.email t@example.com
+git config user.name t
+git config commit.gpgsign false
+
+mkdir -p backend/src/api docker/scanner-adapter .github/release-notes
+printf 'v1\n' > backend/src/lib.rs
+printf 'version = "1.9.0"\n' > Cargo.toml
+printf 'lock\n' > Cargo.lock
+printf 'version = "1.9.0"\n' > backend/src/api/openapi.rs
+printf '## [Unreleased]\n' > CHANGELOG.md
+printf '1.2.3\n' > docker/scanner-adapter/VERSION
+git add -A && git commit -qm "m1: base"
+BASE="$(git rev-parse HEAD)"
+
+printf 'feature\n' > backend/src/feature.rs
+git add -A && git commit -qm "feat: a feature that lands on main first"
+MAIN_FEATURE="$(git rev-parse HEAD)"
+
+printf 'feature2\n' > backend/src/feature2.rs
+git add -A && git commit -qm "feat: a second feature on main"
+MAIN_FEATURE2="$(git rev-parse HEAD)"
+git branch -q main-ref HEAD # stands in for origin/main
+
+run_case() { # <label> <expected-exit> <expected-substring> <head-ref> [base-ref]
+  local label="$1" want="$2" needle="$3" head="$4" base="${5:-$BASE}"
+  local out got
+  out="$(cd "$REPO" && MAIN_REF=main-ref MAIN_SCAN_DEPTH=50 bash "$SCRIPT" "$base" "$head" 2>&1)"
+  got=$?
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    printf '%s\n' "$out" | sed 's/^/        /' >&2
+  elif [ -n "$needle" ] && ! printf '%s\n' "$out" | grep -qF "$needle"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    printf '%s\n' "$out" | sed 's/^/        /' >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+echo "check-release-branch-commits (#1090, #3422)"
+
+# ── Path A: already on main ────────────────────────────────────────────────
+run_case "commit already on main -> pass" 0 "on main" "$MAIN_FEATURE2" "$BASE"
+
+# ── Path B: clean cherry-pick (patch-id match) ─────────────────────────────
+# MAIN_FEATURE2 rather than MAIN_FEATURE: picking a commit straight onto its
+# own parent reproduces it byte for byte, which would exercise path A again.
+git checkout -q -B case-cherry "$BASE"
+git cherry-pick "$MAIN_FEATURE2" > /dev/null 2>&1
+run_case "clean cherry-pick -> pass (patch-id)" 0 "cherry-pick of" case-cherry
+
+# ── Path C: release prep ───────────────────────────────────────────────────
+git checkout -q -B case-prep "$BASE"
+mkdir -p .github/release-notes
+printf 'version = "1.9.1"\n' > Cargo.toml
+printf 'lock2\n' > Cargo.lock
+printf 'version = "1.9.1"\n' > backend/src/api/openapi.rs
+printf '## [Unreleased]\n\n## [1.9.1] - 2026-01-01\n' > CHANGELOG.md
+printf '1.2.4\n' > docker/scanner-adapter/VERSION
+printf 'notes\n' > .github/release-notes/1.9.1.md
+git add -A && git commit -qm "chore(release): prepare 1.9.1"
+run_case "release prep, allowlisted paths only -> pass" 0 "release prep" case-prep
+
+# A rename inside .github/release-notes/ is the shape the real 1.7.6 prep had
+# (1.7.5.md -> 1.7.6.md). Both ends of the rename must be checked, which is
+# why the script uses `git diff-tree -r` WITHOUT rename detection.
+git checkout -q -B case-prep-rename "$BASE"
+mkdir -p .github/release-notes
+printf 'notes\n' > .github/release-notes/1.9.1.md
+git add -A && git commit -qm "docs: seed notes"
+git mv .github/release-notes/1.9.1.md .github/release-notes/1.9.2.md
+printf 'version = "1.9.2"\n' > Cargo.toml
+git add -A && git commit -qm "chore(release): prepare 1.9.2"
+run_case "release prep with a release-notes rename -> pass" 0 "release prep" \
+  case-prep-rename "case-prep-rename~1"
+
+# ── Path C stays narrow ────────────────────────────────────────────────────
+git checkout -q -B case-prep-plus-source "$BASE"
+printf 'version = "1.9.3"\n' > Cargo.toml
+printf 'sneaky\n' > backend/src/sneaky.rs
+git add -A && git commit -qm "chore(release): prepare 1.9.3"
+run_case "chore(release) that also touches source -> FAIL" 1 "✗" case-prep-plus-source
+
+git checkout -q -B case-version-only-wrong-subject "$BASE"
+printf 'version = "1.9.4"\n' > Cargo.toml
+git add -A && git commit -qm "chore: bump the version"
+run_case "version-file-only under a non-release subject -> FAIL" 1 "✗" \
+  case-version-only-wrong-subject
+
+# ── Path D: narrowed backport ──────────────────────────────────────────────
+# Same intent as MAIN_FEATURE but a different patch (a hunk resolved away),
+# carrying the -x trailer. patch-id cannot match by construction.
+git checkout -q -B case-narrowed "$BASE"
+printf 'feature-but-narrowed\n' > backend/src/feature.rs
+git add -A
+git commit -qm "feat: a feature that lands on main first
+
+(cherry picked from commit ${MAIN_FEATURE})"
+run_case "narrowed backport, trailer on main -> pass" 0 "narrowed backport of" case-narrowed
+
+# ── Path D stays narrow ────────────────────────────────────────────────────
+git checkout -q -B case-bogus-trailer "$BASE"
+printf 'invented\n' > backend/src/invented.rs
+git add -A
+git commit -qm "feat: invented locally
+
+(cherry picked from commit 0123456789abcdef0123456789abcdef01234567)"
+run_case "trailer naming a sha main does not have -> FAIL" 1 "not on main-ref" \
+  case-bogus-trailer
+
+# ── The original failure this gate exists for (#1068) ──────────────────────
+git checkout -q -B case-branch-only "$BASE"
+printf 'authored here\n' > backend/src/branch_only.rs
+git add -A && git commit -qm "fix: authored directly against the release branch"
+run_case "branch-only commit -> FAIL" 1 "✗" case-branch-only
+
+# ── Degenerate inputs ──────────────────────────────────────────────────────
+run_case "empty range -> pass with a notice" 0 "nothing to verify" "$BASE" "$BASE"
+
+out="$(cd "$REPO" && MAIN_REF=no-such-ref bash "$SCRIPT" "$BASE" "$MAIN_FEATURE" 2>&1)"
+got=$?
+if [ "$got" = "2" ] && printf '%s\n' "$out" | grep -qF "INFRA"; then
+  pass "unresolvable MAIN_REF -> INFRA (exit 2)"
+else
+  fail "unresolvable MAIN_REF: expected exit 2 with INFRA, got $got"
+fi
+
+out="$(cd "$REPO" && MAIN_REF=main-ref bash "$SCRIPT" 2>&1)"
+got=$?
+if [ "$got" = "2" ] && printf '%s\n' "$out" | grep -qF "usage"; then
+  pass "missing arguments -> INFRA (exit 2)"
+else
+  fail "missing arguments: expected exit 2 with usage, got $got"
+fi
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "$fails case(s) failed"
+  exit 1
+fi
+echo "all cases passed"

--- a/scripts/ci/test-release-preflight.sh
+++ b/scripts/ci/test-release-preflight.sh
@@ -254,6 +254,79 @@ expect1 "token both live and tombstoned -> NOT READY" 1 "BOTH as live suppressio
   "CVE-2099-0001"
 
 echo
+echo "release-preflight ref-awareness"
+
+# --- ref-awareness fixtures -------------------------------------------------
+#   release-preflight.yml hardcoded `ref: main` in its checkout, so a preflight
+#   DISPATCHED on release/1.7.x ran that branch's workflow against MAIN's tree.
+#   v1.7.5, v1.7.6 and v1.7.7 were each cut on a READY verdict that was a
+#   statement about a different branch. Two properties fix that and both are
+#   asserted here, because both are invisible from the happy path:
+#
+#     * the verdict NAMES the ref and sha it evaluated, so a transcript cannot
+#       be mistaken for one about another branch;
+#     * check 1 -- "does MAIN account for every release/* suppression?" -- is
+#       skipped when the audited ref is itself a release branch, because
+#       another branch's suppressions are not a claim about this cut and the
+#       branch comparing against itself is vacuous.
+#
+#   The second must stay NARROW in both directions: skipping it for main (or
+#   for a detached HEAD, which is what a sha checkout gives) would silently
+#   delete the #3039 gate, so case 3 below re-runs the exact forward-port miss
+#   from check-1 case 1 with PREFLIGHT_REF=main and demands it still fails.
+expectref() { # <label> <expected-exit> <expected-substring> <preflight-ref> [main-trivyignore] [rel-trivyignore]
+  local label="$1" want="$2" needle="$3" pref="$4" main_ti="${5:-}" rel_ti="${6:-}" got
+  [ -n "$main_ti" ] && printf '%s\n' "$main_ti" > "$REPO_DIR/.trivyignore"
+  ( cd "$REPO_DIR" && PATH="$STUB:$PATH" \
+      PREFLIGHT_REPO=artifact-keeper/artifact-keeper \
+      PREFLIGHT_REF="$pref" \
+      FAKE_RELEASE_REFS="$REL_REFS" \
+      FAKE_REL_TRIVYIGNORE="$rel_ti" \
+      PREFLIGHT_SKIP_VERSION_PIN=1 \
+      bash scripts/ci/release-preflight.sh > "$WORK/out.txt" 2>&1 )
+  got=$?
+  rm -f "$REPO_DIR/.trivyignore"
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  elif ! grep -qF "$needle" "$WORK/out.txt"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+# 1. The verdict names the ref it evaluated, and strips refs/heads/ so the
+#    caller can pass either spelling.
+expectref "verdict names the audited ref" 0 "READY to cut from release/1.7.x@" \
+  refs/heads/release/1.7.x
+
+# 2. On a release branch, the main-centric drift check does not manufacture a
+#    finding no cut from that branch could act on.
+expectref "release ref -> check 1 is NOT APPLICABLE, not a failure" 0 "NOT APPLICABLE" \
+  release/1.7.x \
+  "CVE-2099-0001" \
+  "CVE-2099-0001
+CVE-2099-0002"
+
+# 3. ...and the exemption stays narrow: the same fixture on main is still the
+#    #3039 hard failure it has always been.
+expectref "main ref -> forward-port miss still blocks" 1 "main is MISSING suppressions" \
+  refs/heads/main \
+  "CVE-2099-0001" \
+  "CVE-2099-0001
+CVE-2099-0002"
+
+# 4. A NOT READY verdict names the ref too -- an unnamed failure is as
+#    ambiguous as an unnamed pass.
+expectref "NOT READY names the audited ref" 1 "NOT READY to cut from main@" \
+  main \
+  "CVE-2099-0001" \
+  "CVE-2099-0001
+CVE-2099-0002"
+
+echo
 echo "release-preflight check 4 (#3339)"
 
 # --- check 4 fixture --------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #3464.

GitHub executes a workflow file **at the ref that triggered it**, not at `main`. The release-engineering fixes of the last few weeks all landed on `main`; 1.7.x releases are cut from `release/1.7.x`. The two have silently diverged, and the divergence is invisible from `main` — nothing there is wrong, and nothing there reports that the maintenance line is broken. This ports the three fixes, and only those.

**1. Commits to `release/1.7.x` published nothing.** The push trigger listed `release/1.1.x`, a branch that no longer exists. `main` has `release/**` (#3422), inert here. So release-preflight check 3 was correct every time it said "no Docker Publish run exists for HEAD" (#3338), and every 1.7.x cut was preceded by an undocumented manual `workflow_dispatch` to create the images the tag needs a digest from. Ported alongside it, because it is part of the same change: the `X.Y-dev` floating alias is now derived from the branch name (`1.7-dev` for `release/1.7.x`) instead of hardcoded to one series.

**2. No compliant backport could pass the release-branch gate.** The gate's logic lived **inlined** in `release-branch-gate.yml` in its pre-#3422 form — a commit passes only if it is on `main` or matches a `main` commit by patch-id. Two shapes a maintenance branch produces *by construction* can do neither: a **release prep** (`chore(release): prepare 1.7.7`) prepares a version that exists only on this branch, and a **narrowed backport** has had hunks resolved away, so patch-id cannot match. Every PR here therefore needed `release-process: approved` — 6 uses in 5 days. A bypass that is mandatory is not a bypass; it is a gate that has been turned off and that nobody reads any more. Ported `main`'s extracted `scripts/ci/check-release-branch-commits.sh`, which accepts a release prep (subject prefix **and** an allowlisted path set — both, so neither alone is a hole) and a narrowed backport carrying a `(cherry picked from commit <sha>)` trailer naming a commit that *is* on main, logged as "narrowed backport of \<sha\>" rather than passed silently.

**3. `release/1.7.x` could not be preflighted at all.** `release-preflight.yml` hardcoded `ref: main` in its checkout — on **both** branches, so this leg is a bug on `main` too. Dispatching Release Preflight from `release/1.7.x` ran this branch's workflow against main's tree. v1.7.5, v1.7.6 and v1.7.7 each received a `READY` verdict that was a statement about `main`, and the verdict line named neither ref nor sha, so the transcript was indistinguishable from one about the branch intended. Now: the checkout follows `inputs.ref || github.ref`, the verdict reads `READY to cut from <ref>@<sha>`, and check 1 (`.trivyignore` forward-port drift, a main-centric invariant) reports NOT APPLICABLE on a `release/*` ref instead of manufacturing findings no cut from that branch can act on.

### Deliberately **not** ported

`main` has drifted in unrelated ways and this is a maintenance branch, so each file was diffed rather than copied wholesale:

- **`docker-publish.yml` #2099** (`cancel-in-progress: false`): a separate fix about cancelled publish runs leaving floating tags on stale digests. Not this drift.
- **`ci.yml` shell-tests**: `main` also added `test-check-duplicate-migrations.sh` and the `check-changelog-unreleased.sh` pair. Unrelated gates; only the release-branch-gate self-test is wired here.
- **`scripts/ci/check-duplicate-migrations.sh`, `check-changelog-unreleased.sh`** and their tests: not ported.

`docker-publish.yml` and `release-branch-gate.yml` are now byte-identical to `main` apart from #2099. `check-release-branch-commits.sh` and its self-test are verbatim from `main`.

### Why this PR needs `release-process: approved`

**It will fail the very gate it fixes.** Its commits are neither clean cherry-picks of `main` commits, nor `chore(release):` preps, nor narrowed backports carrying a trailer — the branch's own (stale) gate has no shape that fits "the change that repairs the gate". That is precisely the chicken-and-egg this PR exists to break, and it is the one legitimate use of the label: not "this is inconvenient", but "no compliant form of this change exists on this branch".

**It should be the last one needed here.** After this merges, a `git cherry-pick -x` of a main commit passes on patch-id, a narrowed backport passes on its trailer, and `chore(release): prepare 1.7.8` passes as a release prep. If a PR against `release/1.7.x` still needs the label after this, that is a signal worth reading rather than routine.

Leg 3 is not a backport — it fixes a bug that is still live on `main`. It needs a forward-port PR to `main`; #3464 tracks that.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`scripts/ci/test-check-release-branch-commits.sh` (ported, newly wired into Shell Tests) asserts both #3422 exemptions from the **failing** side: a `chore(release):` commit that also touches source, a version-file-only commit under another subject, and a trailer naming a sha main does not have must all still fail.

`scripts/ci/test-release-preflight.sh` gains four cases for leg 3, including both narrowness directions — the same forward-port-miss fixture must still hard-fail with `PREFLIGHT_REF=main`, so the new guard cannot silently delete the #3039 gate.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Locally, on this branch: `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace --lib` 15183 passed / 0 failed (`--skip services::http_client`, #3377). No Rust source is touched by this PR. `bash scripts/ci/test-check-release-branch-commits.sh` 12/12 and `bash scripts/ci/test-release-preflight.sh` 22/22 (18 pre-existing + 4 new). All four changed workflows parse; `shellcheck -S warning` clean on all four scripts. DB-backed tests were **not** run — no Postgres was attached, and this PR changes no Rust.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
