### PR TITLE
fix(security): override golang.org/x/mod to v0.40.0 in the grype build (#3465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The bundled `grype` CLI is built against `golang.org/x/mod` v0.40.0, clearing CVE-2026-56864 and CVE-2026-56865** (#3465). Both are HIGH and both are fixed in x/mod v0.40.0; grype v0.117.0 pins v0.38.0, so `Security Scan` reports `usr/local/bin/grype  Total: 2 (HIGH: 2)` against the backend image and fails. Docker Publish on `main` has failed on this for two consecutive runs (32337069636, 32419016885) with every manifest-merge job skipped, so **no images have published from `main` since 2026-08-19** and the `v1.8.1` tag cannot be cut. The same finding burned `v1.7.7` on `release/1.7.x`, where rulesets forbid deleting or moving a tag and the version number was lost.
+
+  Neither lever the `grype-bin` stage already had could reach it. This is a **module**, not the standard library, so the `GO_MIN_PATCH` toolchain floor (#3352) does nothing; and there is no release to bump to — v0.117.0 is the latest anchore/grype release and `main` (`ffbca56`) still pins v0.38.0, with no open or merged PR to move it. Upstream has not made this bump anywhere, which is what makes this an **override** rather than the version bump that clears the same CVE pair in the scanner-adapter's Trivy (upstream v0.74.0 carries x/mod v0.40.0 itself). `docker/Dockerfile.backend` and `docker/Dockerfile.backend.alpine` therefore apply `go get golang.org/x/mod@v0.40.0` after the commit-pin verification and before `go build`, with three build-time guards: the pinned source must still require v0.38.0 (so the tag bump that makes the override redundant is also what stops the build until it is deleted), `go get` must move only the five declared `golang.org/x/*` modules MVS pulls with it, and the compiled binary's Go build info must record v0.40.0 — because that build info is exactly what Trivy reads. `grype --version` still prints `grype 0.117.0` and `Supported DB Schema` is still 6, so `scanner_version` and the DB seeded at build time are unaffected.
+
+  **The vulnerable code was never linked in**, and that is worth recording rather than implying urgency the finding did not have. Both advisories are scoped to `golang.org/x/mod/sumdb` (`Client.Lookup`, GO-2026-6180) and `golang.org/x/mod/sumdb/tlog` (`tileHashReader.ReadHashes`, GO-2026-6179) — the GOSUMDB transparency-log client — and neither package is in grype's build graph: `go mod why golang.org/x/mod/sumdb` answers "main module does not need package", and `go list -deps ./cmd/grype` links only `semver`, `module`, `modfile` and `internal/lazyregexp`, reached via `cmd/grype/cli/commands/internal/jsonschema` → `x/tools/go/packages`. Trivy flags Go binaries at module granularity from the embedded build info and cannot see that, while `govulncheck` would call the binary unaffected. It is fixed at source anyway rather than suppressed in `.trivyignore`, which is reserved for findings with no fix available in a tool we can build.
+
+  This clears the backend image only. The same CVE pair is also reported against `usr/local/bin/trivy` in the scanner-adapter image and is cleared separately by repointing at a Trivy build carrying x/mod v0.40.0; **both are required before `main` publishes again**.
+
 ## [1.8.1] - 2026-08-19
 
 ### Fixed

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -216,6 +216,12 @@ RUN find /mnt/rootfs -xdev -perm /6000 -type f -exec chmod a-s {} + && \
 # artifact-keeper/trivy overrides there is no version to point at. Suppress
 # when there is no fix; rebuild when the fix is a toolchain away.
 #
+# Fixed by this stage as of #3465: golang.org/x/mod. See the override block
+# below the clone. It is the third lever this stage has needed — bump the tag
+# (#3307), rebuild on a newer toolchain (#3352), override a module (#3465) —
+# and the only one that makes our build differ from upstream's, so it carries
+# more machinery than the other two.
+#
 # Build on $BUILDPLATFORM and cross-compile to $TARGETARCH (same pattern as
 # Dockerfile.scanner-adapter) so the multi-arch build does not run the Go
 # compiler under emulation. The output is still a TARGETARCH binary, exactly
@@ -233,6 +239,10 @@ ARG TARGETARCH
 ARG GRYPE_VERSION=0.117.0
 ARG GRYPE_COMMIT=b5fa92bbcbef655497e3be840a2f718380e2cdd3
 ARG GO_MIN_PATCH=1.26.6
+# The single declared divergence from upstream grype at this tag. See the
+# override block below the clone for the justification and removal condition.
+ARG XMOD_FROM=v0.38.0
+ARG XMOD_TO=v0.40.0
 
 RUN apk add --no-cache git ca-certificates
 
@@ -260,6 +270,112 @@ RUN set -eu; \
       exit 1; \
     fi
 
+# ---- Dependency override: golang.org/x/mod ${XMOD_FROM} -> ${XMOD_TO} (#3465)
+#
+# CVE-2026-56864 (GO-2026-6180) and CVE-2026-56865 (GO-2026-6179), both HIGH
+# and both fixed in x/mod v0.40.0, are reported against `usr/local/bin/grype`
+# and failed the Docker Publish Security Scan for the v1.7.7 tag. That tag is
+# unrecoverable — rulesets forbid deleting or moving a tag — so it was the
+# third burned version in this series and the reason this block exists.
+#
+# THIS IS AN OVERRIDE, NOT A BUMP, and that distinction is the whole point.
+# The three levers this stage has, in order of preference:
+#   1. bump GRYPE_VERSION to a release that carries the fix  (#3307)
+#   2. rebuild on a newer Go toolchain, for a stdlib CVE     (#3352)
+#   3. override a module version ourselves                   (here)
+# Lever 1 does not apply: v0.117.0 (2026-08-10) IS the latest anchore/grype
+# release, v0.118.0 does not exist, and anchore/grype `main` (ffbca56,
+# 2026-08-14) still pins x/mod v0.38.0 with no open or merged PR to move it.
+# Upstream has not made this bump ANYWHERE. Lever 2 does not apply either:
+# x/mod is a module in grype's dependency graph, not the standard library, so
+# GO_MIN_PATCH cannot reach it. Only lever 3 is left.
+#
+# Note the contrast with the sibling artifact-keeper/trivy repo, whose override
+# policy this block is modelled on. There, the identical x/mod finding was
+# cleared by a plain version bump because upstream release v0.74.0 carried
+# x/mod v0.40.0 itself; that repo's overrides.yaml is empty as a result. An
+# override that duplicates a shipped release is strictly worse than the bump it
+# imitates — so check the RELEASE, not just `main`, before adding one here:
+#   gh api repos/anchore/grype/releases --jq '.[0].tag_name'
+#   git show <tag>:go.mod | grep golang.org/x/mod
+# That policy also asks that upstream have already made the same bump before we
+# do. Here they have not, on main or in any PR, so this override goes one step
+# further than the trivy repo's rules allow and is recorded as such.
+#
+# URGENCY, honestly stated: the vulnerable code is not linked into the binary.
+# Both advisories are scoped to specific import paths — golang.org/x/mod/sumdb
+# (Client.Lookup) and golang.org/x/mod/sumdb/tlog (tileHashReader.ReadHashes),
+# the GOSUMDB transparency-log client — and neither is in grype's build graph:
+# `go mod why golang.org/x/mod/sumdb` answers "main module does not need
+# package", and `go list -deps ./cmd/grype` links only x/mod's semver, module,
+# modfile and internal/lazyregexp. x/mod arrives via
+# cmd/grype/cli/commands/internal/jsonschema -> x/tools/go/packages ->
+# x/tools/internal/gocommand -> x/mod/semver. Trivy flags Go binaries at MODULE
+# granularity from the embedded build info and cannot see that; govulncheck,
+# which works at symbol granularity, would call this binary unaffected.
+# It is fixed here anyway rather than suppressed in /.trivyignore, because that
+# file is for findings with no fix available in a tool we can build, and this
+# one has a fix. Reachability changes how alarming the finding is, not whether
+# a fixable HIGH gets fixed.
+#
+# REMOVAL CONDITION: delete this block, and the XMOD_FROM/XMOD_TO ARGs, when
+# GRYPE_VERSION is moved to a grype release whose go.mod pins x/mod >= v0.40.0.
+# You do not have to remember: the guard below asserts that the pinned source
+# still requires ${XMOD_FROM} and FAILS THE BUILD when it does not, so the tag
+# bump that makes this block redundant is also what makes it stop the build
+# until it is deleted. Staleness is caught mechanically, the way the trivy
+# repo's apply-overrides.sh catches it, rather than by anyone remembering.
+#
+# `go get` rather than `go mod edit -require` or a `replace` directive, for two
+# reasons. (a) go.sum stays verifiable and complete: `go get` resolves the new
+# requirement through MVS over the real module graph, fetches every module the
+# resolution moves through the proxy, and writes their checksum-database-
+# verified hashes into go.sum in the same step. `go mod edit -require` is a
+# textual edit that writes nothing to go.sum and skips MVS entirely, leaving
+# go.mod internally inconsistent (x/mod v0.40.0 requires x/tools v0.49.0, which
+# -require would not select) until a `go mod tidy` re-does the work properly
+# anyway. (b) a `replace` arrow records the ORIGINAL version in the binary's
+# build info, so a scan and any SBOM we publish would still read v0.38.0 and
+# report a CVE the binary no longer carries; `go get` records the real upgraded
+# version. `go mod tidy` afterwards is a no-op on go.mod here (verified) and
+# only costs a full test-dependency download, so it is not run.
+#
+# MVS consequences are part of the override, not a surprise. Selecting x/mod
+# v0.40.0 also moves x/tools 0.48.0 -> 0.49.0 (required by x/mod v0.40.0), and
+# with it x/crypto 0.54.0 -> 0.55.0, x/net 0.57.0 -> 0.58.0 and x/text
+# 0.40.0 -> 0.41.0. All five are golang.org/x co-released modules and the set is
+# deterministic given the pinned grype commit. It is asserted below: if `go get`
+# ever moves a module outside that declared set, the build fails rather than
+# shipping an undeclared divergence.
+RUN set -eu; \
+    xmod_pin() { sed -n 's|^[[:space:]]*golang\.org/x/mod \(v[^ ]*\).*|\1|p' go.mod | head -n1; }; \
+    have="$(xmod_pin)"; \
+    if [ "${have}" != "${XMOD_FROM}" ]; then \
+      echo "ERROR: grype v${GRYPE_VERSION} pins golang.org/x/mod ${have}, not ${XMOD_FROM}." >&2; \
+      echo "       This override was written against ${XMOD_FROM}. If upstream now" >&2; \
+      echo "       ships >= ${XMOD_TO}, DELETE the override block in this stage." >&2; \
+      echo "       If it moved to some other version, re-review it. See #3465." >&2; \
+      exit 1; \
+    fi; \
+    go get "golang.org/x/mod@${XMOD_TO}"; \
+    got="$(xmod_pin)"; \
+    if [ "${got}" != "${XMOD_TO}" ]; then \
+      echo "ERROR: override did not take: go.mod pins golang.org/x/mod ${got}." >&2; \
+      exit 1; \
+    fi; \
+    moved="$(git --no-pager diff --unified=0 go.mod \
+             | sed -n 's|^+[[:space:]]*\([^ ]*\) v.*|\1|p' | sort -u | tr '\n' ' ')"; \
+    expected="golang.org/x/crypto golang.org/x/mod golang.org/x/net golang.org/x/text golang.org/x/tools "; \
+    if [ "${moved}" != "${expected}" ]; then \
+      echo "ERROR: go get moved an undeclared set of modules." >&2; \
+      echo "       expected: ${expected}" >&2; \
+      echo "       actual:   ${moved}" >&2; \
+      echo "       Re-review the override and update the declared set (#3465)." >&2; \
+      exit 1; \
+    fi; \
+    go mod verify; \
+    echo "grype build: override applied — golang.org/x/mod ${XMOD_FROM} -> ${XMOD_TO}"
+
 # ldflags mirror .goreleaser.yaml at this tag so the built binary reports the
 # same identity upstream's release does. buildDate is the commit timestamp
 # rather than "now": a wall-clock date would make every rebuild produce a
@@ -276,6 +392,31 @@ RUN set -eu; \
           -X main.buildDate=${build_date}" \
         ./cmd/grype; \
     install -Dm644 LICENSE /licenses/grype/LICENSE
+
+# Prove the override reached the artifact, not just the source tree. An
+# override that resolves in go.mod but does not end up in the compiled binary's
+# Go build info fixes nothing: the build info is exactly what Trivy reads, so
+# it is what the gate will see. The dep-record count is a plausibility check in
+# the same spirit as the trivy repo's assert-buildinfo.sh — without it this
+# step would happily report "verified" against a binary whose build info it
+# failed to parse at all.
+RUN set -eu; \
+    info="$(go version -m /grype)"; \
+    deps="$(printf '%s\n' "${info}" | grep -c '^[[:space:]]*dep[[:space:]]')"; \
+    if [ "${deps}" -lt 50 ]; then \
+      echo "ERROR: /grype reports only ${deps} dependency records; build info is" >&2; \
+      echo "       unreadable or implausible, so the override is unverified." >&2; \
+      exit 1; \
+    fi; \
+    recorded="$(printf '%s\n' "${info}" \
+                | sed -n 's|^[[:space:]]*dep[[:space:]]*golang\.org/x/mod[[:space:]]*\(v[^[:space:]]*\).*|\1|p' \
+                | head -n1)"; \
+    if [ "${recorded}" != "${XMOD_TO}" ]; then \
+      echo "ERROR: compiled grype records golang.org/x/mod '${recorded}', want ${XMOD_TO}." >&2; \
+      echo "       The Trivy gate reads this build info; the override did not ship (#3465)." >&2; \
+      exit 1; \
+    fi; \
+    echo "grype build: build info verified — golang.org/x/mod ${recorded} across ${deps} deps"
 
 # ---------- Stage 5b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -71,12 +71,23 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 # github.com/docker/docker v28.5.2 (CVE-2026-34040) is a dependency rather than
 # the toolchain and stays suppressed in /.trivyignore — see Dockerfile.backend
 # for why no override version exists to point at.
+#
+# golang.org/x/mod IS overridden here (#3465), because unlike docker/docker it
+# has a version to point at. CVE-2026-56864 / CVE-2026-56865 (HIGH, fixed in
+# x/mod v0.40.0) burned the v1.7.7 tag; no grype release and not even
+# anchore/grype `main` carries the bump, so this is an override rather than a
+# tag bump, with the removal condition enforced by the guard below. The full
+# justification, the reachability finding and the MVS consequences are in
+# Dockerfile.backend — read it there rather than duplicating a second copy that
+# can drift.
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS grype-bin
 ARG TARGETOS
 ARG TARGETARCH
 ARG GRYPE_VERSION=0.117.0
 ARG GRYPE_COMMIT=b5fa92bbcbef655497e3be840a2f718380e2cdd3
 ARG GO_MIN_PATCH=1.26.6
+ARG XMOD_FROM=v0.38.0
+ARG XMOD_TO=v0.40.0
 
 RUN apk add --no-cache git ca-certificates
 
@@ -100,6 +111,36 @@ RUN set -eu; \
       exit 1; \
     fi
 
+# Dependency override — see Dockerfile.backend for the full note (#3465).
+RUN set -eu; \
+    xmod_pin() { sed -n 's|^[[:space:]]*golang\.org/x/mod \(v[^ ]*\).*|\1|p' go.mod | head -n1; }; \
+    have="$(xmod_pin)"; \
+    if [ "${have}" != "${XMOD_FROM}" ]; then \
+      echo "ERROR: grype v${GRYPE_VERSION} pins golang.org/x/mod ${have}, not ${XMOD_FROM}." >&2; \
+      echo "       This override was written against ${XMOD_FROM}. If upstream now" >&2; \
+      echo "       ships >= ${XMOD_TO}, DELETE the override block in this stage." >&2; \
+      echo "       If it moved to some other version, re-review it. See #3465." >&2; \
+      exit 1; \
+    fi; \
+    go get "golang.org/x/mod@${XMOD_TO}"; \
+    got="$(xmod_pin)"; \
+    if [ "${got}" != "${XMOD_TO}" ]; then \
+      echo "ERROR: override did not take: go.mod pins golang.org/x/mod ${got}." >&2; \
+      exit 1; \
+    fi; \
+    moved="$(git --no-pager diff --unified=0 go.mod \
+             | sed -n 's|^+[[:space:]]*\([^ ]*\) v.*|\1|p' | sort -u | tr '\n' ' ')"; \
+    expected="golang.org/x/crypto golang.org/x/mod golang.org/x/net golang.org/x/text golang.org/x/tools "; \
+    if [ "${moved}" != "${expected}" ]; then \
+      echo "ERROR: go get moved an undeclared set of modules." >&2; \
+      echo "       expected: ${expected}" >&2; \
+      echo "       actual:   ${moved}" >&2; \
+      echo "       Re-review the override and update the declared set (#3465)." >&2; \
+      exit 1; \
+    fi; \
+    go mod verify; \
+    echo "grype build: override applied — golang.org/x/mod ${XMOD_FROM} -> ${XMOD_TO}"
+
 RUN set -eu; \
     build_date="$(TZ=UTC git log -1 --format=%cd --date=format-local:%Y-%m-%dT%H:%M:%SZ)"; \
     CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
@@ -111,6 +152,26 @@ RUN set -eu; \
           -X main.buildDate=${build_date}" \
         ./cmd/grype; \
     install -Dm644 LICENSE /licenses/grype/LICENSE
+
+# Prove the override reached the compiled binary's build info, which is what
+# Trivy actually reads — see Dockerfile.backend (#3465).
+RUN set -eu; \
+    info="$(go version -m /grype)"; \
+    deps="$(printf '%s\n' "${info}" | grep -c '^[[:space:]]*dep[[:space:]]')"; \
+    if [ "${deps}" -lt 50 ]; then \
+      echo "ERROR: /grype reports only ${deps} dependency records; build info is" >&2; \
+      echo "       unreadable or implausible, so the override is unverified." >&2; \
+      exit 1; \
+    fi; \
+    recorded="$(printf '%s\n' "${info}" \
+                | sed -n 's|^[[:space:]]*dep[[:space:]]*golang\.org/x/mod[[:space:]]*\(v[^[:space:]]*\).*|\1|p' \
+                | head -n1)"; \
+    if [ "${recorded}" != "${XMOD_TO}" ]; then \
+      echo "ERROR: compiled grype records golang.org/x/mod '${recorded}', want ${XMOD_TO}." >&2; \
+      echo "       The Trivy gate reads this build info; the override did not ship (#3465)." >&2; \
+      exit 1; \
+    fi; \
+    echo "grype build: build info verified — golang.org/x/mod ${recorded} across ${deps} deps"
 
 # ---------- Stage 4b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted


### PR DESCRIPTION
## Summary

Fixes #3465. **Docker Publish on `main` is red on this and has published no images since 2026-08-19**, so `v1.8.1` cannot be tagged. The same finding burned `v1.7.7` on `release/1.7.x`.

Run [32419016885](https://github.com/artifact-keeper/artifact-keeper/actions/runs/32419016885) (and 32337069636 before it), `Security Scan`:

```
ghcr.io/…/artifact-keeper-backend@sha256:830f1c04…  (redhat 9.8)   0
usr/local/bin/grype                                 (gobinary)     2

usr/local/bin/grype (gobinary)   Total: 2 (HIGH: 2, CRITICAL: 0)
  golang.org/x/mod  CVE-2026-56864  HIGH  fixed  v0.38.0 -> 0.40.0
  golang.org/x/mod  CVE-2026-56865  HIGH  fixed  v0.38.0 -> 0.40.0
```

Note the base OS scans **0** — this binary is the only thing holding the backend image's gate open. Note also it is **two** CVEs, not one; `-56865` is easy to miss behind the merged severity column.

Every `merge-*` job `needs` this gate, so all of them skipped.

## Why an override and not a bump

The `grype-bin` stage already has two levers, and neither reaches this:

* **Not a Go stdlib CVE**, so raising `GO_MIN_PATCH` does nothing (#3352's lever) — `golang.org/x/mod` is a module in grype's dependency graph.
* **No release to bump to.** `v0.117.0` (2026-08-10) is the latest anchore/grype release, `v0.118.0` does not exist, **and `main` (`ffbca56`, 2026-08-14) still pins `x/mod v0.38.0`** with no open or merged PR moving it. Upstream has not made this bump anywhere. Contrast the scanner-adapter's copy of the identical finding, cleared by a plain version bump because upstream Trivy `v0.74.0` carries `x/mod v0.40.0` itself.

So both backend Dockerfiles apply `go get golang.org/x/mod@v0.40.0` after the commit-pin verification (left intact — it is a supply-chain statement, not a naming convention) and before `go build`, modelled on the `artifact-keeper/trivy` override policy.

**Flagging explicitly: that policy's condition 2 is not satisfied here.** It asks that upstream have already made the same bump, on `main` or in a merged PR, so that we are not getting ahead of their judgement about their own dependencies. They have not. This override goes one step further than those rules allow. It is recorded as such in the Dockerfile comment rather than filed as routine, and a reviewer who thinks that line should not be crossed should say so — the alternative is a `.trivyignore` suppression, which the team's standing decision rejects while a fix exists.

`go get` rather than `go mod edit -require`, for two reasons: it resolves through MVS and writes checksum-database-verified hashes into `go.sum` in the same step (a `-require` edit writes no `go.sum` and leaves `go.mod` inconsistent — `x/mod v0.40.0` requires `x/tools v0.49.0`, which `-require` would not select), and unlike a `replace` directive it records the **real** upgraded version in the binary's Go build info, which is exactly what a scan and any published SBOM read. `go mod tidy` afterwards is a verified no-op on `go.mod` and only costs a full test-dependency download, so it is not run.

**MVS consequences are documented, not incidental.** Selecting `x/mod v0.40.0` also moves `x/tools` 0.48→0.49 (required by x/mod v0.40.0), and with it `x/crypto` 0.54→0.55, `x/net` 0.57→0.58, `x/text` 0.40→0.41. All five are `golang.org/x` co-released modules and the set is deterministic given the pinned grype commit.

Three build-time guards, so this cannot rot:

| Guard | Behaviour |
|---|---|
| Pinned source no longer requires `v0.38.0` (upstream shipped the fix) | **fails the build** — the block must be deleted. The tag bump that makes the override redundant is what stops the build until someone removes it. |
| `go get` moved a module outside the declared five | **fails the build** rather than shipping an undeclared divergence |
| The compiled binary's Go build info does not record `v0.40.0` | **fails the build**, with a dependency-record plausibility check so it cannot report "verified" against build info it failed to parse |

## Reachability — why this was correct hygiene, not an emergency

**The vulnerable code was never linked into the binary.** Both advisories are scoped to specific import paths — `golang.org/x/mod/sumdb` (`Client.Lookup`, GO-2026-6180) and `golang.org/x/mod/sumdb/tlog` (`tileHashReader.ReadHashes`, GO-2026-6179), the GOSUMDB transparency-log client:

```
$ go mod why golang.org/x/mod/sumdb
(main module does not need package golang.org/x/mod/sumdb)

$ go list -deps ./cmd/grype | grep ^golang.org/x/mod
golang.org/x/mod/internal/lazyregexp
golang.org/x/mod/semver
golang.org/x/mod/module
golang.org/x/mod/modfile
```

`x/mod` arrives only via `cmd/grype/cli/commands/internal/jsonschema` → `x/tools/go/packages` → `x/tools/internal/gocommand` → `x/mod/semver`. Trivy flags Go binaries at **module** granularity from the embedded build info and cannot see which packages were linked; `govulncheck`, which works at symbol granularity, would call this binary unaffected.

It is still fixed at source rather than suppressed. `.trivyignore` is for findings with no fix available in a tool we can build; this one has a fix. Reachability changes how alarming the finding is, not whether a fixable HIGH gets fixed — and a reviewer should not have to rediscover this to judge the PR.

## Scope and sequencing

**This PR alone does not turn Docker Publish green.** The same run also fails on `usr/local/bin/trivy` in the scanner-adapter image with the identical CVE pair. That is being cleared separately by repointing at a Trivy build carrying `x/mod v0.40.0`; `docker/Dockerfile.scanner-adapter` and `docker/scanner-adapter/VERSION` are deliberately **untouched** here. Both changes are required before `main` publishes again.

`docker/Dockerfile.backend.alpine` carries the identical stage per its own byte-for-byte requirement and the drift rule in `CLAUDE.md`; the two stages share a build-cache entry, which is the proof.

This lands on `main` first and will be cherry-picked to `release/1.7.x` with `-x`, so the maintenance branch gets it through the clean-cherry-pick path of the release-branch gate rather than through a bypass label.

One inaccuracy noticed but **not** fixed here, to keep this diff to one thing: `Dockerfile.backend.alpine`'s comment claims "the guard in `backend/src/config.rs` fails the build if they disagree". No such guard exists — nothing under `backend/` references either Dockerfile. Worth a follow-up; the drift rule is currently enforced by convention only.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The regression test is in the Dockerfile and runs on every build, which is the only place that can catch this class — a Rust unit test cannot observe what a Go linker put in a binary. The build-info assertion fails the build if the override is absent from the compiled artifact, and the `from`-version guard fails it if the override has gone stale: the two ways this fix could silently stop working. Both were exercised (each fails as intended when violated) and pass on this branch.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

**Gate reproduction**, linux/arm64, trivy `0.69.3`, `--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1`, **using `main`'s own `.trivyignore`** (it differs from the 1.7.x copy, so it was re-run rather than assumed):

| | `usr/local/bin/grype` | gate exit |
|---|---|---|
| before | **2 (HIGH: 2)** | **1** |
| after | **0** | **0** |

Also verified end to end on a full backend image built with CI's `no-cache-filters: rootfs-builder,grype-bin,grype-db-seed,runtime` — whole image **0 findings, gate exit 0** — and on a cross-compiled amd64 `grype-bin`, so this is not arch-specific. The grype binary produced from this branch is **byte-identical** (`sha256:cadb1a16…`) to the one produced from the `release/1.7.x` branch of the same change, so the two lines are provably getting the same artifact.

**No collateral.** With all severities and no ignorefile, the only remaining findings in the image are the pre-existing, already-documented `github.com/docker/docker v28.5.2` pair (`CVE-2026-34040` HIGH, `CVE-2026-33997` MEDIUM) that `.trivyignore` covers and for which no resolvable fixed version exists. Zero Go **stdlib** findings — the `GO_MIN_PATCH=1.26.6` floor holds and the binary reports `GoVersion: go1.26.6`. Bumping the five `golang.org/x` modules introduced nothing new.

Worth knowing for whoever cuts the tag: an earlier local scan reported 4 HIGH in the UBI base (`curl-minimal`/`libcurl`, `CVE-2026-8286`, `CVE-2026-9547`) purely because the `rootfs-builder` layer was a local cache hit. A fresh `rootfs-builder` installs the fixed `curl-minimal-7.76.1-40.el9_8.5` and they vanish. CI is already correct (`no-cache-filters` covers it), and the failing run above confirms the base scans 0 — but it is a live reminder that a locally-cached scan is not evidence when clearing a release gate (#2391's failure mode).

**grype still works** (verified against the rebuilt binary):
- `grype --version` prints exactly `grype 0.117.0` — asserted as string equality, since `GrypeScanner` parses it into `scanner_version` (#3287 composes it with the CVE-DB build date).
- `grype version` reports `GitCommit: b5fa92bb…`, `GitDescription: v0.117.0`, `Supported DB Schema: 6` (so the DB seeded in stage 5b still loads), `GoVersion: go1.26.6`.
- `grype db update` succeeds and real scans work on a `docker-archive:` target (correctly reports the `docker/docker` advisories in a Go binary) and a `dir:` target (correctly reports apk packages). Stage 5b's `grype db update` ran fresh in the no-cache build, exercising the pre-seed path end to end.

**Pre-push checks:** `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --lib` **15713 passed / 0 failed / 8 ignored**. **DB-backed tests were not run** — no `AK_TESTS_REQUIRE_DB=1` and no Postgres, so anything requiring a database silently no-opped. This PR changes no Rust, so that gap is not load-bearing here, but it is stated rather than implied.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
