### PR TITLE
fix(ci): port the [Unreleased] CHANGELOG guard to release/1.7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,6 +593,27 @@ jobs:
       - name: Check release-branch gate exemptions stay narrow
         run: bash scripts/ci/test-check-release-branch-commits.sh
 
+      # A release prep that renames `## [Unreleased]` to `## [X.Y.Z]` without
+      # opening a fresh empty one strands every entry that lands after it: PR
+      # branches cut before the rename anchor into the renamed, ALREADY
+      # RELEASED section and merge with no conflict and no warning. That is
+      # how 30 entries of 1.8.0 work ended up filed under `[1.7.5]`, a version
+      # that produced no images and no release object (#3433, #3429).
+      #
+      # It matters at least as much on THIS branch as on main: v1.7.3, v1.7.4,
+      # v1.7.6 and v1.7.8 were all cut from here, and a release prep is
+      # precisely the kind of commit that lands on a maintenance branch. The
+      # gate has been on main since #3436 and was never ported (#3541).
+      #
+      # The assertion is one grep — the first `## [` heading must be
+      # `## [Unreleased]` — and it is a repo-state invariant, so it fires on
+      # whichever PR reaches CI first rather than depending on who did it.
+      - name: Check CHANGELOG has an open [Unreleased] section
+        run: ./scripts/ci/check-changelog-unreleased.sh
+
+      - name: Check the CHANGELOG gate catches what it must
+        run: bash scripts/ci/test-check-changelog-unreleased.sh
+
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `[Unreleased]` CHANGELOG guard now runs on this branch too** (#3541). `scripts/ci/check-changelog-unreleased.sh` has been on `main` since #3436, where it closes the #3433 shape: a release-prep commit that renames `## [Unreleased]` to `## [X.Y.Z]` without opening a fresh empty one, after which every PR branch cut before the rename merges its hunk into the *already-released* section with no conflict and no warning. It was never ported here — yet v1.7.3, v1.7.4, v1.7.6 and v1.7.8 were all cut from this branch, and a release prep is exactly the kind of commit that lands on a maintenance branch. The gate and its self-test now run in the `shell-tests` job.
+
 ## [1.7.8] - 2026-08-21
 
 > **`v1.7.7` is a dead tag — do not use it.** It was tagged at `5828bdb`, its

--- a/scripts/ci/check-changelog-unreleased.sh
+++ b/scripts/ci/check-changelog-unreleased.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# CI gate for issue #3433: a release-prep commit that renames
+# `## [Unreleased]` to `## [X.Y.Z]` WITHOUT opening a fresh empty
+# `## [Unreleased]` above it silently strands every entry that lands after.
+#
+# What happened: `7aab4b7 chore(release): prepare 1.7.5` did exactly that.
+# Every PR branch cut before the rename still anchored its CHANGELOG hunk on
+# the old heading, so the entries merged cleanly into the *renamed, already
+# released* section. No conflict. No warning. 30 entries of 1.8.0 work ended
+# up under `## [1.7.5]` — a version that produced no images and no release
+# object (#3429) — and would have shipped undocumented. Two were
+# upgrade-affecting: #3286 (storage accounting) and #3231 (Rekor SET).
+#
+# The assertion is deliberately the cheapest thing that would have caught it:
+# the FIRST `## [` heading in CHANGELOG.md must be exactly `## [Unreleased]`.
+# That is a repo-state invariant, not a diff check, so it fires on whichever
+# PR notices it first rather than depending on who made the change — and it
+# cannot be satisfied by a heading that merely contains the word.
+#
+# Scope, stated honestly: this runs in the `shell-tests` job, which is skipped
+# on docs-only PRs. A CHANGELOG-only PR that removed the heading would
+# therefore not be caught until the next code PR. That is delayed detection,
+# not a hole: the real failure mode is a release-prep commit, and those always
+# touch Cargo.toml, so they always run this.
+#
+# Env:
+#   CHANGELOG_FILE  file to check (default CHANGELOG.md at the repo root);
+#                   exists so the self-test can point at fixtures.
+#
+# Exit codes: 0 clean, 1 the first heading is not `## [Unreleased]`, 2 infra
+# (file missing).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHANGELOG_FILE="${CHANGELOG_FILE:-$ROOT/CHANGELOG.md}"
+
+if [[ ! -f "$CHANGELOG_FILE" ]]; then
+  echo "INFRA: changelog not found: $CHANGELOG_FILE" >&2
+  exit 2
+fi
+
+# Keep-a-Changelog version headings are `## [...]` at column 0. Anything
+# else (`# Changelog`, `### Added`, prose) is not a version heading.
+first_heading="$(grep -m1 '^## \[' "$CHANGELOG_FILE" || true)"
+
+if [[ -z "$first_heading" ]]; then
+  echo "::error::$(basename "$CHANGELOG_FILE") has no '## [' version heading at all." \
+    "Expected '## [Unreleased]' at the top of the version list (#3433)."
+  exit 1
+fi
+
+# Trailing whitespace is tolerated; a date suffix is not — `## [Unreleased] -
+# 2026-01-01` means the section has been dated, i.e. released.
+trimmed="${first_heading%"${first_heading##*[![:space:]]}"}"
+if [[ "$trimmed" != "## [Unreleased]" ]]; then
+  echo "::error title=CHANGELOG has no open [Unreleased] section::First version heading in $(basename "$CHANGELOG_FILE") is '${first_heading}', expected '## [Unreleased]'."
+  echo
+  echo "A release prep promotes '## [Unreleased]' to '## [X.Y.Z] - <date>' and"
+  echo "MUST open a fresh empty '## [Unreleased]' above it (RELEASING.md step 3)."
+  echo "Without it, PR branches cut before the promotion merge their entries"
+  echo "into the ALREADY-RELEASED section with no conflict and no warning —"
+  echo "that is how 30 entries of 1.8.0 work ended up filed under [1.7.5]"
+  echo "(#3433)."
+  echo
+  echo "Fix: add"
+  echo
+  echo "  ## [Unreleased]"
+  echo
+  echo "immediately above '${first_heading}' in $(basename "$CHANGELOG_FILE")."
+  exit 1
+fi
+
+echo "CHANGELOG: first version heading is '## [Unreleased]'"

--- a/scripts/ci/test-check-changelog-unreleased.sh
+++ b/scripts/ci/test-check-changelog-unreleased.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/check-changelog-unreleased.sh (#3433).
+#
+# The regression case is case 2: the exact shape `7aab4b7 chore(release):
+# prepare 1.7.5` left behind — a dated version heading at the top with no
+# `## [Unreleased]` above it. Everything else exists so the gate cannot pass
+# by accident (a heading that merely mentions Unreleased, an `### Added`
+# subsection reached first, a file with no version headings at all).
+#
+# Usage: bash scripts/ci/test-check-changelog-unreleased.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-changelog-unreleased.sh"
+[ -f "$SCRIPT" ] || {
+  echo "cannot find check-changelog-unreleased.sh next to this test" >&2
+  exit 2
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+n=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+fail() {
+  printf '  \033[31mFAIL\033[0m  %s\n' "$*"
+  fails=$((fails + 1))
+}
+
+run_case() { # <label> <expected-exit> <expected-substring> <changelog body on stdin>
+  local label="$1" want="$2" needle="$3" f out got
+  n=$((n + 1))
+  f="$WORK/changelog.$n.md"
+  cat > "$f"
+  out="$(CHANGELOG_FILE="$f" bash "$SCRIPT" 2>&1)"
+  got=$?
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    printf '%s\n' "$out" | sed 's/^/        /' >&2
+  elif [ -n "$needle" ] && ! printf '%s\n' "$out" | grep -qF "$needle"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    printf '%s\n' "$out" | sed 's/^/        /' >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+echo "check-changelog-unreleased (#3433)"
+
+# 1. The correct shape: a fresh empty Unreleased above the newest release.
+run_case "open [Unreleased] above the newest release -> clean" 0 "## [Unreleased]" << 'EOF'
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [1.8.0] - 2026-08-17
+
+### Fixed
+- something
+EOF
+
+# 2. THE REGRESSION (#3433): the 1.7.5 prep promoted the heading and opened
+#    nothing above it. Entries merged into a released section, silently.
+run_case "newest heading is a released version -> fail" 1 "expected '## [Unreleased]'" << 'EOF'
+# Changelog
+
+## [1.7.5] - 2026-08-14
+
+### Fixed
+- an entry that actually belongs to 1.8.0
+EOF
+
+# 3. A heading that merely mentions the word is not an open section. Dating
+#    `[Unreleased]` is the same mistake wearing the right name.
+run_case "dated [Unreleased] heading -> fail" 1 "expected '## [Unreleased]'" << 'EOF'
+# Changelog
+
+## [Unreleased] - 2026-08-14
+
+### Fixed
+- x
+EOF
+
+# 4. `### Added` must not be mistaken for a version heading (grep anchored on
+#    '^## \[' rather than 'Unreleased' anywhere).
+run_case "subsection heading before the first version heading -> still checked" 1 "expected '## [Unreleased]'" << 'EOF'
+# Changelog
+
+### Added
+- stray subsection
+
+## [1.8.0] - 2026-08-17
+- x
+EOF
+
+# 5. No version headings at all is its own error, not a pass.
+run_case "no version headings -> fail" 1 "no '## [' version heading" << 'EOF'
+# Changelog
+
+Nothing here yet.
+EOF
+
+# 6. Trailing whitespace on the heading is tolerated (editors add it).
+#    Written with printf rather than a heredoc so the trailing spaces survive
+#    every editor and formatter that touches this file.
+printf '# Changelog\n\n## [Unreleased]   \n\n## [1.8.0] - 2026-08-17\n' > "$WORK/trailing.md"
+out="$(CHANGELOG_FILE="$WORK/trailing.md" bash "$SCRIPT" 2>&1)"
+got=$?
+if [ "$got" = "0" ]; then
+  pass "trailing whitespace on the heading tolerated (exit 0)"
+else
+  fail "trailing whitespace: expected exit 0, got $got"
+  printf '%s\n' "$out" | sed 's/^/        /' >&2
+fi
+
+# 7. Missing file is INFRA (exit 2), not a pass.
+out="$(CHANGELOG_FILE="$WORK/nope.md" bash "$SCRIPT" 2>&1)"
+got=$?
+if [ "$got" = "2" ] && printf '%s\n' "$out" | grep -qF "INFRA"; then
+  pass "missing changelog -> INFRA (exit 2)"
+else
+  fail "missing changelog: expected exit 2 with INFRA, got $got"
+fi
+
+# 8. The real tree must be clean — this is the live gate over CHANGELOG.md.
+#    If this fails, main is stranding entries RIGHT NOW.
+out="$(bash "$SCRIPT" 2>&1)"
+got=$?
+if [ "$got" = "0" ]; then
+  pass "CHANGELOG.md on this tree has an open [Unreleased] section"
+else
+  fail "CHANGELOG.md on this tree: expected exit 0, got $got"
+  printf '%s\n' "$out" | sed 's/^/        /' >&2
+fi
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "$fails case(s) failed"
+  exit 1
+fi
+echo "all cases passed"


### PR DESCRIPTION
## Summary

Closes #3541. Companion to #3539 (main); kept separate because 7 of the 8
release-engineering files differ between the two branches.

`scripts/ci/check-changelog-unreleased.sh` has been on `main` since #3436.
It closes the #3433 shape: a release-prep commit that renames
`## [Unreleased]` to `## [X.Y.Z]` without opening a fresh empty one, after
which every PR branch cut before the rename merges its hunk into the
*already-released* section — no conflict, no warning. That is how 29–35
bullets of 1.8.0 work ended up filed under `[1.7.5]`.

It was never ported here, and **this is the branch v1.7.3, v1.7.4, v1.7.6
and v1.7.8 were cut from** — three of the last six releases. A release prep
is exactly the kind of commit that lands on a maintenance branch, so the
gap is not theoretical. The `shell-tests` job already exists here and
already runs the sibling gates, so the port is the two files plus the
wiring.

### Narrowed backport

Only the two script files and the `shell-tests` wiring come across. #3436
also rewrote `docker-publish.yml` and `release-branch-gate.yml`, which this
branch already carries in its own shape, and its CHANGELOG hunk targets
`[Unreleased]` on `main`. The commit carries the
`(cherry picked from commit 5d26971b…)` trailer, so the release-branch gate
resolves it via path D rather than needing `release-process: approved`:

```
✓ narrowed backport of 5d26971b on main (patch differs; hunks were resolved away)
::notice::All 1 PR commit(s) trace back to origin/main. Gate passed.
```

### Verification on this branch's tree

```
$ ./scripts/ci/check-changelog-unreleased.sh
CHANGELOG: first version heading is '## [Unreleased]'

$ bash scripts/ci/test-check-changelog-unreleased.sh
  PASS  open [Unreleased] above the newest release -> clean (exit 0)
  PASS  newest heading is a released version -> fail (exit 1)      <- the 1.7.5 prep
  PASS  dated [Unreleased] heading -> fail (exit 1)
  PASS  subsection heading before the first version heading -> still checked (exit 1)
  PASS  no version headings -> fail (exit 1)
  PASS  trailing whitespace on the heading tolerated (exit 0)
  PASS  missing changelog -> INFRA (exit 2)
  PASS  CHANGELOG.md on this tree has an open [Unreleased] section
all cases passed
```

The gate is demonstrably able to fail: case 2 constructs the exact state
`7aab4b79 chore(release): prepare 1.7.5` left behind and asserts exit 1,
and case 8 runs the gate against this branch's real `CHANGELOG.md`. Both
are in the ported self-test, which is now wired into `shell-tests`.

`shellcheck -x` clean on both files.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
