### PR TITLE
fix(proxy): serve stale when upstream refuses revalidation

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -747,6 +747,23 @@ fn validate_upstream_status(status: StatusCode, url: &str) -> Result<()> {
     Ok(())
 }
 
+/// Whether a revalidation response status says anything about whether the
+/// cached content changed.
+///
+/// A throttle (429), a refusal (403) or an upstream fault (5xx) is the upstream
+/// declining to answer the question, not answering "yes". Treating them as
+/// "changed" discards a valid cached entry and spends a full refill on an
+/// upstream that is already refusing us, which is strictly worse than serving
+/// the copy we hold: the refill cannot succeed where the probe was refused.
+///
+/// 401 is deliberately excluded, the OCI bearer-token exchange depends on it
+/// meaning "re-fetch with a token".
+fn revalidation_status_carries_no_content_information(status: StatusCode) -> bool {
+    status == StatusCode::FORBIDDEN
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
 /// Whether a single path segment is a dot segment, in the same sense the WHATWG
 /// URL parser uses when it normalizes a path.
 ///
@@ -3096,6 +3113,18 @@ impl UpstreamClient {
                     url
                 );
                 Ok(true)
+            }
+            status if revalidation_status_carries_no_content_information(status) => {
+                tracing::warn!(
+                    "Upstream returned {} on the ETag check for {}; serving the cached copy instead of refilling",
+                    status,
+                    redact_url_for_diagnostics(url)
+                );
+                Err(AppError::ServiceUnavailable(format!(
+                    "Upstream returned {} on revalidation: {}",
+                    status,
+                    redact_url_for_diagnostics(url)
+                )))
             }
             status => {
                 tracing::warn!(
@@ -12425,6 +12454,38 @@ mod tests {
                 );
             }
             other => panic!("403 must map to redacted AppError::BadGateway; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_revalidation_status_carries_no_content_information() {
+        for status in [
+            StatusCode::FORBIDDEN,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+        ] {
+            assert!(
+                revalidation_status_carries_no_content_information(status),
+                "{status} is a refusal to answer, not a 'yes, it changed'"
+            );
+        }
+
+        // 401 drives the OCI bearer-token re-fetch, and 404/410 are real
+        // statements about the resource. None of them may take the stale path.
+        for status in [
+            StatusCode::UNAUTHORIZED,
+            StatusCode::NOT_FOUND,
+            StatusCode::GONE,
+            StatusCode::OK,
+            StatusCode::NOT_MODIFIED,
+        ] {
+            assert!(
+                !revalidation_status_carries_no_content_information(status),
+                "{status} must keep its existing handling"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #3571

`check_etag_changed`'s catch-all arm answered "changed" for 403, 429 and 5xx on the revalidation HEAD. Those are the upstream declining to answer, not an answer, so the result was a discarded-but-valid cache entry plus a refill attempt against an upstream that had just refused a far cheaper request. On a throttling upstream that makes every stale-entry read compound the throttling.

New predicate `revalidation_status_carries_no_content_information` classifies those three, and the probe returns an error for them instead of `Ok(true)`. That routes them into the stale-if-error path `revalidate_verdict` already implements, so the cached copy is served for up to `STALE_IF_ERROR_GRACE_SECS` (1 hour) past expiry and falls through to a refill after that. Staleness stays bounded by the existing window; this PR adds no new knob and no new unbounded-stale path.

Deliberately excluded:
- **401** drives the OCI bearer-token re-fetch and must keep meaning "retry with a token".
- **404 / 410** are real statements about the resource and keep their current handling.

Scope worth noting for review: `check_etag_changed` has exactly one production caller, `revalidate_verdict`. The other caller, `check_upstream`, is `pub` but is only reached from tests. So the behaviour change is confined to one path.

The one judgement call here is **403**. Treating it as "no information" means that if a repository's upstream credentials are revoked, reads are served from cache for up to the 1 hour grace window before the failure surfaces, rather than failing immediately. That seemed clearly better than the current behaviour, which evicts the cache entry and then fails the download anyway, but it is a policy choice and I am happy to narrow the predicate to 429 and 5xx only if you would rather 403 stayed fatal.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

`test_revalidation_status_carries_no_content_information` pins both directions of the classifier: 403/429/500/502/503/504 are refusals, and 401/404/410/200/304 must keep their existing handling. The second half is the load-bearing one, since the risk in this change is over-reaching and swallowing a status that legitimately means "re-fetch".

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
