### PR TITLE
fix(rpm): walk virtual members on the upstream catch-all

### DIFF
--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1288,7 +1288,9 @@ async fn repodata_proxy(
 
 async fn upstream_proxy(
     State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, upstream_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
 
@@ -1331,12 +1333,45 @@ async fn upstream_proxy(
         return Err((StatusCode::NOT_FOUND, "Not found").into_response());
     }
 
-    // A normal (non-`@N`) request only serves from Remote repos.
+    let filename = upstream_path.rsplit('/').next().unwrap_or(&upstream_path);
+
+    // Virtual repos walk their members here, same as `download_package` does for
+    // `/packages/`. Without this a group over Remote members 404s every real yum
+    // layout (`9-stream/BaseOS/…`, `elrepo/el9/…`, `rpm/<arch>/…`), because those
+    // paths reach this catch-all rather than the `/packages/` or `/repodata/`
+    // routes above. Worse than the 404: the generated `/repodata/` document a
+    // client fetches first renders from the `artifacts` table, which never holds
+    // proxy-cached content (#1278), so dnf is told the repository is empty and
+    // silently does nothing — the #1447 failure, fixed for Remote and missed here.
+    //
+    // `PathSuffix` matches this file's convention (the Remote arm below and
+    // `download_package` both key on the filename); it only affects Local members,
+    // since Remote members are resolved by proxy-fetching `upstream_path`.
+    if repo.repo_type == RepositoryType::Virtual {
+        return match proxy_helpers::try_remote_or_virtual_download(
+            &state,
+            auth.as_ref(),
+            &repo,
+            &ctx,
+            proxy_helpers::DownloadResponseOpts {
+                upstream_path: &upstream_path,
+                virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(filename),
+                default_content_type: "application/octet-stream",
+                content_disposition_filename: None,
+                suppress_upstream_proxy: false,
+            },
+        )
+        .await?
+        {
+            Some(resp) => Ok(resp),
+            None => Err((StatusCode::NOT_FOUND, "Not found").into_response()),
+        };
+    }
+
+    // A normal (non-`@N`) request otherwise only serves from Remote repos.
     if repo.repo_type != RepositoryType::Remote {
         return Err((StatusCode::NOT_FOUND, "Not found").into_response());
     }
-
-    let filename = upstream_path.rsplit('/').next().unwrap_or(&upstream_path);
 
     // Cache hit by filename: serve the local copy.
     if let Some(hit) =
@@ -3743,6 +3778,63 @@ mod tests {
             .await
             .ok();
         f.teardown().await;
+    }
+
+    /// A virtual repo must walk its members on the arbitrary-path catch-all,
+    /// not just on `/packages/`. Real yum layouts put packages under
+    /// `9-stream/BaseOS/x86_64/os/…`, `elrepo/el9/x86_64/…`, `rpm/<arch>/…`,
+    /// all of which reach `upstream_proxy`, which used to 404 anything that was
+    /// not Remote. Two members, artifact only in the SECOND, so a fix that
+    /// merely tried the first member still fails.
+    #[tokio::test]
+    async fn test_rpm_virtual_upstream_path_resolves_from_later_member() {
+        let Some(f) = tdh::Fixture::setup("virtual", "rpm").await else {
+            return;
+        };
+
+        let (empty_id, _k1, empty_dir) = tdh::create_repo(&f.pool, "local", "rpm").await;
+        let (holder_id, holder_key, holder_dir) = tdh::create_repo(&f.pool, "local", "rpm").await;
+        // Anonymous callers only see PUBLIC members: `authorize_virtual_members`
+        // filters the walk, so private members would 404 for reasons unrelated
+        // to the path resolution under test.
+        tdh::publish_repo(&f.pool, empty_id).await;
+        tdh::publish_repo(&f.pool, holder_id).await;
+        let holder_repo = tdh::make_repo_info(holder_id, &holder_key, &holder_dir, "local", None);
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &holder_repo,
+            "el/9/x86_64/deep-2.0-1.x86_64.rpm",
+            "el/9/x86_64/deep-2.0-1.x86_64.rpm",
+            "deep",
+            "2.0-1",
+            "application/x-rpm",
+            bytes::Bytes::from_static(b"deep-member-rpm"),
+            f.user_id,
+        )
+        .await;
+
+        tdh::link_virtual_member(&f.pool, f.repo_id, empty_id, 0).await;
+        tdh::link_virtual_member(&f.pool, f.repo_id, holder_id, 1).await;
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/el/9/x86_64/deep-2.0-1.x86_64.rpm", f.repo_key)),
+        )
+        .await;
+
+        // Cleanup BEFORE asserting so a failure does not leak member rows/dirs.
+        tdh::cleanup_member_repo(&f.pool, empty_id, &empty_dir).await;
+        tdh::cleanup_member_repo(&f.pool, holder_id, &holder_dir).await;
+        f.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "virtual repo must resolve an arbitrary upstream path from a member"
+        );
+        assert_eq!(&body[..], b"deep-member-rpm");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #3573

`upstream_proxy` (the RPM catch-all for any path that is not `/packages/` or `/repodata/`) served Remote repositories only, so a Virtual repo 404'd every real yum layout: `9-stream/BaseOS/x86_64/os/…`, `elrepo/el9/x86_64/…`, `rpm/<arch>/…`. Combined with generated repodata rendering from the `artifacts` table, which never holds proxy-cached content (#1278), the client is handed a valid empty index and installs nothing without erroring.

The fix walks Virtual members on this route, using the same `try_remote_or_virtual_download` call `download_package` already makes on `/packages/`, with identical options (`VirtualLookup::PathSuffix`, `suppress_upstream_proxy: false`). `PathSuffix` is the documented convention for filename-keyed handlers including rpm, and it only affects Local members, since Remote members resolve by proxy-fetching `upstream_path`.

No new pattern is introduced. `download_package` in this same file already does this, and the debian handler already handles Virtual on its catch-all paths; RPM's catch-all was the outlier.

Placement: the Virtual branch goes after the existing `@N` pinned-member handling so that path is untouched, and before the `repo_type != Remote` rejection it replaces for the Virtual case. Local and Remote behaviour on this route is unchanged.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

`test_rpm_virtual_upstream_path_resolves_from_later_member` builds a Virtual repo over two Local members and stores the artifact in the **second** one, at a nested path (`el/9/x86_64/deep-2.0-1.x86_64.rpm`) that reaches the catch-all rather than `/packages/`. Seeding the second member is deliberate: a fix that only consulted the first member would still pass a single-member test.

Verified in both directions against a live Postgres:
- on this branch, passes
- with the new branch condition neutralized, fails with `404 != 200` at the documented assertion

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean. The test is DB-backed, so it was run with `AK_TESTS_REQUIRE_DB=1` to ensure it could not pass by skipping.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
