### PR TITLE
chore(release): prepare 1.8.2

### DIFF
--- a/.github/release-notes/1.8.2.md
+++ b/.github/release-notes/1.8.2.md
@@ -1,0 +1,122 @@
+# Artifact Keeper 1.8.2
+
+A patch release with **one scanner fix that will change your results** — npm packages published straight to a hosted repository were never actually graded, and now they are — plus a WASM sandbox-escape dependency bump, four proxy/remote repositories that could not do the one job a proxy exists for, and a run of supply-chain work that makes the images and binaries we ship provable rather than merely signed. No schema migrations.
+
+Two sections below are upgrade notes. Read them if you gate on npm scan results, or if you run more than one deployment against a single S3 bucket.
+
+## Read this first — npm scan results change, and npm promotion gates may start blocking
+
+**Before this release, npm packages published directly to a hosted repository were not being scanned** (#3442). They were *reported* as scanned — `completed`, zero findings, no error — but the CVE engine had nothing to look at and graded nothing. The hosted-upload path extracts the tarball and runs the engine in directory mode, and directory-source cataloging reads `package-lock.json` but not the standalone `package/package.json` that a published npm tarball ships. So the engine cataloged nothing, matched nothing, and returned a clean bill of health. "Nothing was assessed" and "the artifact is clean" were the same result.
+
+Measured on a hosted `lodash@4.17.11` — a version with 1 Critical and 3 High against a current database — the old path reported `completed, findings_count = 0, 0 cataloged`. It now reports 7 findings (1 Critical, 3 High, 3 Medium), matching what the engine reports for that coordinate directly. A genuinely clean package still reports zero.
+
+**What this means for you.** Any promotion rule, quarantine policy or severity threshold you have configured against npm has been passing not because the packages were clean but because nothing was examined. After upgrading, those same packages return their real findings, and **gates that have always passed will begin to fail for artifacts that have not changed.** That is the correct outcome — a control that silently passes everything is worse than no control — but it will arrive as a blocked promotion if you are not expecting it.
+
+The change takes effect **at the next scan**, not at upgrade. Stored results are not rewritten, so previously-scanned artifacts keep their zero-finding rows until something rescans them. Note that native `npm publish` does not itself trigger a scan, so a package published that way is graded only when a scan is subsequently triggered against it. A completed zero-finding row is reusable by checksum for 24 hours, so a rescan issued right after upgrading should pass `bypass_dedup: true` to avoid being handed the stale result it is trying to escape.
+
+**To size the blast radius before you upgrade**, list the hosted npm artifacts whose current clean verdict was never actually earned:
+
+```sql
+SELECT r.key AS repository, a.name, a.version, s.completed_at
+FROM scan_results s
+JOIN artifacts a ON a.id = s.artifact_id
+JOIN repositories r ON r.id = a.repository_id
+WHERE r.format IN ('npm', 'yarn', 'bower', 'pnpm')
+  AND r.repo_type IN ('local', 'staging')
+  AND s.scan_type = 'grype'
+  AND s.status = 'completed'
+  AND s.findings_count = 0
+  AND a.is_deleted = false
+ORDER BY r.key, a.name, a.version;
+```
+
+Every row is a package that will be graded for the first time on its next scan. Check those coordinates against your advisory source, or upgrade a staging instance and rescan there, before you decide whether to upgrade with npm gates enabled. If you need to land the upgrade before you have triaged the list, raise the affected repositories' `max_severity` threshold or disable the npm promotion rule for the duration — and put it back once you have looked.
+
+Alongside the grading fix, the scan-reuse identity now carries the coordinate, so a verdict computed for one package can no longer be served for another. Scoped deliberately to npm and its handler aliases (`yarn`, `bower`, `pnpm`); PyPI sdists, RubyGems, Cargo and NuGet have the same blindness on the same path and are tracked in #3603 rather than widened into this fix, because each needs its own design decision and carries its own upgrade note.
+
+## Read this second — one cache-miss burst if you share an S3 bucket
+
+**Two deployments sharing one S3 bucket shared one proxy cache, and served each other's cached upstream bytes** (#3454). Proxy-cache content is anchored at the bucket root rather than under `S3_PREFIX`, deliberately so — that anchoring is what makes a prefixed deployment read back what it wrote (#3368). But the whole namespace was `proxy-cache/<repo_key>/<path>/__content__`, with nothing in the key naming the deployment that produced it. Two deployments pointed at the same bucket and separated only by `S3_PREFIX` therefore shared one key space, and two repositories that happened to carry the same key — `maven-proxy`, `npm-remote`, whatever you called them — addressed the same physical object.
+
+Reproduced live against two deployments on one bucket with distinct prefixes, distinct databases and distinct upstreams: whichever fetched first wrote the object, and the other then served those bytes from its own endpoint — content it never fetched, from an upstream it is not configured to use. It is a two-way exchange rather than a one-way leak, so it is equally a cache-poisoning primitive against the other deployment's users. Neither `S3_PREFIX`, nor separate databases, nor IAM policies scoped to different artifact prefixes prevented it, because the cache is not addressed through any of them.
+
+Cache keys now carry a per-deployment scope segment placed *inside* the reserved namespace: `proxy-cache/<scope>/<repo_key>/<path>/__content__`. Keeping it inside means the IAM `Resource` list you were told to grant (`arn:aws:s3:::<bucket>/proxy-cache/*`) still covers it — **no policy needs re-cutting**. The scope defaults to the deployment's persistent peer instance id, which is stable across restarts and upgrades and shared by every replica, so a horizontally scaled deployment still shares one cache. `PROXY_CACHE_SCOPE` overrides it with a legible token; there is deliberately no value that turns scoping off.
+
+**Upgrade note — expect one cold-cache burst.** A key-layout change cannot both isolate and keep addressing the old objects, so this takes the cold path rather than falling back to the shared layout, which would preserve exactly the cross-deployment reads being fixed. On first start after upgrading, every derived proxy-cache lookup misses once and refetches, then warms normally: a one-off burst of upstream traffic proportional to your working set, and no correctness change — a proxy cache miss is a refetch, not data loss. Nothing becomes unreachable, and **no operator action is required.** Objects cached before the upgrade are left in place and simply stop being read; deleting a repository now sweeps both its scoped subtree and the pre-upgrade unscoped one, reclaiming them over time.
+
+**Upgrade note — a handful of very long paths flip from served to a hard 400.** The scope segment is charged against the 1024-byte object-store key budget, which is the store's own hard limit and cannot be raised. The default scope adds 37 bytes to every key, so a path whose pre-upgrade key was within ~37 bytes of the ceiling — roughly 947–990 bytes depending on repository key length — now exceeds the budget and is rejected with a deterministic `400` rather than being cached. The same path always 400s; it does not flap. This affects only pathologically deep coordinates. Shorten the repository key or set a short `PROXY_CACHE_SCOPE` if you rely on such paths.
+
+## Security
+
+**`wasmtime` is bumped to 36.0.14, closing RUSTSEC-2026-0269** (#3608) — a `cap-std` symlink-resolution bug reachable through `wasmtime-wasi` (`GHSA-vqjp-4c8c-hfgg`, CVSS v4 8.8). A guest given write access to any directory inside its sandbox could reach any filesystem location the host process can. wasmtime is not incidental here: it is the engine for the **WASM plugin system**, the one place this product deliberately executes code it did not build, so a broken filesystem sandbox is a failure of the exact control that system's threat model rests on.
+
+**This was not a live escape on a deployed instance, and saying so is the point.** The advisory's precondition is a directory preopened into the guest sandbox, and there is no such call in the backend — the only WASI context in the codebase is built as `WasiCtxBuilder::new().inherit_stdio().build()`, so a plugin gets an empty preopen set and has no descriptor to walk out of. Upstream also notes the bug does not affect a Linux kernel after 5.6 with `openat2`, which is a normal container host. **Plugin operators need take no action beyond upgrading, and no plugin needs re-reviewing for this.** What the bump buys is that the guarantee is real *before* someone needs it: granting a plugin a scratch directory is a one-line, entirely reasonable future change, and on 36.0.13 that line would silently re-arm an 8.8 with no advisory left to notice it. Every released version from **1.7.0 through 1.8.1 carries an affected pin.** Lockfile and manifest only; no source change and no API moved.
+
+Four more security fixes, none requiring operator action:
+
+- **A backup archive's integrity check could be switched off by editing the archive** (#3373). Every archive got a payload checksum in #3011, but the expected value travelled inside the very file it authenticated, and verification returned early when the manifest checksum was empty — so blanking one JSON field disabled the control, and deleting the manifest disabled it the same way. Restore sits behind admin auth, so the untrusted party is not the caller but **the archive**: one tampered with at rest, or pulled back from compromised or third-party storage. The exported table set necessarily includes users, roles and token records.
+- **An empty repository-key segment let an unauthenticated caller make the server buffer a whole upload in memory** (#3508). The visibility middleware short-circuits on an empty key and handed the request to the format handler before its own write-auth gate ran. The handler's body extractor then buffered the entire request body before the in-line auth check could reject it, so the 401 arrived only after the server had read and allocated the upload.
+- **The `/api/helm` and `/api/cargo` alias routes evaluated authorization against the wrong repository** (#3443, #2941, #3000). Both aliases nest one segment deeper than the key extractor models, so the middleware was handed the literal `"helm"` or `"cargo"` as the repository key while axum handed the handler the real one. The middleware checked one repository and the handler served another.
+- **The LDAP login endpoint no longer reveals whether a username exists in the directory** (#3371). An absent directory entry answered `401 "User not found in LDAP"` while an existing username with a bad password answered `401 "Invalid credentials"` — a user-enumeration oracle on an unauthenticated endpoint, letting an attacker confirm accounts from a list and then spray passwords at a verified target set. Every credential-level arm now returns an identical body.
+
+## Proxy and remote repositories
+
+Four fixes for repositories that cached and served correctly but could not tell a client what they held — the failure mode where the client's error blames your version pin rather than the server that never asked its upstream.
+
+- **A Remote Ansible repository advertised no collection versions, so `ansible-galaxy collection install` could resolve nothing** (#3365). `ansible-galaxy` resolves a version entirely from the versions endpoint before requesting any tarball, and that handler queried locally-catalogued artifacts only, with no Remote branch — which for a proxy is empty. It answered `200` with an empty list, and the client reported `Failed to resolve the requested dependencies map`, naming the requirement so it read as a bad version pin. Fetching the same tarball by its full download path already worked, so serving was fine and only discovery was broken. The Remote branch now merges what the upstream publishes over whatever is held locally, walking the listing to completion rather than stopping at the first page — Galaxy clamps page size server-side, and a pinned requirement on an older version lives on a later page. When the upstream is unreachable, locally-held versions are still served with a warning; with nothing held, the upstream's own error is surfaced rather than an empty list, because an empty list is indistinguishable from "this collection has no versions" and reproducing it in the failure path would be the same bug wearing a different hat.
+
+  Two related hardening fixes ship with it: the registry no longer relays an **unverifiable upstream digest**, which silently disabled client-side verification, nor an **upstream-chosen filename**, which could install a different collection's code under the requested name.
+
+- **Images pulled through a Remote Docker repository now appear on the Packages page** (#3611, #3441). A Remote or Virtual-over-Remote Docker repository cached correctly — `docker pull` worked, manifests and blobs showed in the flat artifact view — but the image never appeared as a *package*, while Maven artifacts through the same instance did. The obvious fix does not work and is worth stating: the proxy service only ever sees **blobs**, which are digest-named and versionless, while the identity a user recognises (`image:tag`) exists only in the manifest path, which sits outside the proxy cache on purpose to avoid reintroducing an older doubled-prefix bug. The catalog write therefore goes where the identity is, mirroring the push path. It is gated on the reference being a tag, so a multi-arch pull produces one row for the tag rather than one per architecture, a digest-only pull produces none, and a re-pull upserts.
+
+  Images are also **no longer advertised when the scan gate refuses to serve them** — a blocked image should not appear in the catalog as though it were available.
+
+- **A Remote (proxy) Helm repository served an empty `index.yaml`** (#3448), so `helm pull`, `install` and `upgrade` could not resolve any chart through it — the same shape as the Ansible defect above.
+
+- **Maven checksum sidecars were cached for 5 minutes**, so a build went back to the upstream registry for every checksum it verified (#3459).
+
+## Scanning
+
+**Proxy rescans now say what went wrong** (#3455). `POST /{key}/security/proxy-scans/rescan` collapsed every way of failing to produce a verdict into one indistinguishable `503` with a generic body. "Go configure a scanner", "the scanner is broken" and "give it more time" each demand a different next step, and the endpoint named none of them. The response now carries a machine-readable `code` — `NO_SCANNER_CONFIGURED`, `RESCAN_SCAN_FAILED` or `RESCAN_BUDGET_EXCEEDED` — with a `Retry-After` where retrying is the right move. The underlying scanner error is logged for triage but deliberately not echoed into the body, since it can name internals the caller can act on none of.
+
+The budget half mattered more than the wording. The rescan shared its 30-second timeout with the inline download-time gate, and that budget was sized for a different problem entirely: bounding how long a client's `pip install` waits on a synchronous scan. A rescan has no client on the other end — the only party waiting is the operator who asked for it — so there was never a latency budget to protect, only a borrowed one. The scanner's cost here is a fixed startup cost of loading a large vulnerability database, which a small artifact does nothing to reduce; measured on a 74-byte input doing no meaningful work, wall-clock time was 2.84s unconstrained but 34.75s at 0.1 vCPU, past the old budget on CPU alone. Burstable instances out of credits and noisy-neighbour contention land exactly there. The endpoint now gets its own budget, derived from the router-wide request timeout rather than fixed, with headroom reserved so the outer backstop cannot win the race and mask the very code this change adds.
+
+## Supply chain and release integrity
+
+The images have been signed for some time. What was missing was anything that *checked*, which is a different claim.
+
+- **Every tag `docker-publish.yml` writes is now re-checked after publish**, against a cosign signature over the digest that tag actually resolves to (#3559). The signing step hard-fails, but on the happy path it prints a couple of lines and stops — a green log was never evidence that a signature reached a registry, and the digest it signed was a value the same job computed. Each merge job now starts over from the published tag, resolves it through the registry exactly as `docker pull` would, and requires a signature over what it finds.
+- **The Docker Hub mirrors are now signed and checked the same way** (#3562). Every image was copied to Docker Hub, but cosign was only ever handed the ghcr reference — so the Docker Hub tags carried no signature on anything they have ever published. A signature lives in the repository it was pushed to, so `backend:1.8.1` resolved to an identical digest on both registries while only the ghcr copy was verifiable. Anyone pulling from Docker Hub, which is what the project's own quick-start line tells them to do, had no way to check what they got.
+- **Release binaries are now signed, attested and carry an SBOM, and the release job refuses to publish until it has verified all three** (#3558). Each binary previously shipped with a `.sha256` beside it and nothing else — served from the same place, by the same authority, as the artifact it describes, so it detects a corrupted download while routinely being read as detecting a substituted one.
+- **`:latest` and the floating `X.Y` tags now move only after the release gate has certified the bytes they name** (#3540). Publishing runs on the tag push, necessarily before the gate that tests what it built, so a floating tag moved before any verdict existed — on 1.8.1, `:latest` named gate-uncertified bytes for 78 minutes on a cut where nothing went wrong. The same shape left a retired version publicly pullable as `:latest` for hours with the gate never run.
+
+## Added
+
+**Silent SSO auto-login** (#3546). Users with a live IdP session had to click "Sign in with Keycloak" on every fresh visit, while the obvious fix — auto-redirecting to the sole provider — would bounce every *anonymous* visitor to a login page they never asked for, and anonymous browsing is a first-class registry state. The backend now supports the invisible middle path: the OIDC login route accepts `prompt=none`, and the callbacks map the IdP's expected "no live session" answers to a clean redirect with no error payload, burning the single-use SSO session so the state cannot be replayed. The explicit sign-in flow is unchanged byte-for-byte. **Operator kill switch:** `OIDC_SILENT_SSO=false` disables the attempt fleet-wide; it gates no endpoint, so flipping it can never lock anyone out.
+
+## Also fixed
+
+- Read paths matched `LIKE` patterns without escaping the value that becomes the pattern, so a path, search term or stored name containing `%`, `_` or `\` returned the wrong rows (#3500) — the read-path half of the Maven delete-guard defect, where the same shape caused data loss.
+- Native format routes refused reads a principal was entitled to, and misreported the refusal as a missing member configuration (#3452, #3387, #3386).
+- Every partially-successful migration was recorded as a total failure (#3497); a paused migration that is resumed and stopped again now keeps the record of what it already migrated (#3510); running migrations report a real denominator instead of `N/0` at 0% (#3378); and pausing or cancelling during the final repository no longer flips the job to a terminal status (#3380).
+- Deleting a Docker/OCI manifest through the REST artifact API now unwinds the OCI index in the same transaction as the delete (#3476).
+- The scheduled storage-GC tick no longer runs on every replica at once, and its slowest guard is no longer a full table scan per candidate (#3384).
+- The unit-test suite hung indefinitely under a plain `cargo test` (#3377); the code-duplication gate silently skipped 45% of `backend/src`, so for the repository's largest files it had never been able to fail (#3495); and the container-scan publication guard had been failing on `main` while running in no CI job at all (#3437).
+- Release bookkeeping is now checked by the pipeline instead of by a human days later (#3537), and `release.yml` now requires a Release Preflight rather than treating it as optional (#3538).
+
+## Thank You
+
+- **@mathewnitz-cmg** for #3442 — the npm scan report that turned out to be the release's headline. A `completed` scan with zero findings is the hardest kind of bug to notice, and noticing it is the whole fix.
+- **@groboclown** for #3454, including the detail that the two deployments were separated by `S3_PREFIX` and distinct databases, which is precisely what made the shared cache surprising.
+- **@kibidouil** for #3365, and **@mruzicka** for #3441 — two reports of a proxy that worked perfectly except at telling clients what it had.
+
+## Sponsors
+
+Thank you to our backers for supporting ongoing development:
+
+- **Ash A.** ([@dragonpaw](https://github.com/dragonpaw))
+- **Gabriel Rodriguez** ([@injectedfusion](https://github.com/injectedfusion))
+
+[Become a sponsor](https://github.com/sponsors/artifact-keeper)
+
+**Full changelog:** https://github.com/artifact-keeper/artifact-keeper/compare/v1.8.1...v1.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-09-01
+
 ### Added
 
 - **Silent SSO auto-login support (OIDC `prompt=none` check-sso)** (#3546). Users with a live IdP session (e.g. Keycloak next to other SSO-protected apps) had to click "Sign in with Keycloak" on every fresh visit, while the obvious fix — auto-redirecting to the sole provider — would bounce every *anonymous* visitor to a visible IdP login page they never asked for, and anonymous browsing is a first-class registry state. The backend now supports the invisible middle path the web UI drives (artifact-keeper-web#812): `GET /api/v1/auth/sso/oidc/{id}/login` accepts an optional `prompt=none` forwarded to the authorize URL (only `none` is accepted — anything else is a 400 before any SSO session is created; the explicit sign-in flow without `prompt` is unchanged byte-for-byte), and the OIDC callbacks map the OIDC Core 3.1.2.6 interaction-required error family (`login_required`, `interaction_required`, `consent_required`, `account_selection_required`) — the IdP's expected "no live session" answer to a silent probe — to a clean 307 to `/callback?silent_denied=1` with no error payload, burning the single-use SSO session so the state cannot be replayed. Every other callback error keeps its existing 400/401 behavior, and the CSRF replay defense, provider binding, PKCE, and SSRF posture are untouched. **Operator kill switch:** `OIDC_SILENT_SSO=false` (or `0`) disables the web UI's silent attempt fleet-wide; the flag is advertised as `auth.silent_sso_enabled` in `GET /api/v1/system/config` (default on, display-only — it gates no endpoint, so flipping it can never lock anyone out).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.8.1"
+version = "1.8.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.8.1",
+        version = "1.8.2",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Closes #3614

Bookkeeping-only release prep for **1.8.2**. No source changes — this is the commit that must land before the `v1.8.2` tag.

Milestone [1.8.2](https://github.com/artifact-keeper/artifact-keeper/milestone/49) is complete: **0 open / 51 closed**.

## Changes

| File | Change |
| --- | --- |
| `Cargo.toml` | `[workspace.package] version` 1.8.1 → 1.8.2 |
| `backend/src/api/openapi.rs` | hardcoded OpenAPI `info(version = ...)` 1.8.1 → 1.8.2 |
| `Cargo.lock` | `artifact-keeper-backend` 1.8.1 → 1.8.2 (regenerated) |
| `CHANGELOG.md` | `## [Unreleased]` → `## [1.8.2] - 2026-09-01`, fresh empty `## [Unreleased]` opened above it |
| `.github/release-notes/1.8.2.md` | **new** — curated release notes |

The first three are exactly the set `scripts/ci/release-preflight.sh` check 2 reconciles three ways. Verified locally:

```
cargo=1.8.2 openapi=1.8.2 lock=1.8.2   ->  THREE-WAY OK
```

`Cargo.lock` was regenerated with `cargo update -w`, not hand-edited; the diff is the single expected line. `scripts/ci/check-changelog-unreleased.sh` passes locally — the fresh `[Unreleased]` is the #3433 invariant, and renaming without reopening is what stranded thirty entries under `[1.7.5]`.

## Release notes

Written as curated prose in the house style rather than a PR dump: the two upgrade-affecting changes lead, then security, then the themes. Both upgrade notes reuse the substance already agreed in the CHANGELOG.

- **npm scanning (#3442)** is the headline and gets the "read this first" slot, because it is a **behavior change with a blast radius outside this repository**. Packages that reported clean will start returning real findings, and promotion gates keyed on them may begin failing for artifacts that have not changed. The notes carry the sizing SQL so an operator can measure the exposure before upgrading, plus the `bypass_dedup: true` caveat for the 24-hour reuse window.
- **Proxy-cache scoping (#3454)** gets the second slot for its two operator-visible effects: a one-off cold-cache burst, and long paths within ~37 bytes of the 1024-byte key ceiling now returning a deterministic 400.
- **wasmtime / RUSTSEC-2026-0269 (#3608)** is stated honestly — **not exploitable in our configuration**, because plugins get no preopened directory, while being clear that every release from 1.7.0 through 1.8.1 carries an affected pin and that the value of the bump is making the guarantee real before someone grants a plugin a directory.
- **#3365** (Ansible collection versions, including the unverifiable-digest and upstream-filename hardening), **#3611/#3441** (proxied Docker images on the Packages page, and not advertised when the scan gate refuses to serve them) and **#3448/#3459** are grouped under one "proxy and remote repositories" theme, since they are the same failure shape.
- **#3455** (discriminated `503` with `Retry-After`) gets the scanning section along with the borrowed-budget explanation.
- A supply-chain section covers #3559/#3562/#3558/#3540, which is a real theme in this release rather than a list of chores.

External reporters are credited in **Thank You**: @mathewnitz-cmg (#3442), @groboclown (#3454), @kibidouil (#3365), @mruzicka (#3441).

## Version-display sweep

Swept the repo for every spot that must track the product version. Two things worth recording:

- **The historical stale-version offenders do not apply here.** There is no `web/` directory, no product `package.json` and no `charts/` in this repository — the web package version and the Helm chart `version`/`appVersion` live in `artifact-keeper-web` and `artifact-keeper-iac` and are cut on their own cadence. The only `package.json` and `Chart.yaml` present are E2E fixtures holding a literal `VERSION_PLACEHOLDER`.
- **`backend/src/api/openapi.rs` is the only hardcoded, non-derived version in backend source**, and it is bumped here. Everything else that reports a version — `build_info.rs`, the health handlers, telemetry, the SBOM service, crash reporting — derives from `CARGO_PKG_VERSION` and tracks the `Cargo.toml` bump automatically. Nothing is currently stuck at an older number.

`docker/scanner-adapter/VERSION` is **deliberately untouched**. It is the adapter's own decoupled semver (1.2.7; MAJOR encodes the Harbor Pluggable Scanner API contract), not the product version, and setting it to 1.8.2 would be wrong. It is bumped to 1.2.8 in #3612 instead, because that PR edits `docker/Dockerfile.scanner-adapter` — a watched source path for the adapter's exact-tag immutability check.

## Blocked on #3612 — do not tag yet

Docker Publish's `Security Scan` is red on `main` (`CVE-2026-14456`, openssl in the scanner-adapter's Alpine base). That job hard-gates the manifest → resolve-digest chain, so no images publish and the release chain stops. **#3612 must be merged and green before `v1.8.2` is tagged.**
