### PR TITLE
fix(api): reject NUL byte in artifact path at the boundary (#3545)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -7362,6 +7362,11 @@ pub async fn get_artifact_metadata(
     Query(version_query): Query<ArtifactVersionQuery>,
     dl_ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response> {
+    // #3545: a `%00` in the wildcard segment decodes to a literal NUL that
+    // Postgres rejects at the wire protocol, turning an unauthenticated
+    // request into a 500. Reject at the boundary, before any query runs.
+    crate::api::validation::reject_nul_in_path(&path)?;
+
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_visible(&repo, &auth, &repo_service).await?;
@@ -7652,6 +7657,10 @@ pub async fn list_artifact_versions(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, path)): Path<(String, String)>,
 ) -> Result<Json<ArtifactVersionListResponse>> {
+    // #3545: same boundary check as the artifact metadata/download routes —
+    // a NUL in the path must be a 400 here, not a driver-level 500.
+    crate::api::validation::reject_nul_in_path(&path)?;
+
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_visible(&repo, &auth, &repo_service).await?;
@@ -8575,6 +8584,10 @@ pub async fn download_artifact(
     // for a body that never arrives (the connection hangs).
     let is_head = request.method() == axum::http::Method::HEAD;
 
+    // #3545: reject a NUL byte in the artifact path at the boundary (400)
+    // instead of letting it reach Postgres as an unauthenticated 500.
+    crate::api::validation::reject_nul_in_path(&path)?;
+
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_visible(&repo, &auth, &repo_service).await?;
@@ -9004,6 +9017,11 @@ pub async fn delete_artifact(
 ) -> Result<()> {
     let auth = require_auth(auth)?;
     auth.require_scope("delete")?;
+
+    // #3545: same boundary check as the artifact read routes — a NUL in the
+    // path must be a 400, not a driver-level 500 from the lookup queries.
+    crate::api::validation::reject_nul_in_path(&path)?;
+
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
@@ -17913,7 +17931,7 @@ mod tests {
         let auth = tdh::make_auth(fx.user_id, &fx.username);
         let router = tdh::router_with_auth(super::router(), state, auth);
 
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("POST")
             .uri(format!(
                 "/{}/cache/invalidate?path=foo%2Fbar-1.2.3.tgz",
@@ -17999,7 +18017,7 @@ mod tests {
 
         // Invalidate the HTML representation only.
         let router = tdh::router_with_auth(super::router(), state, auth);
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("POST")
             .uri(format!(
                 "/{}/cache/invalidate?path=simple%2Fproj3290%2F",
@@ -18051,7 +18069,7 @@ mod tests {
         let auth = tdh::make_auth(fx.user_id, &fx.username);
         let router = tdh::router_with_auth(super::router(), state, auth);
 
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("POST")
             .uri(format!("/{}/cache/invalidate?path=anything", fx.repo_key))
             .body(Body::empty())
@@ -18091,7 +18109,7 @@ mod tests {
         let auth = tdh::make_auth(fx.user_id, &fx.username);
         let router = tdh::router_with_auth(super::router(), fx.state.clone(), auth);
 
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("PATCH")
             .uri(format!("/{}", fx.repo_key))
             .header("content-type", "application/json")
@@ -18140,7 +18158,7 @@ mod tests {
         let auth = tdh::make_auth(fx.user_id, &fx.username);
         let router = tdh::router_with_auth(super::router(), state, auth);
 
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("POST")
             .uri(format!("/{}/cache/invalidate?path=anything", fx.repo_key))
             .body(Body::empty())
@@ -18184,7 +18202,7 @@ mod tests {
         let auth = tdh::make_auth(fx.user_id, &fx.username);
         let router = tdh::router_with_auth(super::router(), state, auth);
 
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("POST")
             .uri(format!("/{}/cache/invalidate?path=anything", fx.repo_key))
             .body(Body::empty())
@@ -19286,6 +19304,170 @@ mod tests {
     //   2. a missing path on a Local repo still maps to 404 (the
     //      NotFound contract the Remote/Virtual fallback arms key on)
     // ---------------------------------------------------------------------
+
+    // ---------------------------------------------------------------------
+    // #3545: a percent-encoded NUL (`%00`) in the artifact path segment must
+    // be rejected with a 400 at the boundary, BEFORE any query runs — not
+    // passed through to Postgres (which rejects `0x00` at the wire protocol
+    // and surfaces it as an unauthenticated `500 DATABASE_ERROR`).
+    //
+    // Anonymous, on a PUBLIC repo (mirrors the report). Two controls in one
+    // fixture make the 400 attributable to the NUL alone:
+    //   * NUL path            -> 400 VALIDATION_ERROR, body free of any
+    //                            "database" implementation detail
+    //   * ordinary missing    -> 404 (the request flows past the boundary,
+    //     path                  reaches the lookup, and 404s normally — so
+    //                            the 400 is not the route simply erroring on
+    //                            everything, and the control does not collapse
+    //                            onto the 400 boundary)
+    // ---------------------------------------------------------------------
+    #[tokio::test]
+    async fn download_nul_byte_in_path_is_400_not_db_500_db() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        tdh::publish_repo(&fx.pool, fx.repo_id).await;
+
+        let router = tdh::router_anon(download_router(), fx.state.clone());
+        // `a%00b` — the exact vector from the issue. axum's Path extractor
+        // percent-decodes this to a literal "a\0b".
+        let req = tdh::get(format!("/{}/download/a%00b", fx.repo_key));
+        let (status, body) = tdh::send(router, req).await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "a NUL in the path must be a 400 at the boundary, not a 500 from \
+             the driver (got body: {})",
+            String::from_utf8_lossy(&body)
+        );
+        let body_str = String::from_utf8_lossy(&body).to_lowercase();
+        assert!(
+            body_str.contains("validation_error"),
+            "boundary rejection must be a VALIDATION_ERROR, got: {body_str}"
+        );
+        assert!(
+            !body_str.contains("database") && !body_str.contains("utf8"),
+            "the 400 must not leak any driver/database detail, got: {body_str}"
+        );
+
+        // Negative control: an ordinary non-existent path on the same public
+        // repo flows past the boundary and 404s. This is a DIFFERENT status
+        // from the 400 above, so it proves the request otherwise reaches the
+        // artifact lookup (the boundary check is not short-circuiting every
+        // request) and the control does not collapse onto the 400.
+        let router = tdh::router_anon(download_router(), fx.state.clone());
+        let req = tdh::get(format!("/{}/download/really/not/here.bin", fx.repo_key));
+        let (status, _body) = tdh::send(router, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::NOT_FOUND,
+            "a legitimate missing path must still 404, proving the request \
+             flows past the NUL boundary check"
+        );
+
+        fx.teardown().await;
+    }
+
+    // Same boundary contract on the artifact-metadata route
+    // (`GET /:key/artifacts/*path`), the other route named in #3545.
+    #[tokio::test]
+    async fn artifact_metadata_nul_byte_in_path_is_400_not_db_500_db() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        tdh::publish_repo(&fx.pool, fx.repo_id).await;
+
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let req = tdh::get(format!("/{}/artifacts/a%00b", fx.repo_key));
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "NUL in the metadata-route path must be a 400 (got body: {})",
+            String::from_utf8_lossy(&body)
+        );
+
+        // Negative control: a normal missing artifact path 404s.
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let req = tdh::get(format!("/{}/artifacts/really/not/here.bin", fx.repo_key));
+        let (status, _body) = tdh::send(app, req).await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+
+        fx.teardown().await;
+    }
+
+    // Same contract on the version-history route (`GET /:key/versions/*path`).
+    #[tokio::test]
+    async fn versions_nul_byte_in_path_is_400_not_db_500_db() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        tdh::publish_repo(&fx.pool, fx.repo_id).await;
+
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let req = tdh::get(format!("/{}/versions/a%00b", fx.repo_key));
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "NUL in the versions-route path must be a 400 (got body: {})",
+            String::from_utf8_lossy(&body)
+        );
+
+        // Negative control: a normal missing path 404s ("No version history"),
+        // proving the request flows past the boundary check.
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let req = tdh::get(format!("/{}/versions/really/not/here.bin", fx.repo_key));
+        let (status, _body) = tdh::send(app, req).await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+
+        fx.teardown().await;
+    }
+
+    // Same contract on the DELETE route (`DELETE /:key/artifacts/*path`).
+    // Authenticated: the boundary check sits just after the scope check and
+    // before the repository/authorization lookups, so a NUL is a 400 for a
+    // valid principal regardless of the downstream authz outcome.
+    #[tokio::test]
+    async fn delete_nul_byte_in_path_is_400_not_db_500_db() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let app = fx.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("DELETE")
+            .uri(format!("/{}/artifacts/a%00b", fx.repo_key))
+            .body(axum::body::Body::empty())
+            .expect("build DELETE request");
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "NUL in the DELETE path must be a 400 (got body: {})",
+            String::from_utf8_lossy(&body)
+        );
+
+        // Negative control: the SAME principal deleting a legitimate (non-NUL)
+        // path does not get a 400 — the boundary check fires only on the NUL,
+        // not on every request. (The exact non-400 status is the downstream
+        // authz/lookup outcome and is deliberately not pinned here.)
+        let app = fx.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("DELETE")
+            .uri(format!("/{}/artifacts/really/not/here.bin", fx.repo_key))
+            .body(axum::body::Body::empty())
+            .expect("build DELETE request");
+        let (status, _body) = tdh::send(app, req).await;
+        assert_ne!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "a non-NUL path must not be rejected by the NUL boundary check"
+        );
+
+        fx.teardown().await;
+    }
 
     #[tokio::test]
     async fn test_download_artifact_local_streams_body_with_headers() {
@@ -23040,7 +23222,7 @@ mod tests {
             state.clone(),
             admin_auth(user_id, &username),
         );
-        let req = Request::builder()
+        let req = axum::http::Request::builder()
             .method("GET")
             .uri(format!("/{}/members", repo_key))
             .body(Body::empty())

--- a/backend/src/api/validation.rs
+++ b/backend/src/api/validation.rs
@@ -169,6 +169,29 @@ pub fn validate_outbound_url(url_str: &str, label: &str) -> Result<()> {
     validate_outbound_url_with(url_str, label, OutboundUrlContext::Upstream)
 }
 
+/// Reject a NUL byte in a client-supplied artifact path before it reaches
+/// the database (#3545).
+///
+/// A percent-encoded `%00` in a wildcard path segment is decoded by axum's
+/// `Path` extractor into a literal `\0` in the `String`. Postgres rejects
+/// that byte at the wire protocol (`invalid byte sequence for encoding
+/// "UTF8": 0x00`), so an unauthenticated read of a public repository
+/// surfaced as `500 DATABASE_ERROR` — one pool checkout plus one failing
+/// query per trivially craftable request — instead of a 400 at the path
+/// boundary. Upload entry points already reject NUL via
+/// `upload_service::validate_artifact_path`; this is the read/delete-side
+/// counterpart. Deliberately NUL-only: read routes must keep serving every
+/// path an upload could ever have stored, so no other character class is
+/// rejected here.
+pub(crate) fn reject_nul_in_path(path: &str) -> Result<()> {
+    if path.contains('\0') {
+        return Err(AppError::Validation(
+            "artifact path must not contain a NUL byte".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Validate a webhook delivery target URL (anti-SSRF). Reads
 /// `WEBHOOK_ALLOW_PRIVATE_IPS` for the private-IP relaxation toggle.
 ///
@@ -2196,5 +2219,54 @@ mod tests {
         assert!(is_blocked_resolved_ip("::1".parse().unwrap()));
         // A public IP passes.
         assert!(!is_blocked_resolved_ip("93.184.216.34".parse().unwrap()));
+    }
+
+    // --- reject_nul_in_path (#3545) -----------------------------------
+
+    #[test]
+    fn test_reject_nul_in_path_maps_to_400_validation_error() {
+        // The exact byte from the report: `a%00b` decodes to "a\0b".
+        let err = reject_nul_in_path("a\0b").expect_err("NUL must be rejected");
+        // The message must not echo any driver/database detail.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NUL byte") && !msg.to_lowercase().contains("database"),
+            "boundary rejection must name the input problem, got: {msg}"
+        );
+        // ...and it maps to a 400, not a 500.
+        use axum::response::IntoResponse;
+        let status = err.into_response().status();
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "a NUL in the path is a client input error, not a 500"
+        );
+    }
+
+    #[test]
+    fn test_reject_nul_in_path_positions() {
+        // Leading, trailing, and lone NUL are all rejected.
+        assert!(reject_nul_in_path("\0a").is_err());
+        assert!(reject_nul_in_path("a\0").is_err());
+        assert!(reject_nul_in_path("\0").is_err());
+        // Percent-encoded traversal probe from the test-suite corpus:
+        // `legit.txt%00../../etc/passwd` decodes to a NUL mid-path.
+        assert!(reject_nul_in_path("legit.txt\0../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_reject_nul_in_path_negative_controls() {
+        // Every path an upload could have stored must stay servable: the
+        // check is NUL-only. These include characters the *upload*
+        // validator treats specially (literal percent escapes appear in
+        // npm scoped-package URL shapes) and non-NUL control characters
+        // that historical uploads could contain.
+        assert!(reject_nul_in_path("foo/bar.tgz").is_ok());
+        assert!(reject_nul_in_path("@scope%2fname/-/name-1.0.0.tgz").is_ok());
+        assert!(reject_nul_in_path("packages/\u{65E5}\u{672C}\u{8A9E}.tar.gz").is_ok());
+        assert!(reject_nul_in_path("weird\tname\n.bin").is_ok());
+        // Boundary control: "%00" as literal text (double-encoded by the
+        // client) contains no NUL byte and must pass.
+        assert!(reject_nul_in_path("a%00b").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

A percent-encoded NUL byte (`%00`) anywhere in the wildcard artifact-path
segment of a repository-scoped route was decoded by axum's `Path` extractor
into a literal `\0` and passed straight to Postgres. The driver rejects
`0x00` at the wire protocol (`invalid byte sequence for encoding "UTF8":
0x00`), which the handler surfaced as an unauthenticated **`500
DATABASE_ERROR`** on any public repository — instead of the request being
rejected at the path boundary with a `400`.

Two defects in one:

- The input was not rejected up front. An unauthenticated caller drives a
  connection-pool checkout plus a failing query per trivially craftable URL
  on any public repository — a cheap pool-amplification and log-noise
  primitive.
- The `500` leaked a coarse implementation detail (`DATABASE_ERROR`) for what
  is a client input error.

The sibling invalid-UTF-8 vector (`%c0%af`) already returned `400 Invalid
URL: Invalid UTF-8 in path` on the same route, so the boundary check existed —
it just did not cover `0x00`.

This adds a NUL-byte check at the same boundary, returning `400
VALIDATION_ERROR`, on the four repository-scoped routes that take a wildcard
path:

- `GET    /api/v1/repositories/{key}/artifacts/{path}` (metadata)
- `GET    /api/v1/repositories/{key}/download/{path}`
- `GET    /api/v1/repositories/{key}/versions/{path}`
- `DELETE /api/v1/repositories/{key}/artifacts/{path}`

The Generic format route (`/general/{key}/{path}`) re-exports
`download_artifact`, so it is covered by the same check. The check is
deliberately **NUL-only** — read routes must keep serving every path an
upload could ever have stored, so no other character class is rejected. The
existing upload validator (`upload_service::validate_artifact_path`) already
rejects NUL on the write side; this is the read/delete-side counterpart.

Before / after (anonymous, public repo):

```
# before
GET .../artifacts/a%00b   -> 500 {"code":"DATABASE_ERROR",...}
# after
GET .../artifacts/a%00b   -> 400 {"code":"VALIDATION_ERROR","message":"artifact path must not contain a NUL byte"}
# unchanged
GET .../download/dir/hello.txt -> 200 (bytes)
GET .../download/dir/missing   -> 404
GET .../artifacts/a%c0%afb     -> 400 (pre-existing invalid-UTF-8 boundary)
```

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added:

- Unit tests for the new `reject_nul_in_path` helper (400 mapping, NUL at every
  position, and negative controls proving the check is NUL-only — percent
  escapes, non-ASCII, and other control characters still pass).
- DB-backed router-level tests driving each of the four routes with `a%00b`
  and asserting `400` (not the driver `500`), each paired with a non-NUL
  negative control that flows past the boundary (`404` / non-`400`).

An `artifact-keeper-test` DTF tier (`nul-byte-path`) demonstrates the anonymous
`500 -> 400` transition end-to-end and is validated RED (baseline: 5/8) →
GREEN (fix: 8/8) locally; it is being batched with the other 1.9.0 tiers
(tracked test-side in artifact-keeper-test#388).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #3545
