### PR TITLE
chore(release): exempt docs(changelog) commits from preflight check 5

### DIFF
--- a/scripts/ci/release-preflight.sh
+++ b/scripts/ci/release-preflight.sh
@@ -753,9 +753,19 @@ else
     while IFS= read -r p; do
       [[ -z "$p" ]] && continue
       subj="$(printf '%s\n' "$subjects" | grep -m1 -F "(#${p})" || true)"
-      # Deliberately narrow: dependency bumps and the release prep itself are
-      # the only commit shapes that legitimately carry no user-facing entry.
-      if [[ "$subj" =~ ^chore(\([^\)]*\))?!?:\ bump\  || "$subj" =~ ^chore\(release\) ]]; then
+      # Deliberately narrow: dependency bumps, the release prep itself, and a
+      # commit whose entire content IS a CHANGELOG edit are the only commit
+      # shapes that legitimately carry no user-facing entry.
+      #
+      # `docs(changelog):` is exempt because it cannot satisfy this check even
+      # in principle. Cutting 1.8.2, #3613 merged after the pending section was
+      # written, so this check correctly blocked; the fix (#3624) added the
+      # missing entry -- and then blocked the cut itself, because a commit that
+      # adds a CHANGELOG entry is a commit in range with no entry describing
+      # it. Writing one produces another such commit, and so on. The exemption
+      # is safe for the same reason `chore(release)` is: the commit's content
+      # is the changelog, so there is nothing it could omit.
+      if [[ "$subj" =~ ^chore(\([^\)]*\))?!?:\ bump\  || "$subj" =~ ^chore\(release\) || "$subj" =~ ^docs\(changelog\) ]]; then
         exempted=$((exempted + 1))
         continue
       fi
@@ -777,7 +787,7 @@ else
       note "  -> add an entry under '## [Unreleased]', or check whether the entry"
       note "     was filed under an ALREADY RELEASED heading (the post-1.7.3 shape:"
       note "     a PR merged after the tag anchored on the released section)."
-      note "  -> dependency bumps and 'chore(release):' commits are exempt; nothing else is."
+      note "  -> dependency bumps, 'chore(release):' and 'docs(changelog):' commits are exempt; nothing else is."
     fi
 
     if [[ -z "$unresolved" && "$undocumented" -eq 0 ]]; then

--- a/scripts/ci/test-release-preflight.sh
+++ b/scripts/ci/test-release-preflight.sh
@@ -588,8 +588,10 @@ git5 tag v9.9.8
 git5 commit -q --allow-empty -m "fix(a): alpha (#101)"
 git5 commit -q --allow-empty -m "fix(b): beta (#102)"
 git5 commit -q --allow-empty -m "chore: bump dep from 1.0 to 1.1 (#103)"
-# PR 101 closes issue 201, PR 102 closes issue 202, the bump closes nothing.
-CLOSES_MAP=$'101:201\n102:202\n103:'
+git5 commit -q --allow-empty -m "docs(changelog): record the late fix (#104)"
+# PR 101 closes issue 201, PR 102 closes issue 202; the bump and the changelog
+# commit close nothing.
+CLOSES_MAP=$'101:201\n102:202\n103:\n104:'
 
 expect5() { # <label> <expected-exit> <expected-substring> <changelog on stdin>
   local label="$1" want="$2" needle="$3" got
@@ -660,6 +662,23 @@ expect5 "commit in range with no pending entry -> NOT READY" 1 "are not describe
 ## [9.9.8] - 2026-01-01
 - older work
 - **beta is fixed** (#202). filed under the RELEASED section, after the tag.
+EOF
+
+# 3b. THE RECURSION. A `docs(changelog):` commit cannot describe itself: its
+#     entire content IS the changelog entry, so demanding an entry for it
+#     produces another such commit, and so on. Real occurrence: cutting 1.8.2,
+#     #3613 merged after the pending section was written and this check
+#     correctly blocked; the fix added the missing entry and then blocked the
+#     cut itself. Drop the `docs(changelog)` arm from the exemption and this
+#     goes red.
+expect5 "docs(changelog) commit is exempt -> READY" 0 "" << 'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+- **alpha is fixed** (#201). prose about alpha.
+- **beta is fixed** (#202). prose about beta.
 EOF
 
 # 4. THE COUNTERWEIGHT. Run after the CHANGELOG promotion and before the tag,


### PR DESCRIPTION
Closes #3632

Check 5 blocked the 1.8.2 cut on the very commit that fixed its previous complaint:

```
[FAIL] commits in v1.8.1..HEAD are not described by the pending section:
    - #3624  docs(changelog): record the scanner-adapter Alpine errata fix in 1.8.2
```

A `docs(changelog):` commit's entire content is the changelog entry, so it cannot describe itself — writing one produces another commit in the same shape. It belongs in the exemption list for the same reason `chore(release):` does.

**Revert-proofed.** Removing the new exemption turns the added case red naming the commit:

```
FAIL  docs(changelog) commit is exempt -> READY: expected exit 0, got 1
      [FAIL] commits in v9.9.8..HEAD are not described by the pending section:
          - #104  docs(changelog): record the late fix (#104)
```

Restored, all cases pass. No behaviour change to any other check.