### PR TITLE
ci(mirror): add the image set #2883 consumes

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -18,18 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: postgres:16-alpine
-            target: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
-          - image: alpine:3.19
-            target: ghcr.io/artifact-keeper/ci-mirror/alpine:3.19
-          - image: alpine:3.23
-            target: ghcr.io/artifact-keeper/ci-mirror/alpine:3.23
-          - image: python:3.12-slim
-            target: ghcr.io/artifact-keeper/ci-mirror/python:3.12-slim
-          - image: node:20-slim
-            target: ghcr.io/artifact-keeper/ci-mirror/node:20-slim
-          - image: rust:1.75-slim
-            target: ghcr.io/artifact-keeper/ci-mirror/rust:1.75-slim
+          - image: postgres:18-alpine
+            target: ghcr.io/artifact-keeper/ci-mirror/postgres:18-alpine
+          - image: alpine:3.24
+            target: ghcr.io/artifact-keeper/ci-mirror/alpine:3.24
+          - image: python:3.14-slim
+            target: ghcr.io/artifact-keeper/ci-mirror/python:3.14-slim
+          - image: node:26-slim
+            target: ghcr.io/artifact-keeper/ci-mirror/node:26-slim
+          - image: rust:1.98-slim
+            target: ghcr.io/artifact-keeper/ci-mirror/rust:1.98-slim
 
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

Prerequisite for #2883. One file, matrix only.

#2883 references `ci-mirror` tags for **postgres 18-alpine, alpine 3.24, python 3.14-slim, node 26-slim, rust 1.98-slim**. `mirror-images.yml` fires only on a weekly cron (`0 4 * * 1`) or a manual dispatch, so those tags do not exist in GHCR until it runs — and until they do, every job referencing them fails `manifest unknown`.

Landing the matrix on its own lets the workflow be **dispatched on `main`** before #2883 merges, instead of merging #2883 and waiting until the following Monday 04:00 UTC for CI to go green.

**Safe to land ahead of #2883.** This only changes which tags a future run publishes; previously mirrored tags are not deleted, so `main`'s current references keep resolving. The matrix is an exact two-way match with what #2883's tree consumes (5 entries, verified by grep in both directions), and the duplicate `alpine` entry — 3.19 and 3.23 both collapsing to 3.24 — is deduped.

### Merge order
1. Merge this
2. Dispatch **Mirror Docker Hub Images** on `main`; confirm all five tags resolve
3. Merge #2883

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes