### PR TITLE
ci(release): accept a successful promote dispatch when resolving the candidate publish run

### DIFF
--- a/.github/scripts/registry-tag-revision.sh
+++ b/.github/scripts/registry-tag-revision.sh
@@ -15,6 +15,16 @@
 # It reads it with `docker buildx imagetools inspect`, which needs a docker
 # daemon and a registry login.
 #
+# The scanner-adapter is the only image whose INDEX is stamped that way. The
+# backend and openscap indexes are assembled by docker/build-push-action +
+# imagetools without index annotations, but every per-arch image CONFIG
+# carries the same fact as the `org.opencontainers.image.revision` LABEL,
+# stamped by docker/metadata-action from `github.sha`. So when the index has
+# no annotation, this walks index -> first real platform manifest (skipping
+# `vnd.docker.reference.type: attestation-manifest` entries) -> config blob,
+# and reads the label. Same source of truth, same three outcomes; `none` still
+# means "read everything fine, no revision recorded anywhere" (#3640).
+#
 # release-preflight.sh has to answer the same question BEFORE a tag exists, and
 # it runs on a maintainer's laptop and on a plain ubuntu runner. Requiring
 # docker + buildx + a registry login there would mean the check silently does
@@ -146,13 +156,76 @@ main() {
   fi
 
   if [[ "$rev" =~ ^[0-9a-f]{40}$ ]]; then
-    log "${registry}/${name}:${tag}: built from ${rev}"
+    log "${registry}/${name}:${tag}: built from ${rev} (index annotation)"
     echo "$rev"
     return 0
   fi
 
-  # Read fine, but there is no usable provenance. A measured answer.
-  log "${registry}/${name}:${tag}: no valid org.opencontainers.image.revision annotation"
+  # No index annotation (backend/openscap shape). Fall back to the per-arch
+  # image config's org.opencontainers.image.revision LABEL: walk to the first
+  # real platform manifest, skipping buildx attestation entries.
+  local media child_digest config_digest config_body
+  media=$(jq -r '.mediaType // empty' "$body" 2>/dev/null)
+  case "$media" in
+    application/vnd.oci.image.index.v1+json | application/vnd.docker.distribution.manifest.list.v2+json)
+      child_digest=$(jq -r '[.manifests[]
+          | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+          | select((.platform.os // "unknown") != "unknown")][0].digest // empty' "$body" 2>/dev/null)
+      if [[ -z "$child_digest" ]]; then
+        log "${registry}/${name}:${tag}: index has no platform manifests to read a config from"
+        echo "$NONE"
+        return 1
+      fi
+      code=$(curl -sSL --proto '=https' --max-time 30 -o "$body" -w '%{http_code}' \
+        -H "Authorization: Bearer ${token}" \
+        "${MANIFEST_ACCEPT[@]}" \
+        "https://${host}/v2/${name}/manifests/${child_digest}" 2>/dev/null)
+      if [[ $? -ne 0 || "$code" != '200' ]]; then
+        log "${registry}/${name}:${tag}: could not read platform manifest ${child_digest} (HTTP ${code})"
+        echo "$INDETERMINATE"
+        return 1
+      fi
+      ;;
+    application/vnd.oci.image.manifest.v1+json | application/vnd.docker.distribution.manifest.v2+json)
+      : # single-arch: $body already is the image manifest
+      ;;
+    *)
+      log "${registry}/${name}:${tag}: unrecognised mediaType '${media}'"
+      echo "$INDETERMINATE"
+      return 1
+      ;;
+  esac
+
+  config_digest=$(jq -r '.config.digest // empty' "$body" 2>/dev/null)
+  if [[ -z "$config_digest" ]]; then
+    log "${registry}/${name}:${tag}: platform manifest has no config digest"
+    echo "$INDETERMINATE"
+    return 1
+  fi
+
+  config_body=$(curl -sSL --proto '=https' --max-time 30 \
+    -H "Authorization: Bearer ${token}" \
+    "https://${host}/v2/${name}/blobs/${config_digest}" 2>/dev/null)
+  if [[ $? -ne 0 || -z "$config_body" ]]; then
+    log "${registry}/${name}:${tag}: could not read config blob ${config_digest}"
+    echo "$INDETERMINATE"
+    return 1
+  fi
+
+  if ! rev=$(jq -r '.config.Labels["org.opencontainers.image.revision"] // empty' <<<"$config_body" 2>/dev/null); then
+    log "${registry}/${name}:${tag}: config blob did not parse as JSON"
+    echo "$INDETERMINATE"
+    return 1
+  fi
+
+  if [[ "$rev" =~ ^[0-9a-f]{40}$ ]]; then
+    log "${registry}/${name}:${tag}: built from ${rev} (config label)"
+    echo "$rev"
+    return 0
+  fi
+
+  # Read fine, but there is no usable provenance anywhere. A measured answer.
+  log "${registry}/${name}:${tag}: no valid org.opencontainers.image.revision annotation or config label"
   echo "$NONE"
   return 1
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,6 +660,16 @@ jobs:
       - name: Check the preflight-evidence gate blocks what it must
         run: bash scripts/ci/test-assert-preflight-evidence.sh
 
+      # release.yml's resolve-candidate-digest job picks WHICH docker-publish
+      # run vouches for the commit being released (#3640). Both directions are
+      # dangerous: accepting a success for another sha/ref is fail-open, and
+      # accepting only event=push deadlocks a re-tagged release forever (the
+      # v1.8.2 shape: the push run fails permanently on image immutability
+      # while the documented promote dispatch succeeded). Stubs `gh`; offline,
+      # ~1s.
+      - name: Check the candidate publish-run resolver selects and blocks correctly
+        run: bash scripts/ci/test-resolve-candidate-publish-run.sh
+
       # Duplicate sqlx migration versions merge CLEAN and abort the backend at
       # startup (#3313, #1128). The live gate runs in test-backend-unit against
       # the merge result; this exercises the script's failure modes (numeric

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,16 @@ jobs:
       - name: Check the candidate publish-run resolver selects and blocks correctly
         run: bash scripts/ci/test-resolve-candidate-publish-run.sh
 
+      # The other half of #3640: when the accepted run is a promote dispatch,
+      # the published bytes were built from a DIFFERENT commit than the tag,
+      # and adoption must be verified against the image's actual input set --
+      # fail-open here certifies stale bytes for a tag they were not built
+      # from. Real git commits in a scratch repo; the refusal legs (backend
+      # source, Dockerfile, .dockerignore, missing provenance) are the point.
+      # Offline, ~1s.
+      - name: Check the image-adoption gate refuses what it must
+        run: bash scripts/ci/test-assert-adopted-image-sources.sh
+
       # Duplicate sqlx migration versions merge CLEAN and abort the backend at
       # startup (#3313, #1128). The live gate runs in test-backend-unit against
       # the merge result; this exercises the script's failure modes (numeric

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,12 +217,17 @@ jobs:
       backend_digest: ${{ steps.resolve.outputs.backend_digest }}   # sha256:...
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      # The resolver script is the only thing needed from the tree; this job
-      # otherwise reads the Actions API and the registry, not the repository.
+      # scripts/ci for the resolver + adoption gate, .github/scripts for the
+      # registry probes, and full history so the adoption gate can diff the
+      # published image's source revision against the tag (the sparse worktree
+      # does not limit object-level `git diff <rev> <sha>`).
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          sparse-checkout: scripts/ci
+          fetch-depth: 0
+          sparse-checkout: |
+            scripts/ci
+            .github/scripts
 
       - name: Wait for a successful docker-publish run for this commit
         env:
@@ -268,7 +273,25 @@ jobs:
                 sleep 60
                 ;;
               20)
-                echo "::error title=docker-publish failed::Every docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA} completed without success. Release blocked; fix and re-run docker-publish (or dispatch it with promote_version=${GITHUB_REF_NAME#v} if the version is already published), then re-run this workflow."
+                # Say something that can actually succeed. On a re-cut of an
+                # already-published version, "fix and re-run docker-publish"
+                # is impossible advice: every push-path rebuild is refused by
+                # the immutability guard, forever. Name the promote dispatch
+                # instead (#3640).
+                V="${GITHUB_REF_NAME#v}"
+                STATE=$(GHCR_TOKEN="${GH_TOKEN}" bash .github/scripts/registry-tag-state.sh \
+                  ghcr.io artifact-keeper/artifact-keeper-backend "${V}" 2>/dev/null || true)
+                case "${STATE}" in
+                  present)
+                    echo "::error title=docker-publish failed (version already published)::Every docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA} completed without success -- and backend:${V} is ALREADY PUBLISHED, so a push-path rebuild will be refused by the immutability guard every time. Recovery: gh workflow run docker-publish.yml --ref ${GITHUB_REF_NAME} -f promote_version=${V} ; when it succeeds, re-run this workflow (the promote re-points tags at the published digest and the next job verifies its sources against this tag)."
+                    ;;
+                  absent)
+                    echo "::error title=docker-publish failed::Every docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA} completed without success and backend:${V} is not published. Release blocked; fix the cause, re-run docker-publish, then re-run this workflow."
+                    ;;
+                  *)
+                    echo "::error title=docker-publish failed::Every docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA} completed without success (and whether backend:${V} is already published could not be read). Release blocked; if the version is already published, dispatch docker-publish with promote_version=${V}; otherwise fix the cause and re-run docker-publish. Then re-run this workflow."
+                    ;;
+                esac
                 exit 1
                 ;;
               21|30)
@@ -383,6 +406,39 @@ jobs:
           echo "backend_digest=${BACKEND_DIGEST}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}"               >> "$GITHUB_OUTPUT"
           echo "Candidate resolved: backend ${VERSION}@${BACKEND_DIGEST}"
+
+      # ── Adoption gate (#3640) ───────────────────────────────────────────────
+      # The run accepted above may be a promote dispatch, i.e. the published
+      # bytes may have been BUILT from a different commit than this tag (a
+      # re-tag after a non-image fix; rebuilds can never match because GIT_SHA
+      # is a build-arg and provenance embeds the revision). Adoption is
+      # verified, never assumed: read the revision the published index was
+      # built from and require it to be byte-identical to this tag across
+      # every input docker/Dockerfile.backend consumes. Any difference inside
+      # that set is a hard refusal -- those bytes are stale for this tag.
+      # Selection + refusal legs are self-tested offline in
+      # scripts/ci/test-assert-adopted-image-sources.sh.
+      - name: Assert the published image was built from this tag's sources
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          REV=$(GHCR_TOKEN="${GH_TOKEN}" bash .github/scripts/registry-tag-revision.sh \
+            ghcr.io artifact-keeper/artifact-keeper-backend "${VERSION}" || true)
+          echo "backend:${VERSION} reports source revision: ${REV}"
+          rc=0
+          ADOPT_TAG_SHA="${GITHUB_SHA}" \
+          ADOPT_PUBLISHED_REV="${REV}" \
+          ADOPT_LABEL="backend:${VERSION}" \
+            bash scripts/ci/assert-adopted-image-sources.sh || rc=$?
+          if [ "${rc}" = "1" ]; then
+            echo "::error title=Published image refused for this tag::backend:${VERSION} was built from ${REV}, which differs from ${GITHUB_SHA} inside the image input set. Adopting it would release stale bytes. Bump the version instead of re-tagging, or revert the input change."
+            exit 1
+          elif [ "${rc}" != "0" ]; then
+            echo "::error title=Image provenance unreadable::Could not verify what backend:${VERSION} was built from (see log). Indeterminate is not a pass; re-run this workflow."
+            exit 1
+          fi
 
   # ════════════════════════════════════════════════════════════════════════════
   # E2E GATE - Must pass before release proceeds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,11 @@ jobs:
   # docker-publish.yml runs INDEPENDENTLY on the same tag push and publishes
   # ghcr.io/.../artifact-keeper-backend:${VERSION} as a manifest list. A
   # cross-workflow `needs:` is impossible, so this job is the explicit gate:
-  # it follows the docker-publish RUN for this exact commit+tag to completion
-  # via the Actions API, then resolves the published digest from the registry.
+  # it waits, via the Actions API, for a SUCCESSFUL docker-publish run for
+  # this exact commit+tag -- the tag push's own run, or the documented
+  # `promote_version` recovery dispatch (#2698), which a re-tagged version
+  # needs because immutability correctly fails the push run forever (#3640) --
+  # then resolves the published digest from the registry.
   # Once merge-backend has pushed the tag, the digest-aware republish guard
   # (`assert-version-digest-consistent`) in docker-publish.yml guarantees it can
   # never be re-pointed to DIFFERENT content -- only re-applied to the same
@@ -214,7 +217,14 @@ jobs:
       backend_digest: ${{ steps.resolve.outputs.backend_digest }}   # sha256:...
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      - name: Wait for the docker-publish run for this commit to complete
+      # The resolver script is the only thing needed from the tree; this job
+      # otherwise reads the Actions API and the registry, not the repository.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: scripts/ci
+
+      - name: Wait for a successful docker-publish run for this commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -222,47 +232,65 @@ jobs:
           echo "Locating the docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA}"
 
           # The same tag push triggers docker-publish.yml independently; find
-          # ITS run for this exact commit+tag. Webhook fan-out can lag, so
-          # allow up to 15 minutes for the run to appear before declaring
-          # docker-publish dead (a dead publish must fail this job RED rather
-          # than let a skipped gate slip the release through).
+          # a SUCCESSFUL run of it for this exact commit+tag. Selection lives
+          # in scripts/ci/resolve-candidate-publish-run.sh (self-tested by its
+          # sibling test-*.sh): it accepts `push` OR `workflow_dispatch` runs,
+          # because on a RE-TAGGED version the push run fails permanently on
+          # image immutability and the documented recovery is a
+          # `promote_version` dispatch (#2698) -- which re-points tags at the
+          # digest :$VERSION already names, rebuilding nothing, so the digest
+          # captured below is still the digest the gate then tests (#3640).
+          # It stays fail-closed: no successful run of either kind for this
+          # sha+ref blocks the release RED.
+          #
+          # Webhook fan-out can lag, so allow up to 15 minutes for a run to
+          # appear before declaring docker-publish dead. Once a run has been
+          # seen, there is deliberately NO fixed clock -- the job-level
+          # timeout-minutes above is the only ceiling, sized for the
+          # cold-cache amd64 build (issue #2711) -- and transient API errors
+          # just keep the loop polling.
           APPEAR_DEADLINE=$(($(date +%s) + 15*60))
-          RUN_ID=""
+          SEEN=0
           while true; do
-            RUN_ID=$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/docker-publish.yml/runs?event=push&head_sha=${GITHUB_SHA}&per_page=20" \
-              --jq '.workflow_runs' 2>/dev/null \
-              | jq -r --arg ref "${GITHUB_REF_NAME}" \
-                  '[.[] | select(.head_branch == $ref)][0].id // empty' || true)
-            [ -n "${RUN_ID}" ] && break
-            if [ "$(date +%s)" -ge "${APPEAR_DEADLINE}" ]; then
-              echo "::error title=docker-publish never started::No docker-publish.yml run found for ${GITHUB_REF_NAME}@${GITHUB_SHA} after 15m. Release blocked."
-              exit 1
-            fi
-            echo "  no docker-publish run visible yet, waiting 30s..."
-            sleep 30
-          done
-          echo "  following docker-publish run ${RUN_ID}"
-
-          # Follow the run to completion. Deliberately NO fixed clock here --
-          # the job-level timeout-minutes above is the only ceiling, sized for
-          # the cold-cache amd64 build (issue #2711). Transient API errors
-          # yield STATUS=unknown and the loop just keeps polling.
-          while true; do
-            STATE=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" \
-              --jq '.status + " " + (.conclusion // "-")' 2>/dev/null || echo "unknown -")
-            STATUS="${STATE%% *}"
-            CONCLUSION="${STATE#* }"
-            if [ "${STATUS}" = "completed" ]; then
-              if [ "${CONCLUSION}" = "success" ]; then
-                echo "  docker-publish run ${RUN_ID} completed successfully."
+            rc=0
+            RESOLVE_REPO="${GITHUB_REPOSITORY}" \
+            RESOLVE_SHA="${GITHUB_SHA}" \
+            RESOLVE_REF="${GITHUB_REF_NAME}" \
+              bash scripts/ci/resolve-candidate-publish-run.sh || rc=$?
+            case "${rc}" in
+              0)
+                echo "  a docker-publish run for this commit completed successfully."
                 break
-              fi
-              echo "::error title=docker-publish failed::docker-publish run ${RUN_ID} completed with conclusion '${CONCLUSION}'. Release blocked; fix and re-run docker-publish, then re-run this workflow."
-              exit 1
-            fi
-            echo "  docker-publish run ${RUN_ID}: ${STATUS}; waiting 60s..."
-            sleep 60
+                ;;
+              10)
+                SEEN=1
+                echo "  docker-publish still running; waiting 60s..."
+                sleep 60
+                ;;
+              20)
+                echo "::error title=docker-publish failed::Every docker-publish run for ${GITHUB_REF_NAME}@${GITHUB_SHA} completed without success. Release blocked; fix and re-run docker-publish (or dispatch it with promote_version=${GITHUB_REF_NAME#v} if the version is already published), then re-run this workflow."
+                exit 1
+                ;;
+              21|30)
+                # none-yet / API blip: before any run is seen these count
+                # against the appear deadline; after one was seen they are
+                # transient and the job timeout is the ceiling.
+                if [ "${SEEN}" = "0" ] && [ "$(date +%s)" -ge "${APPEAR_DEADLINE}" ]; then
+                  if [ "${rc}" = "30" ]; then
+                    echo "::error title=Cannot query docker-publish runs::The Actions API query kept failing for 15m; whether docker-publish ran for ${GITHUB_REF_NAME}@${GITHUB_SHA} is unknown. Release blocked; re-run this workflow."
+                  else
+                    echo "::error title=docker-publish never started::No docker-publish.yml run found for ${GITHUB_REF_NAME}@${GITHUB_SHA} after 15m. Release blocked."
+                  fi
+                  exit 1
+                fi
+                echo "  no verdict yet (state ${rc}); waiting 30s..."
+                sleep 30
+                ;;
+              *)
+                echo "::error title=resolver error::resolve-candidate-publish-run.sh exited ${rc} unexpectedly. Release blocked."
+                exit 1
+                ;;
+            esac
           done
 
       - name: Capture the published :$VERSION digest

--- a/scripts/ci/assert-adopted-image-sources.sh
+++ b/scripts/ci/assert-adopted-image-sources.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Refuse to adopt published images unless they were built from sources
+# byte-identical to the commit being released (issue #3640).
+#
+# WHY THIS EXISTS
+#   resolve-candidate-digest can now accept a `promote_version` dispatch as
+#   the docker-publish run that vouches for a release (the re-tag recovery,
+#   #2698). A promote rebuilds nothing -- it re-points tags at bytes that
+#   already exist -- so on a re-tagged version the published image was built
+#   from a DIFFERENT commit than the tag. Backend builds are non-reproducible
+#   by construction (GIT_SHA is a build-arg, provenance mode=max embeds the
+#   revision), so "same digest" can never be re-proven by rebuilding; the only
+#   sound question is whether the published revision and the tag differ in any
+#   input the image is built FROM. This script asks exactly that question and
+#   hard-refuses on any difference: an under-specified or skipped comparison
+#   here is how a release gate would silently certify stale bytes.
+#
+#   The comparison is the same idiom release-preflight.sh check 4 uses for the
+#   scanner-adapter (`git diff <published-rev> <tag-sha> -- <image inputs>`).
+#
+# THE INPUT SET
+#   Exactly what docker/Dockerfile.backend consumes from the build context --
+#   its only context COPYs are `Cargo.toml Cargo.lock ./`, `backend ./backend`
+#   and `.sqlx ./.sqlx` -- plus the Dockerfile itself (base images, build
+#   steps, tool pins) and .dockerignore (it shapes what `COPY backend` sees).
+#   If the Dockerfile grows a new context COPY, this list MUST grow with it.
+#
+# WHAT IS KNOWINGLY NOT ASSERTED
+#   "The image was built from the tagged commit." On a verified adoption the
+#   published revision differs from the tag by non-image files (changelog,
+#   CI scripts); the image's own revision annotation and embedded GIT_SHA
+#   keep naming the commit that built it. No gate anywhere asserted the
+#   image-built-from-tag property before this script existed either -- it was
+#   lost silently; now the skew is measured, bounded to non-image paths, and
+#   printed loudly.
+#
+# Env:
+#   ADOPT_TAG_SHA        (required) 40-hex commit being released
+#   ADOPT_PUBLISHED_REV  (required) what registry-tag-revision.sh reported for
+#                        the published :VERSION index: a 40-hex sha, `none`,
+#                        or `indeterminate`
+#   ADOPT_PATHS          override the input path set (self-test only)
+#   ADOPT_LABEL          image label for messages (default backend:VERSION)
+#   GITHUB_STEP_SUMMARY  appended to when set
+#
+# Exit:
+#   0  identical revision, or a verified adoption (diff over the input set
+#      is empty)
+#   1  REFUSED -- sources differ inside the input set, or the published image
+#      carries no provenance to verify against
+#   2  INFRA   -- could not measure (unreadable annotation, unfetchable
+#      commit). NOT a verdict about the bytes.
+#
+set -uo pipefail
+
+SHA="${ADOPT_TAG_SHA:-}"
+REV="${ADOPT_PUBLISHED_REV:-}"
+LABEL="${ADOPT_LABEL:-the published backend image}"
+DEFAULT_PATHS="Cargo.toml Cargo.lock backend .sqlx docker/Dockerfile.backend .dockerignore"
+read -r -a PATHS <<< "${ADOPT_PATHS:-$DEFAULT_PATHS}"
+
+summary() {
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  printf '%s\n' "$1"
+}
+
+if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "INFRA: ADOPT_TAG_SHA must be a full 40-char sha (got '${SHA}')" >&2
+  exit 2
+fi
+
+case "$REV" in
+  "$SHA")
+    summary "Image provenance: ${LABEL} was built from the tagged commit ${SHA} -- no adoption needed."
+    exit 0
+    ;;
+  none)
+    # A measured answer: the index exists and carries no revision annotation.
+    # Without provenance there is nothing to verify an adoption against.
+    echo "REFUSED: ${LABEL} is published but carries no org.opencontainers.image.revision annotation; an unverifiable image cannot be adopted." >&2
+    exit 1
+    ;;
+  indeterminate | "")
+    echo "INFRA: the source revision of ${LABEL} could not be read (got '${REV:-<empty>}'); indeterminate, retry." >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! "$REV" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "INFRA: ADOPT_PUBLISHED_REV is not a sha/none/indeterminate (got '${REV}')" >&2
+  exit 2
+fi
+
+# A shallow checkout may not have the published commit; fetch just it.
+for c in "$REV" "$SHA"; do
+  if ! git cat-file -e "${c}^{commit}" 2>/dev/null; then
+    git fetch --no-tags --depth=1 origin "$c" >/dev/null 2>&1 || true
+  fi
+  if ! git cat-file -e "${c}^{commit}" 2>/dev/null; then
+    echo "INFRA: commit ${c} is not fetchable, so the source comparison cannot be made." >&2
+    exit 2
+  fi
+done
+
+if git diff --quiet "$REV" "$SHA" -- "${PATHS[@]}"; then
+  summary "Image provenance: VERIFIED ADOPTION -- ${LABEL} was published from ${REV}, the tag is ${SHA}, and the two are byte-identical across every image input (${PATHS[*]}). The commits differ only outside the image."
+  exit 0
+fi
+
+echo "REFUSED: ${LABEL} was published from ${REV}, but the tag ${SHA} changes image inputs:" >&2
+git diff --name-only "$REV" "$SHA" -- "${PATHS[@]}" | sed 's/^/  /' >&2
+echo "-> these published bytes are STALE for this tag. Bump the version (do not re-tag) or revert the input change." >&2
+summary "Image provenance: REFUSED adoption of ${LABEL} (published from ${REV}; tag ${SHA} changes image inputs)."
+exit 1

--- a/scripts/ci/resolve-candidate-publish-run.sh
+++ b/scripts/ci/resolve-candidate-publish-run.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Locate the docker-publish run that vouches for the commit being released
+# (issue #3640).
+#
+# WHY THIS EXISTS
+#   release.yml's `resolve-candidate-digest` job must not let the release gate
+#   start until a docker-publish pipeline for the EXACT commit+ref being
+#   released has completed successfully. It used to find that run with a query
+#   hard-filtered to `event=push`, which deadlocks a re-tagged release:
+#
+#     * Image immutability makes the re-tag's push-triggered docker-publish
+#       fail at "Refuse to overwrite a published backend version" -- correct,
+#       and permanent: that run can never be made green.
+#     * The documented recovery (#2698) -- dispatch docker-publish with
+#       `promote_version=X.Y.Z` at the tag -- succeeds, but is
+#       `event=workflow_dispatch`, so the resolver never saw it. v1.8.2 hit
+#       exactly this: push run 33514800258 failed on immutability, promote
+#       run 33522347257 succeeded, release blocked forever.
+#
+#   So this script accepts a SUCCESSFUL run for the same head_sha AND
+#   head_branch from EITHER `push` or `workflow_dispatch`, preferring the most
+#   recent success (the promote-floating-tags job in release.yml already
+#   trusts workflow_dispatch runs selected the same way).
+#
+# WHY THIS DOES NOT WEAKEN bytes-tested == bytes-published
+#   This selection is a liveness/ordering gate ("a publish pipeline for these
+#   exact sources completed green"), not the digest identity assertion. The
+#   digest the gate tests is read from the registry AFTER this passes, and
+#   verify-images-published re-asserts it at the end. Two properties keep the
+#   dispatch acceptance sound:
+#     * PROMOTE mode rebuilds nothing: docker-publish.yml skips every build
+#       job when promote_version is set and re-points tags at the digest
+#       `:X.Y.Z` ALREADY names on ghcr.
+#     * The digest-aware republish guard (`assert-version-digest-consistent`)
+#       runs in every mode: once `:X.Y.Z` resolves, no run of any kind can
+#       re-point it to different content -- only re-apply the same digest.
+#   So any successful same-commit run, push or dispatch, leaves `:X.Y.Z`
+#   naming bytes that guard has pinned, and those are the bytes the gate then
+#   pulls by digest.
+#
+# WHAT STAYS CLOSED
+#   * No successful run of either kind -> BLOCKED (a missing or failed publish
+#     must stay RED; "assume the promote happened" is not a verdict).
+#   * A success for a DIFFERENT sha is invisible: both queries filter
+#     server-side on head_sha.
+#   * A success for the same sha on a DIFFERENT ref (e.g. the main-branch push
+#     build of the very commit the tag points at -- real: run 33510770762 for
+#     v1.8.2's commit) is rejected by the head_branch filter: a main build
+#     publishes :main/:dev, never the version tag, and must not vouch for it.
+#   * `schedule` runs are not queried at all.
+#
+# OUTPUT (stdout), one line, machine-readable:
+#   state=resolved run_id=<id>              exit 0
+#   state=pending  run_id=<id> status=<s>   exit 10  (newest unfinished run)
+#   state=blocked                           exit 20  (runs exist, all
+#                                                     completed, none green)
+#   state=none                              exit 21  (no matching runs yet)
+#   state=infra                             exit 30  (could not query; NOT a
+#                                                     verdict either way)
+#
+# Env:
+#   RESOLVE_SHA       (required) 40-hex commit being released
+#   RESOLVE_REF       (required) ref name the release runs on (e.g. v1.8.2)
+#   RESOLVE_REPO      owner/name  (default artifact-keeper/artifact-keeper)
+#   RESOLVE_WORKFLOW  workflow file (default docker-publish.yml)
+#
+set -uo pipefail
+
+SHA="${RESOLVE_SHA:-}"
+REF="${RESOLVE_REF:-}"
+REPO="${RESOLVE_REPO:-artifact-keeper/artifact-keeper}"
+WORKFLOW="${RESOLVE_WORKFLOW:-docker-publish.yml}"
+
+if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "state=infra reason=bad-sha" ; echo "RESOLVE_SHA must be a full 40-char sha (got '${SHA}')" >&2
+  exit 30
+fi
+if [[ -z "$REF" ]]; then
+  echo "state=infra reason=bad-ref" ; echo "RESOLVE_REF must be set" >&2
+  exit 30
+fi
+
+# One query per accepted event, both pinned server-side to head_sha so a stale
+# success for another commit can never appear in the candidate set at all.
+# per_page mirrors the existing idioms (push: 20, dispatch: 50 as in
+# promote-floating-tags).
+fetch() { # $1 = event, $2 = per_page
+  gh api \
+    "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?event=$1&head_sha=${SHA}&per_page=$2" \
+    --jq '.workflow_runs[] | [.id, .event, .head_branch, .status, (.conclusion // "-"), .created_at] | @tsv' \
+    2>/dev/null
+}
+
+query_failed=0
+push_tsv="$(fetch push 20)"            || query_failed=1
+dispatch_tsv="$(fetch workflow_dispatch 50)" || query_failed=1
+if [[ "$query_failed" -eq 1 ]]; then
+  echo "state=infra reason=api"
+  echo "could not query ${WORKFLOW} runs for ${SHA}; indeterminate, retry" >&2
+  exit 30
+fi
+
+# Keep only runs for OUR ref, newest last (sort_by(.created_at) | last, in
+# TSV form). The Actions API's own ordering is never trusted (#3338 lesson).
+runs_sorted="$(printf '%s\n%s\n' "$push_tsv" "$dispatch_tsv" \
+  | awk -F'\t' -v ref="$REF" 'NF >= 6 && $3 == ref' \
+  | sort -t$'\t' -k6,6)"
+
+n_runs=0
+success_id=""                      # newest success wins (input is oldest->newest)
+pending_id=""; pending_status=""   # newest unfinished likewise
+# shellcheck disable=SC2034  # r_branch: already filtered by the awk above;
+# kept in the TSV so the log lines and the self-test stub share one schema.
+while IFS=$'\t' read -r r_id r_event r_branch r_status r_conclusion r_created; do
+  [[ -z "$r_id" ]] && continue
+  n_runs=$((n_runs + 1))
+  echo "  candidate: run ${r_id} event=${r_event} status=${r_status} conclusion=${r_conclusion} created=${r_created}" >&2
+  if [[ "$r_status" == "completed" && "$r_conclusion" == "success" ]]; then
+    success_id="$r_id"
+  elif [[ "$r_status" != "completed" ]]; then
+    pending_id="$r_id"; pending_status="$r_status"
+  fi
+done <<< "$runs_sorted"
+
+if [[ -n "$success_id" ]]; then
+  echo "state=resolved run_id=${success_id}"
+  exit 0
+fi
+if [[ -n "$pending_id" ]]; then
+  echo "state=pending run_id=${pending_id} status=${pending_status}"
+  exit 10
+fi
+if [[ "$n_runs" -gt 0 ]]; then
+  echo "state=blocked"
+  echo "all ${n_runs} ${WORKFLOW} run(s) for ${REF}@${SHA} completed without success" >&2
+  exit 20
+fi
+echo "state=none"
+exit 21

--- a/scripts/ci/test-assert-adopted-image-sources.sh
+++ b/scripts/ci/test-assert-adopted-image-sources.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/assert-adopted-image-sources.sh (issue #3640).
+#
+# WHY THIS EXISTS
+#   The gate under test decides whether ALREADY-PUBLISHED bytes may stand in
+#   for the commit being released. Its dangerous direction is fail-open: an
+#   adoption that should have been refused certifies stale bytes for a tag
+#   they were not built from. So the legs that must REFUSE are the point --
+#   an image-input change (down to the Dockerfile and .dockerignore, which a
+#   path set written from memory would forget), missing provenance, and an
+#   unverifiable commit. The one leg that must PASS is the v1.8.2 shape: the
+#   published revision and the tag differ only outside the image inputs.
+#
+# HOW
+#   A scratch git repo provides real commits; the published revision is
+#   injected through ADOPT_PUBLISHED_REV exactly as release.yml passes the
+#   output of registry-tag-revision.sh. No network, ~1s.
+#
+# Usage: bash scripts/ci/test-assert-adopted-image-sources.sh
+set -uo pipefail
+
+GATE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert-adopted-image-sources.sh"
+[ -f "$GATE" ] || { echo "cannot find assert-adopted-image-sources.sh next to this test" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$*"; fails=$((fails + 1)); }
+
+# --- scratch repo with the real input-set layout ---------------------------
+REPO="$WORK/repo"
+git init -q "$REPO"
+git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+mkdir -p "$REPO/backend/src" "$REPO/.sqlx" "$REPO/docker" "$REPO/scripts/ci"
+echo 'fn main() {}'        > "$REPO/backend/src/main.rs"
+echo '[package]'           > "$REPO/Cargo.toml"
+echo 'lock v1'             > "$REPO/Cargo.lock"
+echo '{"q":1}'             > "$REPO/.sqlx/query-1.json"
+echo 'FROM scratch'        > "$REPO/docker/Dockerfile.backend"
+echo 'target/'             > "$REPO/.dockerignore"
+echo '# changelog'         > "$REPO/CHANGELOG.md"
+echo 'echo ci'             > "$REPO/scripts/ci/x.sh"
+git -C "$REPO" add -A; git -C "$REPO" commit -qm base
+REV_BASE="$(git -C "$REPO" rev-parse HEAD)"
+
+commit_after() { # $1 msg; stdout: new sha (working tree already edited)
+  git -C "$REPO" add -A; git -C "$REPO" commit -qm "$1"; git -C "$REPO" rev-parse HEAD
+}
+
+# <label> <expected-exit> <expected-substring>; env: CASE_SHA CASE_REV
+expect() {
+  local label="$1" want="$2" needle="$3" got=0
+  ( cd "$REPO" && \
+      ADOPT_TAG_SHA="$CASE_SHA" \
+      ADOPT_PUBLISHED_REV="$CASE_REV" \
+      ADOPT_LABEL="backend:9.9.9" \
+      bash "$GATE" >"$WORK/out.txt" 2>&1 ) || got=$?
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  elif ! grep -qF -- "$needle" "$WORK/out.txt"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+echo "adopted-image source gate: the legs"
+
+# 1. The normal release: the image was built from the tagged commit itself.
+CASE_SHA="$REV_BASE"; CASE_REV="$REV_BASE"
+expect "published revision == tag -> ok, no adoption" 0 \
+  "built from the tagged commit"
+
+# 2. THE v1.8.2 SHAPE: the re-tag differs from the published revision only in
+#    CHANGELOG.md and scripts/ci -- nothing the image is built from.
+echo '# changelog v2' >  "$REPO/CHANGELOG.md"
+echo 'echo ci v2'     >  "$REPO/scripts/ci/x.sh"
+SHA_DOCSONLY="$(commit_after 'docs+ci only')"
+CASE_SHA="$SHA_DOCSONLY"; CASE_REV="$REV_BASE"
+expect "tag differs only outside image inputs -> VERIFIED adoption" 0 \
+  "VERIFIED ADOPTION"
+
+# 3. Backend source changed: the published bytes are stale for this tag.
+echo 'fn main() { new(); }' > "$REPO/backend/src/main.rs"
+SHA_SRC="$(commit_after 'backend change')"
+CASE_SHA="$SHA_SRC"; CASE_REV="$REV_BASE"
+expect "backend source changed -> REFUSED, names the file" 1 \
+  "backend/src/main.rs"
+
+# 4. Only the Dockerfile changed (base image bump, tool pin): still an image
+#    input, still a different image. A path set written from the COPY lines
+#    alone would miss this.
+git -C "$REPO" checkout -q "$SHA_DOCSONLY" -- backend 2>/dev/null || true
+git -C "$REPO" reset -q --hard "$SHA_DOCSONLY"
+echo 'FROM scratch AS v2' > "$REPO/docker/Dockerfile.backend"
+SHA_DF="$(commit_after 'dockerfile change')"
+CASE_SHA="$SHA_DF"; CASE_REV="$REV_BASE"
+expect "Dockerfile changed -> REFUSED" 1 \
+  "docker/Dockerfile.backend"
+
+# 5. Only .dockerignore changed: it shapes what COPY backend sees.
+git -C "$REPO" reset -q --hard "$SHA_DOCSONLY"
+echo 'target/ extra/' > "$REPO/.dockerignore"
+SHA_DI="$(commit_after 'dockerignore change')"
+CASE_SHA="$SHA_DI"; CASE_REV="$REV_BASE"
+expect ".dockerignore changed -> REFUSED" 1 \
+  ".dockerignore"
+
+# 6. The published image has no provenance annotation. Unverifiable is not
+#    adoptable -- and it is a real verdict, not an infra retry.
+CASE_SHA="$SHA_DOCSONLY"; CASE_REV="none"
+expect "no revision annotation -> REFUSED as unverifiable" 1 \
+  "no org.opencontainers.image.revision"
+
+# 7. The registry could not be read at all: indeterminate, distinct from both
+#    pass and refuse, so the caller can retry instead of mis-verdicting.
+CASE_SHA="$SHA_DOCSONLY"; CASE_REV="indeterminate"
+expect "indeterminate revision -> INFRA" 2 \
+  "indeterminate"
+
+# 8. The published revision names a commit this repo cannot produce: no
+#    comparison, no verdict, no adoption.
+CASE_SHA="$SHA_DOCSONLY"; CASE_REV="1111111111111111111111111111111111111111"
+expect "unfetchable published commit -> INFRA" 2 \
+  "not fetchable"
+
+# 9. Malformed tag sha -> infra, not a quiet pass.
+CASE_SHA="deadbeef"; CASE_REV="$REV_BASE"
+expect "short tag sha -> INFRA" 2 \
+  "ADOPT_TAG_SHA"
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "${fails} case(s) FAILED"
+  exit 1
+fi
+echo "all cases passed"

--- a/scripts/ci/test-resolve-candidate-publish-run.sh
+++ b/scripts/ci/test-resolve-candidate-publish-run.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/resolve-candidate-publish-run.sh (issue #3640).
+#
+# WHY THIS EXISTS
+#   The resolver decides whether a docker-publish pipeline vouches for the
+#   commit being released. Its two dangerous directions are exercised here:
+#     * fail-OPEN: a success for a different sha, a different ref (the
+#       main-branch build of the same commit), or no success at all must
+#       BLOCK, and an unfinished run is a verdict that does not exist yet
+#       (the v1.7.7 shape);
+#     * fail-CLOSED-forever: the v1.8.2 deadlock -- the tag push's publish
+#       fails on immutability (permanently un-greenable) while the documented
+#       promote dispatch (#2698) succeeded for the same commit+ref. Case 2 is
+#       that exact shape and goes red if the event=push-only selection is
+#       reintroduced.
+#
+# HOW
+#   The resolver reaches GitHub only through `gh`, so a stub `gh` first on
+#   PATH replays canned Actions API answers. The stub honours the server-side
+#   `head_sha` filter for real (rows are tagged with the sha they belong to
+#   and only returned when the query asks for it), so the stale-success case
+#   tests the actual mechanism, not a shortcut. No network, ~1s.
+#
+# Usage: bash scripts/ci/test-resolve-candidate-publish-run.sh
+set -uo pipefail
+
+RESOLVER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/resolve-candidate-publish-run.sh"
+[ -f "$RESOLVER" ] || { echo "cannot find resolve-candidate-publish-run.sh next to this test" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$*"; fails=$((fails + 1)); }
+
+SHA_A=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+SHA_B=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+# --- gh stub ---------------------------------------------------------------
+# Replays  .../actions/workflows/<wf>/runs?event=<e>&head_sha=<sha>&...
+#   FAKE_PUSH_RUNS / FAKE_DISPATCH_RUNS: TSV rows
+#       id \t event \t head_branch \t status \t conclusion \t created_at
+#   FAKE_RUNS_SHA:  the sha the canned rows belong to; rows are returned only
+#                   when the query's head_sha matches (server-side filter).
+#   FAKE_RUNS_FAIL: 1 -> the API call fails.
+STUB="$WORK/bin"; mkdir -p "$STUB"
+cat > "$STUB/gh" <<'STUBGH'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      *actions/workflows/*/runs*)
+        [ "${FAKE_RUNS_FAIL-0}" = "1" ] && exit 1
+        url="$2"
+        qsha="${url##*head_sha=}"; qsha="${qsha%%&*}"
+        [ "$qsha" = "${FAKE_RUNS_SHA-}" ] || exit 0
+        case "$url" in
+          *event=push*)              [ -n "${FAKE_PUSH_RUNS-}" ]     && printf '%s\n' "$FAKE_PUSH_RUNS" ;;
+          *event=workflow_dispatch*) [ -n "${FAKE_DISPATCH_RUNS-}" ] && printf '%s\n' "$FAKE_DISPATCH_RUNS" ;;
+        esac
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+STUBGH
+chmod +x "$STUB/gh"
+
+# <label> <expected-exit> <expected-substring>
+# Reads the scenario from FAKE_* / CASE_* already exported by the caller.
+expect() {
+  local label="$1" want="$2" needle="$3" got=0
+  ( PATH="$STUB:$PATH" \
+      RESOLVE_REPO=artifact-keeper/artifact-keeper \
+      RESOLVE_SHA="${CASE_SHA:-$SHA_A}" \
+      RESOLVE_REF="${CASE_REF:-v9.9.9}" \
+      FAKE_PUSH_RUNS="${FAKE_PUSH_RUNS-}" \
+      FAKE_DISPATCH_RUNS="${FAKE_DISPATCH_RUNS-}" \
+      FAKE_RUNS_SHA="${FAKE_RUNS_SHA-$SHA_A}" \
+      FAKE_RUNS_FAIL="${FAKE_RUNS_FAIL-0}" \
+      bash "$RESOLVER" >"$WORK/out.txt" 2>&1 ) || got=$?
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected exit $want, got $got"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  elif ! grep -qF -- "$needle" "$WORK/out.txt"; then
+    fail "$label: exit $got correct but output lacks '$needle'"
+    sed 's/^/        /' "$WORK/out.txt" >&2
+  else
+    pass "$label (exit $got)"
+  fi
+}
+
+reset_case() {
+  FAKE_PUSH_RUNS=""; FAKE_DISPATCH_RUNS=""
+  FAKE_RUNS_SHA="$SHA_A"; FAKE_RUNS_FAIL=0
+  CASE_SHA="$SHA_A"; CASE_REF=v9.9.9
+}
+
+echo "candidate publish-run resolver: the legs"
+
+# 1. The normal release: the tag push's own docker-publish succeeded.
+reset_case
+FAKE_PUSH_RUNS=$'101\tpush\tv9.9.9\tcompleted\tsuccess\t2026-09-01T13:00:00Z'
+expect "push run succeeded -> resolved" 0 \
+  "state=resolved run_id=101"
+
+# 2. THE v1.8.2 DEADLOCK. The re-tag's push publish failed on image
+#    immutability (permanently red) and the documented promote dispatch
+#    (#2698) succeeded for the same commit+ref. Must resolve to the dispatch
+#    run; with an event=push-only selection this leg goes red.
+reset_case
+FAKE_PUSH_RUNS=$'201\tpush\tv9.9.9\tcompleted\tfailure\t2026-09-01T13:00:00Z'
+FAKE_DISPATCH_RUNS=$'202\tworkflow_dispatch\tv9.9.9\tcompleted\tsuccess\t2026-09-01T14:00:00Z'
+expect "push failed, promote dispatch succeeded -> resolved to the dispatch run" 0 \
+  "state=resolved run_id=202"
+
+# 3. Both failed: nothing vouches. Fail closed, do not assume a promote.
+reset_case
+FAKE_PUSH_RUNS=$'301\tpush\tv9.9.9\tcompleted\tfailure\t2026-09-01T13:00:00Z'
+FAKE_DISPATCH_RUNS=$'302\tworkflow_dispatch\tv9.9.9\tcompleted\tfailure\t2026-09-01T14:00:00Z'
+expect "push and dispatch both failed -> BLOCKED" 20 \
+  "state=blocked"
+
+# 4. No run of either kind exists (yet). Distinct from blocked so the caller
+#    can keep waiting for webhook fan-out inside its appear-deadline.
+reset_case
+expect "no runs at all -> none (caller blocks at its deadline)" 21 \
+  "state=none"
+
+# 5. A success exists only for a DIFFERENT sha. The server-side head_sha
+#    filter must keep it invisible: stale green is not evidence.
+reset_case
+FAKE_RUNS_SHA="$SHA_B"
+FAKE_PUSH_RUNS=$'501\tpush\tv9.9.9\tcompleted\tsuccess\t2026-09-01T13:00:00Z'
+FAKE_DISPATCH_RUNS=$'502\tworkflow_dispatch\tv9.9.9\tcompleted\tsuccess\t2026-09-01T14:00:00Z'
+expect "successes exist only for another sha -> not resolved" 21 \
+  "state=none"
+
+# 6. Same sha, different ref: the main-branch build of the very commit the
+#    tag points at (real shape: run 33510770762 next to v1.8.2). It publishes
+#    :main/:dev, never the version tag, and must not vouch for the release.
+reset_case
+FAKE_PUSH_RUNS=$'601\tpush\tmain\tcompleted\tsuccess\t2026-09-01T12:59:45Z\n602\tpush\tv9.9.9\tcompleted\tfailure\t2026-09-01T13:40:26Z'
+expect "main-branch success for the same sha -> BLOCKED, not resolved" 20 \
+  "state=blocked"
+
+# 7. A run is still going. An unfinished run is a verdict that does not exist
+#    yet (the v1.7.7 lesson); the caller keeps following, nothing passes.
+reset_case
+FAKE_PUSH_RUNS=$'701\tpush\tv9.9.9\tin_progress\t-\t2026-09-01T13:00:00Z'
+expect "push run in flight -> pending, names the run" 10 \
+  "state=pending run_id=701"
+
+# 8. Failed push + a promote dispatch still running: pending, not blocked --
+#    the recovery in flight must not be called dead.
+reset_case
+FAKE_PUSH_RUNS=$'801\tpush\tv9.9.9\tcompleted\tfailure\t2026-09-01T13:00:00Z'
+FAKE_DISPATCH_RUNS=$'802\tworkflow_dispatch\tv9.9.9\tqueued\t-\t2026-09-01T14:00:00Z'
+expect "push failed, dispatch queued -> pending on the dispatch" 10 \
+  "state=pending run_id=802"
+
+# 9. Two successes: the most recent one is taken (created_at, not API order).
+reset_case
+FAKE_PUSH_RUNS=$'901\tpush\tv9.9.9\tcompleted\tsuccess\t2026-09-01T13:00:00Z'
+FAKE_DISPATCH_RUNS=$'902\tworkflow_dispatch\tv9.9.9\tcompleted\tsuccess\t2026-09-01T15:00:00Z'
+expect "multiple successes -> the most recent wins" 0 \
+  "state=resolved run_id=902"
+
+# 10. The API is down. Indeterminate is neither green nor red -- it must be
+#     distinguishable from a genuine block so the caller can retry.
+reset_case
+FAKE_RUNS_FAIL=1
+expect "API failure -> infra, distinct from blocked" 30 \
+  "state=infra"
+
+# 11. Malformed inputs are infra, not a quiet pass.
+reset_case
+CASE_SHA=deadbeef
+expect "short sha -> infra" 30 \
+  "state=infra reason=bad-sha"
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "${fails} case(s) FAILED"
+  exit 1
+fi
+echo "all cases passed"


### PR DESCRIPTION
## Summary

Closes #3640.

`resolve-candidate-digest` located the docker-publish run for the release commit with a query hard-filtered to `event=push`. That deadlocks any re-tagged version, permanently: the re-tag's push-triggered publish fails on the image-immutability guard (correct, and un-greenable by design), while the documented recovery — `gh workflow run docker-publish.yml --ref vX.Y.Z -f promote_version=X.Y.Z` (#2698) — succeeds but is `event=workflow_dispatch`, so the resolver never saw it. v1.8.2 is live in exactly this state (push run 33514800258 failed on immutability; promote run 33522347257 succeeded for the same commit+ref; release blocked, and the job's error message prescribes a recovery that cannot ever succeed).

Three pieces, each a self-tested script per the `scripts/ci` convention:

**1. Accept a successful promote dispatch** (`scripts/ci/resolve-candidate-publish-run.sh`). A successful docker-publish run for the same `head_sha` **and** `head_branch` now vouches, whether `event=push` or `event=workflow_dispatch`, preferring the most recent success — the same dispatch-lookup idiom `promote-floating-tags` already uses.

**2. Verify the adoption, never assume it** (`scripts/ci/assert-adopted-image-sources.sh`). A promote means the published bytes may have been *built from a different commit* than the tag, and rebuilds can never match by construction (`GIT_SHA` build-arg, provenance `mode=max`). So after the digest is captured, the job reads the source revision the published index was built from (`.github/scripts/registry-tag-revision.sh`, which learns to fall back from the index annotation — only scanner-adapter has one — to the per-arch config's `org.opencontainers.image.revision` label) and **hard-refuses** unless published-revision and tag are byte-identical across every input `docker/Dockerfile.backend` consumes. The input set was taken from the Dockerfile itself, not from memory: its only context COPYs are `Cargo.toml Cargo.lock ./`, `backend ./backend`, `.sqlx ./.sqlx`; plus the Dockerfile (base images, build steps, pins) and `.dockerignore` (it shapes what `COPY backend` sees). Same idiom as preflight check 4's scanner-adapter comparison. A verified skew is recorded loudly in the step summary — "published from `<rev>`, tag is `<sha>`, byte-identical across every image input" — never silently.

No annotated-tag trailer gates the adoption, deliberately: `Preflight-Override:` exists for a *schedule* gate that cannot be machine-proved, whereas source compatibility here **is** machine-proved, and stronger than an operator assertion; the promote dispatch is already a deliberate per-version manual act; and the freeze policy's rule is "skip schedule, never integrity" — an integrity-adjacent gate should not grow an override channel.

**3. Stop printing impossible advice.** The blocked path now probes whether `backend:X.Y.Z` is already published (`registry-tag-state.sh`): published → the error names the `promote_version` dispatch explicitly; absent → the old "fix and re-run docker-publish" advice, which is only then achievable; unreadable → both options, labelled as such.

## Why bytes-tested == bytes-published still holds

- A `promote_version` dispatch **rebuilds nothing**: docker-publish.yml skips every build job in PROMOTE mode and re-points tags at the digest `:X.Y.Z` already names on ghcr (verified against `Resolve publish plan` / `Resolve incoming digest`).
- The digest-aware republish guard (`assert-version-digest-consistent`) runs in **every** mode: once `:X.Y.Z` resolves, no run of any kind can re-point it to different content. This includes `promote_floating`, which only moves `:latest`/`:X.Y` at that same digest.
- The digest the gate deploys is read **from the registry** after the wait, and `verify-images-published` re-asserts it at the end of the chain.
- The full release gate already ran green against these exact published bytes on the first v1.8.2 attempt (run 33474745112); only the binary-SBOM check after it failed.

The one property that changes is "image built from the tagged commit" — which no gate asserted before, was already lost the moment the version first published, and is now *measured and bounded*: adoption is only permitted when the published revision and the tag are byte-identical across the image's entire input set, and the skew is printed, not hidden.

## What stays closed (fail-closed inventory)

- No successful run of either kind → BLOCKED red ("assume the promote happened" is not a verdict).
- A success for a **different sha** is excluded server-side (`head_sha=` in both queries).
- The **main-branch build of the very same commit** (real neighbour: run 33510770762) is excluded by the `head_branch == ref` filter.
- Published bytes whose sources differ from the tag *anywhere in the image input set* → REFUSED ("bump the version, do not re-tag").
- Published bytes with no readable provenance → REFUSED as unverifiable (`none` is a measured verdict, not a retry).
- An unfinished run is pending, not a pass (the v1.7.7 lesson); the wait keeps the event-driven no-fixed-clock behavior from #2711.
- Actions API / registry failures are INFRA, distinguishable from a genuine block.
- `schedule` runs are not queried at all.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Two new self-tests, wired into the ci.yml script self-tests job, offline (stubbed `gh` / scratch git repo):

- `test-resolve-candidate-publish-run.sh` — 11 legs; the stub implements the server-side `head_sha` filter for real. Revert-proof: with the `event=push`-only selection reinstated, the deadlock leg fails:

  ```
  FAIL  push failed, promote dispatch succeeded -> resolved to the dispatch run: expected exit 0, got 20
        state=blocked
        all 1 docker-publish.yml run(s) for v9.9.9@aaaa... completed without success
  ```

- `test-assert-adopted-image-sources.sh` — 9 legs; the refusal legs are the point (backend source change, Dockerfile-only change, `.dockerignore`-only change, missing provenance, unfetchable revision).

## Test Checklist
- [x] Unit tests added/updated (20 self-test legs across the two scripts; full scripts/ci battery green locally)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — live dry-runs against the stuck release: the resolver returns `state=resolved run_id=33522347257` (the successful promote dispatch; failed push run and main-branch run correctly not selected); `registry-tag-revision.sh` reads `c8dc5f7d…` off the published `backend:1.8.2` config label; the adoption gate verifies it against `d8c497e8…` (real diff: `CHANGELOG.md` + two `scripts/ci/*.sh` — outside the image input set) and prints VERIFIED ADOPTION; `registry-tag-state.sh` reports `present` for the truthful error branch; the embedded wait loop smoke-tested for resolved, pending→resolved and blocked paths
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
