### PR TITLE
fix(projects): accept service_account as a project-member principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Consumers still have to opt in. In artifact-keeper-web five admin screens read this endpoint — the permissions principal picker, the users list, the group member picker, the audit actor filter and the age-gate approver picker — and four of them have no other source for the distinction; the picker is fixed page-locally in artifact-keeper-web#823, the rest wait on an SDK release carrying this field.
 
+- **A service account could not be granted access through a project, leaving project-managed deployments with no grant channel for it at all** (#3683). `POST /api/v1/projects/{id}/members` refused `principal_type: "service_account"` outright — `valid_principal_type` accepted only `user | group`, even though its own doc comment claimed to match the principal domain `PermissionService::query_actions` resolves, which has matched `principal_type IN ('user','service_account')` since #2499/#2433. So the read plane happily resolved a `service_account` grant on a `project` target while the write plane refused to create one. A service account is created with no role and no grant, and token scopes only ever *narrow* — they never confer — so with the project endpoint closed and the shipped web UI able to emit only `principal_type: "user"` (rejected for a service-account row by the #2503 correspondence guard, listing half fixed in #3634/#3635), an operator who manages access by project had no way to give the account anything. Every push then failed the repository gate exactly as reported: `denied: You do not have access to this repository` from `docker push`, `403 FORBIDDEN` from a generic `PUT`. Enforcement was never the defect — the deny was `user_can_access_repo` correctly answering "no" because no row named the account. `valid_principal_type` now accepts `service_account` as well. This is not a 1.8.x regression: the gap dates to #2483 (v1.6.0).
+
+  The #2503 mistype guard is untouched. `add_project_member` calls `PermissionService::validate_principal` immediately after the type allowlist, so the `principal_type`/`principal_id` correspondence is still checked against the database: `service_account` naming a person's id is still a 400, and so is `user` naming a service account's id. Widening the allowlist only stops refusing a grant the resolver already honours.
+
+  **Workaround without upgrading**, on any 1.6+ build — grant the service account directly, with the right principal type, on the endpoint that already accepts it:
+
+  ```
+  curl -X POST $AK/api/v1/permissions \
+    -H "Authorization: Bearer <admin token>" -H 'Content-Type: application/json' \
+    -d '{"principal_type":"service_account","principal_id":"<sa uuid>",
+         "target_type":"repository","target_id":"<repo uuid>","actions":["read","write"]}'
+  ```
+
+  Adding the service account to a group that holds the grant works too. Note this is the API, not the UI: the web form still submits `principal_type: "user"`, and that half is tracked in artifact-keeper-web — this release does not change it.
+
+  **"Admin permissions don't work either" is a different, deliberate behaviour, not this bug.** A token minted without the `admin` (or `*`) scope is demoted to a non-admin principal by `with_scope_gated_admin` even when the account itself is an admin — that is GHSA-vvc3-h39c-mrq5's scope gate working as designed, and it is why an admin-owned service account with a `read`/`write`-only token is still denied. Mint the token with the `admin` scope if you want admin authority through it, or, better, grant the account the actions it needs and leave the token narrow.
+
 ### Security
 
 - **One remote repository's upstream credentials could be spent by another repository that has none** (#3606). The in-memory OCI bearer-token cache was keyed on `realm`, `service` and `scope` only. That map belongs to the single `UpstreamClient` the process-wide `ProxyService` owns, so it is shared by every Remote repository in the deployment: a repository holding upstream credentials exchanged them for a token against a private registry, and a *different* Remote repository pointed at the same registry — potentially another team's, with no credentials configured at all — produced the identical key on its next pull and was handed that token. It then read whatever the credentialed repository could read, for as long as the entry stayed inside its TTL. The credential itself was never disclosed; the access it grants was. No configuration flag was involved — two Remote repositories against one registry with credentials on one of them is all it took, which is the ordinary shape when one team mirrors a private registry and another mirrors its public subset.

--- a/backend/src/api/handlers/projects.rs
+++ b/backend/src/api/handlers/projects.rs
@@ -55,9 +55,13 @@ pub fn router() -> Router<SharedState> {
 
 /// Principal types accepted for project membership grants. Matches the
 /// principal domain resolved by `PermissionService::query_actions` (`user`
-/// directly, `group` via `user_group_members`).
+/// and `service_account` directly — the resolver matches
+/// `principal_type IN ('user','service_account')` since #2499/#2433 — and
+/// `group` via `user_group_members`). Refusing `service_account` here (#3683)
+/// left a service account with no project-level grant channel at all while
+/// the read side happily resolved such a row.
 pub(crate) fn valid_principal_type(principal_type: &str) -> bool {
-    matches!(principal_type, "user" | "group")
+    matches!(principal_type, "user" | "service_account" | "group")
 }
 
 /// Membership grants must carry at least one action: an empty action list is
@@ -103,7 +107,7 @@ pub(crate) fn validate_project_key(key: &str) -> Result<()> {
 pub(crate) fn validate_member_grant(principal_type: &str, actions: &[String]) -> Result<()> {
     if !valid_principal_type(principal_type) {
         return Err(AppError::Validation(format!(
-            "Invalid principal_type '{}': must be 'user' or 'group'",
+            "Invalid principal_type '{}': must be 'user', 'service_account' or 'group'",
             principal_type
         )));
     }
@@ -156,7 +160,7 @@ pub struct ProjectMemberListResponse {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct AddProjectMemberRequest {
-    /// "user" or "group".
+    /// "user", "service_account" or "group".
     pub principal_type: String,
     pub principal_id: Uuid,
     /// Actions granted on every repository in the project (e.g. ["read"],
@@ -485,7 +489,8 @@ pub async fn add_project_member(
 
     validate_member_grant(&payload.principal_type, &payload.actions)?;
     // #2503 (defense-in-depth): `validate_member_grant` only enforces the
-    // project-member *type allowlist* (user|group) and non-empty actions — it
+    // project-member *type allowlist* (user|service_account|group) and
+    // non-empty actions — it
     // never checks that `principal_id` actually names a principal of that type.
     // Without this, a mistyped grant (e.g. `principal_type = 'user'` naming a
     // service-account id) is upserted here and, because project grants are
@@ -625,12 +630,14 @@ mod tests {
     fn test_valid_principal_type_user_and_group() {
         assert!(valid_principal_type("user"));
         assert!(valid_principal_type("group"));
+        // #3683: the resolver has matched `service_account` since #2499/#2433;
+        // refusing it here was the authoring-side gap, not a guard.
+        assert!(valid_principal_type("service_account"));
     }
 
     #[test]
     fn test_invalid_principal_types_rejected() {
         assert!(!valid_principal_type("admin"));
-        assert!(!valid_principal_type("service_account"));
         assert!(!valid_principal_type("USER"));
         assert!(!valid_principal_type(""));
         assert!(!valid_principal_type("project"));
@@ -1009,6 +1016,123 @@ mod tests {
                 .bind(sa_id)
                 .execute(&pool)
                 .await;
+        }
+
+        /// #3683: a service account must be grantable through a project.
+        ///
+        /// `valid_principal_type` refused `service_account`, so a
+        /// project-managed deployment had no channel at all to write the one
+        /// principal type the read predicates already resolve
+        /// (`permission_service::query_actions`,
+        /// `repository_service::permissions_grant_exists`) — the service
+        /// account's token then failed `require_repo_write_access` and the
+        /// docker/generic push came back 403.
+        ///
+        /// Drives the reporter's shape end to end: add the SA as a project
+        /// member, then assert its token clears the write gate on a private
+        /// repository assigned to that project. Fails on main at the
+        /// `add_project_member` call (400 Validation).
+        #[tokio::test]
+        async fn test_service_account_project_member_can_write_to_project_repo() {
+            use crate::api::handlers::repositories::require_repo_write_access;
+            use crate::models::access_scope::AccessScope;
+            use crate::services::repository_service::RepositoryService;
+
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let dir = std::env::temp_dir().join(format!("prj-sa-{}", Uuid::new_v4()));
+            let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+            let (admin_id, admin_name) = tdh::create_user(&pool).await;
+            let admin = tdh::admin_auth(admin_id, &admin_name);
+            let (sa_id, sa_name) = tdh::create_service_account(&pool).await;
+            let (repo_id, repo_key, repo_dir) = tdh::create_repo(&pool, "local", "generic").await;
+            let project_id = create_project_row(&pool, "sa").await;
+            assign_repo_to_project(&pool, repo_id, project_id).await;
+
+            // The service account's own API token: action scopes only, no
+            // repository restriction (the reporter's "w/o repo scope" case).
+            let sa_auth = AuthExtension {
+                is_api_token: true,
+                is_service_account: true,
+                scopes: Some(vec!["read".to_string(), "write".to_string()]),
+                allowed_repo_ids: AccessScope::Admin,
+                ..tdh::make_auth(sa_id, &sa_name)
+            };
+            let repo_service = RepositoryService::new(pool.clone());
+            let repo = repo_service.get_by_key(&repo_key).await.expect("repo");
+
+            let denied_before = require_repo_write_access(&sa_auth, &repo, &repo_service)
+                .await
+                .is_err();
+
+            let call = |ptype: &str, pid: Uuid| {
+                let state = state.clone();
+                let admin = admin.clone();
+                let body = axum::body::Bytes::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "principal_type": ptype,
+                        "principal_id": pid,
+                        "actions": ["read", "write"],
+                    }))
+                    .unwrap(),
+                );
+                async move {
+                    add_project_member(State(state), Extension(Some(admin)), Path(project_id), body)
+                        .await
+                }
+            };
+
+            let granted = call("service_account", sa_id).await;
+            let grant_ok = granted.is_ok();
+            state.permission_service.invalidate_cache();
+
+            let allowed_after = require_repo_write_access(&sa_auth, &repo, &repo_service)
+                .await
+                .is_ok();
+            let action_after = state
+                .permission_service
+                .check_repository_action(sa_id, repo_id, "write", false)
+                .await
+                .unwrap_or(false);
+
+            // #2503 mistype guard is untouched: `validate_principal` runs right
+            // after the type allowlist, so a `service_account`-typed grant naming
+            // a plain user id is still a 400.
+            let (plain_user_id, _) = tdh::create_user(&pool).await;
+            let mistyped = call("service_account", plain_user_id).await;
+
+            cleanup_project(&pool, project_id).await;
+            tdh::cleanup(&pool, repo_id, sa_id).await;
+            tdh::cleanup_user(&pool, plain_user_id).await;
+            tdh::cleanup_user(&pool, admin_id).await;
+            let _ = std::fs::remove_dir_all(&repo_dir);
+            let _ = std::fs::remove_dir_all(&dir);
+
+            assert!(
+                denied_before,
+                "precondition: the service account must start with no access"
+            );
+            assert!(
+                grant_ok,
+                "#3683: POST /projects/{{id}}/members must accept \
+                 principal_type = 'service_account' (got {granted:?})"
+            );
+            assert!(
+                allowed_after,
+                "#3683: the granted service account's token must clear \
+                 require_repo_write_access on the project's repository"
+            );
+            assert!(
+                action_after,
+                "#3683: the inherited project grant must also satisfy the \
+                 canonical write-action check"
+            );
+            assert!(
+                matches!(mistyped, Err(AppError::Validation(_))),
+                "#2503 guard must survive: a 'service_account' grant naming a \
+                 plain user id is still a 400, got {mistyped:?}"
+            );
         }
 
         /// (2) Cross-project isolation: a grant on project B conveys nothing

--- a/backend/src/api/handlers/projects.rs
+++ b/backend/src/api/handlers/projects.rs
@@ -627,7 +627,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_valid_principal_type_user_and_group() {
+    fn test_valid_principal_type_accepts_user_group_and_service_account() {
         assert!(valid_principal_type("user"));
         assert!(valid_principal_type("group"));
         // #3683: the resolver has matched `service_account` since #2499/#2433;


### PR DESCRIPTION
## Summary

`POST /api/v1/projects/{id}/members` refused `principal_type: "service_account"` outright — `valid_principal_type` (`backend/src/api/handlers/projects.rs`) matched only `"user" | "group"`, although its own doc comment claimed to match the principal domain `PermissionService::query_actions` resolves, which has been `principal_type IN ('user','service_account')` since #2499/#2433. The read plane resolved a `service_account` grant on a `project` target; the write plane refused to create one.

A service account is created with no role and no grant, and token scopes only *narrow* — they never confer. With the project endpoint closed and the shipped web UI able to emit only `principal_type: "user"` (rejected for a service-account row by the #2503 correspondence guard; listing half fixed in #3634/#3635), an operator who manages access by project had **no** grant channel at all, and every push failed the repository gate exactly as reported.

**Enforcement was never the defect.** The 403 in the reporter's log is `user_can_access_repo` correctly answering "no" because no row named the account. This is also not a 1.8.x regression — the gap dates to #2483 (v1.6.0).

The fix is one line plus its now-false doc comment.

## The #2503 mistype guard is untouched

`add_project_member` calls `PermissionService::validate_principal` immediately after the type allowlist, so the `principal_type`/`principal_id` correspondence is still checked against the database. `service_account` naming a person's id is still a 400, and `user` naming a service account's id is still a 400. Widening the allowlist only stops refusing a grant the resolver already honours; it changes nothing about resolution.

## Also worth knowing (no code change)

The "admin permissions don't work either" reports on the issue are a *different, deliberate* behaviour: a token minted without the `admin` (or `*`) scope is demoted to a non-admin principal by `with_scope_gated_admin` even when the account is an admin — GHSA-vvc3-h39c-mrq5's scope gate working as designed. The CHANGELOG bullet says so explicitly so operators stop reading it as the same bug.

## Changes

- `backend/src/api/handlers/projects.rs` — `valid_principal_type` accepts `service_account`; doc comment corrected; validation-error message and the `AddProjectMemberRequest.principal_type` schema doc list the three types.
- Flipped `test_valid_principal_type_user_and_group` / `test_invalid_principal_types_rejected`, which pinned the rejection.
- New DB-backed regression test.
- `CHANGELOG.md` — one bullet under `### Fixed`, including the pre-upgrade curl workaround and the GHSA-vvc3 note.

## Regression test

`api::handlers::projects::tests::db::test_service_account_project_member_can_write_to_project_repo`

Drives the reporter's shape end to end: seeds a service account, a private generic repository, and a project holding that repository; asserts the SA token is **denied** by `require_repo_write_access` first; adds the SA as a project member through `add_project_member`; then asserts the same token clears `require_repo_write_access` **and** the canonical `check_repository_action(.., "write", ..)`. It also pins the negative case — a `service_account`-typed grant naming a plain user id is still a 400 — so the #2503 guard cannot be regressed silently.

**Proof it fails without the change** (one-line `matches!` reverted, test kept):

```
FAIL api::handlers::projects::tests::db::test_service_account_project_member_can_write_to_project_repo
  #3683: POST /projects/{id}/members must accept principal_type = 'service_account'
  (got Err(Validation("Invalid principal_type 'service_account': must be 'user', 'service_account' or 'group'")))
FAIL api::handlers::projects::tests::test_valid_principal_type_user_and_group
  assertion failed: valid_principal_type("service_account")
Summary: 2 tests run: 0 passed, 2 failed
```

## Verified

Postgres 16 (throwaway container, `backend/migrations` 001-211 applied), `AK_TESTS_REQUIRE_DB=1`.

- `cargo fmt` — clean.
- `cargo check -p artifact-keeper-backend --lib --tests` — clean.
- `cargo clippy -p artifact-keeper-backend --all-targets -- -D warnings` — clean.
- `cargo nextest run -p artifact-keeper-backend --lib -E 'test(/api::handlers::projects::/) or test(/api::handlers::permissions::/) or test(/services::permission_service::/) or test(service_account)'` — **253 passed, 0 failed** (includes all 32 `projects::` tests and `repository_service::tests::db::test_user_can_access_repo_service_account_grant_honored`).
- Counterfactual as quoted above.

**Not run:** the full `--lib` suite, integration/e2e tests, and anything requiring a live registry or the web UI. The web-side half — the permissions form still submitting `principal_type: "user"` — is in `artifact-keeper-web` and is out of scope here.

Part of #3683 — closes the project-membership grant channel; the reporter's own repro (no project) is served by `POST /api/v1/permissions` with `principal_type: "service_account"`, and the web UI half is artifact-keeper-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6pg381RiaM9GsdVEyrN8M