### PR TITLE
docs(helm): fix comments left describing the absolute-URL approach (#3680)

### DIFF
--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -1662,14 +1662,6 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
         assert_eq!(key, "helm/grafana/7.0.0/grafana-7.0.0.tgz");
     }
 
-    #[test]
-    fn test_helm_chart_url() {
-        let repo_key = "helm-local";
-        let filename = "ingress-nginx-4.8.0.tgz";
-        let url = format!("/helm/{}/charts/{}", repo_key, filename);
-        assert_eq!(url, "/helm/helm-local/charts/ingress-nginx-4.8.0.tgz");
-    }
-
     /// Pins the PATH arm on its own: an OCI-shaped `artifacts.path` with a
     /// content type that matches NO entry in the media-type list. If the
     /// `path.starts_with("v2/") && path.contains("/manifests/")` arm is
@@ -1862,14 +1854,15 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
         assert_eq!(
             chart_url, "charts/mychart-0.1.0.tgz",
             "index.yaml must advertise the actual stored filename, not the \
-             broken name/version reconstruction — absolute, so that \
-             `helm dependency update` does not join it onto the repo URL (#3680)"
+             broken name/version reconstruction — and relative, so that the \
+             join `helm dependency update` performs against the repository URL \
+             resolves instead of doubling the path (#3680)"
         );
 
-        // THE POINT: the advertised URL must actually serve the chart. The
-        // router under test is mounted without the `/helm` nest prefix, and the
-        // test request carries no Host header, so the advertised base is the
-        // extractor's `http://localhost` fallback.
+        // THE POINT: the advertised URL must actually serve the chart. It is
+        // relative, so this performs the same join a client does — against the
+        // repository URL — except that the router under test is mounted without
+        // the `/helm` nest prefix, leaving `/{repo_key}/{advertised}`.
         let download_path = format!("/{}/{}", f.repo_key, chart_url);
         let app = f.router_anon(super::router());
         let (status, got) = tdh::send(app, tdh::get(download_path.to_string())).await;
@@ -2439,9 +2432,8 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
         let chart_url = entries[0].urls.first().expect("chart url");
         assert_eq!(chart_url, "charts/provchart-0.1.0.tgz");
         let prov_url = format!("{}.prov", chart_url);
-        // The router under test is mounted without the `/helm` nest prefix, and
-        // the test request carries no Host header, so the advertised base is
-        // the extractor's `http://localhost` fallback.
+        // Same join as the chart above: the advertised URL is relative, and the
+        // router under test is mounted without the `/helm` nest prefix.
         let prov_path = format!("/{}/{}", f.repo_key, prov_url);
 
         let app = f.router_anon(super::router());


### PR DESCRIPTION
Closes #3724

Follow-up to #3682, which you offered to tidy — these are my comments, so I'd rather not leave them for you. Filed as #3724 so this has a linked issue.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — comments and a vacuous test; no production behaviour changes

## Summary

Three spots still described the round-1 absolute-URL approach after the merged fix switched to relative:

1. `test_helm_index_url_resolves_for_bare_path_generic_upload`'s assertion message said the URL is *"absolute, so that `helm dependency update` does not join it onto the repo URL"*. That join is now the mechanism the fix relies on, not the thing it avoids — the message now says relative, so the join resolves instead of doubling.
2. Two comments (the chart round-trip and the `.prov` round-trip) explained that the advertised base is the `RequestBaseUrl` `http://localhost` fallback because the test request carries no `Host` header. That extractor is gone from this path; both now say what the test actually does — the same join a client performs, against a router mounted without the `/helm` nest prefix.

Also drops `test_helm_chart_url`. It built a string with `format!` and asserted it equalled the same literal, so it never exercised production code — and the literal it pinned was `/helm/{repo}/charts/{file}`, the root-relative form the code no longer emits. The advertised URL is covered by `test_chart_download_url_*` and by the two DB-backed round-trips that fetch it.

## Test Checklist

- [x] Unit tests added/updated — one removed, none added
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — helm module **73/73** against a live Postgres (`AK_TESTS_REQUIRE_DB=1`); `cargo fmt --check` clean
- [x] No regressions in existing tests

## API Changes

- [x] N/A - no API changes
