### PR TITLE
docs(changelog): sync the 1.9.0 release notes with the published description

### DIFF
--- a/.github/release-notes/1.9.0.md
+++ b/.github/release-notes/1.9.0.md
@@ -1,6 +1,6 @@
 # Artifact Keeper 1.9.0
 
-A security and proxy-correctness release. Two things change behaviour you may be relying on, and one restores caching that has been silently off since 1.7.4 — read the first three sections before upgrading.
+A security and proxy-correctness release. Two things change behaviour you may be relying on, one restores caching that has been silently off since 1.7.4, and the bundled PostgreSQL moves to 18, which is not an in-place upgrade — read the first four sections before upgrading.
 
 ## Read this first — proxied Maven and npm artifacts start caching again
 
@@ -18,41 +18,53 @@ Caching resumes at the next fetch with no action from you. Expect a one-time inc
 
 ## Read this third — expired images are now actually reclaimed
 
-A Docker or OCI image expired by a lifecycle policy kept its last tag, and both storage GC and blob GC treated that tag as a live reference, so nothing was ever reclaimed until the next restart (#3732). The tag is now pruned when no live artifact backs its digest, and images stranded by earlier releases are reclaimed on the next lifecycle run. If you have been sizing storage around the old behaviour, expect a one-time drop.
+A Docker or OCI image expired by a lifecycle policy kept its last tag, and both storage GC and blob GC treated that tag as a live reference, so nothing was ever reclaimed until the next restart (#3732). The tag is now pruned when no live artifact backs its digest, and images stranded by earlier releases are reclaimed on the next lifecycle run. If you have been sizing storage around the old behaviour, expect a one-time drop. Blob GC remains opt-in (`BLOB_GC_ENABLED`).
 
 Deleting a repository still leaves its OCI objects on disk (#3733); that fix is scheduled for 1.10.0. Until then, delete the images first, let GC run, then delete the repository.
 
+## Read this fourth — the bundled PostgreSQL moves to 18, and its mount point moved
+
+**Base, CI and e2e images move to current releases** (#2883, #3639), including PostgreSQL 16 → 18 in the compose stack. The PostgreSQL 18 image expects its volume at `/var/lib/postgresql`, not `/var/lib/postgresql/data` (the old path fails with `unused mount/volume`), and refuses a data directory initialised by an older major, so on an existing deployment `docker compose up` fails with `FATAL: database files are incompatible with server` and the backend never starts. **No data is lost**, but the stack stays down until you act: `pg_dumpall` before upgrading and restore into a fresh volume, run `pg_upgrade`, or pin `postgres:16-alpine` in an override file. The bundled compose files are updated; managed database services are unaffected.
+
 ## Security
 
-Eighteen fixes, the largest group being existence oracles and unauthenticated error paths:
+Seventeen fixes, the largest group being existence oracles and unauthenticated error paths:
 
-- Repository existence is no longer inferable from a denied read on any surface (#3524, #3716, #3717, #3730), and the login endpoint no longer reveals whether a username exists (#3504).
+- Repository existence is no longer inferable from a denied read on any surface (#3524, #3716, #3717, #3730), and the login endpoint no longer reveals whether a username exists (#3504). A locked account now gets the same `Invalid username or password` as every other failure — the lockout is still enforced and still logged, with a new audit `reason` field — and the bcrypt padding that closes the timing half is budgeted per source IP by a new `RATE_LIMIT_LOGIN_FAILED_PER_IP_PER_WINDOW` (default 30 per 300 s), which gates the pad, never the login.
 - A NUL byte in a URL path, a query parameter, a login username or a JSON body field no longer reaches Postgres as an unauthenticated `500` (#3622, #3673, #3713).
-- 41 handler-local error paths returned the raw Postgres, sqlx or IO error in their response body, most of them to unauthenticated callers; all now emit the sanitised envelope with the raw error going to the log (#3667), and a gate test keeps the phrasing from returning.
-- A crafted archive could make the scanner, the PyPI upload route, or four other ingestion paths decompress a tar extension record in full before any per-entry limit applied (#3662, #3672).
+- 41 handler-local error paths returned the raw Postgres, sqlx or IO error in their response body, most of them to unauthenticated callers; all now emit the sanitised envelope with the raw error going to the log (#3667), and a gate test keeps the phrasing from returning. The shared `handlers::db_err` mapper behind 114 format-handler call sites did the same and now answers the `{"code":"DATABASE_ERROR"}` envelope (#3623); read the JSON `code`, not the old `Database error:` text, and expect those sites to log a server-side ERROR for the first time.
+- A crafted archive could make the scanner, the PyPI upload route, or four other ingestion paths decompress a tar extension record in full before any per-entry limit applied (#3528, #3662, #3672). The 128 MiB `MAX_INGEST_DECOMPRESSED_BYTES` ceiling now applies before an archive's metadata file is reached, and a PyPI sdist that breaches it is refused with `400` rather than stored.
 - One Remote repository's upstream credentials could be spent by another repository that had none (#3606).
-- Search and listing filters treated `%`, `_` and `\` in a user's term as wildcards (#3621).
-- The bundled `grype` and `trivy` scanners are rebuilt, clearing CVE-2026-84304 and the earlier grpc-go and x/mod findings from both scanner images (#3696, #3753).
+- A repository-scoped token — the shape CI tokens take — was refused a read of a *public* repository that the same request served anonymously, on the native format routes (#3648) and on OCI `/v2`, the tree browser and the REST artifact gate (#3704, #3703). Reads only; private repositories never take the bypass.
+- Search and listing filters treated `%`, `_` and `\` in a user's term as wildcards (#3557). Search boxes are now a literal substring search; only `GET /api/v1/search/advanced?name=` keeps `*` as a wildcard.
+- The bundled `grype` is rebuilt from v0.118.0 with grpc at v1.83.1, and the scanner adapter on trivy 0.74.0-r2, clearing CVE-2026-84304 from both scanner images (#3655, #3696, #3753); v0.118.0 also retires the `x/mod` override from #3465.
 
 ## Proxy and virtual repositories
 
-- A throttled or broken upstream no longer makes the proxy discard a good cache entry and re-download it: `429` and `5xx` on the revalidation probe now serve stale instead (#3571, #3760).
-- An OCI Remote kept serving an expired mutable tag without asking upstream, so a moved `:latest` resolved to the old digest indefinitely (#3712). The same gap through an OCI Virtual fronting a Remote member is fixed too (#3725), along with pulls through a Virtual leaving no tag, artifact or package on the member (#3731) and tagged images pulled by Docker or containerd never appearing in the catalog (#3707).
+- A throttled or broken upstream no longer makes the proxy discard a good cache entry and re-download it: `429` and `5xx` on the revalidation probe now serve stale instead (#3571, #3756, #3760).
+- An OCI Remote kept serving an expired mutable tag without asking upstream, so a moved `:latest` resolved to the old digest indefinitely (#3712). The same gap through an OCI Virtual fronting a Remote member is fixed too (#3725), along with pulls through a Virtual leaving no tag, artifact or package on the member (#3731) and tagged images pulled by Docker or containerd never appearing in the catalog (#3707). **Upgrade note:** a warm pull by tag now costs one upstream request per tag once its `cache_ttl_secs` (default 300 s) has elapsed. An unreachable upstream still serves the cached copy, but only after the attempt fails, so an offline or seeded-once mirror sees slower pulls; raise `cache_ttl_secs` there to keep tags local.
 - A Virtual RPM repository over Remote members served an empty repository, so `dnf` installed nothing (#3573).
 - An npm Virtual advertised tarball URLs that answered `404` on that same repository (#3646). Note the policy consequence: a hosted package name no longer blocks upstream versions of that name from being served through a Virtual, which matches what the merged packument has advertised since 1.8.0. An opt-in isolate mode is #3767.
-- A chart hosted in a Helm repository could not be consumed as a subchart dependency (#3680).
+- A chart hosted in a Helm repository could not be consumed as a subchart dependency (#3680, #3720); advertised chart URLs are now relative (`charts/{file}`) on hosted, remote and virtual indexes alike.
 
 ## Other fixes worth knowing
 
-- An SSO-only instance whose built-in admin had been deactivated was locked out permanently (#3723).
-- A repository reachable only through a fine-grained permission grant was invisible to global search (#3697) and listed none of its webhooks (#3702); service accounts could not be granted access through a project (#3683).
-- `go.sum` verification never routed through a GOPROXY repository (#3642), and `npm audit` through a Remote npm repository reported no vulnerabilities for dependencies it could not resolve (#3541).
+- An SSO-only instance whose built-in admin had been deactivated was locked out permanently (#3723). A locked instance unlocks on its own after upgrading, and the `403` now names `SKIP_ADMIN_PROVISIONING=true`, the right long-term setting when every admin comes from SSO.
+- A repository reachable only through a fine-grained permission grant was invisible to global search (#3697) and listed none of its webhooks (#3702); service accounts could not be granted access through a project (#3683). Search results grow for grants carrying `read` or `admin`; a `{write}`-only grant does not become searchable.
+- Charts pushed to a hosted Helm repository never appeared on the Packages page (#3531). Nothing backfills the catalog, so charts pushed before this release stay off it until pushed again.
+- `GET /api/v1/users` now carries `is_service_account` and accepts it as an opt-in filter (#3634), so a permission picker can tell people from the service accounts that `POST /api/v1/permissions` rejects; the web UI still has to adopt it.
+- A scan cancelled by its wall-clock budget leaked its workspace directory (#3565), so an instance whose scans time out regularly filled its scan-workspace volume. The workspace is now removed on every exit path, cancellation included; Grype's `registry:`-mode BOM under `grype-bom/` is the one sidecar still not covered.
+- `go.sum` verification never routed through a GOPROXY repository (#3642), and `npm audit` through a Remote npm repository reported "found 0 vulnerabilities" for trees with known-vulnerable packages (#3644): npm gzips the audit POST, nothing decoded it, and the upstream rejection came back as an empty advisory set with `200`. An audit that cannot be performed is now a `400` or `415`, never an empty all-clear.
 - `GET /repositories/{key}/cache-ttl` reported 86400 s for a Remote with no stored override while the proxy applied the 300 s mutable-path default; the API now reports what the proxy applies (#3706). No caching behaviour changed.
 
 ## Added
 
 Maven repositories now publish a Resolver prefixes file at `.meta/prefixes.txt` (#3383), on hosted, remote and virtual repositories. Maven 3.9+ and Resolver 1.9+ use it to skip a repository that cannot serve an artifact, which removes a round trip per miss. A virtual repository answers `404` whenever any member's set is unknown, so a partial allowlist is never published as authoritative.
 
-## Supply chain and CI
+## Release process, supply chain and CI
 
-The digest-pinned trivy base image is now watched weekly rather than audited at the release cut (#3755), and a version-pinned component whose sources change without a VERSION bump now fails on the pull request that changed it instead of at the cut (#3754). Both were found the hard way during this release.
+**Releases are now cut by certifying a commit; nothing gets a permanent name until the full Release Gate has passed on that exact commit** (#3769, #3771, #3772, #3773, #3774, #3775). A gate failure used to burn a version number, because the tag, `:X.Y.Z` and the adapter's `:latest` were already irreversible when the gate ran — 1.9.0 hit every edge of that at once. Two dispatch workflows replace the tag push. **Release Candidate** takes a commit on `main`, reads its version from `Cargo.toml`, refuses it unless Release Preflight is READY and the version has no tag or Release, runs the Release Gate against the `sha-<sha>` images Docker Publish already built, and records a signed attestation on each digest. **Release Promote** verifies that certification, applies `:X.Y.Z` to the certified digests, creates the `vX.Y.Z` tag last and dispatches the publish workflows on it. A hand-pushed stable tag is refused outright by both workflows, and `release.yml` refuses a dispatched stable tag with no certification. Every check that ran only on a clean tag ref now runs in the candidate (#3773); a failed gate is never re-run, since "Re-run failed jobs" replays the `deploy` outputs into a namespace already torn down — recovery is a new candidate (#3774). `-rc.N` tags keep the old path as the fallback. A `grep -q` under `pipefail` refused the first certified candidate as lacking a trigger it carried (#3780); fixed.
+
+Floating tags are fixed twice: the post-gate `apply-floating-tags` job had been skipped on every promote since it shipped, because its implicit `success()` guard counted the intentionally-skipped build jobs (#3652), and the scanner adapter's own `:latest`, `:1.2` and `:1` still moved on the tag push, before a single gate test ran (#3770). The adapter now follows the same post-gate rule — only to an adapter version a published release ships, never backwards — so a base-image errata fix reaches the chart-pinned `:1` by bumping `VERSION` and cutting a release.
+
+The scanner adapter is published as 1.2.9 — its Dockerfile changed with #3579's Go toolchain bump and exact version tags are never republished (#3752) — and then as 1.2.10 for the trivy repoint (#3753). The digest-pinned trivy base image is now watched weekly rather than audited at the release cut (#3755), and a version-pinned component whose sources change without a VERSION bump now fails on the pull request that changed it instead of at the cut (#3754). Both were found the hard way during this release. The toolchain-pin assertion no longer fails on a runner whose rustup auto-installs the pinned toolchain (#3742), and the backend image's Rust toolchain moves to 1.98.0, matching `rust-toolchain.toml` (#3639).


### PR DESCRIPTION
## Summary

Brings `.github/release-notes/1.9.0.md` in line with the release description now published at https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.9.0. The file was written at prep time; 24 of the 48 `[1.9.0]` changelog bullets were missing, under-covered, or cited under the wrong number. Every pre-existing sentence is kept.

What was added: a "Read this fourth" section for the PostgreSQL 16→18 compose change and its mount point (#2883, #3639); a "Release process, supply chain and CI" section for the certified-candidate flow (#3769–#3775, #3780), the floating-tag fixes (#3652, #3770), adapter 1.2.9/1.2.10 (#3752, #3753) and the toolchain-pin fix (#3742); Security additions (#3623, #3648/#3704/#3703, #3504, #3672, grype detail); proxy upgrade notes (#3712, #3680/#3720); and #3531, #3634, #3565 under other fixes. References corrected: #3541→#3644, #3621→#3557; PR and issue both cited for #3528/#3662, #3655/#3696, #3756/#3760.

Part of #3769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6pg381RiaM9GsdVEyrN8M
