### PR TITLE
chore(release): forward-port the release tooling so 1.9.x can be certified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,13 +662,21 @@ jobs:
 
       # The candidate-then-promote release flow (#3771, #3772, #3773; epic
       # #3769): nothing gets a permanent name until the full gate has passed
-      # on the exact commit. Five scripts carry it, and every one has a
+      # on the exact commit. Six scripts carry it, and every one has a
       # fail-open direction that a live run would only reveal at a cut:
       #   * assert-candidate-certified.sh -- the certification gate the
       #     promote, release.yml and docker-publish.yml all stand behind;
       #     must refuse a missing, foreign-workflow, other-commit, or
       #     digest-drifted certification, and report INFRA, never a pass,
       #     when it cannot measure;
+      #   * resolve-certified-ref.sh -- WHICH branch may have certified a
+      #     commit, and therefore which signing identity the gate demands
+      #     once a patch release can be cut from release/X.Y.x. Its
+      #     permissive direction hands an attacker-controlled branch the
+      #     right to sign, so it must refuse an arbitrary branch, a case
+      #     variant of a real one, a commit on neither, and a
+      #     release-candidate.yml that is not byte-identical to a copy that
+      #     lives on main;
       #   * registry-tag-digest.sh -- the digest probe the certification is
       #     compared against; must never invent a digest or read a 404 from
       #     an unreadable repository as absence;
@@ -681,6 +689,8 @@ jobs:
       # All stub gh / curl / the registry probes; offline, ~1s each.
       - name: Check the release-candidate certification gate blocks what it must
         run: bash scripts/ci/test-assert-candidate-certified.sh
+      - name: Check the certifying-ref resolver refuses every branch but the two
+        run: bash scripts/ci/test-resolve-certified-ref.sh
       - name: Check the registry digest probe never guesses
         run: bash scripts/ci/test-registry-tag-digest.sh
       - name: Check the scanner-adapter exact-version parity check

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -269,10 +269,28 @@ jobs:
               echo "::error title=Prerelease with promote_source_sha::${V} is a prerelease; only a stable X.Y.Z is promoted from a certified candidate."
               exit 1
             fi
-            cmp=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${SRC}...${GITHUB_REF_NAME}" --jq '.status' 2>/dev/null || echo "unreadable")
+            # WHICH BRANCH the certified commit belongs to, derived from
+            # repository state by the resolver every consumer shares -- main,
+            # or the release/X.Y.x its own Cargo.toml names. It is NOT the ref
+            # this run was dispatched on: release-promote.yml always dispatches
+            # here on `main` (so this file, and the tooling it runs, are main's
+            # copies) while the certified commit may live on a maintenance
+            # branch. Deriving it here rather than accepting it as an input is
+            # the point: an attacker who could name the branch would only have
+            # to put their version in Cargo.toml. The same call refuses a
+            # commit whose release-candidate.yml is not byte-identical to a
+            # copy that lives on main.
+            rc=0
+            resolved="$(GITHUB_OUTPUT='' scripts/ci/resolve-certified-ref.sh "$SRC")" || rc=$?
+            if [[ "$rc" -ne 0 ]]; then
+              echo "::error title=promote_source_sha is on no releasable branch::${SRC} is on neither main nor the maintenance branch its Cargo.toml names, or its release-candidate.yml is not a copy that lives on main (resolver exit ${rc}; its message is above). Nothing is promoted."
+              exit 1
+            fi
+            SRC_BRANCH="$(sed -n 's/^certified_branch=//p' <<<"$resolved" | head -1)"
+            cmp=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${SRC}...${SRC_BRANCH}" --jq '.status' 2>/dev/null || echo "unreadable")
             case "$cmp" in
-              ahead|identical) echo "${SRC} is reachable from ${GITHUB_REF_NAME} (${cmp})." ;;
-              *) echo "::error title=promote_source_sha is not on the dispatched ref::${SRC} is '${cmp}' relative to ${GITHUB_REF_NAME}; a promote only names bytes built from the ref it is dispatched on."; exit 1 ;;
+              ahead|identical) echo "${SRC} is reachable from ${SRC_BRANCH} (${cmp}); dispatched on ${GITHUB_REF_NAME}." ;;
+              *) echo "::error title=promote_source_sha is not on its derived branch::${SRC} is '${cmp}' relative to ${SRC_BRANCH}; a promote only names bytes built from the branch the certified commit belongs to."; exit 1 ;;
             esac
             # Dispatch readiness: release-promote.yml goes on to dispatch
             # release.yml and this workflow ON THE TAG it creates, i.e. the

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -64,6 +64,40 @@ name: Release Candidate
 #   edited out. `resolve` also refuses, case-sensitively, any dispatch ref
 #   but main.
 #
+# PATCH RELEASES FROM `release/X.Y.x` (1.9.1 and after)
+#   A patch release is cut from its maintenance branch -- but this workflow
+#   is STILL DISPATCHED ON MAIN and certifies the branch's commit from
+#   there. The signing identity therefore never widens: main's copy of this
+#   file remains the only thing that can produce an accepted certification,
+#   and a copy on any other branch -- including a `release/*` branch an
+#   attacker managed to create -- signs with an identity nothing accepts.
+#   That was the alternative to widening the pin to
+#   `@refs/heads/release/1.9.x`, and it is strictly stronger: the attack of
+#   creating a `release/*` ref, putting an edited copy of this file on it and
+#   satisfying an exact pin does not exist, rather than being mitigated.
+#
+#   Nothing here relies on the dispatched ref for that to work, and -- since
+#   the r1 review -- nothing runs the certified commit's code either: EVERY
+#   checkout in this file is `refs/heads/main`, and the commit enters only as
+#   named data. The reusable gate is an absolute cross-repository reference
+#   (`artifact-keeper-test/...@main`) that takes the images by digest, so it
+#   tests the maintenance commit's bytes whoever calls it.
+#
+#   WHICH COMMITS main may certify is then a second, independent control:
+#   scripts/ci/resolve-certified-ref.sh derives the line a commit belongs to
+#   from repository state alone and never from a dispatch input -- an
+#   ancestor of `main`, failing that an ancestor of
+#   `refs/heads/release/<X>.<Y>.x` with X.Y read from `Cargo.toml` AT THAT
+#   COMMIT. It also pins the CONTENT of this file: `release-candidate.yml` at
+#   the certified commit must be byte-identical (same blob id) to the copy
+#   `main` carries at the merge base, or to main's current copy, which is what
+#   a forward-port produces. That is not load-bearing for the identity any
+#   more, but it is cheap and it backstops the window during which an admin
+#   has the release ruleset toggled off to create a line. The predicate
+#   records the resolved line as `certified_ref`, which the verifier checks
+#   against the same derivation. See RELEASING.md, "Patch releases from a
+#   `release/X.Y.x` branch".
+#
 # PARITY (#3773). Every check that used to run only on a clean `refs/tags/v*`
 # ref, or was skipped for prereleases, runs here against the same inputs:
 # release bookkeeping, the CHANGELOG entry, the curated notes file, the
@@ -84,7 +118,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'Commit to certify: a full 40-hex sha that is on main. Empty = the current tip of main.'
+        description: 'Commit to certify: a full 40-hex sha on main, or on the release/X.Y.x branch this is dispatched on. Empty = the tip of the dispatched ref.'
         required: false
         type: string
         default: ''
@@ -119,6 +153,9 @@ jobs:
       short: ${{ steps.resolve.outputs.short }}
       version: ${{ steps.resolve.outputs.version }}
       tag: ${{ steps.resolve.outputs.tag }}
+      certified_ref: ${{ steps.resolve.outputs.certified_ref }}
+      certified_branch: ${{ steps.resolve.outputs.certified_branch }}
+      workflow_blob: ${{ steps.resolve.outputs.workflow_blob }}
     steps:
       # The certification is only valid when this workflow ran on main (the
       # verifier pins the exact signing identity
@@ -128,24 +165,32 @@ jobs:
       # file. Refused first, before anything is read. In the SHELL, not in an
       # `if:` expression: Actions expressions compare strings
       # case-insensitively, and a branch named `Main` is a different ref.
+      # A maintenance release does NOT relax this: a release/X.Y.x commit is
+      # certified from main too, which is why the identity never widens.
       - name: Refuse a dispatch that is not on main
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
-            echo "::error title=Not dispatched on main::Release Candidate was dispatched on ${GITHUB_REF}. It certifies commits on main and its certification is only accepted when the workflow itself ran on main (scripts/ci/assert-candidate-certified.sh pins the signing identity to release-candidate.yml@refs/heads/main). Dispatch it with --ref main; pick the commit with -f sha=<40-hex>."
+            echo "::error title=Not dispatched on main::Release Candidate was dispatched on ${GITHUB_REF}. It certifies commits from main -- including commits on a release/X.Y.x maintenance branch -- and its certification is only accepted when the workflow itself ran on main (scripts/ci/assert-candidate-certified.sh pins the signing identity to release-candidate.yml@refs/heads/main). Dispatch it with --ref main; pick the commit with -f sha=<40-hex>."
             exit 1
           fi
           echo "Dispatched on ${GITHUB_REF}."
 
-      # Always main, never the ref the dispatch was made on: the candidate
-      # flow certifies commits ON MAIN (maintenance branches keep the -rc
-      # path for now), and full history is what `merge-base --is-ancestor`
-      # needs to prove that.
+      # Always main, never anything else: this workflow runs main's tooling
+      # and signs with main's identity whatever line the commit is on. The
+      # maintenance lines are fetched as remote-tracking refs so
+      # `git show <sha>:<path>` can reach a commit on one of them and the
+      # resolver's answer can be re-checked against the same objects.
       - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/heads/main
           fetch-depth: 0
+
+      - name: Fetch the maintenance lines
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin '+refs/heads/release/*:refs/remotes/origin/release/*'
 
       # The version is READ FROM Cargo.toml at the commit, never typed. A
       # free-text version input is exactly what release.yml removed: it let
@@ -154,6 +199,7 @@ jobs:
         id: resolve
         env:
           INPUT_SHA: ${{ inputs.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           SHA="${INPUT_SHA:-}"
@@ -169,11 +215,36 @@ jobs:
             echo "::error title=Unknown commit::${SHA} is not a commit in this repository."
             exit 1
           fi
-          if ! git merge-base --is-ancestor "$SHA" HEAD; then
-            echo "::error title=Commit is not on main::${SHA} is not reachable from main. The candidate flow certifies main; cut maintenance releases with the documented -rc path for now."
+          # WHICH LINE this commit belongs to. Not an identity question --
+          # the identity is main's, always -- but the constraint on WHICH
+          # commits main may certify: an ancestor of main, else of the
+          # release/X.Y.x its own Cargo.toml names. Derived by the one
+          # resolver every consumer uses, from repository state and never
+          # from a dispatch input. The same call pins the content of this
+          # file at the certified commit to a copy that lives on main.
+          # CERTREF_REQUIRE_MAIN_WORKFLOW: this run is the moment of blessing,
+          # and the only one. It demands that release-candidate.yml at the
+          # certified commit be main's CURRENT copy; the blob is then recorded
+          # in the signed predicate and every later consumer compares against
+          # THAT, not against main's tip -- which moves, and would otherwise
+          # strand an already-certified commit on an unrelated merge (r2 N1).
+          rc=0
+          resolved="$(GITHUB_OUTPUT='' CERTREF_REQUIRE_MAIN_WORKFLOW=1 scripts/ci/resolve-certified-ref.sh "$SHA")" || rc=$?
+          if [[ "$rc" -ne 0 ]]; then
+            echo "::error title=Commit cannot be certified::${SHA} is on neither main nor the maintenance line its Cargo.toml names, or its release-candidate.yml is not a copy that lives on main (resolver exit ${rc}; its message is above)."
             exit 1
           fi
-          VERSION="$(git show "${SHA}:Cargo.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+          CERTIFIED_REF="$(sed -n 's/^certified_ref=//p' <<<"$resolved" | head -1)"
+          VERSION="$(sed -n 's/^version=//p' <<<"$resolved" | head -1)"
+          WORKFLOW_BLOB="$(sed -n 's/^workflow_blob=//p' <<<"$resolved" | head -1)"
+
+          # The resolver read the repository over the API; this is the same
+          # question asked of the objects in this checkout. They agree or
+          # nothing is certified.
+          if ! git merge-base --is-ancestor "$SHA" "refs/remotes/origin/${CERTIFIED_REF#refs/heads/}"; then
+            echo "::error title=Ancestry disagreement::${SHA} resolves to ${CERTIFIED_REF} over the API but is not reachable from origin/${CERTIFIED_REF#refs/heads/} in this checkout. Failing closed."
+            exit 1
+          fi
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error title=Not a stable version::Cargo.toml at ${SHA} says '${VERSION:-<none>}'. A candidate certifies a stable X.Y.Z (land the release prep first); prereleases keep the -rc.N tag path."
             exit 1
@@ -200,12 +271,16 @@ jobs:
           need .github/workflows/docker-publish.yml '^[[:space:]]*promote_version:'   'promotable docker-publish.yml'
           need scripts/ci/follow-dispatched-run.sh  '.'                               'scripts/ci/follow-dispatched-run.sh'
           need scripts/ci/assert-candidate-certified.sh '.'                           'scripts/ci/assert-candidate-certified.sh'
-          echo "Candidate: ${VERSION} at ${SHA} ($(git log -1 --format='%s' "$SHA"))"
+          need scripts/ci/resolve-certified-ref.sh  '.'                               'scripts/ci/resolve-certified-ref.sh'
+          echo "Candidate: ${VERSION} at ${SHA} on ${CERTIFIED_REF} ($(git log -1 --format='%s' "$SHA"))"
           {
             echo "sha=${SHA}"
             echo "short=${SHA:0:7}"
             echo "version=${VERSION}"
             echo "tag=v${VERSION}"
+            echo "certified_ref=${CERTIFIED_REF}"
+            echo "certified_branch=${CERTIFIED_REF#refs/heads/}"
+            echo "workflow_blob=${WORKFLOW_BLOB}"
           } >> "$GITHUB_OUTPUT"
 
   # ── the preflight, reused, and its evidence ─────────────────────────────────
@@ -223,10 +298,21 @@ jobs:
       contents: read
       actions: write   # dispatch release-preflight.yml and follow it
     steps:
-      - name: Checkout
+      # CODE FROM MAIN, DATA FROM THE COMMIT (adversarial review, finding 1).
+      # This job holds a token, so nothing it EXECUTES may come from the
+      # certified commit: a maintenance commit that edited only `scripts/ci`
+      # would otherwise get arbitrary shell in a job whose OIDC identity is
+      # `release-candidate.yml@refs/heads/main`, which is precisely the
+      # certification the pin exists to make unforgeable. The `need` checks in
+      # `resolve` still assert those scripts EXIST at the commit -- that is
+      # about what the promote runs later at the tag -- but their copies are
+      # never run here.
+      # Nothing here reads the commit as data: both scripts are driven entirely
+      # by the environment and the API.
+      - name: Checkout main's tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.resolve.outputs.sha }}
+          ref: refs/heads/main
           sparse-checkout: scripts/ci
 
       - name: Dispatch the Release Preflight on this commit
@@ -281,14 +367,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout the commit
+      # CODE FROM MAIN, DATA FROM THE COMMIT (adversarial review, finding 1).
+      # This job holds a token, so nothing it EXECUTES may come from the
+      # certified commit: a maintenance commit that edited only `scripts/ci`
+      # would otherwise get arbitrary shell in a job whose OIDC identity is
+      # `release-candidate.yml@refs/heads/main`, which is precisely the
+      # certification the pin exists to make unforgeable. The `need` checks in
+      # `resolve` still assert those scripts EXIST at the commit -- that is
+      # about what the promote runs later at the tag -- but their copies are
+      # never run here.
+      - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.resolve.outputs.sha }}
-          sparse-checkout: |
-            .github/scripts
-            .github/release-notes
-            scripts/ci
+          ref: refs/heads/main
+          fetch-depth: 0
+
+      # The bookkeeping assertions are ABOUT the commit's CHANGELOG and its
+      # curated notes file, so those two paths -- and only those two -- are
+      # overlaid from the certified commit. They are read, never executed.
+      - name: Overlay the certified commit's release bookkeeping
+        env:
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin '+refs/heads/release/*:refs/remotes/origin/release/*'
+          git checkout "$SHA" -- CHANGELOG.md .github/release-notes
+          echo "CHANGELOG.md and .github/release-notes/ are now ${SHA}'s; every script run here is main's."
 
       # A tag that already exists means a release attempt already happened for
       # this version; whatever it points at, this commit cannot become vX.Y.Z.
@@ -348,33 +452,48 @@ jobs:
       adapter_version: ${{ steps.digests.outputs.adapter_version }}
       publish_run_id: ${{ steps.publish.outputs.run_id }}
     steps:
-      # Full history: the adapter check diffs the published revision against
-      # this commit (object-level, so the sparse worktree does not limit it).
-      - name: Checkout the commit
+      # CODE FROM MAIN, DATA FROM THE COMMIT (adversarial review, finding 1).
+      # This job holds a token, so nothing it EXECUTES may come from the
+      # certified commit: a maintenance commit that edited only `scripts/ci`
+      # would otherwise get arbitrary shell in a job whose OIDC identity is
+      # `release-candidate.yml@refs/heads/main`, which is precisely the
+      # certification the pin exists to make unforgeable. The `need` checks in
+      # `resolve` still assert those scripts EXIST at the commit -- that is
+      # about what the promote runs later at the tag -- but their copies are
+      # never run here.
+      # Full history, and the maintenance lines, so the adapter check can diff
+      # the published revision against the certified commit at the OBJECT
+      # level -- which is how it already read that commit, and why the
+      # worktree never needs to be the commit's.
+      - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.resolve.outputs.sha }}
+          ref: refs/heads/main
           fetch-depth: 0
-          sparse-checkout: |
-            scripts/ci
-            .github/scripts
-            docker/scanner-adapter
 
-      # The same selection release.yml makes for a tag, keyed on `main`: a
-      # SUCCESSFUL Docker Publish run for this exact commit on main. Nothing is
-      # rebuilt; a commit that has no run (a docs-only tip, #3629) cannot be
-      # certified, and says so.
+      - name: Fetch the maintenance lines
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin '+refs/heads/release/*:refs/remotes/origin/release/*'
+
+      # The same selection release.yml makes for a tag, keyed on the branch
+      # the commit is on: a SUCCESSFUL Docker Publish run for this exact
+      # commit on that branch. docker-publish.yml runs on `release/**` pushes
+      # too, so a maintenance commit has its own `sha-<sha>` images. Nothing
+      # is rebuilt; a commit that has no run (a docs-only tip, #3629) cannot
+      # be certified, and says so.
       - name: Wait for a successful Docker Publish run for this commit
         id: publish
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ needs.resolve.outputs.sha }}
+          BRANCH: ${{ needs.resolve.outputs.certified_branch }}
         run: |
           set -euo pipefail
           APPEAR_DEADLINE=$(($(date +%s) + 15*60))
           while true; do
             rc=0; out=""
-            out="$(RESOLVE_REPO="${GITHUB_REPOSITORY}" RESOLVE_SHA="${SHA}" RESOLVE_REF=main \
+            out="$(RESOLVE_REPO="${GITHUB_REPOSITORY}" RESOLVE_SHA="${SHA}" RESOLVE_REF="${BRANCH}" \
               bash scripts/ci/resolve-candidate-publish-run.sh)" || rc=$?
             case "$rc" in
               0)
@@ -384,11 +503,11 @@ jobs:
               10)
                 echo "  Docker Publish for ${SHA} is still running; waiting 60s..."; sleep 60 ;;
               20)
-                echo "::error title=Docker Publish failed for this commit::Every Docker Publish run for main@${SHA} completed without success, so there are no scanned images to certify. Fix the cause on main; the next commit that publishes cleanly is the candidate."
+                echo "::error title=Docker Publish failed for this commit::Every Docker Publish run for ${BRANCH}@${SHA} completed without success, so there are no scanned images to certify. Fix the cause on main; the next commit that publishes cleanly is the candidate."
                 exit 1 ;;
               21|30)
                 if [[ "$(date +%s)" -ge "$APPEAR_DEADLINE" ]]; then
-                  echo "::error title=No Docker Publish run for this commit::No docker-publish.yml run exists for main@${SHA} after 15m. A commit that touches only Markdown gets no build (#3629): certify the newest commit that has one, or land a code change."
+                  echo "::error title=No Docker Publish run for this commit::No docker-publish.yml run exists for ${BRANCH}@${SHA} after 15m. A commit that touches only Markdown gets no build (#3629): certify the newest commit that has one, or land a code change."
                   exit 1
                 fi
                 echo "  no verdict yet (state ${rc}); waiting 30s..."; sleep 30 ;;
@@ -428,7 +547,9 @@ jobs:
           resolve backend  "${BACKEND_IMAGE#ghcr.io/}"
           resolve openscap "${OPENSCAP_IMAGE#ghcr.io/}"
           resolve adapter  "${ADAPTER_IMAGE#ghcr.io/}"
-          echo "adapter_version=$(tr -d '[:space:]' < docker/scanner-adapter/VERSION)" >> "$GITHUB_OUTPUT"
+          # From the CERTIFIED COMMIT's object, not the worktree (which is
+          # main's): the adapter version belongs to the commit being certified.
+          echo "adapter_version=$(git show "${SHA}:docker/scanner-adapter/VERSION" | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
 
       # ── parity: the exact-tag digest guard (#3773) ──────────────────────────
       # docker-publish.yml runs assert-version-digest-consistent.sh only when
@@ -515,14 +636,28 @@ jobs:
     env:
       SHA: ${{ needs.resolve.outputs.sha }}
       VERSION: ${{ needs.resolve.outputs.version }}
+      CERTIFIED_REF: ${{ needs.resolve.outputs.certified_ref }}
+      WORKFLOW_BLOB: ${{ needs.resolve.outputs.workflow_blob }}
       BACKEND_DIGEST: ${{ needs.images.outputs.backend_digest }}
       OPENSCAP_DIGEST: ${{ needs.images.outputs.openscap_digest }}
       ADAPTER_DIGEST: ${{ needs.images.outputs.adapter_digest }}
     steps:
-      - name: Checkout the commit
+      # CODE FROM MAIN, DATA FROM THE COMMIT (adversarial review, finding 1).
+      # This job holds a token, so nothing it EXECUTES may come from the
+      # certified commit: a maintenance commit that edited only `scripts/ci`
+      # would otherwise get arbitrary shell in a job whose OIDC identity is
+      # `release-candidate.yml@refs/heads/main`, which is precisely the
+      # certification the pin exists to make unforgeable. The `need` checks in
+      # `resolve` still assert those scripts EXIST at the commit -- that is
+      # about what the promote runs later at the tag -- but their copies are
+      # never run here.
+      # THE job that holds `id-token: write` and `attestations: write`. It
+      # reads nothing from the certified commit at all; the predicate is built
+      # from job outputs and the verification is API-driven.
+      - name: Checkout main's tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.resolve.outputs.sha }}
+          ref: refs/heads/main
           sparse-checkout: |
             scripts/ci
             .github/scripts
@@ -537,7 +672,8 @@ jobs:
           set -euo pipefail
           mkdir -p certification
           jq -n \
-            --arg sha "$SHA" --arg version "$VERSION" \
+            --arg sha "$SHA" --arg version "$VERSION" --arg certified_ref "$CERTIFIED_REF" \
+            --arg workflow_blob "$WORKFLOW_BLOB" \
             --arg run "$GITHUB_RUN_ID" --arg attempt "$GITHUB_RUN_ATTEMPT" \
             --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --arg publish_run "$PUBLISH_RUN_ID" \
@@ -548,6 +684,16 @@ jobs:
             '{
               commit_sha: $sha,
               version: $version,
+              # The branch this run signed on, written down at signing time so
+              # the verifier can cross-check it against the ref it derives
+              # from the repository (scripts/ci/resolve-certified-ref.sh).
+              certified_ref: $certified_ref,
+              # The git blob id of release-candidate.yml at the certified
+              # commit, blessed against the copy on main by THIS run.
+              # Verifiers compare against this record, never against the
+              # moving tip of main. (No apostrophes in here: the whole jq
+              # program is single-quoted in the shell.)
+              certified_workflow_blob: $workflow_blob,
               sha_tag: ("sha-" + ($sha | .[0:7])),
               candidate_run_id: $run,
               candidate_run_attempt: $attempt,
@@ -651,5 +797,5 @@ jobs:
             echo "| openscap | \`${OPENSCAP_DIGEST}\` |"
             echo "| scanner-adapter | \`${ADAPTER_DIGEST}\` |"
             echo
-            echo "Next: dispatch **Release Promote** with \`sha=${SHA}\` (or empty, if it is still the tip of main). It re-applies \`:${VERSION}\` to these digests, creates \`v${VERSION}\` last, and hands over to the release workflow."
+            echo "Next: dispatch **Release Promote** on main with \`sha=${SHA}\`. It re-applies \`:${VERSION}\` to these digests, creates \`v${VERSION}\` last, and hands over to the release workflow."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -3,10 +3,20 @@ name: Release Promote
 # ══════════════════════════════════════════════════════════════════════════════
 # A RELEASE IS THE PROMOTION OF A CERTIFIED COMMIT  (issue #3772; epic #3769)
 #
-# Input: a commit sha on main (default: the tip). The version is READ FROM
-# Cargo.toml at that commit -- never typed, for the reason release.yml's old
-# free-text `version` input was removed: a typed version can drift from the
-# ref that was tested. Then, in this order, and nothing before its turn:
+# Input: a certified commit sha (default: the tip of main). The version is
+# READ FROM Cargo.toml at that commit -- never typed, for the reason
+# release.yml's old free-text `version` input was removed: a typed version can
+# drift from the ref that was tested. Then, in this order, and nothing before
+# its turn:
+#
+#   0a. derive WHICH BRANCH the commit belongs to, from repository state
+#       alone -- `main` if it is an ancestor of main, else
+#       `refs/heads/release/<X>.<Y>.x` with X.Y read from Cargo.toml AT THAT
+#       COMMIT (scripts/ci/resolve-certified-ref.sh). This workflow is always
+#       dispatched on `main`, so the branch is never the ref it runs on and
+#       never a dispatch input; it decides which signing identity step 2 will
+#       demand, and the same call refuses a commit whose release-candidate.yml
+#       is not byte-identical to a copy that lives on main;
 #
 #   0. verify the commit can be released this way at all: release.yml and
 #      docker-publish.yml AT THE COMMIT must carry the triggers steps 7-8
@@ -73,7 +83,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'Certified commit to release: a full 40-hex sha on main. Empty = the current tip of main.'
+        description: 'Certified commit to release: a full 40-hex sha on main or on a release/X.Y.x maintenance branch. Empty = the current tip of main. Dispatch this workflow on main; the branch is derived from the commit.'
         required: false
         type: string
         default: ''
@@ -101,16 +111,25 @@ jobs:
       actions: write    # dispatch docker-publish.yml and release.yml, follow them
       packages: read    # read the registry back
     steps:
+      # Always main: the promote runs main's tooling whatever branch the
+      # commit is on. The maintenance lines are fetched as remote-tracking
+      # refs so `git show <sha>:<path>` can reach a commit on one of them.
       - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/heads/main
           fetch-depth: 0
 
+      - name: Fetch the maintenance lines
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin '+refs/heads/release/*:refs/remotes/origin/release/*'
+
       - name: Resolve the commit and its version
         id: resolve
         env:
           INPUT_SHA: ${{ inputs.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           SHA="${INPUT_SHA:-}"
@@ -120,8 +139,21 @@ jobs:
           fi
           [[ "$SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error title=Not a full sha::'${SHA}' is not a 40-character commit sha."; exit 1; }
           git cat-file -e "${SHA}^{commit}" 2>/dev/null || { echo "::error title=Unknown commit::${SHA} is not a commit in this repository."; exit 1; }
-          git merge-base --is-ancestor "$SHA" HEAD || { echo "::error title=Commit is not on main::${SHA} is not reachable from main."; exit 1; }
-          VERSION="$(git show "${SHA}:Cargo.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+          # ── 0a. which branch, and therefore which signer ─────────────────
+          # From repository state, by the one resolver every consumer uses;
+          # never from a dispatch input. It also refuses a commit whose
+          # release-candidate.yml is not a copy that lives on main.
+          rc=0
+          resolved="$(GITHUB_OUTPUT='' scripts/ci/resolve-certified-ref.sh "$SHA")" || rc=$?
+          if [[ "$rc" -ne 0 ]]; then
+            echo "::error title=Commit cannot be promoted::${SHA} is on neither main nor the maintenance branch its Cargo.toml names, or its release-candidate.yml is not a copy that lives on main (resolver exit ${rc}; its message is above). Nothing was created."
+            exit 1
+          fi
+          CERTIFIED_REF="$(sed -n 's/^certified_ref=//p' <<<"$resolved" | head -1)"
+          VERSION="$(sed -n 's/^version=//p' <<<"$resolved" | head -1)"
+          BRANCH="${CERTIFIED_REF#refs/heads/}"
+          git merge-base --is-ancestor "$SHA" "refs/remotes/origin/${BRANCH}" \
+            || { echo "::error title=Ancestry disagreement::${SHA} resolves to ${CERTIFIED_REF} over the API but is not reachable from origin/${BRANCH} in this checkout. Failing closed."; exit 1; }
           [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error title=Not a stable version::Cargo.toml at ${SHA} says '${VERSION:-<none>}'; only a stable X.Y.Z is promoted."; exit 1; }
           # ── 0. dispatch readiness, before anything permanent ─────────────
           # Steps 7-8 dispatch docker-publish.yml and release.yml ON THE TAG,
@@ -141,11 +173,14 @@ jobs:
           }
           need .github/workflows/release.yml        '^[[:space:]]*workflow_dispatch:' 'dispatchable release.yml'
           need .github/workflows/docker-publish.yml '^[[:space:]]*promote_version:'   'promotable docker-publish.yml'
-          echo "Promoting ${VERSION} at ${SHA} ($(git log -1 --format='%s' "$SHA"))"
+          need scripts/ci/resolve-certified-ref.sh  '.'                               'scripts/ci/resolve-certified-ref.sh'
+          echo "Promoting ${VERSION} at ${SHA} on ${CERTIFIED_REF} ($(git log -1 --format='%s' "$SHA"))"
           {
             echo "sha=${SHA}"
             echo "version=${VERSION}"
             echo "tag=v${VERSION}"
+            echo "certified_ref=${CERTIFIED_REF}"
+            echo "certified_branch=${BRANCH}"
           } >> "$GITHUB_OUTPUT"
 
       # ── 1. nothing permanent exists yet (or it already names this commit) ──

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,26 @@ jobs:
             scripts/ci
             .github/scripts
 
+      # DEFENCE IN DEPTH, NOT THE AUTHORITY. This run is dispatched on the tag,
+      # so the workflow and the scripts it executes are the TAGGED commit's --
+      # and since a stable tag may now name a `release/X.Y.x` commit, that is
+      # the maintenance line's copy of this gate and of the ref resolver.
+      # A line that could edit them could weaken this check. It is kept
+      # because it costs nothing and catches drift between the promote and the
+      # release, but the AUTHORITATIVE verification already happened in
+      # release-promote.yml, from MAIN's tree, before the tag existed.
+      #
+      # It is NOT true that nothing else can reach here. The guards above
+      # refuse a stable tag PUSH (`github.event_name == 'push'`); a
+      # workflow_dispatch on an existing stable tag is not refused, because
+      # the promote's own hand-over is exactly that, and ruleset 19144026 has
+      # no `creation` rule, so a stable tag can be created by hand and then
+      # dispatched. What that reaches is this job -- running the tagged
+      # commit's copy of the gate. So: the promote is the authority; these
+      # outputs are the tag-side plumbing that decides whether release.yml
+      # re-runs the gate, and they are only as trustworthy as the ref they
+      # were computed on. Closing the dispatch path needs a marker that says
+      # "the promote created this tag"; tracked separately.
       - name: Verify the certification (stable tags) or note the exemption (prereleases)
         id: cert
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -228,10 +228,11 @@ existing tag that names the same commit.
    **Fallback: a prerelease tag.** `vX.Y.Z-rc.N` still works as it always
    did (the ruleset excludes `v*-rc*`, `v*-beta*`, `v*-alpha*` from
    immutability, so it is deletable and re-cuttable) and still runs the gate
-   inside `release.yml`. It is the old path, kept for maintenance branches
-   and for a rehearsal that needs a real tag; it certifies nothing and it
-   does not run the stable-only checks. Cut stable releases with the
-   candidate.
+   inside `release.yml`. It is the old path, kept for a rehearsal that needs
+   a real tag; it certifies nothing and it does not run the stable-only
+   checks. Cut stable releases with the candidate — including patch releases
+   from a maintenance branch, which now have their own candidate path (see
+   "Patch releases from a `release/X.Y.x` branch").
 
 7. **Dispatch the Release Promote.** With the candidate green:
 
@@ -334,6 +335,166 @@ existing tag that names the same commit.
    `SECURITY.md` carries the same commands written out for a user who does
    not have the repository checked out; keep the two in step.
 
+## Patch releases from a `release/X.Y.x` branch
+
+A patch release (1.9.1, 1.7.6) is cut from its maintenance branch, not from
+`main`. The candidate-then-promote flow above is the same flow, dispatched the
+same way: **both workflows are dispatched on `main`**, and you name the commit.
+
+```bash
+# 0. the branch exists and carries the flow
+#    Ruleset 20038606 has no `creation` rule; what refuses a new
+#    release/X.Y.x ref is its required-status-check rule with
+#    do_not_enforce_on_create: false and no bypass actor, so the push is
+#    rejected with "Required status check ... is expected". Cutting a NEW
+#    line therefore means an admin toggling that ruleset off for as long as
+#    the push takes -- deliberate, and worth announcing, because during the
+#    toggle creation is unguarded for everyone with write access. An
+#    existing line needs no toggle.
+#    The branch must carry scripts/ci/resolve-certified-ref.sh,
+#    assert-candidate-certified.sh, follow-dispatched-run.sh and a
+#    dispatchable release.yml / promotable docker-publish.yml; the candidate
+#    refuses the commit by name if any is missing.
+
+# 1. land the fixes on main first, then cherry-pick onto release/1.9.x
+#    (Release Branch Gate enforces this)
+
+# 2. the release prep commit on release/1.9.x sets Cargo.toml to 1.9.1 and
+#    opens the CHANGELOG section, exactly as on main
+
+# 3. certify — ON MAIN, naming the maintenance commit
+gh workflow run release-candidate.yml --repo artifact-keeper/artifact-keeper \
+  --ref main -f sha=<the release/1.9.x commit>
+
+# 4. promote — ON MAIN, same commit
+gh workflow run release-promote.yml --repo artifact-keeper/artifact-keeper \
+  --ref main -f sha=<the certified commit>
+```
+
+There is no `--ref release/1.9.x` step, and that is the security property.
+
+### The signing identity never widens
+
+A certification is trusted because of one thing: the Sigstore certificate's
+SubjectAlternativeName, pinned byte-for-byte to
+`...release-candidate.yml@refs/heads/main`. A maintenance release does **not**
+relax that pin. `release-candidate.yml` is dispatched on `main` and certifies
+the maintenance commit from there, so main's copy of the workflow remains the
+only thing that can produce an accepted certification. A copy of that file on
+a `release/*` branch — including one an attacker managed to create — signs
+with an identity nothing accepts, exactly as a copy on any topic branch does.
+The alternative was to widen the pin to
+`...release-candidate.yml@refs/heads/release/1.9.x`; certifying from main is
+strictly stronger, because the attack of creating a `release/*` ref, putting
+an edited workflow on it and satisfying an exact pin has no identity to reach
+for at all, rather than being bounded by argument.
+
+Nothing in the workflow depended on the dispatched ref for this to work: the
+reusable Release Gate is an absolute cross-repository reference
+(`artifact-keeper-test/.../release-gate.yml@main`) that takes the images by
+digest, and no job needs the certified commit on disk (see "What runs from the
+certified commit" below — the answer is nothing).
+
+### Which commits main may certify
+
+That is the second, independent control, and it lives in one place:
+`scripts/ci/resolve-certified-ref.sh`. Three consumers ask **main's copy** of
+it, and they are the ones that decide: the candidate, `release-promote.yml`,
+and `docker-publish.yml`'s certified-candidate promote (dispatched `--ref
+main`). `release.yml` on the tag asks it too, but runs the **tagged commit's**
+copy — see "What runs from the certified commit" below. The commit must be an ancestor of `main`; failing
+that, an ancestor of `refs/heads/release/<X>.<Y>.x`, where X and Y are read
+from `Cargo.toml` **at that commit**, its existence checked case-sensitively
+against the git-refs API. The line is therefore a function of the commit's own
+content and the repository's refs; no dispatch input names it. The predicate
+records the resolved line as `certified_ref`, and the verifier asks the
+repository the same question again at promote time — a disagreement is never
+promoted.
+
+For a commit on a maintenance line the candidate also **blesses the content**
+of `release-candidate.yml` once, at certification time: it must be
+byte-identical (same git blob id) to the copy `main` carries then. The blob is
+recorded in the signed predicate, and every later consumer compares against
+**that record**, never against main's tip — otherwise any merge to main that
+touched the workflow would strand an already-certified commit permanently, and
+recovery would mean a new commit and a full gate re-run. Not to the copy at the merge base — the merge
+base is a function of the commit's own ancestry, so whoever chooses the
+commit's parent would be choosing which historical copy gets blessed,
+including one from before a guard existed, permanently. Main's current copy is
+the only copy nobody but main can choose, and cherry-picking it forward was
+already the documented remedy. So: if the candidate refuses with "not main's
+current copy", do **not** edit the workflow on the branch — cherry-pick main's
+copy across and dispatch a new candidate. (Nothing is demanded, explicitly,
+for a commit on `main`, where comparing main to itself decides nothing.)
+
+The blessing is no longer load-bearing for the identity; it backstops the
+window in which an admin has the release ruleset toggled off to create a
+line.
+
+### What runs from the certified commit
+
+Nothing, in the candidate. Every `actions/checkout` in `release-candidate.yml`
+is `refs/heads/main`, so every script it executes is main's reviewed code —
+including in `certify`, the job that holds `id-token: write` and
+`attestations: write`. That matters more than it looks: those steps share the
+job's OIDC environment, so a single checkout of the certified commit would
+hand a maintenance commit arbitrary shell with the signing identity in scope,
+and the certification the identity pin exists to make unforgeable would be
+forgeable after all — attempt 2's attack relocated from the workflow file to
+the scripts beside it.
+
+The certified commit therefore enters only as **named data**:
+`CHANGELOG.md` and `.github/release-notes/` are overlaid into the bookkeeping
+job's worktree (`git checkout <sha> -- …`, read, never executed),
+`docker/scanner-adapter/VERSION` and `Cargo.toml` are read as git objects or
+over the API, and the images themselves are pinned by digest. `resolve`'s
+`need` checks still assert that `scripts/ci/*` exist at the commit — that is
+about what the *promote* runs later at the tag, not about this run. A self-test
+(`scripts/ci/test-resolve-certified-ref.sh`) pins all of this structurally, so
+a future checkout of the certified sha fails CI.
+
+**Downstream of the tag is a different story, deliberately.** The promote
+dispatches `release.yml` and `docker-publish.yml` on the tag, which runs the
+tagged commit's copies — the maintenance line's, now that a stable tag can
+name one. `release.yml`'s re-verification of the certification is therefore
+defence in depth that cannot be trusted above the line; the authoritative
+verification is the one `release-promote.yml` performs from main's tree
+*before* the tag exists.
+
+Do not overstate that. Both workflows refuse a stable tag **push**
+(`github.event_name == 'push'`), and nothing else — a `workflow_dispatch` on
+an existing stable tag is accepted, because the promote's own hand-over is
+exactly that. Ruleset 19144026 restricts `update`, `deletion` and
+`non_fast_forward` on `refs/tags/v*` but has **no `creation` rule**, and it
+carries one always-bypass user, so a stable tag can be created by hand and
+then dispatched. That reaches `release.yml`'s tag-side check — the tagged
+commit's copy of it. Release assets are separately verified with
+`--signer-workflow`, which carries no `@ref`. Treat every tag-side check as
+corroboration, never as the proof; the promote is the proof.
+
+### Branch protection, for reference
+
+Relevant because it decides who can put a commit on a release line at all
+(ruleset 20038606 vs `branches/main/protection`), not because the
+certification depends on it:
+
+| write path | `main` | `refs/heads/release/X.Y.x` |
+|---|---|---|
+| direct push | allowed, if the required contexts are green on that sha | **refused** — a pull request is required |
+| force push / rewrite | blocked (`allow_force_pushes: false`) | blocked (`non_fast_forward`) |
+| deletion | blocked (`allow_deletions: false`) | blocked (`deletion`) |
+| ref creation | n/a (it exists) | **refused** — by the required-status-check rule (`do_not_enforce_on_create: false`, no bypass actor); there is no separate `creation` rule |
+| required checks | 3 | 2, incl. `Verify commits trace back to main` |
+| required approvals | none configured | none configured |
+| admin bypass | **yes** — `enforce_admins: false` | **no** — `bypass_actors: []` |
+
+One thing to fix, and it is bigger than the release flow: on **both**
+branches, a pull request's required checks are defined by workflows the pull
+request itself can edit, and neither branch requires an approval. The real
+floor under a release is therefore *write access*, not review. Raising
+`required_approving_review_count` above 0 on ruleset 20038606, and giving
+`main` a ruleset of its own, would raise it.
+
 ## Supply chain: what the release job signs, and what it refuses
 
 Release binaries used to ship with a `<name>.sha256` beside them and nothing
@@ -435,6 +596,17 @@ scanned bytes; deleting it breaks every chart that pins it.
 - `CHANGELOG.md` always has an open `## [Unreleased]` as its first `## [`
   heading. Enforced by `scripts/ci/check-changelog-unreleased.sh` in CI's
   shell-tests job (#3433).
+- A stable release is the promotion of a **certified commit**, and which
+  branch may have certified it is **derived** from the commit
+  (`scripts/ci/resolve-certified-ref.sh`), never passed in: `main`, or the
+  `release/X.Y.x` its own `Cargo.toml` names, and every script the candidate
+  executes comes from `main`, never from the certified commit. The Release
+  Candidate is always
+  dispatched on `main`, including for a maintenance release, so the signing
+  identity is always `...release-candidate.yml@refs/heads/main` and never
+  widens; `release-candidate.yml` at the certified commit must additionally be
+  byte-identical to a copy that lives on `main`. See "Patch releases from a
+  `release/X.Y.x` branch".
 - Floating tags (`:latest`, `:X.Y`) are applied ONLY after the release gate
   and the GitHub Release, by a build-free promotion that re-points them at the
   digest `:X.Y.Z` already names. A floating tag may only name a version with a

--- a/scripts/ci/assert-candidate-certified.sh
+++ b/scripts/ci/assert-candidate-certified.sh
@@ -34,6 +34,19 @@
 #   case-sensitive. `--source-ref refs/heads/main` is still passed as a
 #   second, independent check on the ref extension. release-candidate.yml
 #   also refuses to run off main, by a case-sensitive shell comparison.
+#
+#   THIS PIN DOES NOT WIDEN for maintenance releases. A patch release is cut
+#   from `release/X.Y.x`, but the candidate is still DISPATCHED ON MAIN and
+#   certifies the branch's commit from there, so the only identity that can
+#   ever produce an accepted certification remains main's copy of
+#   release-candidate.yml. Which commits main may certify is a separate,
+#   independent control: scripts/ci/resolve-certified-ref.sh derives the line
+#   a commit belongs to from repository state (main, else the
+#   `release/<X>.<Y>.x` its own Cargo.toml names) and refuses a commit whose
+#   `release-candidate.yml` is not byte-identical to a copy that lives on
+#   main. The predicate's `certified_ref` is checked against that derivation
+#   below: it says which line the certified commit came from, and a
+#   certification whose line disagrees with the repository is not promoted.
 #   Nothing that can write an artifact or a commit status can forge it:
 #   producing one needs the OIDC identity of release-candidate.yml, on
 #   main, in this repository. A workflow artifact and a commit status are
@@ -78,6 +91,7 @@
 #   CERT_IMAGES          space-separated `<key>=<registry/repository>` pairs
 #                        (default: backend, openscap, scanner_adapter on ghcr)
 #   CERT_DIGEST_CMD      digest probe (default .github/scripts/registry-tag-digest.sh)
+#   CERT_RESOLVE_CMD     line resolver (default scripts/ci/resolve-certified-ref.sh)
 #   GHCR_TOKEN, GH_TOKEN for the probe and for gh
 #
 set -uo pipefail
@@ -91,6 +105,7 @@ EXPECT_VERSION="${CERT_EXPECT_VERSION:-}"
 IMAGES="${CERT_IMAGES:-backend=ghcr.io/${REPO}-backend openscap=ghcr.io/${REPO}-openscap scanner_adapter=ghcr.io/${REPO}-scanner-adapter}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIGEST_CMD="${CERT_DIGEST_CMD:-${ROOT}/.github/scripts/registry-tag-digest.sh}"
+RESOLVE_CMD="${CERT_RESOLVE_CMD:-${ROOT}/scripts/ci/resolve-certified-ref.sh}"
 
 RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; RST=$'\033[0m'
 [[ -t 1 ]] || { RED=""; GRN=""; YEL=""; RST=""; }
@@ -104,6 +119,7 @@ fi
 command -v gh >/dev/null 2>&1 || infra "gh is not on PATH; the attestation cannot be verified."
 command -v jq >/dev/null 2>&1 || infra "jq is not on PATH."
 [[ -x "$DIGEST_CMD" ]] || infra "digest probe ${DIGEST_CMD} is not executable."
+[[ -x "$RESOLVE_CMD" ]] || infra "line resolver ${RESOLVE_CMD} is not executable."
 
 SHORT="${SHA:0:7}"
 SIGNER="${REPO}/${WORKFLOW}"
@@ -223,6 +239,81 @@ gate_run="$(jq -r '.gate_run_id // empty' <<<"$p0")"
 [[ -n "$gate_run" ]] || blocked "the certification names no Release Gate run id."
 if [[ -n "$EXPECT_VERSION" && "$cert_version" != "$EXPECT_VERSION" ]]; then
   blocked "the certification is for version '${cert_version:-<none>}', but this release is ${EXPECT_VERSION}. Cargo.toml at ${SHA} must name the version being released; certify again."
+fi
+
+# WHICH LINE the commit belongs to -- main, or the `release/X.Y.x` its own
+# Cargo.toml names -- derived from repository state, never from a caller. The
+# same call refuses a commit whose release-candidate.yml is not byte-identical
+# to a copy that lives on main. This is the second, independent control: the
+# identity pin above says only main's workflow may certify; this says which
+# commits it may certify. GITHUB_OUTPUT is withheld from the child so its keys
+# do not land in this job's outputs alongside the gate's own.
+rc=0
+resolved="$(GITHUB_OUTPUT='' "$RESOLVE_CMD" "$SHA")" || rc=$?
+case "$rc" in
+  0) ;;
+  1) blocked "${SHA} is on no line that may be released, or its ${WORKFLOW} is not a copy that lives on main (see the resolver's message above)." ;;
+  *) infra "could not resolve which line ${SHA} belongs to (resolver exit ${rc})." ;;
+esac
+derived_ref="$(sed -n 's/^certified_ref=//p' <<<"$resolved" | head -1)"
+[[ "$derived_ref" == refs/heads/* ]] || infra "the line resolver named '${derived_ref:-<none>}', which is not a branch ref."
+derived_blob="$(sed -n 's/^workflow_blob=//p' <<<"$resolved" | head -1)"
+
+# The predicate records the line the certifying run resolved at signing time.
+# It must agree with the line the repository names now: the same question,
+# asked twice, at two different moments. Absent is tolerated only for main,
+# where certifications minted before maintenance-branch candidates carry no
+# such field and the line could not have been anything else.
+cert_ref="$(jq -r '.certified_ref // empty' <<<"$p0")"
+if [[ -z "$cert_ref" ]]; then
+  if [[ "$derived_ref" != "refs/heads/main" ]]; then
+    blocked "the certification names no certified_ref, but ${SHA} belongs to ${derived_ref}. A maintenance-line certification must record the line it certified; re-certify the commit."
+  fi
+  echo "  line:      ${derived_ref} (this certification predates certified_ref)"
+elif [[ "$cert_ref" != "$derived_ref" ]]; then
+  # ONE disagreement is not a disagreement: a maintenance commit that has
+  # since been forward-merged to main. The resolver answers `main` from then
+  # on (main wins), while the predicate still records the line the commit was
+  # certified on -- and it is signed, so it cannot have been rewritten. Both
+  # statements are true of the same commit. Refusing it would permanently kill
+  # the documented idempotent re-promote after a transient failure, which is
+  # exactly when it is needed (adversarial review, finding 4).
+  # The line named must be the one THIS version belongs to, not merely a
+  # well-shaped release ref (r2, finding N6): `release/9.9.x` on a 1.9.0
+  # predicate is not a forward-merge, it is a disagreement.
+  expected_line="refs/heads/release/$(cut -d. -f1-2 <<<"${cert_version}").x"
+  if [[ "$derived_ref" == "refs/heads/main" && "$cert_ref" == "$expected_line" ]]; then
+    echo "  line:      ${cert_ref} at signing time; ${SHA} has since been forward-merged to main. Both are true of this commit; accepted."
+  else
+    blocked "the certification says it certified '${cert_ref}', but ${SHA} belongs to ${derived_ref}. The signer and the repository disagree about which line this commit is on; nothing is promoted on a disagreement."
+  fi
+else
+  echo "  line:      ${derived_ref}"
+fi
+
+# The workflow the certification was BLESSED with. The candidate demanded, at
+# signing time, that release-candidate.yml at this commit be main's copy, and
+# recorded its blob id here. Comparing against that record rather than against
+# main's tip is deliberate: main moves, and re-deciding the question at every
+# promote would strand an already-certified commit on an unrelated merge (r2,
+# finding N1). Both sides of this comparison are fixed by the commit, so it
+# cannot rot. Absent is tolerated only for main, where nothing was demanded.
+cert_blob="$(jq -r '.certified_workflow_blob // empty' <<<"$p0")"
+if [[ -z "$cert_blob" ]]; then
+  # A LEGACY certification carries NEITHER field -- both were added together.
+  # So the tolerance requires both to be absent and the line to be main; a
+  # certification that names a line but records no blob is not legacy, however
+  # the line resolves now (r3, item 1). Without the `cert_ref` clause a
+  # forward-merged maintenance certification would slip through this branch
+  # too, which is wider than the case it was written for.
+  if [[ -n "$cert_ref" || "$derived_ref" != "refs/heads/main" ]]; then
+    blocked "the certification records no certified_workflow_blob (certified_ref='${cert_ref:-<none>}', line ${derived_ref}). Only a certification predating both fields, on main, is accepted without one; re-certify ${SHA} with the current release-candidate.yml."
+  fi
+  echo "  workflow:  ${derived_blob:0:12} (this certification predates certified_workflow_blob)"
+elif [[ "$cert_blob" != "$derived_blob" ]]; then
+  blocked "the certification was made with ${WORKFLOW} blob ${cert_blob:0:12}, but ${SHA} carries ${derived_blob:0:12}. The commit's own tree cannot change, so this means the certification does not describe this commit."
+else
+  echo "  workflow:  ${derived_blob:0:12} (as blessed at certification time)"
 fi
 
 for key in "${keys[@]}"; do

--- a/scripts/ci/resolve-certified-ref.sh
+++ b/scripts/ci/resolve-certified-ref.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Which branch is allowed to have certified this commit -- decided from
+# REPOSITORY STATE ALONE, never from a dispatch input (issues #3771, #3772;
+# release-branch candidates).
+#
+# WHY THIS EXISTS
+#   The release-candidate certification is trusted because of ONE thing: the
+#   Sigstore certificate's SubjectAlternativeName, pinned byte-for-byte to
+#   `.../release-candidate.yml@<ref>`. While `<ref>` was only ever
+#   `refs/heads/main`, "which ref" needed no thought. A patch release is cut
+#   from `release/X.Y.x`, so the candidate runs there and signs with THAT
+#   ref -- and the moment more than one ref can sign, "which ref" becomes the
+#   whole security question.
+#
+#   It is answered here, and only here, so every consumer answers it the same
+#   way. Two rules, both derived, neither typed:
+#
+#     1. THE REF. The certified commit must be an ancestor of `main`; if it is
+#        not, it must be an ancestor of `refs/heads/release/<X>.<Y>.x`, where
+#        X and Y are read from `Cargo.toml` AT THAT COMMIT. The branch name is
+#        therefore a function of the commit's own content and the repository's
+#        refs. A `release/*` wildcard is never used and no caller may name the
+#        branch: an attacker who could pick the name would only have to put
+#        their version in Cargo.toml and their branch name would be "derived".
+#        Existence is checked case-sensitively against the git-refs API
+#        (`refs/heads/release/1.9.x` and `refs/heads/release/1.9.X` are
+#        different refs; GitHub's compare API is more forgiving than git is).
+#
+#     2. THE CONTENT (defence in depth), for a maintenance line only, and
+#        BLESSED ONCE rather than re-decided forever. This script always
+#        reports `workflow_blob`, the git blob id of `release-candidate.yml`
+#        at the certified commit. Only the CANDIDATE, which is the moment of
+#        blessing, additionally demands that it equal main's CURRENT copy --
+#        by setting CERTREF_REQUIRE_MAIN_WORKFLOW=1. Every later consumer
+#        compares the blob against the one recorded in the SIGNED PREDICATE,
+#        not against main's tip.
+#
+#        That split is the whole point. Comparing against main's tip at
+#        promote time makes a certification perishable: any merge to main
+#        touching release-candidate.yml would strand an already-certified
+#        maintenance commit, permanently, with recovery meaning a new commit
+#        and a full gate re-run (adversarial review r2, finding N1). Nothing
+#        about that failure involves an attacker -- main moves constantly --
+#        and it is a worse outcome than the one the pin defends against.
+#        Pinning in the predicate keeps the property that matters (the
+#        committer cannot choose which historical copy is blessed; only
+#        main's current copy is ever blessed) without the moving target.
+#
+#        Not the merge base: it is a function of the certified commit's own
+#        ancestry, so whoever chooses the commit's parent would choose which
+#        historical copy gets blessed -- including one from before a guard in
+#        this very file existed (r1, finding 3).
+#
+#        The demand is SKIPPED, explicitly, when the line is main: a commit on
+#        main carries whatever release-candidate.yml main carried at that
+#        commit, and comparing main to itself decides nothing.
+#
+# WHAT IT IS NOT
+#   Not an authorisation check. It says which ref *would* be allowed to sign
+#   for this commit; `gh attestation verify` still has to prove that ref
+#   actually did. See scripts/ci/assert-candidate-certified.sh.
+#
+# Output: `key=value` lines on STDOUT (and appended to $GITHUB_OUTPUT when
+# set); all human chatter on STDERR, so a caller can read stdout directly.
+#   certified_ref=refs/heads/release/1.9.x
+#   certified_branch=release/1.9.x
+#   version=1.9.1
+#   workflow_blob=<git blob id of release-candidate.yml at the commit>
+#
+# Exit codes (same vocabulary as assert-candidate-certified.sh):
+#   0  resolved
+#   1  BLOCKED -- the commit is on no releasable branch, or (when
+#      CERTREF_REQUIRE_MAIN_WORKFLOW=1) the workflow file at it is not main's
+#      current copy
+#   2  INFRA   -- could not measure (API). NOT a pass.
+#
+# Env / args:
+#   $1 or CERTREF_SHA         (required) 40-hex commit
+#   CERTREF_REPO / CERT_REPO  owner/name (default artifact-keeper/artifact-keeper)
+#   CERTREF_MAIN_BRANCH       default `main`
+#   CERTREF_WORKFLOW_PATH     default .github/workflows/release-candidate.yml
+#   CERTREF_REQUIRE_MAIN_WORKFLOW
+#                             1 = also demand that the workflow at the commit
+#                             be main's CURRENT copy. Set by the candidate
+#                             only; this is the moment of blessing.
+#   GH_TOKEN                  for gh
+#
+set -uo pipefail
+
+SHA="${1:-${CERTREF_SHA:-}}"
+REPO="${CERTREF_REPO:-${CERT_REPO:-artifact-keeper/artifact-keeper}}"
+MAIN_BRANCH="${CERTREF_MAIN_BRANCH:-main}"
+WORKFLOW_PATH="${CERTREF_WORKFLOW_PATH:-.github/workflows/release-candidate.yml}"
+REQUIRE_MAIN_WORKFLOW="${CERTREF_REQUIRE_MAIN_WORKFLOW:-0}"
+
+blocked() { echo "::error title=Commit is on no releasable branch::$1" >&2; printf 'BLOCKED: %s\n' "$1" >&2; exit 1; }
+infra()   { echo "::error title=Certified ref could not be resolved::$1 Retry; do not interpret as a pass." >&2; printf 'INFRA: %s\n' "$1" >&2; exit 2; }
+
+[[ "$SHA" =~ ^[0-9a-f]{40}$ ]] || infra "a full 40-character commit sha is required (got '${SHA}')."
+command -v gh >/dev/null 2>&1 || infra "gh is not on PATH."
+command -v jq >/dev/null 2>&1 || infra "jq is not on PATH."
+
+ERRF="$(mktemp)"
+trap 'rm -f "$ERRF"' EXIT
+
+# `gh api` with the one distinction that matters: a 404 is an answer ("not
+# there"), anything else is a failure to measure. Prints the body; returns 0
+# on success, 3 on a clean 404, 2 on anything else.
+api() {
+  local out rc=0
+  : >"$ERRF"
+  out="$(gh api "$@" 2>"$ERRF")" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    grep -q 'HTTP 404' "$ERRF" && return 3
+    return 2
+  fi
+  printf '%s' "$out"
+  return 0
+}
+api_err() { tr '\n' ' ' <"$ERRF"; }
+
+raw_at() { # <ref> <path>
+  api -H 'Accept: application/vnd.github.raw+json' "repos/${REPO}/contents/$2?ref=$1"
+}
+blob_at() { # <ref> <path> -> the git blob id, i.e. content identity
+  api "repos/${REPO}/contents/$2?ref=$1" --jq '.sha'
+}
+
+# ── the version at the commit, which names the maintenance line ──────────────
+rc=0; cargo_toml="$(raw_at "$SHA" Cargo.toml)" || rc=$?
+case "$rc" in
+  0) ;;
+  3) blocked "${SHA} has no Cargo.toml (is it a commit in ${REPO}?)." ;;
+  *) infra "could not read Cargo.toml at ${SHA} ($(api_err))." ;;
+esac
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' <<<"$cargo_toml" | head -1)"
+# No leading zeros: `01.9.1` is not semver, and left alone it would derive the
+# branch name `release/01.9.x` and lean on the refs echo-back to catch it.
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  blocked "Cargo.toml at ${SHA} says version '${VERSION:-<none>}'. A certified commit names a stable X.Y.Z; prereleases keep the -rc.N tag path."
+fi
+MAJOR="${BASH_REMATCH[1]}"; MINOR="${BASH_REMATCH[2]}"
+REL_BRANCH="release/${MAJOR}.${MINOR}.x"
+
+echo "== certified ref =="                >&2
+echo "repo:    ${REPO}"                   >&2
+echo "commit:  ${SHA}"                    >&2
+echo "version: ${VERSION}"                >&2
+
+# ── 1. ancestor of main? ─────────────────────────────────────────────────────
+# `compare/<base>...<head>`: `behind` means head is an ancestor of base,
+# `identical` means they are the same commit. Both mean "on main".
+rc=0; cmp_main="$(api "repos/${REPO}/compare/${MAIN_BRANCH}...${SHA}")" || rc=$?
+case "$rc" in
+  0) ;;
+  3) infra "${MAIN_BRANCH} could not be compared with ${SHA} (404); the branch or the commit is missing." ;;
+  *) infra "could not compare ${MAIN_BRANCH}...${SHA} ($(api_err))." ;;
+esac
+main_status="$(jq -r '.status // empty' <<<"$cmp_main")"
+[[ -n "$main_status" ]] || infra "the comparison of ${MAIN_BRANCH} with ${SHA} named no status."
+
+if [[ "$main_status" == "behind" || "$main_status" == "identical" ]]; then
+  CERTIFIED_BRANCH="$MAIN_BRANCH"
+  echo "ref:     refs/heads/${MAIN_BRANCH} (${SHA} is on ${MAIN_BRANCH}: ${main_status})" >&2
+else
+  # ── 2. else the maintenance line the version names ─────────────────────────
+  # Case-sensitively: git refs are, and the compare API is not to be trusted
+  # for that. `release/1.9.X` is a different branch and must not resolve here.
+  rc=0; ref_json="$(api "repos/${REPO}/git/ref/heads/${REL_BRANCH}")" || rc=$?
+  case "$rc" in
+    0) ;;
+    3) blocked "${SHA} is '${main_status}' relative to ${MAIN_BRANCH} and refs/heads/${REL_BRANCH} does not exist. A commit is certified from ${MAIN_BRANCH} or from the maintenance branch its own Cargo.toml names (${VERSION} -> ${REL_BRANCH}); cut that branch first, or certify a commit that is on ${MAIN_BRANCH}." ;;
+    *) infra "could not look up refs/heads/${REL_BRANCH} ($(api_err))." ;;
+  esac
+  actual_ref="$(jq -r '.ref // empty' <<<"$ref_json")"
+  if [[ "$actual_ref" != "refs/heads/${REL_BRANCH}" ]]; then
+    blocked "the refs API answered '${actual_ref:-<none>}' for refs/heads/${REL_BRANCH}. Git refs are case-sensitive and only the exact name is accepted."
+  fi
+  rc=0; cmp_rel="$(api "repos/${REPO}/compare/${REL_BRANCH}...${SHA}")" || rc=$?
+  case "$rc" in
+    0) ;;
+    3) blocked "refs/heads/${REL_BRANCH} could not be compared with ${SHA} (404)." ;;
+    *) infra "could not compare ${REL_BRANCH}...${SHA} ($(api_err))." ;;
+  esac
+  rel_status="$(jq -r '.status // empty' <<<"$cmp_rel")"
+  if [[ "$rel_status" != "behind" && "$rel_status" != "identical" ]]; then
+    blocked "${SHA} is on neither branch: '${main_status}' relative to ${MAIN_BRANCH}, '${rel_status}' relative to ${REL_BRANCH}. Cargo.toml at that commit says ${VERSION}, so ${REL_BRANCH} is the only maintenance line it could be certified from."
+  fi
+  CERTIFIED_BRANCH="$REL_BRANCH"
+  echo "ref:     refs/heads/${REL_BRANCH} (${SHA} is on it: ${rel_status}; ${main_status} relative to ${MAIN_BRANCH})" >&2
+fi
+
+# ── 3. the workflow blob: always reported, demanded only at blessing time ───
+rc=0; WORKFLOW_BLOB="$(blob_at "$SHA" "$WORKFLOW_PATH")" || rc=$?
+case "$rc" in
+  0) ;;
+  3) blocked "${WORKFLOW_PATH} does not exist at ${SHA}. Cherry-pick ${MAIN_BRANCH}'s copy onto ${CERTIFIED_BRANCH}." ;;
+  *) infra "could not read ${WORKFLOW_PATH} at ${SHA} ($(api_err))." ;;
+esac
+
+if [[ "$REQUIRE_MAIN_WORKFLOW" != "1" ]]; then
+  echo "workflow: ${WORKFLOW_PATH} at ${SHA} is blob ${WORKFLOW_BLOB:0:12} (reported; the certification's own record is what a verifier compares it against)." >&2
+elif [[ "$CERTIFIED_BRANCH" == "$MAIN_BRANCH" ]]; then
+  echo "workflow: blob ${WORKFLOW_BLOB:0:12}; nothing to demand -- ${SHA} is on ${MAIN_BRANCH}, so its ${WORKFLOW_PATH} is by definition a copy ${MAIN_BRANCH} carried." >&2
+else
+  rc=0; blob_tip="$(blob_at "$MAIN_BRANCH" "$WORKFLOW_PATH")" || rc=$?
+  case "$rc" in
+    0) ;;
+    3) infra "${WORKFLOW_PATH} does not exist on ${MAIN_BRANCH}; there is nothing to bless against." ;;
+    *) infra "could not read ${WORKFLOW_PATH} on ${MAIN_BRANCH} ($(api_err))." ;;
+  esac
+  if [[ "$WORKFLOW_BLOB" != "$blob_tip" ]]; then
+    blocked "${WORKFLOW_PATH} at ${SHA} (blob ${WORKFLOW_BLOB:0:12}) is not ${MAIN_BRANCH}'s current copy (blob ${blob_tip:0:12}). A maintenance line certifies nothing with a workflow of its own: cherry-pick ${MAIN_BRANCH}'s ${WORKFLOW_PATH} onto ${CERTIFIED_BRANCH} and dispatch a new candidate. (An older copy is refused deliberately -- blessing whatever copy the commit's ancestry happens to reach would let the committer pick a pre-hardening version and keep it forever.)"
+  fi
+  echo "workflow: ${WORKFLOW_PATH} at ${SHA} is ${MAIN_BRANCH}'s current copy (blob ${WORKFLOW_BLOB:0:12}); blessed." >&2
+fi
+
+emit() {
+  echo "$1=$2"
+  [[ -n "${GITHUB_OUTPUT:-}" ]] && echo "$1=$2" >> "$GITHUB_OUTPUT"
+  return 0
+}
+emit certified_ref "refs/heads/${CERTIFIED_BRANCH}"
+emit certified_branch "$CERTIFIED_BRANCH"
+emit version "$VERSION"
+emit workflow_blob "$WORKFLOW_BLOB"
+exit 0

--- a/scripts/ci/test-assert-candidate-certified.sh
+++ b/scripts/ci/test-assert-candidate-certified.sh
@@ -11,9 +11,17 @@
 #   digests no longer match the registry, an image set stitched together from
 #   two candidate runs. A digest carrying two certifications (the same commit
 #   certified twice) must resolve to the same run on every image, whatever
-#   order gh returns them in. The registry and the
-#   attestations API are stubbed (a digest probe script and a `gh` on PATH),
-#   so this runs offline in ~1s.
+#   order gh returns them in. A maintenance release is certified FROM MAIN,
+#   so the accepted identity never widens -- a case below pins that a
+#   certification signed on `release/1.9.x` is still refused -- and the cases
+#   around it cover the second control instead: the DERIVED release line the
+#   commit belongs to, the predicate's `certified_ref` cross-check against it,
+#   and the gate inheriting the resolver's refusal rather than shrugging it
+#   off. The
+#   registry, the attestations API and the ref resolver are stubbed (a digest
+#   probe script, a `gh` on PATH and a resolver script), so this runs offline
+#   in ~1s. The resolver's own decisions are tested in
+#   scripts/ci/test-resolve-certified-ref.sh.
 #
 # Usage: bash scripts/ci/test-assert-candidate-certified.sh
 set -uo pipefail
@@ -101,9 +109,25 @@ jq -c --arg t "$ptype" '[.[] | {attestation:{bundle:{}},verificationResult:{stat
 STUBGH
 chmod +x "$STUB/gh"
 
-good_predicate() { # <sha> <run>
-  printf '{"commit_sha":"%s","version":"1.9.0","candidate_run_id":"%s","gate_run_id":"777","digests":{"backend":"%s","openscap":"%s","scanner_adapter":"%s"}}' \
-    "$1" "$2" "$D_BACKEND" "$D_OPENSCAP" "$D_ADAPTER"
+# Ref-resolver stub: the gate must take the ref from here and nowhere else.
+# FAKE_RESOLVE_RC lets a case assert that the gate inherits a refusal (1) or a
+# measurement failure (2) instead of falling back to a default ref.
+cat > "$STUB/resolve" <<'STUBRESOLVE'
+#!/usr/bin/env bash
+[ "${FAKE_RESOLVE_RC:-0}" = "0" ] || { echo "stub resolver refusing" >&2; exit "${FAKE_RESOLVE_RC}"; }
+ref="${FAKE_RESOLVED_REF:-refs/heads/main}"
+echo "certified_ref=${ref}"
+echo "certified_branch=${ref#refs/heads/}"
+echo "workflow_blob=${FAKE_RESOLVED_BLOB:-blobWF}"
+STUBRESOLVE
+chmod +x "$STUB/resolve"
+
+good_predicate() { # <sha> <run> [certified_ref] [blob]  (empty = field absent)
+  local ref="${3-refs/heads/main}" blob="${4-blobWF}" extra=""
+  [ -n "$ref" ] && extra="$(printf '"certified_ref":"%s",' "$ref")"
+  [ -n "$blob" ] && extra="${extra}$(printf '"certified_workflow_blob":"%s",' "$blob")"
+  printf '{"commit_sha":"%s","version":"1.9.0",%s"candidate_run_id":"%s","gate_run_id":"777","digests":{"backend":"%s","openscap":"%s","scanner_adapter":"%s"}}' \
+    "$1" "$extra" "$2" "$D_BACKEND" "$D_OPENSCAP" "$D_ADAPTER"
 }
 
 # <label> <expected-exit> <expected-substring>; scenario from exported env.
@@ -113,6 +137,7 @@ expect() {
       CERT_REPO=artifact-keeper/artifact-keeper \
       CERT_SHA="${SHA:-$SHA_A}" \
       CERT_DIGEST_CMD="$STUB/probe" \
+      CERT_RESOLVE_CMD="$STUB/resolve" \
       CERT_PREDICATE_TYPE="$PTYPE" \
       GITHUB_OUTPUT="$WORK/out" \
       bash "$GATE" 2>&1 )" || got=$?
@@ -128,7 +153,8 @@ expect() {
 export FAKE_DIGEST_backend="$D_BACKEND" FAKE_DIGEST_openscap="$D_OPENSCAP" FAKE_DIGEST_adapter="$D_ADAPTER"
 export FAKE_PREDICATE; FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242)"
 unset FAKE_GH_NETFAIL FAKE_GH_NONE FAKE_GH_SIGNER FAKE_GH_SOURCE_REF FAKE_PREDICATE_backend FAKE_PREDICATE_openscap FAKE_PREDICATE_adapter \
-      FAKE_PREDICATES_backend FAKE_PREDICATES_openscap FAKE_PREDICATES_adapter SHA CERT_EXPECT_VERSION
+      FAKE_PREDICATES_backend FAKE_PREDICATES_openscap FAKE_PREDICATES_adapter SHA CERT_EXPECT_VERSION \
+      FAKE_RESOLVE_RC FAKE_RESOLVED_REF FAKE_RESOLVED_BLOB CERT_SOURCE_REF
 
 echo "assert-candidate-certified.sh self-test"
 
@@ -221,6 +247,94 @@ FAKE_PREDICATE='{"commit_sha":"'"$SHA_A"'","version":"1.9.0","digests":{"backend
 
 # 11. bad input
 SHA=abc expect "malformed CERT_SHA -> INFRA (exit 2)" 2 "40-character"
+
+# ── the DERIVED release line (maintenance-branch candidates) ───────────────
+# A patch release is certified FROM MAIN, so the accepted identity is
+# unchanged: `...release-candidate.yml@refs/heads/main`, whatever line the
+# commit is on. What the line decides is which commits main may certify, and
+# the predicate's certified_ref is checked against it.
+export FAKE_RESOLVED_REF=refs/heads/release/1.9.x
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/1.9.x)"
+expect "a release/1.9.x commit certified from main -> accepted" 0 "release-candidate.yml@refs/heads/main"
+
+# THE POINT of certifying from main: a copy of release-candidate.yml on a
+# release branch signs with an identity nothing accepts, so the "create a
+# release/* ref and put an edited workflow on it" attack has no identity to
+# reach for -- it is refused by the same unwidened pin that refuses any other
+# branch, not by a widened one that has to be argued about.
+export FAKE_GH_SOURCE_REF=refs/heads/release/1.9.x
+expect "a certification signed on release/1.9.x is refused, pin unwidened" 1 "carries no release-candidate certification"
+unset FAKE_GH_SOURCE_REF
+
+# The predicate records the line the signer resolved; the repository is asked
+# the same question again at promote time. A disagreement is never promoted.
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/main)"
+expect "predicate certified_ref disagreeing with the derived line is refused" 1 "disagree about which line"
+
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 "")"
+expect "a maintenance-line certification with no certified_ref is refused" 1 "must record the line"
+
+# A maintenance commit forward-merged to main: the resolver answers `main` from
+# then on, while the signed predicate still names the line it was certified on.
+# Both are true of the commit, so this must NOT block -- refusing it would kill
+# the documented idempotent re-promote exactly when it is needed.
+export FAKE_RESOLVED_REF=refs/heads/main
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/1.9.x)"
+expect "a line certification survives the commit being forward-merged to main" 0 "forward-merged to main"
+
+# The reverse is still a disagreement: a certification claiming a line for a
+# commit that main never had is not a forward-merge.
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/9.9.x)"
+export FAKE_RESOLVED_REF=refs/heads/release/1.9.x
+expect "a certification naming another line is still refused" 1 "disagree about which line"
+
+# ...and a well-shaped release ref that is not THIS version's line is not a
+# forward-merge either (r2, finding N6): the predicate says version 1.9.0.
+export FAKE_RESOLVED_REF=refs/heads/main
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/9.9.x)"
+expect "a forward-merge claim naming another version's line is refused" 1 "disagree about which line"
+
+# ── the blessed workflow blob (r2, finding N1) ──────────────────────────────
+# The verifier compares against the blob the certification RECORDED, which is
+# fixed by the commit, never against main's tip, which moves. A certification
+# must not rot because an unrelated merge touched release-candidate.yml.
+export FAKE_RESOLVED_REF=refs/heads/release/1.9.x FAKE_RESOLVED_BLOB=blobPINNED
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/1.9.x blobPINNED)"
+expect "the recorded workflow blob matching the commit's -> accepted" 0 "as blessed at certification time"
+
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/1.9.x blobOTHER)"
+expect "a certification recording another workflow blob is refused" 1 "does not describe this commit"
+
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/1.9.x "")"
+expect "a maintenance-line certification with no recorded blob is refused" 1 "records no certified_workflow_blob"
+
+# The legacy tolerance covers certifications predating BOTH fields, and only
+# those (r3, item 1). A certification that names a line but records no blob is
+# not legacy, even once the commit has been forward-merged and the line
+# resolves to main -- which is the case the old condition let through.
+export FAKE_RESOLVED_REF=refs/heads/main
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 refs/heads/release/1.9.x "")"
+expect "a forward-merged line certification with no blob is refused, not read as legacy" 1 "records no certified_workflow_blob"
+
+export FAKE_RESOLVED_REF=refs/heads/main
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 "" "")"
+expect "a legacy main certification with neither field still passes" 0 "predates certified_workflow_blob"
+unset FAKE_RESOLVED_BLOB
+
+# Certifications minted before certified_ref existed stay promotable, but only
+# for main, where the line could not have been anything else.
+export FAKE_RESOLVED_REF=refs/heads/main
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242 "")"
+expect "a legacy main certification with no certified_ref still passes" 0 "predates certified_ref"
+
+# The gate inherits the resolver's verdict -- which is where the content pin
+# on release-candidate.yml is enforced -- and never shrugs it off.
+FAKE_PREDICATE="$(good_predicate "$SHA_A" 4242)"
+export FAKE_RESOLVE_RC=1
+expect "a refused resolver blocks the gate (exit 1)" 1 "no line that may be released"
+export FAKE_RESOLVE_RC=2
+expect "an unmeasurable resolver is INFRA (exit 2), never a pass" 2 "could not resolve which line"
+unset FAKE_RESOLVE_RC FAKE_RESOLVED_REF
 
 echo
 if [ "$fails" -eq 0 ]; then echo "all assert-candidate-certified.sh cases passed"; exit 0; fi

--- a/scripts/ci/test-resolve-certified-ref.sh
+++ b/scripts/ci/test-resolve-certified-ref.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/resolve-certified-ref.sh and for the parts of
+# .github/workflows/release-candidate.yml that CI must pin: the dispatch-ref
+# guard, the audit that no code from the certified commit runs, and the
+# certification predicate (extracted and EXECUTED).
+#
+# WHY THIS EXISTS
+#   The resolver decides WHICH COMMITS main's Release Candidate may certify.
+#   Get it wrong in the permissive direction and a commit on no release line
+#   becomes releasable; get it wrong in the strict direction and a security
+#   patch cannot be cut. Neither can be exercised by opening a PR, so
+#   the whole world it reads -- the version at the commit, the two ancestry
+#   comparisons, the case-sensitive refs lookup and the three workflow blob
+#   ids -- is stubbed behind a `gh` on PATH, and this runs offline in ~1s.
+#
+#   Most cases assert a REFUSAL, because that is the failure direction that
+#   matters: an arbitrary branch, a case variant of a real release branch, a
+#   commit on neither branch, and -- the backstop for the window in which an
+#   admin has the release ruleset toggled off -- a commit whose
+#   release-candidate.yml is not the copy main carries. The guard section at
+#   the end pins the decision that keeps the signing identity unwidened.
+#
+# Usage: bash scripts/ci/test-resolve-certified-ref.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="${HERE}/resolve-certified-ref.sh"
+WORKFLOW="${HERE}/../../.github/workflows/release-candidate.yml"
+[ -f "$RESOLVER" ] || { echo "cannot find resolve-certified-ref.sh next to this test" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$*"; fails=$((fails + 1)); }
+
+SHA_A=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+MB=cccccccccccccccccccccccccccccccccccccccc
+
+STUB="$WORK/bin"; mkdir -p "$STUB"
+
+# `gh api` stub. The world is described by W_* env vars; every call the
+# resolver can make is answered from them, and anything else is a loud 64 so
+# a new call cannot be added without a decision here.
+#   W_VERSION     the `version = "..."` line Cargo.toml carries at the commit
+#   W_MAIN_STATUS status of compare main...<sha>  (behind|identical|ahead|diverged)
+#   W_MERGE_BASE  merge_base_commit.sha of that comparison
+#   W_REL_REF     what the refs API answers for the derived branch ('' = 404)
+#   W_REL_STATUS  status of compare <branch>...<sha>
+#   W_BLOB_SHA / W_BLOB_MAIN
+#                 release-candidate.yml's blob id at the commit ('' = 404) and
+#                 on main's tip
+#   W_FAIL        a path fragment whose call fails as a non-404 error
+cat > "$STUB/gh" <<'STUBGH'
+#!/usr/bin/env bash
+[ "${1:-}" = "api" ] || { echo "stub gh: unexpected '${1:-}'" >&2; exit 64; }
+shift
+path=""; raw=0; want_jq=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -H) case "$2" in *raw+json*) raw=1 ;; esac; shift 2 ;;
+    --jq) want_jq="$2"; shift 2 ;;
+    repos/*) path="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+[ -n "$path" ] || { echo "stub gh: no repos/ path" >&2; exit 64; }
+if [ -n "${W_FAIL:-}" ] && case "$path" in *"$W_FAIL"*) true ;; *) false ;; esac; then
+  echo "gh: Internal Server Error (HTTP 500)" >&2; exit 1
+fi
+notfound() { echo "gh: Not Found (HTTP 404)" >&2; exit 1; }
+emit() { if [ -n "$want_jq" ]; then jq -r "$want_jq" <<<"$1"; else printf '%s' "$1"; fi; }
+case "$path" in
+  */contents/Cargo.toml*)
+    [ "$raw" = 1 ] || { echo "stub gh: Cargo.toml must be read raw" >&2; exit 64; }
+    printf '[package]\nname = "artifact-keeper"\nversion = "%s"\n' "${W_VERSION}" ;;
+  */contents/.github/workflows/release-candidate.yml*)
+    ref="${path##*ref=}"
+    case "$ref" in
+      main) b="${W_BLOB_MAIN}" ;;
+      *)    b="${W_BLOB_SHA}" ;;
+    esac
+    [ -n "$b" ] || notfound
+    emit "$(jq -nc --arg s "$b" '{sha:$s}')" ;;
+  */git/ref/heads/*)
+    [ -n "${W_REL_REF}" ] || notfound
+    emit "$(jq -nc --arg r "$W_REL_REF" '{ref:$r}')" ;;
+  */compare/main...*)
+    emit "$(jq -nc --arg s "$W_MAIN_STATUS" --arg m "$W_MERGE_BASE" '{status:$s,merge_base_commit:{sha:$m}}')" ;;
+  */compare/*)
+    emit "$(jq -nc --arg s "$W_REL_STATUS" '{status:$s}')" ;;
+  *) echo "stub gh: unhandled ${path}" >&2; exit 64 ;;
+esac
+STUBGH
+chmod +x "$STUB/gh"
+
+# A world where the commit sits on release/1.9.x with main's workflow file.
+reset_world() {
+  export W_VERSION=1.9.1
+  export W_MAIN_STATUS=diverged
+  export W_MERGE_BASE="$MB"
+  export W_REL_REF=refs/heads/release/1.9.x
+  export W_REL_STATUS=behind
+  export W_BLOB_SHA=blob1111
+  export W_BLOB_MAIN=blob1111
+  # Most content cases are about the moment of BLESSING, which is the only
+  # time main's current copy is demanded.
+  export CERTREF_REQUIRE_MAIN_WORKFLOW=1
+  export W_FAIL=""
+}
+
+# <label> <expected-exit> <expected-substring>; world from exported W_*.
+expect() {
+  local label="$1" want="$2" needle="$3" got=0 out
+  out="$( PATH="$STUB:$PATH" CERTREF_REPO=artifact-keeper/artifact-keeper \
+      GITHUB_OUTPUT="" bash "$RESOLVER" "${SHA:-$SHA_A}" 2>&1 )" || got=$?
+  if [ "$got" = "$want" ] && printf '%s' "$out" | grep -qF -- "$needle"; then
+    pass "$label"
+  else
+    fail "$label (wanted exit ${want} containing '${needle}', got exit ${got})"
+    printf '%s\n' "$out" | sed 's/^/        /' | tail -n 5
+  fi
+}
+
+echo "resolve-certified-ref.sh self-test"
+
+# ── the two accepted shapes ─────────────────────────────────────────────────
+reset_world
+expect "a commit on release/1.9.x resolves to that line" 0 "certified_ref=refs/heads/release/1.9.x"
+
+reset_world; W_MAIN_STATUS=behind
+expect "a commit on main still resolves to main" 0 "certified_ref=refs/heads/main"
+
+reset_world; W_MAIN_STATUS=identical
+expect "the tip of main resolves to main" 0 "certified_ref=refs/heads/main"
+
+# A commit that is on BOTH -- a maintenance commit forward-merged to main --
+# resolves to main, deterministically, and is not subject to the content pin.
+reset_world; W_MAIN_STATUS=behind; W_REL_STATUS=behind; W_BLOB_SHA=blobOLD
+expect "a commit on both lines resolves to main, deterministically" 0 "certified_ref=refs/heads/main"
+
+# ── the refusals ────────────────────────────────────────────────────────────
+# An arbitrary topic branch: the commit is on neither main nor the release
+# line its own Cargo.toml names, whatever branch it may be reachable from.
+reset_world; W_REL_STATUS=diverged
+expect "a commit on an arbitrary branch is refused" 1 "is on neither branch"
+
+reset_world; W_MAIN_STATUS=ahead; W_REL_STATUS=ahead
+expect "a commit no branch has merged is refused" 1 "is on neither branch"
+
+# Git refs are case-sensitive and the compare API is not to be trusted for it.
+# The DERIVED name is always lowercase, so this catches a refs API that
+# answered with a different ref than the one asked for -- a prefix match, or a
+# case-folded one.
+reset_world; W_REL_REF=refs/heads/Release/1.9.x
+expect "the refs API answering a case variant is refused" 1 "case-sensitive"
+
+reset_world; W_REL_REF=refs/heads/release/1.9.X
+expect "the refs API answering a different .x suffix is refused" 1 "case-sensitive"
+
+reset_world; W_REL_REF=refs/heads/release/1.9.x-old
+expect "the refs API answering a longer name is refused" 1 "case-sensitive"
+
+reset_world; W_REL_REF=""
+expect "a version whose release line does not exist is refused" 1 "does not exist"
+
+# THE CONTENT PIN: an edited release-candidate.yml on a line that would
+# otherwise be allowed to certify -- and, since finding 3, a STALE one too.
+# Only main's CURRENT copy is accepted, because the merge base is chosen by
+# whoever chose the commit's parent.
+reset_world; W_BLOB_SHA=blobEVIL
+expect "an edited release-candidate.yml on a line is refused at blessing" 1 "is not main's current copy"
+
+reset_world; W_BLOB_SHA=blobOLD
+expect "a STALE release-candidate.yml on a line is refused at blessing" 1 "cherry-pick"
+
+reset_world; W_BLOB_SHA=""
+expect "a line with no release-candidate.yml at all is refused" 1 "does not exist at"
+
+# BLESSED ONCE (r2, finding N1). Outside the candidate the resolver only
+# REPORTS the blob; main's tip moving must never invalidate a certification
+# that already exists, or an unrelated merge strands it permanently.
+reset_world; CERTREF_REQUIRE_MAIN_WORKFLOW=0; W_BLOB_MAIN=blobMAINMOVED
+expect "main's workflow moving does not invalidate a certified commit" 0 "certified_ref=refs/heads/release/1.9.x"
+
+reset_world; CERTREF_REQUIRE_MAIN_WORKFLOW=0; W_BLOB_MAIN=blobMAINMOVED
+expect "the blob at the commit is reported for the verifier to compare" 0 "workflow_blob=blob1111"
+
+reset_world
+expect "blessing reports the same blob it demanded" 0 "workflow_blob=blob1111"
+
+# On main the pin decides nothing and says so, rather than passing vacuously.
+reset_world; W_MAIN_STATUS=behind; W_BLOB_SHA=blobANYTHING
+expect "on main nothing is demanded, explicitly, rather than vacuously passed" 0 "nothing to demand"
+
+# ── shape and measurement ───────────────────────────────────────────────────
+reset_world; W_VERSION=1.9.1-rc.1
+expect "a prerelease version is refused" 1 "stable X.Y.Z"
+
+reset_world; W_VERSION=""
+expect "a Cargo.toml with no version is refused" 1 "stable X.Y.Z"
+
+reset_world; W_FAIL="compare/main"
+expect "an unreadable comparison is INFRA, never a pass" 2 "could not compare"
+
+reset_world; W_VERSION=01.9.1
+expect "a leading-zero version is refused" 1 "stable X.Y.Z"
+
+reset_world; W_VERSION=1.9
+expect "a two-component version is refused" 1 "stable X.Y.Z"
+
+reset_world; W_FAIL="contents/Cargo.toml"
+expect "an unreadable Cargo.toml is INFRA, never a pass" 2 "could not read Cargo.toml"
+
+reset_world; W_FAIL="git/ref/heads"
+expect "an unreadable refs lookup is INFRA, never a pass" 2 "could not look up"
+
+reset_world; W_FAIL="compare/release"
+expect "an unreadable release-line comparison is INFRA, never a pass" 2 "could not compare"
+
+reset_world; W_FAIL="release-candidate.yml"
+expect "an unreadable workflow blob is INFRA, never a pass" 2 "could not read"
+
+reset_world
+SHA=abc expect "a short sha is INFRA (exit 2)" 2 "40-character"
+unset SHA
+
+# ── the dispatch-ref guard in release-candidate.yml ─────────────────────────
+# The candidate certifies maintenance commits FROM MAIN, so the guard must
+# stay main-only. This is the regression test for that decision: the day
+# someone widens the guard to accept `refs/heads/release/*`, the signing
+# identity widens with it and the "create a release/* ref, put an edited
+# release-candidate.yml on it, satisfy the exact pin" attack becomes
+# reachable again. Read out of the workflow that actually ships.
+echo "release-candidate.yml dispatch-ref guard"
+if [ ! -f "$WORKFLOW" ]; then
+  fail "cannot find release-candidate.yml to read the guard from"
+else
+  # Deliberately single-quoted: this is the literal text that must appear in
+  # the workflow, not something to expand here.
+  # shellcheck disable=SC2016
+  if grep -q '\[\[ "${GITHUB_REF}" != "refs/heads/main" \]\]' "$WORKFLOW"; then
+    pass "the guard refuses every dispatch ref but refs/heads/main"
+  else
+    fail "release-candidate.yml no longer carries the exact main-only dispatch guard"
+  fi
+  if grep -qE '=~ \^refs/heads/release' "$WORKFLOW"; then
+    fail "the dispatch guard accepts a release/* ref -- that widens the signing identity (see the header of assert-candidate-certified.sh)"
+  else
+    pass "the guard does not accept a release/* ref, so the signing identity stays unwidened"
+  fi
+fi
+
+# ── FINDING 1: no code from the certified commit runs in release-candidate.yml ─
+# The certification's whole value is that only main's release-candidate.yml
+# can mint one. That is a property of the JOB, not just of the workflow file:
+# `certify` holds `id-token: write` and `attestations: write` for every one of
+# its steps, so any route that puts the certified commit's tree on disk there
+# hands a maintenance commit arbitrary shell with the signing identity in
+# scope -- attempt 2's attack, relocated from the workflow file to the scripts
+# beside it.
+#
+# Three routes are checked (r2 N3, widened in r3): any action given a `ref:`
+# other than main -- not just `actions/checkout`, since a third-party action
+# takes the same input; any `git` command that can write another tree
+# (`checkout`, `switch`, `restore`, `archive`, `worktree`, `read-tree`), with
+# the verb matched anywhere after `git` so global options like `git -C .`
+# cannot hide it; and any fetch of a commit archive over HTTP
+# (`tarball`/`zipball`/`/archive/`), because `| tar xz` is as good as a
+# checkout. The only permitted way for the commit's tree to touch the disk is
+# a pathspec-scoped checkout of release bookkeeping DATA.
+#
+# BE HONEST ABOUT WHAT THIS IS: a text audit of the workflow, not a parse of
+# it. It catches the routes named above in the forms they are written in, and
+# the fixtures below are the evidence for each. It cannot catch a tree
+# smuggled in by something it does not know to look for -- an action that
+# fetches by digest, a script that reconstructs files from `git cat-file`, a
+# `uses:` of a local composite action. It is a tripwire on the known routes,
+# and the reason it is worth having is that those are the routes an ordinary
+# edit takes.
+#
+# The check is a function so it can be run against fixtures that reintroduce
+# the hole -- a test that has never been shown to fail is not a test.
+audit_workflow() { # <file>; echoes one `verdict:reason` line per problem
+  local wf="$1" line paths path marker body
+  # The workflow's literal text. `$SHA` here is the WORKFLOW's variable, so
+  # the marker must never be expanded by this shell.
+  # shellcheck disable=SC2016
+  marker='git checkout "$SHA" -- '
+  # Comments are not code; a comment that merely NAMES one of these commands
+  # must not trip the audit.
+  body="$(sed 's/^[[:space:]]*#.*$//' "$wf")"
+
+  # 1. Every `ref:` an action is given must be main. Counting
+  #    `actions/checkout` alone missed a third-party checkout action taking
+  #    the same input (r3, item 2), and this covers any action with a `ref`.
+  local refs bad_refs
+  refs="$(grep -cE '^[[:space:]]+ref:[[:space:]]' <<<"$body" || true)"
+  [ "$refs" -gt 0 ] || echo "no-checkouts:the workflow gives no action a ref at all"
+  bad_refs="$(grep -E '^[[:space:]]+ref:[[:space:]]' <<<"$body" | grep -vE '^[[:space:]]+ref: refs/heads/main$' || true)"
+  if [ -n "$bad_refs" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] && echo "declarative:${line# }"
+    done <<EOF_REFS
+$bad_refs
+EOF_REFS
+  fi
+
+  # 2. Any git command that can put another tree on disk. The verb is matched
+  #    anywhere after `git`, so global options (`git -C .`, `-c`) cannot hide
+  #    it (r3, item 2), and `read-tree` is included.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      *"$marker"*) paths="${line#*"$marker"}" ;;
+      *) echo "git-cmd:${line# }"; continue ;;
+    esac
+    for path in $paths; do
+      case "$path" in
+        CHANGELOG.md|.github/release-notes) ;;
+        *) echo "overlay-path:${path}" ;;
+      esac
+    done
+  done <<EOF_GIT
+$(grep -E 'git .*(checkout|switch|restore|archive|worktree|read-tree)' <<<"$body" || true)
+EOF_GIT
+
+  # 3. The tree can also arrive over HTTP. GitHub serves any commit as an
+  #    archive, and `| tar xz` is as good as a checkout (r3, item 2).
+  local archives
+  archives="$(grep -E 'tarball|zipball|/archive/' <<<"$body" || true)"
+  [ -z "$archives" ] || printf 'archive-fetch:%s\n' "$(tr -s ' ' <<<"$archives")"
+}
+
+echo "release-candidate.yml runs no code from the certified commit"
+if [ ! -f "$WORKFLOW" ]; then
+  fail "cannot find release-candidate.yml"
+else
+  problems="$(audit_workflow "$WORKFLOW")"
+  if [ -z "$problems" ]; then
+    pass "no route puts the certified commit's tree on disk except the bookkeeping overlay"
+  else
+    fail "release-candidate.yml exposes the certified commit's tree:"
+    printf '%s\n' "$problems" | sed 's/^/          /'
+  fi
+fi
+
+# The audit must FAIL on each way the hole comes back. Fixtures, not prose.
+fixture() { # <name> <body>
+  local f="$WORK/wf-$1.yml"
+  printf '%s\n' "$2" > "$f"
+  if [ -n "$(audit_workflow "$f")" ]; then
+    pass "the audit catches: $1"
+  else
+    fail "the audit MISSES: $1 -- finding 1 would come back silently"
+  fi
+}
+BASE='      - uses: actions/checkout@abc
+        with:
+          ref: refs/heads/main'
+fixture "a declarative checkout of the certified sha" \
+  "$BASE
+      - uses: actions/checkout@abc
+        with:
+          ref: \${{ needs.resolve.outputs.sha }}"
+fixture "a declarative checkout of an env alias for it" \
+  "$BASE
+      - uses: actions/checkout@abc
+        with:
+          ref: \${{ env.SHA }}"
+fixture "a forced git checkout inside a run block" \
+  "$BASE
+      - run: git fetch origin \"\$SHA\" && git checkout --force \"\$SHA\""
+fixture "a braced git checkout smuggling a script path" \
+  "$BASE
+      - run: git checkout \"\${SHA}\" -- CHANGELOG.md .github/release-notes scripts/ci"
+fixture "the exact overlay form with a script path appended" \
+  "$BASE
+      - run: git checkout \"\$SHA\" -- CHANGELOG.md .github/release-notes scripts/ci"
+fixture "a git switch to the certified sha" \
+  "$BASE
+      - run: git switch --detach \"\$SHA\""
+fixture "a git archive of the certified sha extracted in place" \
+  "$BASE
+      - run: git archive \"\$SHA\" | tar -x"
+fixture "a second worktree at the certified sha" \
+  "$BASE
+      - run: git worktree add /tmp/c \"\$SHA\""
+fixture "a git checkout hidden behind a global option" \
+  "$BASE
+      - run: git -C . checkout --force \"\$SHA\""
+fixture "a git checkout hidden behind -c" \
+  "$BASE
+      - run: git -c core.fsmonitor=false checkout \"\$SHA\""
+fixture "a THIRD-PARTY checkout action given the certified sha" \
+  "      - uses: some-org/checkout-action@v1
+        with:
+          ref: \${{ needs.resolve.outputs.sha }}"
+fixture "the commit fetched as a tarball over HTTP" \
+  "$BASE
+      - run: gh api repos/o/r/tarball/\$SHA | tar xz"
+fixture "the commit fetched as a zipball over HTTP" \
+  "$BASE
+      - run: curl -L https://github.com/o/r/archive/\$SHA.zip -o c.zip"
+fixture "git read-tree materialising the certified sha" \
+  "$BASE
+      - run: git read-tree -u --reset \"\$SHA\""
+
+# ...and must PASS the shape that actually ships, so it is not merely strict.
+printf '%s\n' "$BASE
+      - run: git checkout \"\$SHA\" -- CHANGELOG.md .github/release-notes" > "$WORK/wf-ok.yml"
+if [ -z "$(audit_workflow "$WORK/wf-ok.yml")" ]; then
+  pass "the audit accepts the bookkeeping overlay it is meant to allow"
+else
+  fail "the audit rejects the shipped overlay shape -- it would block every edit"
+fi
+
+# ── the certification predicate, EXECUTED ───────────────────────────────────
+# The suites stub `gh` and audit text; the workflow's own inline shell was
+# covered only by actionlint's embedded shellcheck. That is exactly the gap
+# that let an apostrophe inside the single-quoted jq program through until a
+# re-run happened to catch it -- a bug that would have broken every
+# certification at runtime, not in CI (r3, item 3). So the predicate step is
+# extracted from the workflow and RUN here, offline, and its output is
+# checked for the fields the verifier reads back.
+echo "release-candidate.yml builds a valid certification predicate"
+if [ ! -f "$WORKFLOW" ]; then
+  fail "cannot find release-candidate.yml"
+elif ! command -v jq >/dev/null 2>&1; then
+  fail "jq is not on PATH; the predicate cannot be executed"
+else
+  prog="$(awk '
+    /^ +jq -n \\$/      { f = 1 }
+    f                   { sub(/^          /, ""); print }
+    /certification\/predicate\.json$/ { if (f) exit }
+  ' "$WORKFLOW")"
+  if [ -z "$prog" ]; then
+    fail "could not find the jq predicate program in release-candidate.yml"
+  else
+    pdir="$WORK/pred"; mkdir -p "$pdir/certification"
+    {
+      echo 'set -euo pipefail'
+      echo 'SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      echo 'VERSION=1.9.1'
+      echo 'CERTIFIED_REF=refs/heads/release/1.9.x'
+      echo 'WORKFLOW_BLOB=b1b1b1b1'
+      echo 'GITHUB_RUN_ID=4242'
+      echo 'GITHUB_RUN_ATTEMPT=1'
+      echo 'GITHUB_SERVER_URL=https://github.com'
+      echo 'GITHUB_REPOSITORY=artifact-keeper/artifact-keeper'
+      echo 'PUBLISH_RUN_ID=99'
+      echo 'ADAPTER_VERSION=2.3.4'
+      echo 'BACKEND_DIGEST=sha256:1111111111111111111111111111111111111111111111111111111111111111'
+      echo 'OPENSCAP_DIGEST=sha256:2222222222222222222222222222222222222222222222222222222222222222'
+      echo 'ADAPTER_DIGEST=sha256:3333333333333333333333333333333333333333333333333333333333333333'
+      echo 'BACKEND_IMAGE=ghcr.io/o/r-backend'
+      echo 'OPENSCAP_IMAGE=ghcr.io/o/r-openscap'
+      echo 'ADAPTER_IMAGE=ghcr.io/o/r-scanner-adapter'
+      printf '%s\n' "$prog"
+    } > "$pdir/run.sh"
+    out=""; rc=0
+    out="$(cd "$pdir" && bash run.sh 2>&1)" || rc=$?
+    if [ "$rc" != 0 ]; then
+      fail "the predicate step does not run (exit ${rc}) -- a quoting or jq error that CI would otherwise meet at a real cut"
+      printf '%s\n' "$out" | sed 's/^/          /' | tail -n 4
+    elif ! jq -e . "$pdir/certification/predicate.json" >/dev/null 2>&1; then
+      fail "the predicate step ran but did not write valid JSON"
+    else
+      pass "the predicate step runs and writes valid JSON"
+      # Every field the verifier reads back must be present and correct;
+      # a predicate that parses but omits one blocks a real promote.
+      for probe in \
+        '.commit_sha == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        '.version == "1.9.1"' \
+        '.certified_ref == "refs/heads/release/1.9.x"' \
+        '.certified_workflow_blob == "b1b1b1b1"' \
+        '.candidate_run_id == "4242"' \
+        '.gate_run_id == "4242"' \
+        '(.digests | keys) == ["backend","openscap","scanner_adapter"]' \
+        '.sha_tag == "sha-aaaaaaa"'
+      do
+        if jq -e "$probe" "$pdir/certification/predicate.json" >/dev/null 2>&1; then
+          pass "predicate: ${probe}"
+        else
+          fail "predicate: ${probe} -- the verifier reads this field"
+        fi
+      done
+    fi
+  fi
+fi
+
+if [ "$fails" -eq 0 ]; then echo "all resolve-certified-ref.sh cases passed"; exit 0; fi
+echo "${fails} resolve-certified-ref.sh case(s) FAILED"; exit 1


### PR DESCRIPTION
## Why

The 1.9.1 candidate refused, correctly, on its first run:

```
BLOCKED: .github/workflows/release-candidate.yml at 539ab875 (blob bc19069565c7)
is not main's current copy (blob 15901ae68d7c). A maintenance line certifies
nothing with a workflow of its own.
```

`release/1.9.x` was cut from the `v1.9.0` tag, so it carries the release tooling as it stood then. #3821 (merged to `main` today) is what teaches the flow to certify a maintenance line at all, and its content pin requires the certified commit's `release-candidate.yml` to be main's current copy — precisely so a maintenance branch cannot certify with a workflow of its own. The remedy the error names is this forward-port.

Note the resolver worked: it derived `refs/heads/release/1.9.x` from `Cargo.toml` at that commit and confirmed the commit is on it. Only the content pin blocked.

## What

Cherry-pick of `5a8b6934` (#3821) with `-x`. Ten files: the four release workflows, `ci.yml`'s test wiring, `RELEASING.md`, and the two scripts plus their self-tests.

`CHANGELOG.md` is deliberately **not** taken from the cherry-pick — this branch has already promoted `[1.9.1]`, and #3821's entry belongs to 1.10.0 on `main`, not to this release. Verified: `git diff origin/release/1.9.x HEAD -- CHANGELOG.md` is empty.

Verified after the pick: `release-candidate.yml` on this branch now hashes to `15901ae68d7c`, identical to main's, so the content pin will pass.

## After this merges

Docker Publish rebuilds the branch's `sha-` images for the new commit, then the candidate is re-dispatched against it.