### PR TITLE
docs(changelog): describe the release-tooling forward-port in 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.9.1] - 2026-09-10
 
+### Changed
+
+- **Release tooling forward-ported from `main` so this line can be certified** (#3827, #3821). The certified-candidate flow refuses to certify a maintenance branch whose `release-candidate.yml` is not `main`'s current copy, so a line cut from an older tag cannot be released until its tooling is brought forward. Workflows, `scripts/ci` and `RELEASING.md` only — no runtime code, no behaviour change in the product.
+
 ### Security
 
 - **SBOM mutation endpoints now require the repository write/delete action instead of read visibility** (#3826, #3824, GHSA-ww52-pmcg-f53c). `DELETE /api/v1/sbom/{id}`, `POST /api/v1/sbom/{id}/convert`, and `POST /api/v1/sbom` (including `force_regenerate`) gated only on read visibility of the owning repository, so any read-only member — and on a public repository any authenticated user — could hard-delete an SBOM attestation, convert it, or force a regeneration that deleted the existing document. All three now pass through `require_repo_action`: delete requires `delete`, convert and generate require `write`, matching the gRPC siblings and native artifact writes. Non-members can no longer generate or convert SBOMs on public repositories, and members whose role lacks `delete` (e.g. `developer`) can no longer delete SBOMs.


### PR DESCRIPTION
The 1.9.1 candidate was refused by the release preflight:

```
[FAIL] commits in v1.9.0..HEAD are not described by the pending section:
    - #3827  feat(release): certify release/X.Y.x commits from main, …
```

#3827 forward-ported the release tooling so this line could be certified at all. It is plumbing rather than product, but it *is* in the release, and "in the release and undescribed" is precisely what preflight check 5 exists to catch — the same gate that caught the misfiled entries on `main` this week.

Adds one entry under `### Changed` in `[1.9.1]` stating what it is and, explicitly, that no runtime code changed. The seven security entries are untouched.

Worth noting for the next maintenance cut: the gate exempts `chore(release):` and `docs(changelog):` subjects. The forward-port was a `git cherry-pick -x`, so it inherited `feat(release):` from `main` and was not exempt. Retitling such a cherry-pick to `chore(release): forward-port …` on the maintenance line would avoid this round trip next time.